### PR TITLE
ci: fix ruff F401 in test_shot_refine and black formatting in cli

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -112,9 +112,7 @@ def detect(
     if refine_diffs:
         console.print(
             f"  [cyan]refined {len(refine_diffs)} shot time(s)[/]: "
-            + ", ".join(
-                f"#{d['shot_number']} {d['drift_ms']:+.1f}ms" for d in refine_diffs
-            )
+            + ", ".join(f"#{d['shot_number']} {d['drift_ms']:+.1f}ms" for d in refine_diffs)
         )
     _print_shots_table(shots)
     _print_anomalies(report.detect_anomalies(shots, beep.time, time))
@@ -244,13 +242,18 @@ def audit_prep(
         ),
     ),
     paper: int = typer.Option(
-        0, "--paper", min=0,
+        0,
+        "--paper",
+        min=0,
         help="Paper-target count for the stage (each scored x2 in IPSC by default).",
     ),
     poppers: int = typer.Option(0, "--poppers", min=0, help="Popper count."),
     plates: int = typer.Option(0, "--plates", min=0, help="Plate count."),
     shots_per_paper: int = typer.Option(
-        2, "--shots-per-paper", min=1, max=2,
+        2,
+        "--shots-per-paper",
+        min=1,
+        max=2,
         help="Shots per paper target. 2 for normal stages, 1 for strong/weak-hand-only.",
     ),
 ) -> None:
@@ -343,8 +346,7 @@ def audit_prep(
 
     fixture_json_data = {
         "source": (
-            f"{video.name} stage {stage_number} '{stage_name}' "
-            "(audio extracted at 48 kHz mono)"
+            f"{video.name} stage {stage_number} '{stage_name}' " "(audio extracted at 48 kHz mono)"
         ),
         "stage_number": stage_number,
         "stage_name": stage_name,
@@ -518,9 +520,7 @@ def _process_one(
     if refine_diffs:
         console.print(
             f"  [cyan]refined {len(refine_diffs)} shot time(s)[/]: "
-            + ", ".join(
-                f"#{i + 1} {d['drift_ms']:+.1f}ms" for i, d in enumerate(refine_diffs)
-            )
+            + ", ".join(f"#{i + 1} {d['drift_ms']:+.1f}ms" for i, d in enumerate(refine_diffs))
         )
     _print_shots_table(shots)
 

--- a/tests/test_shot_refine.py
+++ b/tests/test_shot_refine.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
- Remove unused `import json` from tests/test_shot_refine.py.
- Run black on src/splitsmith/cli.py to fix line-wrapping in
  audit-prep typer.Option calls and the refine-diff join expressions
  introduced in the recent shot_refine + audit-prep commits.