### PR TITLE
Sub 1 of #11: UI v1 foundation -- FastAPI backend, React/Vite/shadcn SPA, design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ uv run splitsmith process \
 
 If videos can't be matched cleanly (multiple candidates for one stage, no candidate, ambiguity across stages), the offending stages and videos are listed and the run aborts. Re-run with the videos renamed/separated, or use `single` for each stage explicitly.
 
+### `ui` -- production UI (issue #11/#12, in progress)
+
+The localhost SPA that orchestrates the full ingest -> audit -> export workflow. State lives on disk under `--project`; closing the browser and re-running resumes where you left off.
+
+```bash
+uv run splitsmith ui --project ~/matches/tallmilan-2026
+```
+
+Opens `http://127.0.0.1:5174/` in your default browser. Sub 1 (#12) ships the foundation: app shell, project model, three-screen navigation, design system at `/_design`. The actual ingest / audit / export screens land in #13, #15, #17.
+
+For frontend development:
+
+```bash
+cd src/splitsmith/ui_static
+pnpm install
+pnpm build           # produces dist/ which the FastAPI backend serves
+pnpm dev             # Vite dev server on :5173, proxies /api to backend on :5174
+```
+
 ### `review` -- audit a fixture in a local web UI
 
 Open a single-page browser UI for reviewing detected shots against the fixture's audio (and optional video). Marker pins on the waveform: click to toggle keep/reject, drag to fine-tune time, double-click empty waveform space to add a manual marker. Save (`Cmd+S`) writes back to the fixture JSON's `shots[]`.

--- a/README.md
+++ b/README.md
@@ -277,12 +277,23 @@ video_match:
 
 output:
   trim_buffer_seconds: 5.0
+  trim_mode: lossless          # "lossless" (CLI default) or "audit"
+  trim_gop_frames: 15          # audit mode: keyframe every N frames (0.5s @ 30fps)
+  trim_audit_crf: 20           # audit mode: x264 CRF (lower = better quality, larger files)
+  trim_audit_preset: fast      # audit mode: x264 preset
   fcpxml_version: "1.10"
   split_color_thresholds:
     green_max: 0.25
     yellow_max: 0.35
     transition_min: 1.0
 ```
+
+`trim_mode` controls how `trim.py` cuts videos:
+
+- `lossless` (default): `ffmpeg -c copy`. Instant; archival quality; inherits the source GOP. Insta360 head-cam typically has keyframes every 1-4 seconds.
+- `audit`: re-encodes with a short GOP (default 0.5s) so browser `<video>` scrubbing in the production UI's audit screen (#15) lands within ~1 frame of the pointer. Encoding cost is roughly 1-2x realtime on Apple Silicon. Audio is stream-copied either way so the detector's input is bit-exact across modes.
+
+Override per command via `--trim-mode lossless|audit` on `splitsmith single` and `splitsmith process`.
 
 Lower `shot_detect.onset_delta` if you're under-detecting shots from a heavily-comped open gun. Tighten `beep_detect.min_amplitude` if a louder ambient noise is being mistaken for the beep.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -329,6 +329,15 @@ The **primary** is the audit truth — detection runs on its audio and audit JSO
 
 The pipeline is **idempotent**: re-entering ingest only processes videos with `processed.* == false`. Adding a secondary to an audited stage runs only beep + trim for that file; the audit JSON is untouched.
 
+### Accessibility (locked, see #21)
+
+- **WCAG 2.2 Level AA** is the target across the production UI.
+- **Color is never the only signal** (WCAG 1.4.1). Splits, statuses and audit markers all carry shape, glyph, or text in addition to color.
+- **Color-blind safe palette** (Okabe-Ito derived) for split colors. Distinguishable under deuteranopia, protanopia, and tritanopia.
+- `fcpxml_gen.py` emits band names as text (`[GREEN]` / `[YELLOW]` / `[RED]` / `[BLUE]`); FCP renders marker color from FCP-side preferences. The in-app palette and FCPXML output are decoupled.
+- The `MarkerGlyph` component encodes audit-marker state by shape (filled triangle / outline triangle with strikethrough / dashed diamond) so users who can't perceive color can still distinguish detected / rejected / manual.
+- `prefers-reduced-motion` is respected globally.
+
 ### Implementation status
 
 Sub 1 (#12, this commit) lands:

--- a/SPEC.md
+++ b/SPEC.md
@@ -75,9 +75,10 @@ Tuning notes:
 - AGC ducking on Insta360 Go 3S: follow-up shots may have lower amplitude. Don't filter on absolute amplitude; use relative.
 - Open guns / heavy comp: shots blend. May need to lower the onset detection delta parameter.
 
-**`trim.py`** — Lossless video trim via ffmpeg subprocess.
-- Command: `ffmpeg -ss <start> -i <input> -to <duration> -c copy <output>`
-- Note: `-ss` before `-i` is fast but may not be frame-accurate. For our purposes (we want a buffer before the beep anyway) this is fine.
+**`trim.py`** — Video trim via ffmpeg subprocess. Two modes (issue #16):
+- `lossless` (CLI default): `ffmpeg -ss <start> -i <input> -t <duration> -c copy <output>`. Instant, archival, but inherits source GOP (1-4s on Insta360 head-cam).
+- `audit` (UI-screen default for #15): re-encodes with `libx264 -preset fast -crf 20 -g 15 -keyint_min 15 -sc_threshold 0 -pix_fmt yuv420p -c:a copy`. 0.5s keyframe spacing at 30fps so browser scrubbing lands within ~1 frame of the pointer. Audio is stream-copied so the detector input is bit-exact across modes.
+- Note: `-ss` before `-i` is fast but may not be frame-accurate; the buffer absorbs any seek imprecision. In audit mode the re-encode re-aligns frames, so the concern is moot.
 - Start: `max(0, beep_time - 5)`
 - End: `beep_time + stage_time + 5`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -258,6 +258,89 @@ The `fcpxml` regeneration command matters — the user will manually fix detecti
 
 These might be valuable later but are explicitly out of scope for v1. Ship the boring useful core first.
 
+## Production UI v1 (issue #11/#12) — match-project on-disk layout
+
+The production UI (`splitsmith ui --project PATH`) treats a *match* as the persistence unit. A match project is a directory on disk with a fixed layout; the UI is just a view over it. Videos can be added to an existing match at any time (head-cam now, bay-cam from a friend a day later) without invalidating prior audit work — the model is intentionally append-friendly.
+
+### Directory layout
+
+```
+<project-root>/
+  project.json              # MatchProject metadata + per-stage index
+  raw/                      # original video files (or symlinks)
+  audio/                    # extracted .wav cache
+  trimmed/                  # per-stage trimmed MP4s (Sub 5 / #16)
+  audit/                    # per-stage audit JSON (same shape as fixture format)
+  exports/                  # CSV / FCPXML / report.txt
+  scoreboard/               # cached SSI JSON + raw fetch responses
+```
+
+### `project.json` shape
+
+Pydantic model `splitsmith.ui.project.MatchProject`. All writes go through `atomic_write_json` (temp file + `os.replace`) so a crashed save can never corrupt the file.
+
+```jsonc
+{
+  "schema_version": 1,
+  "name": "Tallmilan 2026",
+  "created_at": "2026-04-30T08:10:32+00:00",
+  "updated_at": "2026-05-01T19:28:21+00:00",
+  "competitor_name": "Mathias",
+  "scoreboard_match_id": "ssi-12345",
+  "stages": [
+    {
+      "stage_number": 3,
+      "stage_name": "Per told me to do it",
+      "time_seconds": 14.74,
+      "scorecard_updated_at": "2026-04-26T16:41:00+00:00",
+      "skipped": false,
+      "videos": [
+        {
+          "path": "raw/VID_20260426_162417.mp4",
+          "role": "primary",
+          "added_at": "2026-04-26T18:00:00+00:00",
+          "processed": { "beep": true, "shot_detect": true, "trim": true },
+          "beep_time": 12.453,
+          "notes": ""
+        },
+        {
+          "path": "raw/baycam_friend.mp4",
+          "role": "secondary",
+          "added_at": "2026-04-28T09:14:00+00:00",
+          "processed": { "beep": true, "shot_detect": false, "trim": true },
+          "beep_time": 12.501,
+          "notes": "bay cam from friend, added 2 days post-match"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Per-video role and pipeline
+
+| `role`    | beep detect | shot detect | trim |
+|-----------|:-----------:|:-----------:|:----:|
+| primary   |     ✓       |     ✓       |  ✓   |
+| secondary |     ✓       |     —       |  ✓   |
+| ignored   |     —       |     —       |  —   |
+
+The **primary** is the audit truth — detection runs on its audio and audit JSON timestamps live on its timeline. **Secondaries** are alternate viewing angles; their beep is detected so they can be aligned to the primary by beep offset, but their shots are not detected (the primary's audit is the truth). **Ignored** videos are skipped entirely (warmups, neighbor-bay grabs).
+
+The pipeline is **idempotent**: re-entering ingest only processes videos with `processed.* == false`. Adding a secondary to an audited stage runs only beep + trim for that file; the audit JSON is untouched.
+
+### Implementation status
+
+Sub 1 (#12, this commit) lands:
+- `MatchProject` Pydantic model + atomic write
+- FastAPI backend at `splitsmith.ui.server`
+- React + Vite + shadcn/ui SPA at `src/splitsmith/ui_static/`
+- Design tokens locked, `/_design` page renders the visual spec
+- App shell with `/`, `/ingest`, `/audit/:stage`, `/export/:stage`, `/_design`
+- Dark / light / system theme toggle persisted to `localStorage`
+
+Subsequent sub-issues fill in the screens (#13 ingest, #15 audit, #17 export) and add the short-GOP trim mode (#16).
+
 ## References
 
 - librosa onset detection: https://librosa.org/doc/main/generated/librosa.onset.onset_detect.html

--- a/SPEC.md
+++ b/SPEC.md
@@ -340,15 +340,15 @@ The pipeline is **idempotent**: re-entering ingest only processes videos with `p
 
 ### Implementation status
 
-Sub 1 (#12, this commit) lands:
-- `MatchProject` Pydantic model + atomic write
-- FastAPI backend at `splitsmith.ui.server`
-- React + Vite + shadcn/ui SPA at `src/splitsmith/ui_static/`
-- Design tokens locked, `/_design` page renders the visual spec
-- App shell with `/`, `/ingest`, `/audit/:stage`, `/export/:stage`, `/_design`
-- Dark / light / system theme toggle persisted to `localStorage`
+Sub 1 (#12) shipped: `MatchProject` Pydantic model + atomic write, FastAPI backend, React + Vite + shadcn/ui SPA, locked design tokens with `/_design` visual spec, app shell, dark/light/system theme toggle.
 
-Subsequent sub-issues fill in the screens (#13 ingest, #15 audit, #17 export) and add the short-GOP trim mode (#16).
+Sub 2 (#13) shipped: ingest screen + supporting backend.
+
+- `MatchProject.unassigned_videos` plus helper methods: `import_scoreboard`, `register_video` (symlinks into `<project>/raw/`, falls back to copy on systems without symlink support), `assign_video` (move between stages or back to unassigned, with primary-demotion semantics), `auto_match` (runs `video_match.py` heuristic, returns suggestions without mutation).
+- API: `POST /api/scoreboard/import`, `POST /api/videos/scan`, `POST /api/videos/auto-match`, `POST /api/assignments/move`. Scoreboard import refuses overwriting existing stages by default (would orphan video assignments) — caller passes `overwrite=true` to force.
+- Ingest screen: drop SSI JSON, scan a folder of videos by path, see auto-suggested primary assignments, drag/click to reassign, mark as ignored, unassign back to tray, conflict highlighting on duplicate primaries.
+
+Subsequent sub-issues fill in the audit screen (#15), short-GOP trim (#16), and analysis/export (#17).
 
 ## References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "rich>=13.7.0",
     "pyyaml>=6.0.1",
     "soundfile>=0.12.1",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
 ]
 
 [project.scripts]
@@ -28,6 +30,20 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/splitsmith"]
+# Frontend dev artefacts and node_modules don't belong in the published wheel.
+# The built SPA at src/splitsmith/ui_static/dist/ IS shipped (FastAPI serves it
+# from there); everything else under ui_static/ is build input.
+exclude = [
+  "**/ui_static/node_modules",
+  "**/ui_static/src",
+  "**/ui_static/package.json",
+  "**/ui_static/pnpm-lock.yaml",
+  "**/ui_static/vite.config.ts",
+  "**/ui_static/tsconfig*.json",
+  "**/ui_static/index.html",
+  "**/ui_static/.gitignore",
+  "**/ui_static/dist/**/*.map",
+]
 
 [dependency-groups]
 dev = [

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -220,6 +220,52 @@ def review(
         server.server_close()
 
 
+@app.command()
+def ui(
+    project: Path = typer.Option(
+        ...,
+        "--project",
+        help="Match-project root directory. Created (with subdirs) if missing.",
+    ),
+    project_name: str | None = typer.Option(
+        None,
+        "--name",
+        help=(
+            "Display name for the match. Defaults to the project directory's "
+            "basename. Ignored if the project already has a name on disk."
+        ),
+    ),
+    host: str = typer.Option("127.0.0.1", "--host"),
+    port: int = typer.Option(5174, "--port"),
+    no_browser: bool = typer.Option(False, "--no-browser", help="Skip auto-opening browser."),
+) -> None:
+    """Start the production UI server (issue #11/#12).
+
+    The UI is a localhost SPA driven by a FastAPI backend that orchestrates
+    the existing engine modules unchanged. State persists to disk under
+    ``--project`` so closing the browser and re-running resumes where you
+    left off.
+    """
+    from .ui.server import serve
+
+    project = project.expanduser().resolve()
+    name = project_name or project.name or "match"
+
+    url = f"http://{host}:{port}/"
+    console.print(f"[green]splitsmith UI[/]: [bold]{url}[/]   (Ctrl+C to stop)")
+    console.print(f"  project: {project}")
+
+    if not no_browser:
+        import webbrowser
+
+        webbrowser.open(url)
+
+    try:
+        serve(project_root=project, project_name=name, host=host, port=port)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Stopped.[/]")
+
+
 @app.command("audit-prep")
 def audit_prep(
     video: Path = typer.Option(..., "--video", help="Source video file (mp4/mov)."),

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -66,9 +66,20 @@ def single(
     write_trim: bool = typer.Option(True, "--trim/--no-trim"),
     write_csv: bool = typer.Option(True, "--csv/--no-csv"),
     write_fcpxml: bool = typer.Option(True, "--fcpxml/--no-fcpxml"),
+    trim_mode: str | None = typer.Option(
+        None,
+        "--trim-mode",
+        help=(
+            "Override trim mode: 'lossless' (-c copy, instant, archival) or "
+            "'audit' (re-encode with short GOP for scrub-friendly playback). "
+            "Default: from config (lossless)."
+        ),
+    ),
 ) -> None:
     """Process a single video with an explicit stage time."""
     config = Config.load(config_path)
+    if trim_mode is not None:
+        config = config.model_copy(update={"output": _override_trim_mode(config.output, trim_mode)})
     output.mkdir(parents=True, exist_ok=True)
 
     stage = StageData(
@@ -127,9 +138,16 @@ def process(
     write_trim: bool = typer.Option(True, "--trim/--no-trim"),
     write_csv: bool = typer.Option(True, "--csv/--no-csv"),
     write_fcpxml: bool = typer.Option(True, "--fcpxml/--no-fcpxml"),
+    trim_mode: str | None = typer.Option(
+        None,
+        "--trim-mode",
+        help="Override trim mode: 'lossless' or 'audit'. Default: from config (lossless).",
+    ),
 ) -> None:
     """Batch-process every stage in a stage JSON, matching videos by file timestamp."""
     config = Config.load(config_path)
+    if trim_mode is not None:
+        config = config.model_copy(update={"output": _override_trim_mode(config.output, trim_mode)})
     output.mkdir(parents=True, exist_ok=True)
 
     competitor_stages = _load_stage_json(stages)
@@ -579,6 +597,10 @@ def _process_one(
             beep_time=beep.time,
             stage_time=stage.time_seconds,
             buffer_seconds=config.output.trim_buffer_seconds,
+            mode=config.output.trim_mode,
+            gop_frames=config.output.trim_gop_frames,
+            crf=config.output.trim_audit_crf,
+            preset=config.output.trim_audit_preset,
             overwrite=True,
         )
         console.print(f"  [green]trimmed video[/]: {files.video}")
@@ -713,6 +735,14 @@ _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 def _slugify(name: str) -> str:
     return _SLUG_RE.sub("-", name.lower()).strip("-") or "stage"
+
+
+def _override_trim_mode(output_config, value: str):
+    """Validate ``--trim-mode`` against the OutputConfig.trim_mode literal and
+    return a copy with the override applied."""
+    if value not in ("lossless", "audit"):
+        raise typer.BadParameter("--trim-mode must be 'lossless' or 'audit'")
+    return output_config.model_copy(update={"trim_mode": value})
 
 
 def _dummy_scorecard_time():

--- a/src/splitsmith/config.py
+++ b/src/splitsmith/config.py
@@ -221,6 +221,20 @@ class OutputConfig(BaseModel):
     trim_buffer_seconds: float = 5.0
     fcpxml_version: str = "1.10"
     split_color_thresholds: SplitColorThresholds = Field(default_factory=SplitColorThresholds)
+    # Trim mode (issue #16):
+    # - "lossless": ffmpeg -c copy. Instant, archival-quality, but inherits the
+    #   source's 1-4s GOP -- bad for in-browser scrubbing in the audit screen.
+    # - "audit":    re-encodes video with a short GOP (default 0.5s @ 30fps) so
+    #   browser <video> seeks land on a keyframe within ~1 frame of the
+    #   pointer. Audio is stream-copied to keep the detector's input bit-exact.
+    # CLI default stays "lossless" for backward compatibility; the production
+    # UI defaults to "audit" because real-time scrubbing depends on it.
+    trim_mode: Literal["lossless", "audit"] = "lossless"
+    # Audit-mode encoding parameters. ``trim_gop_frames=15`` at 30fps means a
+    # keyframe every 0.5s; lower for tighter scrub, higher for smaller files.
+    trim_gop_frames: int = 15
+    trim_audit_crf: int = 20
+    trim_audit_preset: str = "fast"
 
 
 class Config(BaseModel):

--- a/src/splitsmith/thumbnail.py
+++ b/src/splitsmith/thumbnail.py
@@ -1,0 +1,113 @@
+"""ffmpeg thumbnail extraction with mtime/size-keyed disk cache.
+
+Pairs with :mod:`splitsmith.video_probe` for the production UI (issue #24):
+the picker and tray render thumbnails so the user can tell which clip is
+which without filenames doing all the work.
+
+Cache layout: one ``<sha1>.jpg`` per source video under ``cache_dir``, where
+the SHA1 keys on absolute path + mtime + size. A source-side change flips
+the key automatically.
+
+Frame selection: 1.0 s by default; clamped to ``min(1.0, duration * 0.1)``
+when the source is shorter so we don't seek past the end. Caller passes
+``duration`` if known (saves a redundant ffprobe).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from .video_probe import source_cache_key
+
+
+class ThumbnailError(RuntimeError):
+    """ffmpeg failed or timed out."""
+
+
+def cached(path: Path, cache_dir: Path) -> Path | None:
+    """Return the cached thumbnail path for ``path`` if it exists, else ``None``."""
+    key = source_cache_key(path)
+    if not key:
+        return None
+    candidate = cache_dir / f"{key}.jpg"
+    return candidate if candidate.exists() else None
+
+
+def thumbnail_path(path: Path, cache_dir: Path) -> Path | None:
+    """Resolve the thumbnail path (existing or expected) for ``path``.
+
+    Returns ``None`` only when ``path`` cannot be stat'd. The returned path
+    may not exist yet -- use :func:`cached` for an existence-aware lookup.
+    """
+    key = source_cache_key(path)
+    if not key:
+        return None
+    return cache_dir / f"{key}.jpg"
+
+
+def ensure(
+    source: Path,
+    *,
+    cache_dir: Path,
+    duration: float | None = None,
+    width: int = 320,
+    ffmpeg_binary: str = "ffmpeg",
+    timeout: float = 6.0,
+) -> Path:
+    """Extract a thumbnail for ``source`` (or return the cached one).
+
+    Picks ``t = min(1.0, duration * 0.1)`` when ``duration`` is known and
+    short, otherwise 1.0 s. Always clamps to >= 0.1 s so the seek isn't
+    negative for very short clips.
+
+    Returns the absolute path to the thumbnail jpg. Raises
+    :class:`ThumbnailError` on ffmpeg failure / missing binary / timeout.
+    """
+    hit = cached(source, cache_dir)
+    if hit is not None:
+        return hit
+
+    dest = thumbnail_path(source, cache_dir)
+    if dest is None:
+        raise ThumbnailError(f"cannot stat source: {source}")
+
+    if not shutil.which(ffmpeg_binary):
+        raise ThumbnailError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    if duration is not None and duration > 0:
+        t = max(0.1, min(1.0, duration * 0.1))
+    else:
+        t = 1.0
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{t:.3f}",
+        "-i",
+        str(source),
+        "-frames:v",
+        "1",
+        "-vf",
+        f"scale={width}:-2",
+        "-q:v",
+        "4",
+        str(dest),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise ThumbnailError(f"ffmpeg timed out extracting thumbnail for {source}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise ThumbnailError(
+            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
+        ) from exc
+    if not dest.exists():
+        raise ThumbnailError(f"ffmpeg produced no output for {source}")
+    return dest

--- a/src/splitsmith/trim.py
+++ b/src/splitsmith/trim.py
@@ -1,8 +1,18 @@
-"""Lossless video trim via ffmpeg subprocess.
+"""Video trim via ffmpeg subprocess.
 
-Produces a clip of ``[beep_time - buffer, beep_time + stage_time + buffer]`` from
-the source video using stream copy. Per SPEC.md, ``-ss`` before ``-i`` is used
-for fast (non-keyframe-exact) seeking; the buffer absorbs any seek imprecision.
+Two modes:
+
+- ``lossless`` (default): stream copy with ``-c copy``. Instant, archival-quality,
+  but inherits the source GOP. Insta360 head-cam footage typically has keyframes
+  every 1-4s, which makes browser-side scrubbing chunky in the production UI.
+
+- ``audit`` (#16): re-encodes the video with a short GOP (default 0.5s at 30fps)
+  so browser ``<video>`` seeks land on a keyframe within ~1 frame of the pointer.
+  Audio is stream-copied so the detector's input is bit-exact regardless of mode.
+
+Per SPEC.md, ``-ss`` before ``-i`` is used for fast (non-keyframe-exact) seeking;
+the buffer absorbs any seek imprecision. In audit mode, the re-encode also
+re-aligns frames, so the seek-imprecision concern is moot anyway.
 
 Pure orchestration: validation + command construction + a single subprocess call.
 The runner is injectable so unit tests can verify the ffmpeg invocation without
@@ -14,10 +24,12 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 from .config import TrimResult
 
 Runner = Callable[..., subprocess.CompletedProcess]
+TrimMode = Literal["lossless", "audit"]
 
 
 class FFmpegError(RuntimeError):
@@ -31,14 +43,24 @@ def trim_video(
     stage_time: float,
     *,
     buffer_seconds: float = 5.0,
+    mode: TrimMode = "lossless",
+    gop_frames: int = 15,
+    crf: int = 20,
+    preset: str = "fast",
     ffmpeg_binary: str = "ffmpeg",
     overwrite: bool = False,
     runner: Runner = subprocess.run,
 ) -> TrimResult:
-    """Losslessly cut ``input_path`` to ``output_path`` around ``beep_time``.
+    """Cut ``input_path`` to ``output_path`` around ``beep_time``.
 
-    Returns the absolute-source-time window of the cut. Raises
-    ``FFmpegError`` if ffmpeg fails or is not installed.
+    ``mode`` selects the encoding strategy:
+
+    - ``"lossless"``: stream copy (instant, archival).
+    - ``"audit"``: re-encode video with a short GOP for scrub-friendly playback
+      in the production UI's audit screen. Audio is stream-copied.
+
+    Returns the absolute-source-time window of the cut. Raises ``FFmpegError``
+    if ffmpeg fails or is not installed.
     """
     if beep_time < 0.0:
         raise ValueError(f"beep_time must be non-negative, got {beep_time}")
@@ -46,6 +68,12 @@ def trim_video(
         raise ValueError(f"stage_time must be non-negative, got {stage_time}")
     if buffer_seconds < 0.0:
         raise ValueError(f"buffer_seconds must be non-negative, got {buffer_seconds}")
+    if mode not in ("lossless", "audit"):
+        raise ValueError(f"mode must be 'lossless' or 'audit', got {mode!r}")
+    if gop_frames < 1:
+        raise ValueError(f"gop_frames must be >= 1, got {gop_frames}")
+    if not 0 <= crf <= 51:
+        raise ValueError(f"crf must be 0..51, got {crf}")
     if not input_path.exists():
         raise FileNotFoundError(f"input video not found: {input_path}")
 
@@ -65,10 +93,29 @@ def trim_video(
         str(input_path),
         "-t",
         f"{duration:.3f}",
-        "-c",
-        "copy",
-        str(output_path),
     ]
+    if mode == "lossless":
+        cmd += ["-c", "copy"]
+    else:  # audit
+        cmd += [
+            "-c:v",
+            "libx264",
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-g",
+            str(gop_frames),
+            "-keyint_min",
+            str(gop_frames),
+            "-sc_threshold",
+            "0",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "copy",
+        ]
+    cmd.append(str(output_path))
 
     try:
         runner(cmd, check=True, capture_output=True, text=True)

--- a/src/splitsmith/ui/__init__.py
+++ b/src/splitsmith/ui/__init__.py
@@ -1,0 +1,10 @@
+"""Production UI package for splitsmith.
+
+The UI is a localhost SPA driven by a FastAPI backend that orchestrates the
+existing engine modules unchanged. See docs/PRODUCTION_UI.md and issue #11
+for the v1 contract.
+
+Sub-packages:
+- ``project``: Pydantic models for the on-disk match-project layout
+- ``server``: FastAPI app + static asset serving
+"""

--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -17,14 +17,27 @@ from pathlib import Path
 
 from .. import beep_detect
 from ..config import BeepDetectConfig, BeepDetection
+from .project import MatchProject
 
 
 class AudioExtractionError(RuntimeError):
     """ffmpeg or ffprobe failed during audio extraction."""
 
 
-def primary_audio_path(project_root: Path, stage_number: int) -> Path:
-    return project_root / "audio" / f"stage{stage_number}_primary.wav"
+def primary_audio_path(
+    project_root: Path,
+    stage_number: int,
+    *,
+    project: MatchProject | None = None,
+) -> Path:
+    """Resolve the cached primary-audio path for a stage.
+
+    When ``project`` is provided, its configured ``audio_dir`` (issue #23) is
+    honoured. When omitted, defaults to ``<project_root>/audio/`` for backwards
+    compatibility with callers that don't have the project model handy.
+    """
+    audio_dir = project.audio_path(project_root) if project else project_root / "audio"
+    return audio_dir / f"stage{stage_number}_primary.wav"
 
 
 def ensure_primary_audio(
@@ -34,14 +47,16 @@ def ensure_primary_audio(
     *,
     sample_rate: int = 48000,
     ffmpeg_binary: str = "ffmpeg",
+    project: MatchProject | None = None,
 ) -> Path:
     """Extract a mono WAV from ``source_video`` if not already cached.
 
-    Cache location is ``<project>/audio/stage<N>_primary.wav``. Re-extracts
-    when the source mtime is newer than the cached file's. Returns the path
-    to the cached WAV.
+    Cache location is ``<audio_dir>/stage<N>_primary.wav`` where ``audio_dir``
+    comes from the project's configured ``audio_dir`` override (issue #23) or
+    defaults to ``<project_root>/audio/``. Re-extracts when the source mtime
+    is newer than the cached file's. Returns the path to the cached WAV.
     """
-    audio_path = primary_audio_path(project_root, stage_number)
+    audio_path = primary_audio_path(project_root, stage_number, project=project)
     audio_path.parent.mkdir(parents=True, exist_ok=True)
 
     src_resolved = source_video.resolve()
@@ -85,6 +100,7 @@ def detect_primary_beep(
     *,
     config: BeepDetectConfig | None = None,
     ffmpeg_binary: str = "ffmpeg",
+    project: MatchProject | None = None,
 ) -> BeepDetection:
     """Run ``beep_detect.detect_beep`` against the primary's cached audio.
 
@@ -97,6 +113,7 @@ def detect_primary_beep(
         stage_number,
         source_video,
         ffmpeg_binary=ffmpeg_binary,
+        project=project,
     )
     audio, sr = beep_detect.load_audio(audio_path)
     cfg = config or BeepDetectConfig()

--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -1,0 +1,103 @@
+"""Audio extraction + caching for the production UI.
+
+The CLI does this inline in ``cli.py:_extract_or_load_audio`` (caching the WAV
+next to the source video). The production UI prefers project-local caching so
+the project directory stays self-contained:
+
+  <project>/audio/stage<N>_primary.wav
+
+The cache is invalidated when the source video's mtime changes.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from .. import beep_detect
+from ..config import BeepDetectConfig, BeepDetection
+
+
+class AudioExtractionError(RuntimeError):
+    """ffmpeg or ffprobe failed during audio extraction."""
+
+
+def primary_audio_path(project_root: Path, stage_number: int) -> Path:
+    return project_root / "audio" / f"stage{stage_number}_primary.wav"
+
+
+def ensure_primary_audio(
+    project_root: Path,
+    stage_number: int,
+    source_video: Path,
+    *,
+    sample_rate: int = 48000,
+    ffmpeg_binary: str = "ffmpeg",
+) -> Path:
+    """Extract a mono WAV from ``source_video`` if not already cached.
+
+    Cache location is ``<project>/audio/stage<N>_primary.wav``. Re-extracts
+    when the source mtime is newer than the cached file's. Returns the path
+    to the cached WAV.
+    """
+    audio_path = primary_audio_path(project_root, stage_number)
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+
+    src_resolved = source_video.resolve()
+    if not src_resolved.exists():
+        raise FileNotFoundError(f"primary video missing on disk: {src_resolved}")
+
+    if audio_path.exists() and audio_path.stat().st_mtime >= src_resolved.stat().st_mtime:
+        return audio_path
+
+    if not shutil.which(ffmpeg_binary):
+        raise AudioExtractionError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(src_resolved),
+        "-ac",
+        "1",
+        "-ar",
+        str(sample_rate),
+        "-vn",
+        str(audio_path),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        raise AudioExtractionError(
+            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
+        ) from exc
+    return audio_path
+
+
+def detect_primary_beep(
+    project_root: Path,
+    stage_number: int,
+    source_video: Path,
+    *,
+    config: BeepDetectConfig | None = None,
+    ffmpeg_binary: str = "ffmpeg",
+) -> BeepDetection:
+    """Run ``beep_detect.detect_beep`` against the primary's cached audio.
+
+    Audio extraction happens transparently if not yet cached. Returns the
+    ``BeepDetection`` result; the caller is responsible for persisting the
+    relevant fields to the ``StageVideo``.
+    """
+    audio_path = ensure_primary_audio(
+        project_root,
+        stage_number,
+        source_video,
+        ffmpeg_binary=ffmpeg_binary,
+    )
+    audio, sr = beep_detect.load_audio(audio_path)
+    cfg = config or BeepDetectConfig()
+    return beep_detect.detect_beep(audio, sr, cfg)

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -25,12 +25,18 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from ..config import StageData, VideoMatchConfig
+from ..video_match import match_videos_to_stages
+
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
 
 PROJECT_FILE = "project.json"
 SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard")
@@ -81,6 +87,10 @@ class StageEntry(BaseModel):
         return None
 
 
+class ScoreboardImportConflictError(Exception):
+    """Raised when ``import_scoreboard`` would overwrite existing stage data."""
+
+
 class MatchProject(BaseModel):
     """Top-level on-disk match project."""
 
@@ -91,6 +101,10 @@ class MatchProject(BaseModel):
     competitor_name: str | None = None
     scoreboard_match_id: str | None = None
     stages: list[StageEntry] = Field(default_factory=list)
+    # Videos registered with the project but not yet assigned to any stage.
+    # The Sub 2 (#13) ingest screen surfaces these in a "tray" so the user can
+    # drag them onto stages or mark them as ignored.
+    unassigned_videos: list[StageVideo] = Field(default_factory=list)
 
     @classmethod
     def init(cls, root: Path, *, name: str) -> MatchProject:
@@ -129,6 +143,215 @@ class MatchProject(BaseModel):
             if s.stage_number == stage_number:
                 return s
         raise KeyError(f"no stage {stage_number} in project {self.name!r}")
+
+    # ------------------------------------------------------------------
+    # Video registry helpers (Sub 2 / #13)
+    # ------------------------------------------------------------------
+
+    def all_videos(self) -> list[StageVideo]:
+        """Every video known to the project, assigned or not."""
+        out: list[StageVideo] = list(self.unassigned_videos)
+        for s in self.stages:
+            out.extend(s.videos)
+        return out
+
+    def find_video(self, path: Path) -> tuple[StageEntry | None, StageVideo] | None:
+        """Locate a video by path. Returns ``(stage_or_None, video)`` or ``None``.
+
+        ``stage`` is ``None`` when the video lives in ``unassigned_videos``.
+        Path comparison uses string equality on the stored value (the project
+        stores paths relative to the project root, so this is unambiguous).
+        """
+        target = str(path)
+        for v in self.unassigned_videos:
+            if str(v.path) == target:
+                return None, v
+        for s in self.stages:
+            for v in s.videos:
+                if str(v.path) == target:
+                    return s, v
+        return None
+
+    def import_scoreboard(self, raw: dict[str, Any], *, overwrite: bool = False) -> None:
+        """Populate ``stages`` (and metadata) from a parsed SSI Scoreboard JSON.
+
+        Picks the first competitor (multi-competitor support is v2 / out of
+        scope per #11). Raises :class:`ScoreboardImportConflictError` if stages
+        already exist and ``overwrite`` is ``False``; overwriting would orphan
+        existing video assignments, so the default is to refuse.
+        """
+        if self.stages and not overwrite:
+            raise ScoreboardImportConflictError(
+                "project already has stages; pass overwrite=True to replace "
+                "(this orphans current video assignments)"
+            )
+        match_meta = raw.get("match", {}) or {}
+        competitors = raw.get("competitors") or []
+        if not competitors:
+            raise ValueError("no competitors in scoreboard JSON")
+        primary_competitor = competitors[0]
+
+        match_name = match_meta.get("name")
+        if match_name:
+            self.name = match_name
+        self.scoreboard_match_id = (
+            match_meta.get("id") or match_meta.get("match_id") or self.scoreboard_match_id
+        )
+        self.competitor_name = primary_competitor.get("name")
+
+        new_stages: list[StageEntry] = []
+        for s in primary_competitor.get("stages", []):
+            stage_data = StageData.model_validate(s)
+            new_stages.append(
+                StageEntry(
+                    stage_number=stage_data.stage_number,
+                    stage_name=stage_data.stage_name,
+                    time_seconds=stage_data.time_seconds,
+                    scorecard_updated_at=stage_data.scorecard_updated_at,
+                )
+            )
+        new_stages.sort(key=lambda s: s.stage_number)
+        self.stages = new_stages
+
+    def register_video(
+        self,
+        source: Path,
+        root: Path,
+        *,
+        link_mode: Literal["symlink", "copy"] = "symlink",
+    ) -> StageVideo:
+        """Register a video file with the project.
+
+        The file is symlinked (or copied) into ``<root>/raw/`` so the project
+        directory is self-describing. The ``StageVideo`` is appended to
+        ``unassigned_videos``; the caller is responsible for moving it onto a
+        stage via :meth:`assign_video`. If a video at the same destination
+        path is already registered, returns the existing entry unchanged.
+
+        Raises ``FileNotFoundError`` if the source doesn't exist or isn't a
+        video file (mp4 / mov / m4v).
+        """
+        source = source.expanduser().resolve()
+        if not source.exists():
+            raise FileNotFoundError(f"source video not found: {source}")
+        if source.suffix.lower() not in VIDEO_EXTENSIONS:
+            raise ValueError(f"not a video file: {source}")
+
+        raw_dir = root / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        dest = raw_dir / source.name
+        rel = Path("raw") / source.name
+
+        # Idempotency: if a video at this path is already registered, return it.
+        existing = self.find_video(rel)
+        if existing is not None:
+            return existing[1]
+
+        # If something is already at the destination, leave it (don't clobber
+        # what the user might have placed there themselves). Otherwise create
+        # a symlink (preferred) or a copy.
+        if not dest.exists():
+            if link_mode == "symlink":
+                try:
+                    dest.symlink_to(source)
+                except OSError:
+                    # Fallback (Windows without dev mode, etc.): copy.
+                    shutil.copy2(source, dest)
+            else:
+                shutil.copy2(source, dest)
+
+        video = StageVideo(path=rel)
+        self.unassigned_videos.append(video)
+        return video
+
+    def assign_video(
+        self,
+        path: Path,
+        *,
+        to_stage_number: int | None,
+        role: VideoRole = "secondary",
+    ) -> StageVideo:
+        """Move a video to a target stage (or back to unassigned if ``None``).
+
+        - ``to_stage_number=None``: move to ``unassigned_videos`` regardless of
+          ``role``.
+        - ``to_stage_number=N, role="primary"``: there can be only one primary
+          per stage; any existing primary is demoted to ``"secondary"``.
+
+        Returns the moved ``StageVideo``. Raises ``KeyError`` if the video or
+        stage doesn't exist.
+        """
+        located = self.find_video(path)
+        if located is None:
+            raise KeyError(f"video {path} not registered with project")
+        current_stage, video = located
+
+        # Detach from current location.
+        if current_stage is None:
+            self.unassigned_videos = [
+                v for v in self.unassigned_videos if str(v.path) != str(video.path)
+            ]
+        else:
+            current_stage.videos = [
+                v for v in current_stage.videos if str(v.path) != str(video.path)
+            ]
+
+        # Reattach.
+        if to_stage_number is None:
+            video.role = "secondary"  # role is meaningless when unassigned
+            self.unassigned_videos.append(video)
+            return video
+
+        target = self.stage(to_stage_number)
+        if role == "primary":
+            for v in target.videos:
+                if v.role == "primary":
+                    v.role = "secondary"
+        video.role = role
+        target.videos.append(video)
+        return video
+
+    def auto_match(
+        self,
+        root: Path,
+        *,
+        config: VideoMatchConfig | None = None,
+    ) -> dict[int, Path]:
+        """Run :func:`video_match.match_videos_to_stages` against unassigned videos
+        and the project's stages.
+
+        ``root`` is the project root directory; needed to resolve the videos'
+        project-relative paths to real filesystem paths so ``os.stat`` works.
+
+        Returns ``{stage_number: video_relative_path}`` for every confident
+        match. **Does not mutate the project**; the caller decides whether to
+        apply via :meth:`assign_video` (and with what role).
+        """
+        cfg = config or VideoMatchConfig()
+        unassigned_abs: dict[Path, Path] = {}
+        for v in self.unassigned_videos:
+            # Resolve project-relative path against the project root, then
+            # resolve symlinks so video_match.py's stat() reads the real file.
+            abs_path = v.path if v.path.is_absolute() else (root / v.path).resolve()
+            unassigned_abs[abs_path] = v.path
+        if not unassigned_abs:
+            return {}
+
+        stage_data = [
+            StageData(
+                stage_number=s.stage_number,
+                stage_name=s.stage_name,
+                time_seconds=s.time_seconds,
+                scorecard_updated_at=s.scorecard_updated_at or datetime.now(UTC),
+            )
+            for s in self.stages
+            if s.scorecard_updated_at is not None
+        ]
+        if not stage_data:
+            return {}
+
+        result = match_videos_to_stages(list(unassigned_abs.keys()), stage_data, cfg)
+        return {m.stage_number: unassigned_abs[m.video_path] for m in result.matches}
 
 
 def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -117,6 +117,15 @@ class MatchProject(BaseModel):
     # Last folder the user scanned for videos. Persisted so the folder picker
     # in the ingest UI can default back here on the next scan.
     last_scanned_dir: str | None = None
+    # Storage path overrides (issue #23). All four are optional; ``None`` means
+    # "use the default subdirectory under the project root" (raw / audio /
+    # trimmed / exports). Relative paths are resolved against the project root.
+    # Absolute paths are used as-is so users can put heavy intermediates on a
+    # scratch SSD or outputs next to a Final Cut Pro library.
+    raw_dir: str | None = None
+    audio_dir: str | None = None
+    trimmed_dir: str | None = None
+    exports_dir: str | None = None
 
     @classmethod
     def init(cls, root: Path, *, name: str) -> MatchProject:
@@ -155,6 +164,34 @@ class MatchProject(BaseModel):
             if s.stage_number == stage_number:
                 return s
         raise KeyError(f"no stage {stage_number} in project {self.name!r}")
+
+    # ------------------------------------------------------------------
+    # Storage path resolvers (issue #23)
+    # ------------------------------------------------------------------
+    #
+    # Each resolver returns an absolute, mkdir-ready path. ``None`` overrides
+    # default to ``<root>/<subdir>`` so existing projects keep working with
+    # zero changes. Relative overrides are resolved against the project root,
+    # which keeps "zip and share" projects portable. Absolute overrides are
+    # used as-is so users can keep heavy intermediates off the project drive.
+
+    def _resolve_dir(self, root: Path, override: str | None, default_subdir: str) -> Path:
+        if override is None:
+            return root / default_subdir
+        candidate = Path(override).expanduser()
+        return candidate if candidate.is_absolute() else root / candidate
+
+    def raw_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.raw_dir, "raw")
+
+    def audio_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.audio_dir, "audio")
+
+    def trimmed_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.trimmed_dir, "trimmed")
+
+    def exports_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.exports_dir, "exports")
 
     # ------------------------------------------------------------------
     # Video registry helpers (Sub 2 / #13)
@@ -234,11 +271,17 @@ class MatchProject(BaseModel):
     ) -> StageVideo:
         """Register a video file with the project.
 
-        The file is symlinked (or copied) into ``<root>/raw/`` so the project
-        directory is self-describing. The ``StageVideo`` is appended to
-        ``unassigned_videos``; the caller is responsible for moving it onto a
-        stage via :meth:`assign_video`. If a video at the same destination
-        path is already registered, returns the existing entry unchanged.
+        The file is **referenced** -- a symlink (or copy as fallback on systems
+        without symlink support) is placed under :meth:`raw_path` pointing at
+        the original source. The original is never moved or duplicated by
+        default. This works for USB-camera ingest: source on the cam, symlink
+        in the project. When the cam is unplugged the symlink dangles
+        temporarily but the project keeps working when it's plugged back in.
+
+        The ``StageVideo`` is appended to ``unassigned_videos``; the caller is
+        responsible for moving it onto a stage via :meth:`assign_video`. If a
+        video at the same destination path is already registered, the existing
+        entry is returned unchanged (idempotent).
 
         Raises ``FileNotFoundError`` if the source doesn't exist or isn't a
         video file (mp4 / mov / m4v).
@@ -249,13 +292,22 @@ class MatchProject(BaseModel):
         if source.suffix.lower() not in VIDEO_EXTENSIONS:
             raise ValueError(f"not a video file: {source}")
 
-        raw_dir = root / "raw"
-        raw_dir.mkdir(parents=True, exist_ok=True)
-        dest = raw_dir / source.name
-        rel = Path("raw") / source.name
+        raw_dir_abs = self.raw_path(root)
+        raw_dir_abs.mkdir(parents=True, exist_ok=True)
+        dest = raw_dir_abs / source.name
 
-        # Idempotency: if a video at this path is already registered, return it.
-        existing = self.find_video(rel)
+        # The path stored on the StageVideo is project-relative when raw_dir is
+        # under the project root (the common case), absolute otherwise. This
+        # keeps zip-and-share portable for default projects while letting
+        # USB-cam / scratch-SSD setups still work.
+        try:
+            stored = dest.relative_to(root)
+        except ValueError:
+            stored = dest
+
+        # Idempotency: if a video at this stored path is already registered,
+        # return it.
+        existing = self.find_video(stored)
         if existing is not None:
             return existing[1]
 
@@ -272,9 +324,14 @@ class MatchProject(BaseModel):
             else:
                 shutil.copy2(source, dest)
 
-        video = StageVideo(path=rel)
+        video = StageVideo(path=stored)
         self.unassigned_videos.append(video)
         return video
+
+    def resolve_video_path(self, root: Path, video_path: Path) -> Path:
+        """Resolve a ``StageVideo.path`` (which may be project-relative or
+        absolute) to an absolute filesystem path."""
+        return video_path if video_path.is_absolute() else root / video_path
 
     def assign_video(
         self,
@@ -344,7 +401,7 @@ class MatchProject(BaseModel):
         for v in self.unassigned_videos:
             # Resolve project-relative path against the project root, then
             # resolve symlinks so video_match.py's stat() reads the real file.
-            abs_path = v.path if v.path.is_absolute() else (root / v.path).resolve()
+            abs_path = self.resolve_video_path(root, v.path).resolve()
             unassigned_abs[abs_path] = v.path
         if not unassigned_abs:
             return {}

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -66,6 +66,15 @@ class StageVideo(BaseModel):
         default_factory=lambda: {"beep": False, "shot_detect": False, "trim": False}
     )
     beep_time: float | None = None
+    # Provenance for ``beep_time``: who set it. ``None`` = not yet detected;
+    # ``"auto"`` = beep_detect.detect_beep() result; ``"manual"`` = user override
+    # via the ingest screen. Manual overrides survive subsequent auto-detect
+    # attempts unless the user explicitly forces re-detection (issue #22).
+    beep_source: Literal["auto", "manual"] | None = None
+    # Diagnostic outputs from ``detect_beep`` -- not used by the pipeline but
+    # surfaced in the UI to help the user judge auto-detection confidence.
+    beep_peak_amplitude: float | None = None
+    beep_duration_ms: float | None = None
     notes: str = ""
 
 

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -1,0 +1,161 @@
+"""Match-project on-disk model.
+
+A *match* is the persistence unit. The project directory IS the match. Videos
+can be added incrementally (head-cam now, bay-cam from a friend a day later);
+secondary videos only need beep + trim, anchored to the primary's already-
+audited timeline (issue #11).
+
+On-disk layout::
+
+    <project-root>/
+      project.json              # MatchProject metadata + index
+      raw/                      # original video files (or symlinks)
+      audio/                    # extracted .wav cache
+      trimmed/                  # per-stage trimmed MP4s
+      audit/                    # per-stage audit JSON
+      exports/                  # CSV / FCPXML / report.txt
+      scoreboard/               # cached SSI JSON + raw fetch responses
+
+All writes to ``project.json`` and per-stage audit JSONs go through
+``atomic_write_json`` so a crashed save can never corrupt project state. This
+is the foundation that makes incremental ingest safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+PROJECT_FILE = "project.json"
+SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard")
+
+# Bumped when the on-disk schema changes in a backwards-incompatible way.
+SCHEMA_VERSION = 1
+
+
+VideoRole = Literal["primary", "secondary", "ignored"]
+
+
+class StageVideo(BaseModel):
+    """One video file assigned to a stage.
+
+    ``role`` drives the pipeline: primary runs the full pipeline (beep + shot
+    detect + trim), secondary only needs beep + trim (anchored to primary's
+    timeline), ignored is skipped entirely.
+
+    ``processed`` is the source of truth for what's been done; the UI computes
+    per-stage status by scanning these flags rather than re-running detection.
+    """
+
+    path: Path
+    role: VideoRole = "secondary"
+    added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    processed: dict[str, bool] = Field(
+        default_factory=lambda: {"beep": False, "shot_detect": False, "trim": False}
+    )
+    beep_time: float | None = None
+    notes: str = ""
+
+
+class StageEntry(BaseModel):
+    """A stage in the match: scoreboard data + assigned videos + audit status."""
+
+    stage_number: int
+    stage_name: str
+    time_seconds: float
+    scorecard_updated_at: datetime | None = None
+    videos: list[StageVideo] = Field(default_factory=list)
+    skipped: bool = False
+
+    def primary(self) -> StageVideo | None:
+        """Return the primary video, or ``None`` if no video is the primary yet."""
+        for v in self.videos:
+            if v.role == "primary":
+                return v
+        return None
+
+
+class MatchProject(BaseModel):
+    """Top-level on-disk match project."""
+
+    schema_version: int = SCHEMA_VERSION
+    name: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    competitor_name: str | None = None
+    scoreboard_match_id: str | None = None
+    stages: list[StageEntry] = Field(default_factory=list)
+
+    @classmethod
+    def init(cls, root: Path, *, name: str) -> MatchProject:
+        """Create a fresh project at ``root`` with the standard subdirectory layout.
+
+        Idempotent: if ``project.json`` already exists, the existing project is
+        loaded and returned unchanged. Subdirectories are created if missing.
+        """
+        root.mkdir(parents=True, exist_ok=True)
+        for sub in SUBDIRS:
+            (root / sub).mkdir(exist_ok=True)
+        existing = root / PROJECT_FILE
+        if existing.exists():
+            return cls.load(root)
+        project = cls(name=name)
+        project.save(root)
+        return project
+
+    @classmethod
+    def load(cls, root: Path) -> MatchProject:
+        """Load the project from ``root``. Raises ``FileNotFoundError`` if missing."""
+        path = root / PROJECT_FILE
+        if not path.exists():
+            raise FileNotFoundError(f"no project.json in {root}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls.model_validate(data)
+
+    def save(self, root: Path) -> None:
+        """Atomically persist the project to ``root/project.json``."""
+        self.updated_at = datetime.now(UTC)
+        atomic_write_json(root / PROJECT_FILE, self.model_dump(mode="json"))
+
+    def stage(self, stage_number: int) -> StageEntry:
+        """Return the stage with this number; raises ``KeyError`` if absent."""
+        for s in self.stages:
+            if s.stage_number == stage_number:
+                return s
+        raise KeyError(f"no stage {stage_number} in project {self.name!r}")
+
+
+def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
+    """Write ``data`` as JSON to ``path`` atomically (temp + rename).
+
+    On POSIX, ``os.replace`` is atomic within the same filesystem, so an
+    interrupted save never leaves a half-written file at the destination. The
+    temp file lives in the same directory as the destination to guarantee that.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=indent, default=_json_default)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        tmp.replace(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, Path):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON-serializable")

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -27,7 +27,7 @@ import json
 import os
 import shutil
 import tempfile
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -87,6 +87,12 @@ class StageEntry(BaseModel):
     scorecard_updated_at: datetime | None = None
     videos: list[StageVideo] = Field(default_factory=list)
     skipped: bool = False
+    # Placeholder stages are created without a scoreboard ("I shot 6 stages,
+    # let me start ingesting"). They carry stage_number + a generic name so the
+    # rest of the pipeline works; importing a real scoreboard later overlays
+    # the proper metadata while preserving any video assignments. See
+    # MatchProject.init_placeholder_stages and import_scoreboard.
+    placeholder: bool = False
 
     def primary(self) -> StageVideo | None:
         """Return the primary video, or ``None`` if no video is the primary yet."""
@@ -109,6 +115,11 @@ class MatchProject(BaseModel):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     competitor_name: str | None = None
     scoreboard_match_id: str | None = None
+    # Optional match date (the day the match was shot). Used as a hint for the
+    # SSI Scoreboard suggestion flow and surfaced in the UI. Auto-filled from
+    # the earliest video mtime when starting source-first; overwritten by
+    # ``import_scoreboard`` when a real scoreboard arrives.
+    match_date: date | None = None
     stages: list[StageEntry] = Field(default_factory=list)
     # Videos registered with the project but not yet assigned to any stage.
     # The Sub 2 (#13) ingest screen surfaces these in a "tray" so the user can
@@ -221,18 +232,81 @@ class MatchProject(BaseModel):
                     return s, v
         return None
 
+    def init_placeholder_stages(
+        self,
+        count: int,
+        *,
+        match_name: str | None = None,
+        match_date: date | None = None,
+    ) -> None:
+        """Create ``count`` placeholder stages with no scoreboard data.
+
+        Used when the user starts source-first ("I shot 6 stages, here are the
+        videos"). Each placeholder gets ``stage_number = 1..count`` and a
+        generic name; ``time_seconds`` is 0.0 and ``scorecard_updated_at`` is
+        None, which keeps :meth:`auto_match` from misfiring (it filters stages
+        without ``scorecard_updated_at``).
+
+        If non-placeholder stages already exist, this raises
+        :class:`ScoreboardImportConflictError` -- placeholders are a
+        bootstrap-only concept and should not stomp real scoreboard data.
+        Existing placeholders are replaced; any video assignments are moved
+        back to ``unassigned_videos`` so the user can re-bind to the new
+        layout.
+        """
+        if count < 1:
+            raise ValueError("placeholder stage count must be >= 1")
+        real = [s for s in self.stages if not s.placeholder]
+        if real:
+            raise ScoreboardImportConflictError(
+                "project already has scoreboard-backed stages; "
+                "clear them or import via overwrite first"
+            )
+        # Move any videos out of existing placeholders -- the new placeholder
+        # layout might have a different stage count.
+        for stage in self.stages:
+            for video in stage.videos:
+                video.role = "secondary"
+                self.unassigned_videos.append(video)
+
+        if match_name:
+            self.name = match_name
+        if match_date is not None:
+            self.match_date = match_date
+
+        self.stages = [
+            StageEntry(
+                stage_number=i,
+                stage_name=f"Stage {i}",
+                time_seconds=0.0,
+                placeholder=True,
+            )
+            for i in range(1, count + 1)
+        ]
+
     def import_scoreboard(self, raw: dict[str, Any], *, overwrite: bool = False) -> None:
         """Populate ``stages`` (and metadata) from a parsed SSI Scoreboard JSON.
 
         Picks the first competitor (multi-competitor support is v2 / out of
-        scope per #11). Raises :class:`ScoreboardImportConflictError` if stages
-        already exist and ``overwrite`` is ``False``; overwriting would orphan
-        existing video assignments, so the default is to refuse.
+        scope per #11). Raises :class:`ScoreboardImportConflictError` if
+        scoreboard-backed stages already exist and ``overwrite`` is ``False``;
+        overwriting would orphan existing video assignments, so the default is
+        to refuse.
+
+        Placeholder stages (created via :meth:`init_placeholder_stages`) are
+        always overlaid: video assignments keyed on ``stage_number`` are
+        preserved, scoreboard metadata replaces the generic placeholder data,
+        and the ``placeholder`` flag clears. If the scoreboard has fewer
+        stages than the placeholders, any extras are dropped; videos in
+        dropped extras are moved back to ``unassigned_videos`` so nothing is
+        lost.
         """
-        if self.stages and not overwrite:
+        real_stages = [s for s in self.stages if not s.placeholder]
+        if real_stages and not overwrite:
             raise ScoreboardImportConflictError(
-                "project already has stages; pass overwrite=True to replace "
-                "(this orphans current video assignments)"
+                "project already has scoreboard-backed stages; pass "
+                "overwrite=True to replace (this orphans current video "
+                "assignments)"
             )
         match_meta = raw.get("match", {}) or {}
         competitors = raw.get("competitors") or []
@@ -248,19 +322,42 @@ class MatchProject(BaseModel):
         )
         self.competitor_name = primary_competitor.get("name")
 
+        # Overlay path: snapshot existing placeholders' videos by stage_number
+        # so we can replant them into the matching scoreboard stage. If
+        # ``overwrite`` was used to wipe real stages, those videos are *not*
+        # preserved (overwrite is the user's explicit "orphan everything"
+        # choice).
+        videos_by_stage: dict[int, list[StageVideo]] = {}
+        if not real_stages:
+            for s in self.stages:
+                if s.videos:
+                    videos_by_stage[s.stage_number] = list(s.videos)
+
         new_stages: list[StageEntry] = []
+        scoreboard_numbers: set[int] = set()
         for s in primary_competitor.get("stages", []):
             stage_data = StageData.model_validate(s)
+            scoreboard_numbers.add(stage_data.stage_number)
             new_stages.append(
                 StageEntry(
                     stage_number=stage_data.stage_number,
                     stage_name=stage_data.stage_name,
                     time_seconds=stage_data.time_seconds,
                     scorecard_updated_at=stage_data.scorecard_updated_at,
+                    videos=videos_by_stage.get(stage_data.stage_number, []),
                 )
             )
         new_stages.sort(key=lambda s: s.stage_number)
         self.stages = new_stages
+
+        # Any placeholder videos whose stage_number didn't survive the import
+        # land back in unassigned_videos -- the user can reassign manually.
+        for stage_number, videos in videos_by_stage.items():
+            if stage_number in scoreboard_numbers:
+                continue
+            for v in videos:
+                v.role = "secondary"
+                self.unassigned_videos.append(v)
 
     def register_video(
         self,

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -39,7 +39,7 @@ from ..video_match import match_videos_to_stages
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
 
 PROJECT_FILE = "project.json"
-SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard")
+SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard", "probes", "thumbs")
 
 # Bumped when the on-disk schema changes in a backwards-incompatible way.
 SCHEMA_VERSION = 1
@@ -106,6 +106,25 @@ class ScoreboardImportConflictError(Exception):
     """Raised when ``import_scoreboard`` would overwrite existing stage data."""
 
 
+class RemovalPlan(BaseModel):
+    """Side-effect description returned by :meth:`MatchProject.remove_video`.
+
+    The model mutates project state (drops the StageVideo, optionally clears
+    audit) but never touches the filesystem. The endpoint walks this plan to
+    do the actual deletes -- keeping pure model logic separate from I/O so
+    tests can exercise the model without disk fixtures.
+    """
+
+    video_path: Path  # the path that was removed (project-relative or absolute)
+    raw_link_path: Path  # symlink under raw_dir to unlink
+    audio_cache_path: Path | None = None  # WAV cache to clear if cached
+    trimmed_cache_path: Path | None = None  # trimmed clip to clear if cached
+    audit_path: Path | None = None  # stage audit JSON to clear when reset_audit
+    was_primary: bool = False
+    stage_number: int | None = None
+    audit_reset: bool = False  # caller-facing flag: did we wipe stage audit?
+
+
 class MatchProject(BaseModel):
     """Top-level on-disk match project."""
 
@@ -137,6 +156,11 @@ class MatchProject(BaseModel):
     audio_dir: str | None = None
     trimmed_dir: str | None = None
     exports_dir: str | None = None
+    # Probe + thumbnail caches (issue #24). Same override semantics as the
+    # other path fields: ``None`` -> default subdir under project root,
+    # relative -> resolved against project root, absolute -> as-is.
+    probes_dir: str | None = None
+    thumbs_dir: str | None = None
 
     @classmethod
     def init(cls, root: Path, *, name: str) -> MatchProject:
@@ -203,6 +227,17 @@ class MatchProject(BaseModel):
 
     def exports_path(self, root: Path) -> Path:
         return self._resolve_dir(root, self.exports_dir, "exports")
+
+    def probes_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.probes_dir, "probes")
+
+    def thumbs_path(self, root: Path) -> Path:
+        return self._resolve_dir(root, self.thumbs_dir, "thumbs")
+
+    def audit_path(self, root: Path) -> Path:
+        # Audit output is always project-local; surface a resolver for the
+        # remove-video flow so it can clean up the per-stage JSON.
+        return root / "audit"
 
     # ------------------------------------------------------------------
     # Video registry helpers (Sub 2 / #13)
@@ -476,6 +511,79 @@ class MatchProject(BaseModel):
         video.role = role
         target.videos.append(video)
         return video
+
+    def remove_video(
+        self,
+        path: Path,
+        root: Path,
+        *,
+        reset_audit: bool = False,
+    ) -> RemovalPlan:
+        """Remove a registered video and return a :class:`RemovalPlan`.
+
+        Drops the ``StageVideo`` from its stage or ``unassigned_videos``. The
+        symlink under ``raw_dir`` is included in the plan so the caller can
+        unlink it; the actual filesystem call is the caller's job (keeps this
+        method pure-mutation on the model).
+
+        ``reset_audit=True`` and the video was a primary clears the per-stage
+        audit JSON path (``<root>/audit/stage<N>.json``) and resets the
+        primary's ``processed`` flags. Default is ``False``: stage audit is
+        preserved so a re-ingest of the same stage with a different file can
+        pick up where the user left off.
+
+        Raises ``KeyError`` if the video isn't registered with the project.
+        """
+        located = self.find_video(path)
+        if located is None:
+            raise KeyError(f"video {path} not registered with project")
+        current_stage, video = located
+        was_primary = video.role == "primary" and current_stage is not None
+        stage_number = current_stage.stage_number if current_stage else None
+
+        if current_stage is None:
+            self.unassigned_videos = [
+                v for v in self.unassigned_videos if str(v.path) != str(video.path)
+            ]
+        else:
+            current_stage.videos = [
+                v for v in current_stage.videos if str(v.path) != str(video.path)
+            ]
+
+        raw_link = self.resolve_video_path(root, video.path)
+
+        audio_cache: Path | None = None
+        trimmed_cache: Path | None = None
+        if was_primary and stage_number is not None:
+            audio_cache = self.audio_path(root) / f"stage{stage_number}_primary.wav"
+            trimmed_cache = self.trimmed_path(root) / f"stage{stage_number}_trimmed.mp4"
+
+        audit_path: Path | None = None
+        audit_reset = False
+        if reset_audit and stage_number is not None:
+            audit_path = self.audit_path(root) / f"stage{stage_number}.json"
+            audit_reset = True
+            if was_primary and current_stage is not None:
+                # No primary remains; reset processed flags on any other
+                # primaries that may have been demoted (defensive -- the data
+                # model only allows one primary at a time).
+                for v in current_stage.videos:
+                    v.processed = {"beep": False, "shot_detect": False, "trim": False}
+                    v.beep_time = None
+                    v.beep_source = None
+                    v.beep_peak_amplitude = None
+                    v.beep_duration_ms = None
+
+        return RemovalPlan(
+            video_path=video.path,
+            raw_link_path=raw_link,
+            audio_cache_path=audio_cache,
+            trimmed_cache_path=trimmed_cache,
+            audit_path=audit_path,
+            was_primary=was_primary,
+            stage_number=stage_number,
+            audit_reset=audit_reset,
+        )
 
     def auto_match(
         self,

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -105,6 +105,9 @@ class MatchProject(BaseModel):
     # The Sub 2 (#13) ingest screen surfaces these in a "tray" so the user can
     # drag them onto stages or mark them as ignored.
     unassigned_videos: list[StageVideo] = Field(default_factory=list)
+    # Last folder the user scanned for videos. Persisted so the folder picker
+    # in the ingest UI can default back here on the next scan.
+    last_scanned_dir: str | None = None
 
     @classmethod
     def init(cls, root: Path, *, name: str) -> MatchProject:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1,15 +1,21 @@
 """FastAPI app for the production UI.
 
-This is the v1 (Sub 1 / issue #12) skeleton: app shell, project endpoints,
-static asset serving for the built SPA. Ingest / audit / export endpoints
-land in their own sub-issues (#13, #15, #17) and will be added here as
-separate routers.
+Endpoints (locked v1 surface):
+
+  GET  /api/health                  -- project metadata + schema version
+  GET  /api/project                 -- full MatchProject dump
+  POST /api/scoreboard/import       -- import an SSI Scoreboard JSON
+  POST /api/videos/scan             -- enumerate videos in a folder, register them
+  POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
+  POST /api/assignments/move        -- set role / unassign / move between stages
 
 Design notes:
 - Localhost only. No auth, no CORS configuration beyond what Vite needs in dev.
 - The server holds a single ``MatchProject`` open at a time, identified by
   ``project_root`` at startup. Multi-project orchestration lives in the SPA.
 - All on-disk mutations go through the project model's atomic save.
+- The server re-loads the project from disk for every request (no caching), so
+  external edits are visible without restart.
 """
 
 from __future__ import annotations
@@ -17,13 +23,19 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from .project import MatchProject
+from .project import (
+    VIDEO_EXTENSIONS,
+    MatchProject,
+    ScoreboardImportConflictError,
+    VideoRole,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +57,32 @@ class HealthResponse(BaseModel):
     project_name: str
     project_root: str
     schema_version: int
+
+
+# Request bodies ----------------------------------------------------------
+
+
+class ScoreboardImportRequest(BaseModel):
+    data: dict[str, Any]
+    overwrite: bool = False
+
+
+class ScanRequest(BaseModel):
+    source_dir: str
+    auto_assign_primary: bool = True
+    link_mode: str = "symlink"
+
+
+class ScanResponse(BaseModel):
+    registered: list[str]
+    auto_assigned: dict[int, str]
+    skipped: list[str]
+
+
+class MoveRequest(BaseModel):
+    video_path: str
+    to_stage_number: int | None = None
+    role: VideoRole = "secondary"
 
 
 def create_app(*, project_root: Path, project_name: str) -> FastAPI:
@@ -80,6 +118,81 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     @app.get("/api/project")
     def get_project() -> JSONResponse:
         return JSONResponse(state.load().model_dump(mode="json"))
+
+    @app.post("/api/scoreboard/import")
+    def import_scoreboard(req: ScoreboardImportRequest) -> JSONResponse:
+        project = state.load()
+        try:
+            project.import_scoreboard(req.data, overwrite=req.overwrite)
+        except ScoreboardImportConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except (KeyError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/videos/scan", response_model=ScanResponse)
+    def scan_videos(req: ScanRequest) -> ScanResponse:
+        source = Path(req.source_dir).expanduser()
+        if not source.exists():
+            raise HTTPException(status_code=400, detail=f"source dir not found: {source}")
+        if not source.is_dir():
+            raise HTTPException(status_code=400, detail=f"not a directory: {source}")
+        if req.link_mode not in ("symlink", "copy"):
+            raise HTTPException(status_code=400, detail="link_mode must be 'symlink' or 'copy'")
+
+        project = state.load()
+        registered: list[str] = []
+        skipped: list[str] = []
+        for entry in sorted(source.iterdir()):
+            if entry.is_dir() or entry.suffix.lower() not in VIDEO_EXTENSIONS:
+                continue
+            try:
+                video = project.register_video(
+                    entry, state.project_root, link_mode=req.link_mode  # type: ignore[arg-type]
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                skipped.append(f"{entry.name}: {exc}")
+                continue
+            registered.append(str(video.path))
+
+        auto_assigned: dict[int, str] = {}
+        if req.auto_assign_primary:
+            suggestions = project.auto_match(state.project_root)
+            for stage_num, video_path in suggestions.items():
+                stage = project.stage(stage_num)
+                # Only auto-assign primary when the stage has no primary yet.
+                if stage.primary() is not None:
+                    continue
+                project.assign_video(video_path, to_stage_number=stage_num, role="primary")
+                auto_assigned[stage_num] = str(video_path)
+
+        project.save(state.project_root)
+        return ScanResponse(
+            registered=registered,
+            auto_assigned=auto_assigned,
+            skipped=skipped,
+        )
+
+    @app.post("/api/videos/auto-match")
+    def auto_match() -> JSONResponse:
+        project = state.load()
+        suggestions = project.auto_match(state.project_root)
+        return JSONResponse({str(stage_num): str(path) for stage_num, path in suggestions.items()})
+
+    @app.post("/api/assignments/move")
+    def move_assignment(req: MoveRequest) -> JSONResponse:
+        project = state.load()
+        try:
+            project.assign_video(
+                Path(req.video_path),
+                to_stage_number=req.to_stage_number,
+                role=req.role,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
 
     # ----------------------------------------------------------------------
     # Static asset serving (SPA)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -9,6 +9,9 @@ Endpoints (locked v1 surface):
   POST /api/videos/scan             -- enumerate videos in a folder, register them
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
   POST /api/assignments/move        -- set role / unassign / move between stages
+  POST /api/stages/{n}/detect-beep  -- run beep_detect on the primary, save result
+  POST /api/stages/{n}/beep         -- manual beep_time override
+  GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
 
 Design notes:
 - Localhost only. No auth, no CORS configuration beyond what Vite needs in dev.
@@ -31,6 +34,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from . import audio as audio_helpers
 from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
@@ -84,6 +88,10 @@ class MoveRequest(BaseModel):
     video_path: str
     to_stage_number: int | None = None
     role: VideoRole = "secondary"
+
+
+class BeepOverrideRequest(BaseModel):
+    beep_time: float | None  # None clears the override
 
 
 class FsEntry(BaseModel):
@@ -191,6 +199,108 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             registered=registered,
             auto_assigned=auto_assigned,
             skipped=skipped,
+        )
+
+    @app.post("/api/stages/{stage_number}/detect-beep")
+    def detect_beep(stage_number: int, force: bool = False) -> JSONResponse:
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"stage {stage_number} has no primary video",
+            )
+        if primary.beep_source == "manual" and not force:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "stage has a manual beep override; pass ?force=true to "
+                    "replace it with auto-detected output"
+                ),
+            )
+
+        source_video = state.project_root / primary.path
+        try:
+            result = audio_helpers.detect_primary_beep(
+                state.project_root, stage_number, source_video
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except audio_helpers.AudioExtractionError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        primary.beep_time = result.time
+        primary.beep_source = "auto"
+        primary.beep_peak_amplitude = result.peak_amplitude
+        primary.beep_duration_ms = result.duration_ms
+        primary.processed["beep"] = True
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/beep")
+    def override_beep(stage_number: int, req: BeepOverrideRequest) -> JSONResponse:
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"stage {stage_number} has no primary video",
+            )
+        if req.beep_time is None:
+            # Clear: back to "no beep yet"
+            primary.beep_time = None
+            primary.beep_source = None
+            primary.beep_peak_amplitude = None
+            primary.beep_duration_ms = None
+            primary.processed["beep"] = False
+        else:
+            if req.beep_time < 0.0:
+                raise HTTPException(status_code=400, detail="beep_time must be >= 0")
+            primary.beep_time = req.beep_time
+            primary.beep_source = "manual"
+            primary.processed["beep"] = True
+            # Diagnostics from a previous auto-detect are no longer authoritative.
+            primary.beep_peak_amplitude = None
+            primary.beep_duration_ms = None
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.get("/api/stages/{stage_number}/audio")
+    def stage_audio(stage_number: int) -> FileResponse:
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"stage {stage_number} has no primary video",
+            )
+        try:
+            audio_path = audio_helpers.ensure_primary_audio(
+                state.project_root,
+                stage_number,
+                state.project_root / primary.path,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except audio_helpers.AudioExtractionError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        # FileResponse handles HTTP Range automatically.
+        return FileResponse(
+            audio_path,
+            media_type="audio/wav",
+            filename=audio_path.name,
         )
 
     @app.get("/api/fs/list", response_model=FsListing)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6,6 +6,7 @@ Endpoints (locked v1 surface):
   GET  /api/project                 -- full MatchProject dump
   GET  /api/fs/list?path=...        -- list directory entries (folder picker)
   POST /api/scoreboard/import       -- import an SSI Scoreboard JSON
+  POST /api/project/placeholder-stages -- bootstrap source-first (no scoreboard yet)
   POST /api/videos/scan             -- register videos (folder or explicit paths)
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
   POST /api/assignments/move        -- set role / unassign / move between stages
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Any, Literal
 
@@ -73,6 +75,14 @@ class ScoreboardImportRequest(BaseModel):
     overwrite: bool = False
 
 
+class PlaceholderStagesRequest(BaseModel):
+    """Bootstrap request: create N placeholder stages without a scoreboard."""
+
+    stage_count: int
+    match_name: str | None = None
+    match_date: date | None = None
+
+
 class ScanRequest(BaseModel):
     """Either ``source_dir`` (folder scan, current behaviour) or
     ``source_paths`` (explicit list of files, USB-cam workflow). Exactly one
@@ -93,12 +103,14 @@ class ScanResponse(BaseModel):
 class SettingsRequest(BaseModel):
     """Partial update for project storage overrides (#23). Any field omitted
     is left unchanged. Pass ``""`` (empty string) to clear an override back to
-    the project-root default."""
+    the project-root default. Set ``confirm=True`` to acknowledge that any
+    existing files in the *old* directories will be left behind (no migration)."""
 
     raw_dir: str | None = None
     audio_dir: str | None = None
     trimmed_dir: str | None = None
     exports_dir: str | None = None
+    confirm: bool = False
 
 
 class MoveRequest(BaseModel):
@@ -168,6 +180,25 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except ScoreboardImportConflictError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except (KeyError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/project/placeholder-stages")
+    def create_placeholder_stages(req: PlaceholderStagesRequest) -> JSONResponse:
+        """Create N placeholder stages so source-first ingest works without a
+        scoreboard. A real scoreboard import later overlays the placeholders
+        and preserves video assignments by ``stage_number``."""
+        project = state.load()
+        try:
+            project.init_placeholder_stages(
+                req.stage_count,
+                match_name=req.match_name,
+                match_date=req.match_date,
+            )
+        except ScoreboardImportConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
@@ -248,7 +279,13 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     @app.post("/api/project/settings")
     def update_settings(req: SettingsRequest) -> JSONResponse:
         """Update storage path overrides. Any None field is left unchanged;
-        pass an empty string to clear back to the project-root default."""
+        pass an empty string to clear back to the project-root default.
+
+        If a path field is changing and the *old* directory contains files,
+        return 409 with a structured ``non_empty_old_dirs`` payload unless
+        ``confirm=True`` is sent. Existing files are not auto-migrated --
+        the warning lets the caller surface "you'll be leaving these behind".
+        """
         project = state.load()
         update: dict[str, str | None] = {}
         for field in ("raw_dir", "audio_dir", "trimmed_dir", "exports_dir"):
@@ -257,6 +294,49 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 continue
             normalized = value.strip() or None
             update[field] = normalized
+
+        # Detect non-empty old dirs for fields that are actually changing.
+        resolver_for = {
+            "raw_dir": project.raw_path,
+            "audio_dir": project.audio_path,
+            "trimmed_dir": project.trimmed_path,
+            "exports_dir": project.exports_path,
+        }
+        non_empty: list[dict[str, object]] = []
+        for field, new_value in update.items():
+            if new_value == getattr(project, field):
+                continue  # no change
+            old_path = resolver_for[field](state.project_root)
+            if not old_path.exists() or not old_path.is_dir():
+                continue
+            try:
+                file_count = sum(1 for _ in old_path.iterdir())
+            except OSError:
+                continue
+            if file_count == 0:
+                continue
+            non_empty.append(
+                {
+                    "field": field,
+                    "path": str(old_path),
+                    "file_count": file_count,
+                }
+            )
+
+        if non_empty and not req.confirm:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "non_empty_old_dirs",
+                    "message": (
+                        "Changing these paths will leave existing files behind "
+                        "in the old location -- splitsmith does not migrate. "
+                        "Resend with confirm=true to proceed."
+                    ),
+                    "dirs": non_empty,
+                },
+            )
+
         for field, value in update.items():
             setattr(project, field, value)
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4,6 +4,7 @@ Endpoints (locked v1 surface):
 
   GET  /api/health                  -- project metadata + schema version
   GET  /api/project                 -- full MatchProject dump
+  GET  /api/fs/list?path=...        -- list directory entries (folder picker)
   POST /api/scoreboard/import       -- import an SSI Scoreboard JSON
   POST /api/videos/scan             -- enumerate videos in a folder, register them
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
@@ -23,9 +24,9 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -83,6 +84,21 @@ class MoveRequest(BaseModel):
     video_path: str
     to_stage_number: int | None = None
     role: VideoRole = "secondary"
+
+
+class FsEntry(BaseModel):
+    name: str
+    kind: Literal["dir", "video", "file"]
+    video_count: int | None = None  # populated for dirs
+    size_bytes: int | None = None  # populated for files
+    mtime: float | None = None
+
+
+class FsListing(BaseModel):
+    path: str
+    parent: str | None
+    entries: list[FsEntry]
+    suggested_starts: list[str]  # bookmarks: home, ~/Movies, last_scanned_dir, etc.
 
 
 def create_app(*, project_root: Path, project_name: str) -> FastAPI:
@@ -167,11 +183,73 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 project.assign_video(video_path, to_stage_number=stage_num, role="primary")
                 auto_assigned[stage_num] = str(video_path)
 
+        # Remember this folder so the picker defaults back here next time.
+        project.last_scanned_dir = str(source.resolve())
+
         project.save(state.project_root)
         return ScanResponse(
             registered=registered,
             auto_assigned=auto_assigned,
             skipped=skipped,
+        )
+
+    @app.get("/api/fs/list", response_model=FsListing)
+    def fs_list(path: str | None = Query(default=None)) -> FsListing:
+        """List a directory's children for the in-app folder picker.
+
+        - ``path=None`` returns the user's home directory plus suggested-start
+          bookmarks (last scanned, ~/Movies, ~/Videos, ~).
+        - Hidden entries (dot-prefixed) are skipped.
+        - Symlinks are resolved before listing; broken symlinks are silently
+          dropped from the entries list.
+        - Per-directory ``video_count`` is computed by a single shallow scan.
+        """
+        project = state.load()
+        target = Path(path).expanduser() if path else _default_start(project.last_scanned_dir)
+        try:
+            target = target.resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise HTTPException(status_code=404, detail=f"path not found: {target}") from exc
+        if not target.is_dir():
+            raise HTTPException(status_code=400, detail=f"not a directory: {target}")
+
+        entries: list[FsEntry] = []
+        try:
+            children = sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+        for child in children:
+            if child.name.startswith("."):
+                continue
+            try:
+                if child.is_dir():
+                    video_count = _count_videos_shallow(child)
+                    entries.append(FsEntry(name=child.name, kind="dir", video_count=video_count))
+                elif child.is_file():
+                    is_video = child.suffix.lower() in VIDEO_EXTENSIONS
+                    stat = child.stat()
+                    entries.append(
+                        FsEntry(
+                            name=child.name,
+                            kind="video" if is_video else "file",
+                            size_bytes=stat.st_size,
+                            mtime=stat.st_mtime,
+                        )
+                    )
+            except (PermissionError, OSError):
+                # Broken symlink, permission issue on a child -- skip rather
+                # than fail the whole listing.
+                continue
+
+        parent = str(target.parent) if target.parent != target else None
+        suggested = _suggested_starts(project.last_scanned_dir)
+
+        return FsListing(
+            path=str(target),
+            parent=parent,
+            entries=entries,
+            suggested_starts=suggested,
         )
 
     @app.post("/api/videos/auto-match")
@@ -229,6 +307,62 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             return FileResponse(index)
 
     return app
+
+
+def _default_start(last_scanned_dir: str | None) -> Path:
+    """Pick a default starting directory for the folder picker.
+
+    Preference: last-scanned-dir (if it still exists) → ~/Movies → ~/Videos → ~.
+    """
+    if last_scanned_dir:
+        p = Path(last_scanned_dir).expanduser()
+        if p.is_dir():
+            return p
+    home = Path.home()
+    for candidate in (home / "Movies", home / "Videos"):
+        if candidate.is_dir():
+            return candidate
+    return home
+
+
+def _suggested_starts(last_scanned_dir: str | None) -> list[str]:
+    """Bookmarks the folder picker shows in a sidebar."""
+    home = Path.home()
+    candidates = []
+    if last_scanned_dir:
+        p = Path(last_scanned_dir).expanduser()
+        if p.is_dir():
+            candidates.append(str(p))
+    for c in (home, home / "Movies", home / "Videos", home / "Downloads", home / "Desktop"):
+        if c.is_dir():
+            candidates.append(str(c))
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    result = []
+    for c in candidates:
+        if c in seen:
+            continue
+        seen.add(c)
+        result.append(c)
+    return result
+
+
+def _count_videos_shallow(directory: Path, *, cap: int = 200) -> int:
+    """Count video files directly inside ``directory`` (no recursion).
+
+    Capped at ``cap`` to keep the picker responsive on huge folders. The UI
+    only uses this as a ranking hint ("this folder has videos in it").
+    """
+    count = 0
+    try:
+        for entry in directory.iterdir():
+            if entry.is_file() and entry.suffix.lower() in VIDEO_EXTENSIONS:
+                count += 1
+                if count >= cap:
+                    return count
+    except (PermissionError, OSError):
+        return 0
+    return count
 
 
 def serve(

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -9,8 +9,11 @@ Endpoints (locked v1 surface):
   POST /api/project/placeholder-stages -- bootstrap source-first (no scoreboard yet)
   POST /api/videos/scan             -- register videos (folder or explicit paths)
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
+  POST /api/videos/remove           -- remove a registered video + cleanup caches
   POST /api/assignments/move        -- set role / unassign / move between stages
   POST /api/project/settings        -- update raw/audio/trimmed/exports dir overrides
+  GET  /api/fs/probe?path=...       -- probe + thumbnail one source file on demand
+  GET  /api/thumbnails/{key}.jpg    -- serve cached thumbnail
   POST /api/stages/{n}/detect-beep  -- run beep_detect on the primary, save result
   POST /api/stages/{n}/beep         -- manual beep_time override
   GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
@@ -27,6 +30,7 @@ Design notes:
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -37,6 +41,8 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from .. import thumbnail as thumbnail_helpers
+from .. import video_probe
 from . import audio as audio_helpers
 from .project import (
     VIDEO_EXTENSIONS,
@@ -110,6 +116,8 @@ class SettingsRequest(BaseModel):
     audio_dir: str | None = None
     trimmed_dir: str | None = None
     exports_dir: str | None = None
+    probes_dir: str | None = None
+    thumbs_dir: str | None = None
     confirm: bool = False
 
 
@@ -123,12 +131,30 @@ class BeepOverrideRequest(BaseModel):
     beep_time: float | None  # None clears the override
 
 
+class RemoveVideoRequest(BaseModel):
+    """Body for POST /api/videos/remove (#24).
+
+    ``reset_audit`` only takes effect when removing a primary; otherwise it
+    is ignored (audit is stage-level state, and non-primary removals do not
+    invalidate it).
+    """
+
+    video_path: str
+    reset_audit: bool = False
+
+
 class FsEntry(BaseModel):
     name: str
     kind: Literal["dir", "video", "file"]
     video_count: int | None = None  # populated for dirs
     size_bytes: int | None = None  # populated for files
     mtime: float | None = None
+    # Populated for videos when probed (issue #24). ``duration`` may be null
+    # if probing was skipped (no ?probe=true) or hit the per-listing budget.
+    # ``thumbnail_url`` points at /api/thumbnails/{key}.jpg when a thumbnail
+    # is cached; the caller can hit /api/fs/probe to generate one on demand.
+    duration: float | None = None
+    thumbnail_url: str | None = None
 
 
 class FsListing(BaseModel):
@@ -288,7 +314,14 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         """
         project = state.load()
         update: dict[str, str | None] = {}
-        for field in ("raw_dir", "audio_dir", "trimmed_dir", "exports_dir"):
+        for field in (
+            "raw_dir",
+            "audio_dir",
+            "trimmed_dir",
+            "exports_dir",
+            "probes_dir",
+            "thumbs_dir",
+        ):
             value = getattr(req, field)
             if value is None:
                 continue
@@ -301,6 +334,8 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             "audio_dir": project.audio_path,
             "trimmed_dir": project.trimmed_path,
             "exports_dir": project.exports_path,
+            "probes_dir": project.probes_path,
+            "thumbs_dir": project.thumbs_path,
         }
         non_empty: list[dict[str, object]] = []
         for field, new_value in update.items():
@@ -347,6 +382,8 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             project.audio_path,
             project.trimmed_path,
             project.exports_path,
+            project.probes_path,
+            project.thumbs_path,
         ):
             target = resolver(state.project_root)
             try:
@@ -467,7 +504,10 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         )
 
     @app.get("/api/fs/list", response_model=FsListing)
-    def fs_list(path: str | None = Query(default=None)) -> FsListing:
+    def fs_list(
+        path: str | None = Query(default=None),
+        probe: bool = Query(default=False),
+    ) -> FsListing:
         """List a directory's children for the in-app folder picker.
 
         - ``path=None`` returns the user's home directory plus suggested-start
@@ -476,6 +516,13 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         - Symlinks are resolved before listing; broken symlinks are silently
           dropped from the entries list.
         - Per-directory ``video_count`` is computed by a single shallow scan.
+        - When ``probe=true``, video entries get ``duration`` + thumbnail
+          generation via ffprobe / ffmpeg, bounded by a wall-clock budget
+          (~5 s) so a USB-mounted directory with hundreds of clips doesn't
+          stall the picker. Entries past the budget come back with null
+          fields and a per-row Generate affordance in the SPA. Cached
+          probes / thumbnails always populate -- the budget only gates the
+          first-time work.
         """
         project = state.load()
         target = Path(path).expanduser() if path else _default_start(project.last_scanned_dir)
@@ -492,6 +539,10 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
 
+        probes_dir = project.probes_path(state.project_root)
+        thumbs_dir = project.thumbs_path(state.project_root)
+        budget_deadline = time.monotonic() + 5.0  # wall-clock budget for new probes
+
         for child in children:
             if child.name.startswith("."):
                 continue
@@ -502,12 +553,24 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 elif child.is_file():
                     is_video = child.suffix.lower() in VIDEO_EXTENSIONS
                     stat = child.stat()
+                    duration: float | None = None
+                    thumbnail_url: str | None = None
+                    if is_video:
+                        duration, thumbnail_url = _video_metadata_for(
+                            child,
+                            probes_dir=probes_dir,
+                            thumbs_dir=thumbs_dir,
+                            allow_new=probe and time.monotonic() < budget_deadline,
+                            duration_for_thumb=None,
+                        )
                     entries.append(
                         FsEntry(
                             name=child.name,
                             kind="video" if is_video else "file",
                             size_bytes=stat.st_size,
                             mtime=stat.st_mtime,
+                            duration=duration,
+                            thumbnail_url=thumbnail_url,
                         )
                     )
             except (PermissionError, OSError):
@@ -525,11 +588,125 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             suggested_starts=suggested,
         )
 
+    @app.get("/api/fs/probe")
+    def fs_probe(path: str = Query(...)) -> JSONResponse:
+        """Probe a single video file on demand: ffprobe + thumbnail extraction.
+
+        Used by the SPA when a picker row came back with null fields (the
+        list-time budget was exhausted, or ``probe=true`` wasn't passed).
+        Cached results are returned without re-running the binaries.
+        """
+        target = Path(path).expanduser()
+        try:
+            target = target.resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise HTTPException(status_code=404, detail=f"path not found: {target}") from exc
+        if not target.is_file():
+            raise HTTPException(status_code=400, detail=f"not a file: {target}")
+        if target.suffix.lower() not in VIDEO_EXTENSIONS:
+            raise HTTPException(status_code=400, detail=f"not a video: {target}")
+
+        project = state.load()
+        probes_dir = project.probes_path(state.project_root)
+        thumbs_dir = project.thumbs_path(state.project_root)
+        duration, thumbnail_url = _video_metadata_for(
+            target,
+            probes_dir=probes_dir,
+            thumbs_dir=thumbs_dir,
+            allow_new=True,
+            duration_for_thumb=None,
+        )
+        return JSONResponse({"duration": duration, "thumbnail_url": thumbnail_url})
+
+    @app.get("/api/thumbnails/{cache_key}.jpg", include_in_schema=False)
+    def serve_thumbnail(cache_key: str) -> FileResponse:
+        """Serve a cached thumbnail by its content-addressed key.
+
+        Keys are 16-char hex from :func:`video_probe.source_cache_key`. We
+        validate the key shape so we never accept an arbitrary path that
+        could escape the thumbs directory.
+        """
+        if not cache_key.isalnum() or len(cache_key) > 32:
+            raise HTTPException(status_code=400, detail="invalid thumbnail key")
+        project = state.load()
+        thumbs_dir = project.thumbs_path(state.project_root)
+        candidate = thumbs_dir / f"{cache_key}.jpg"
+        if not candidate.exists():
+            raise HTTPException(status_code=404, detail="thumbnail not cached")
+        return FileResponse(candidate, media_type="image/jpeg", filename=candidate.name)
+
     @app.post("/api/videos/auto-match")
     def auto_match() -> JSONResponse:
         project = state.load()
         suggestions = project.auto_match(state.project_root)
         return JSONResponse({str(stage_num): str(path) for stage_num, path in suggestions.items()})
+
+    @app.post("/api/videos/remove")
+    def remove_video(req: RemoveVideoRequest) -> JSONResponse:
+        """Remove a registered video and clean up its caches.
+
+        Walks the :class:`RemovalPlan` returned by the model: unlinks the
+        symlink under ``raw_dir`` (the source on USB / external storage is
+        never touched), and clears the audio + trimmed caches if the removed
+        video was a primary that had been processed. When ``reset_audit`` is
+        set and the video was a primary, the per-stage audit JSON is
+        deleted too -- otherwise audit data is preserved so a re-ingest of
+        the same stage with a different file picks up where the user left
+        off.
+        """
+        project = state.load()
+        try:
+            plan = project.remove_video(
+                Path(req.video_path),
+                state.project_root,
+                reset_audit=req.reset_audit,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        # Symlink under raw_dir: remove only if it's actually a symlink we
+        # created. If the user pointed raw_dir at the source and the link is
+        # in fact the original file, leave it alone.
+        try:
+            if plan.raw_link_path.is_symlink():
+                plan.raw_link_path.unlink()
+            elif plan.raw_link_path.exists():
+                # Treat as a copy splitsmith placed (link_mode="copy"). We
+                # only delete files inside raw_dir; never anything beyond.
+                raw_dir = project.raw_path(state.project_root).resolve()
+                try:
+                    plan.raw_link_path.resolve().relative_to(raw_dir)
+                    plan.raw_link_path.unlink()
+                except ValueError:
+                    logger.debug(
+                        "skipping raw cleanup; %s is outside raw_dir %s",
+                        plan.raw_link_path,
+                        raw_dir,
+                    )
+        except OSError as exc:
+            logger.warning("could not unlink %s: %s", plan.raw_link_path, exc)
+
+        for cache_path in (plan.audio_cache_path, plan.trimmed_cache_path):
+            if cache_path is None:
+                continue
+            try:
+                cache_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("could not remove cache %s: %s", cache_path, exc)
+
+        if plan.audit_path is not None:
+            try:
+                plan.audit_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("could not remove audit %s: %s", plan.audit_path, exc)
+
+        project.save(state.project_root)
+        return JSONResponse(
+            {
+                "project": project.model_dump(mode="json"),
+                "plan": plan.model_dump(mode="json"),
+            }
+        )
 
     @app.post("/api/assignments/move")
     def move_assignment(req: MoveRequest) -> JSONResponse:
@@ -618,6 +795,51 @@ def _suggested_starts(last_scanned_dir: str | None) -> list[str]:
         seen.add(c)
         result.append(c)
     return result
+
+
+def _video_metadata_for(
+    source: Path,
+    *,
+    probes_dir: Path,
+    thumbs_dir: Path,
+    allow_new: bool,
+    duration_for_thumb: float | None,
+) -> tuple[float | None, str | None]:
+    """Return ``(duration, thumbnail_url)`` for a source video.
+
+    Always uses cached results when available. Runs ffprobe / ffmpeg only
+    when ``allow_new`` is True (i.e. the caller wants on-demand work and is
+    OK paying the cost). Failures are swallowed -- the picker's contract is
+    "best effort, never block the listing".
+    """
+    duration: float | None = None
+    cached_probe = video_probe.cached(source, probes_dir)
+    if cached_probe is not None:
+        duration = cached_probe.duration
+    elif allow_new:
+        try:
+            result = video_probe.probe(source, cache_dir=probes_dir)
+            duration = result.duration
+        except video_probe.ProbeError as exc:
+            logger.debug("probe failed for %s: %s", source, exc)
+
+    thumbnail_url: str | None = None
+    cached_thumb = thumbnail_helpers.cached(source, thumbs_dir)
+    if cached_thumb is not None:
+        thumbnail_url = f"/api/thumbnails/{cached_thumb.stem}.jpg"
+    elif allow_new:
+        try:
+            t_dur = duration_for_thumb if duration_for_thumb is not None else duration
+            extracted = thumbnail_helpers.ensure(
+                source,
+                cache_dir=thumbs_dir,
+                duration=t_dur,
+            )
+            thumbnail_url = f"/api/thumbnails/{extracted.stem}.jpg"
+        except thumbnail_helpers.ThumbnailError as exc:
+            logger.debug("thumbnail failed for %s: %s", source, exc)
+
+    return duration, thumbnail_url
 
 
 def _count_videos_shallow(directory: Path, *, cap: int = 200) -> int:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1,0 +1,140 @@
+"""FastAPI app for the production UI.
+
+This is the v1 (Sub 1 / issue #12) skeleton: app shell, project endpoints,
+static asset serving for the built SPA. Ingest / audit / export endpoints
+land in their own sub-issues (#13, #15, #17) and will be added here as
+separate routers.
+
+Design notes:
+- Localhost only. No auth, no CORS configuration beyond what Vite needs in dev.
+- The server holds a single ``MatchProject`` open at a time, identified by
+  ``project_root`` at startup. Multi-project orchestration lives in the SPA.
+- All on-disk mutations go through the project model's atomic save.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from .project import MatchProject
+
+logger = logging.getLogger(__name__)
+
+STATIC_DIR = Path(__file__).parent.parent / "ui_static" / "dist"
+
+
+@dataclass
+class AppState:
+    """Per-process state. One project root per server instance."""
+
+    project_root: Path
+
+    def load(self) -> MatchProject:
+        return MatchProject.load(self.project_root)
+
+
+class HealthResponse(BaseModel):
+    status: str = "ok"
+    project_name: str
+    project_root: str
+    schema_version: int
+
+
+def create_app(*, project_root: Path, project_name: str) -> FastAPI:
+    """Create the FastAPI app bound to a single match project on disk.
+
+    The project is initialized on first call (idempotent), then the app keeps
+    the root path and re-loads on every request that needs it. We avoid
+    caching the model in memory so external edits to ``project.json`` are
+    visible without restarting the server.
+    """
+    MatchProject.init(project_root, name=project_name)
+    state = AppState(project_root=project_root.resolve())
+
+    app = FastAPI(
+        title="splitsmith UI",
+        description="Production UI backend (issue #11/#12).",
+        version="0.1.0",
+    )
+
+    # ----------------------------------------------------------------------
+    # API
+    # ----------------------------------------------------------------------
+
+    @app.get("/api/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        project = state.load()
+        return HealthResponse(
+            project_name=project.name,
+            project_root=str(state.project_root),
+            schema_version=project.schema_version,
+        )
+
+    @app.get("/api/project")
+    def get_project() -> JSONResponse:
+        return JSONResponse(state.load().model_dump(mode="json"))
+
+    # ----------------------------------------------------------------------
+    # Static asset serving (SPA)
+    # ----------------------------------------------------------------------
+    #
+    # In dev, the user runs ``npm run dev`` in ``ui_static/`` and Vite serves
+    # the SPA on its own port, proxying ``/api/*`` to this backend. In that
+    # mode ``STATIC_DIR`` may not exist; the API routes still work and the
+    # browser hits the Vite dev server directly.
+    #
+    # In prod, ``ui_static/dist`` is built and we serve it here.
+
+    if STATIC_DIR.exists():
+        # Mount built assets at /assets (matches Vite's default output).
+        assets_dir = STATIC_DIR / "assets"
+        if assets_dir.exists():
+            app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+
+        # SPA fallback: any non-API route returns index.html so the React
+        # router can handle it client-side.
+        @app.get("/{full_path:path}", include_in_schema=False)
+        def spa_fallback(full_path: str) -> FileResponse:
+            if full_path.startswith("api/"):
+                raise HTTPException(status_code=404, detail="api route not found")
+            index = STATIC_DIR / "index.html"
+            if not index.exists():
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "SPA bundle not built. Run `npm run build` in "
+                        "src/splitsmith/ui_static/ or use `npm run dev`."
+                    ),
+                )
+            return FileResponse(index)
+
+    return app
+
+
+def serve(
+    *,
+    project_root: Path,
+    project_name: str,
+    host: str = "127.0.0.1",
+    port: int = 5174,
+    reload: bool = False,
+) -> None:
+    """Boot uvicorn synchronously. Used by the ``splitsmith ui`` CLI command."""
+    import uvicorn
+
+    if reload:
+        # Reload mode requires an importable factory; pass the path string and
+        # use environment variables to feed the project context. Simpler: just
+        # log a warning and run without reload for now. Reload is a dev
+        # convenience that we can wire properly when we have a real config.
+        logger.warning("reload=True is not supported yet; running without reload")
+
+    app = create_app(project_root=project_root, project_name=project_name)
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6,9 +6,10 @@ Endpoints (locked v1 surface):
   GET  /api/project                 -- full MatchProject dump
   GET  /api/fs/list?path=...        -- list directory entries (folder picker)
   POST /api/scoreboard/import       -- import an SSI Scoreboard JSON
-  POST /api/videos/scan             -- enumerate videos in a folder, register them
+  POST /api/videos/scan             -- register videos (folder or explicit paths)
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
   POST /api/assignments/move        -- set role / unassign / move between stages
+  POST /api/project/settings        -- update raw/audio/trimmed/exports dir overrides
   POST /api/stages/{n}/detect-beep  -- run beep_detect on the primary, save result
   POST /api/stages/{n}/beep         -- manual beep_time override
   GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
@@ -73,7 +74,12 @@ class ScoreboardImportRequest(BaseModel):
 
 
 class ScanRequest(BaseModel):
-    source_dir: str
+    """Either ``source_dir`` (folder scan, current behaviour) or
+    ``source_paths`` (explicit list of files, USB-cam workflow). Exactly one
+    must be provided."""
+
+    source_dir: str | None = None
+    source_paths: list[str] | None = None
     auto_assign_primary: bool = True
     link_mode: str = "symlink"
 
@@ -82,6 +88,17 @@ class ScanResponse(BaseModel):
     registered: list[str]
     auto_assigned: dict[int, str]
     skipped: list[str]
+
+
+class SettingsRequest(BaseModel):
+    """Partial update for project storage overrides (#23). Any field omitted
+    is left unchanged. Pass ``""`` (empty string) to clear an override back to
+    the project-root default."""
+
+    raw_dir: str | None = None
+    audio_dir: str | None = None
+    trimmed_dir: str | None = None
+    exports_dir: str | None = None
 
 
 class MoveRequest(BaseModel):
@@ -157,20 +174,47 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
 
     @app.post("/api/videos/scan", response_model=ScanResponse)
     def scan_videos(req: ScanRequest) -> ScanResponse:
-        source = Path(req.source_dir).expanduser()
-        if not source.exists():
-            raise HTTPException(status_code=400, detail=f"source dir not found: {source}")
-        if not source.is_dir():
-            raise HTTPException(status_code=400, detail=f"not a directory: {source}")
         if req.link_mode not in ("symlink", "copy"):
             raise HTTPException(status_code=400, detail="link_mode must be 'symlink' or 'copy'")
+        if (req.source_dir is None) == (req.source_paths is None):
+            raise HTTPException(
+                status_code=400,
+                detail="exactly one of source_dir or source_paths must be provided",
+            )
+
+        # Build the list of files to register and capture the directory we'll
+        # remember as last_scanned_dir. For source_paths mode we use the parent
+        # of the first file as a sensible default for the picker next time.
+        candidates: list[Path] = []
+        last_dir: Path | None = None
+        if req.source_dir is not None:
+            source = Path(req.source_dir).expanduser()
+            if not source.exists():
+                raise HTTPException(status_code=400, detail=f"source dir not found: {source}")
+            if not source.is_dir():
+                raise HTTPException(status_code=400, detail=f"not a directory: {source}")
+            for entry in sorted(source.iterdir()):
+                if entry.is_dir() or entry.suffix.lower() not in VIDEO_EXTENSIONS:
+                    continue
+                candidates.append(entry)
+            last_dir = source.resolve()
+        else:
+            assert req.source_paths is not None
+            if not req.source_paths:
+                raise HTTPException(status_code=400, detail="source_paths must be non-empty")
+            for raw in req.source_paths:
+                p = Path(raw).expanduser()
+                if not p.exists():
+                    raise HTTPException(status_code=400, detail=f"file not found: {p}")
+                if not p.is_file():
+                    raise HTTPException(status_code=400, detail=f"not a file: {p}")
+                candidates.append(p)
+            last_dir = candidates[0].parent.resolve() if candidates else None
 
         project = state.load()
         registered: list[str] = []
         skipped: list[str] = []
-        for entry in sorted(source.iterdir()):
-            if entry.is_dir() or entry.suffix.lower() not in VIDEO_EXTENSIONS:
-                continue
+        for entry in candidates:
             try:
                 video = project.register_video(
                     entry, state.project_root, link_mode=req.link_mode  # type: ignore[arg-type]
@@ -191,8 +235,8 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 project.assign_video(video_path, to_stage_number=stage_num, role="primary")
                 auto_assigned[stage_num] = str(video_path)
 
-        # Remember this folder so the picker defaults back here next time.
-        project.last_scanned_dir = str(source.resolve())
+        if last_dir is not None:
+            project.last_scanned_dir = str(last_dir)
 
         project.save(state.project_root)
         return ScanResponse(
@@ -200,6 +244,41 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             auto_assigned=auto_assigned,
             skipped=skipped,
         )
+
+    @app.post("/api/project/settings")
+    def update_settings(req: SettingsRequest) -> JSONResponse:
+        """Update storage path overrides. Any None field is left unchanged;
+        pass an empty string to clear back to the project-root default."""
+        project = state.load()
+        update: dict[str, str | None] = {}
+        for field in ("raw_dir", "audio_dir", "trimmed_dir", "exports_dir"):
+            value = getattr(req, field)
+            if value is None:
+                continue
+            normalized = value.strip() or None
+            update[field] = normalized
+        for field, value in update.items():
+            setattr(project, field, value)
+
+        # Make sure each configured directory is creatable; surface a 400
+        # rather than failing later in detect-beep / trim / export.
+        for resolver in (
+            project.raw_path,
+            project.audio_path,
+            project.trimmed_path,
+            project.exports_path,
+        ):
+            target = resolver(state.project_root)
+            try:
+                target.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"cannot create directory {target}: {exc}",
+                ) from exc
+
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/stages/{stage_number}/detect-beep")
     def detect_beep(stage_number: int, force: bool = False) -> JSONResponse:
@@ -223,10 +302,13 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 ),
             )
 
-        source_video = state.project_root / primary.path
+        source_video = project.resolve_video_path(state.project_root, primary.path)
         try:
             result = audio_helpers.detect_primary_beep(
-                state.project_root, stage_number, source_video
+                state.project_root,
+                stage_number,
+                source_video,
+                project=project,
             )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -290,7 +372,8 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             audio_path = audio_helpers.ensure_primary_audio(
                 state.project_root,
                 stage_number,
-                state.project_root / primary.path,
+                project.resolve_video_path(state.project_root, primary.path),
+                project=project,
             )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/src/splitsmith/ui_static/.gitignore
+++ b/src/splitsmith/ui_static/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+*.tsbuildinfo

--- a/src/splitsmith/ui_static/index.html
+++ b/src/splitsmith/ui_static/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>splitsmith</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/splitsmith/ui_static/package-lock.json
+++ b/src/splitsmith/ui_static/package-lock.json
@@ -1,0 +1,3032 @@
+{
+  "name": "splitsmith-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "splitsmith-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-tooltip": "^1.1.6",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.479.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.5",
+        "tailwind-merge": "^3.0.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/node": "^22.13.0",
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "@vitejs/plugin-react": "^4.3.4",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.7.3",
+        "vite": "^6.1.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.479.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.479.0.tgz",
+      "integrity": "sha512-aBhNnveRhorBOK7uA4gDjgaf+YlHMdMhQ/3cupk6exM10hWlEU+2QtWYOfhXhjAsmdb6LeKR+NZnow4UxRRiTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/src/splitsmith/ui_static/package.json
+++ b/src/splitsmith/ui_static/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "splitsmith-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Splitsmith production UI SPA (issue #11/#12)",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tooltip": "^1.1.6",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.479.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.5",
+    "tailwind-merge": "^3.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^22.13.0",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.1.0"
+  }
+}

--- a/src/splitsmith/ui_static/pnpm-lock.yaml
+++ b/src/splitsmith/ui_static/pnpm-lock.yaml
@@ -1,0 +1,2009 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.1.6
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.479.0
+        version: 0.479.0(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.1.5
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.0.1
+        version: 3.5.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.0
+        version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@types/node':
+        specifier: ^22.13.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.2.4':
+    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.4':
+    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.4':
+    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.25:
+    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.348:
+    resolution: {integrity: sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.479.0:
+    resolution: {integrity: sha512-aBhNnveRhorBOK7uA4gDjgaf+YlHMdMhQ/3cupk6exM10hWlEU+2QtWYOfhXhjAsmdb6LeKR+NZnow4UxRRiTQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.1': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@tailwindcss/node@4.2.4':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.0
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.4
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.4':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-x64': 4.2.4
+      '@tailwindcss/oxide-freebsd-x64': 4.2.4
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+
+  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.25: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.25
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.348
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001791: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  electron-to-chromium@1.5.348: {}
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.479.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
+  react@19.2.5: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  source-map-js@1.2.1: {}
+
+  tailwind-merge@3.5.0: {}
+
+  tailwindcss@4.2.4: {}
+
+  tapable@2.3.3: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+
+  yallist@3.1.1: {}

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -1,0 +1,30 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+
+import { AppShell } from "@/components/AppShell";
+import { ThemeProvider } from "@/lib/theme";
+import { Audit } from "@/pages/Audit";
+import { Design } from "@/pages/Design";
+import { Export } from "@/pages/Export";
+import { Home } from "@/pages/Home";
+import { Ingest } from "@/pages/Ingest";
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route index element={<Home />} />
+            <Route path="ingest" element={<Ingest />} />
+            <Route path="audit" element={<Audit />} />
+            <Route path="audit/:stage" element={<Audit />} />
+            <Route path="export" element={<Export />} />
+            <Route path="export/:stage" element={<Export />} />
+            <Route path="_design" element={<Design />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/AppShell.tsx
+++ b/src/splitsmith/ui_static/src/components/AppShell.tsx
@@ -1,0 +1,79 @@
+import { Crosshair, FileBarChart, FolderInput, Home, Palette } from "lucide-react";
+import { NavLink, Outlet } from "react-router-dom";
+
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { cn } from "@/lib/utils";
+
+const NAV = [
+  { to: "/", label: "Overview", icon: Home, end: true },
+  { to: "/ingest", label: "Ingest", icon: FolderInput },
+  { to: "/audit", label: "Audit", icon: Crosshair },
+  { to: "/export", label: "Export", icon: FileBarChart },
+];
+
+export function AppShell() {
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <aside className="flex w-60 flex-col border-r border-border bg-card">
+        <div className="flex h-14 items-center gap-2 px-4 font-semibold tracking-tight">
+          <Crosshair className="size-5 text-primary" />
+          splitsmith
+        </div>
+        <nav className="flex flex-1 flex-col gap-0.5 p-2">
+          {NAV.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                  isActive
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                )
+              }
+            >
+              <Icon className="size-4" />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+        <div className="border-t border-border p-2">
+          <NavLink
+            to="/_design"
+            className={({ isActive }) =>
+              cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                isActive
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              )
+            }
+          >
+            <Palette className="size-4" />
+            Design system
+          </NavLink>
+        </div>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="flex h-14 items-center justify-between border-b border-border px-6">
+          <ProjectHeader />
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto px-6 py-6">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function ProjectHeader() {
+  // Project name is fetched from /api/health; for the v1 shell we keep this
+  // simple and let pages render their own headings. A future iteration can
+  // surface the active project name here once the project context is wired.
+  return <div className="text-sm text-muted-foreground">Production UI v1 (Sub 1)</div>;
+}

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -1,0 +1,265 @@
+/**
+ * Per-stage beep detection + correction (issue #22).
+ *
+ * The beep timestamp anchors the trim window, secondary-video alignment, and
+ * shot-detection input window for the audit screen (#15). If detection is
+ * wrong, every downstream artefact is wrong. This component exposes:
+ *
+ *   - Status: none / auto / manual
+ *   - Detect-beep action (or re-detect, with confirmation when overriding manual)
+ *   - Manual override: numeric input (seconds, ms precision) + verify-by-ear audio playback
+ *   - Clear action: drops the override back to "no beep yet"
+ *
+ * Used inside the Ingest screen's <StageCard>; #15 will surface a richer
+ * waveform-based correction inline with the audit waveform.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Check, Pencil, Play, RefreshCw, Trash2, Volume2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ApiError, api, type MatchProject, type StageVideo } from "@/lib/api";
+
+interface Props {
+  stageNumber: number;
+  primary: StageVideo;
+  busy: boolean;
+  onProjectUpdate: (next: MatchProject) => void;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+}
+
+export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBusy, setError }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(primary.beep_time?.toFixed(3) ?? "");
+
+  useEffect(() => {
+    setDraft(primary.beep_time?.toFixed(3) ?? "");
+  }, [primary.beep_time]);
+
+  const detect = async (force: boolean) => {
+    setBusy(true);
+    try {
+      const updated = await api.detectBeep(stageNumber, force);
+      onProjectUpdate(updated);
+      setError(null);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        const ok = window.confirm(
+          "This stage has a manual beep override. Replace it with the auto-detected value?",
+        );
+        if (ok) await detect(true);
+        else setError(null);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const save = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setError("Enter a beep time in seconds, e.g. 12.453");
+      return;
+    }
+    const value = Number(trimmed);
+    if (Number.isNaN(value) || value < 0) {
+      setError("Beep time must be a non-negative number of seconds");
+      return;
+    }
+    setBusy(true);
+    try {
+      const updated = await api.overrideBeep(stageNumber, value);
+      onProjectUpdate(updated);
+      setError(null);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    try {
+      const updated = await api.overrideBeep(stageNumber, null);
+      onProjectUpdate(updated);
+      setError(null);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm">
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">Beep time (seconds)</span>
+            <input
+              type="number"
+              step="0.001"
+              min="0"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="h-8 w-32 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              disabled={busy}
+              aria-label={`Beep time for stage ${stageNumber}`}
+              autoFocus
+            />
+          </label>
+          <Button size="sm" onClick={save} disabled={busy}>
+            <Check />
+            Apply
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setEditing(false)} disabled={busy}>
+            Cancel
+          </Button>
+        </div>
+        <AudioVerifier stageNumber={stageNumber} suspectedTime={Number(draft) || primary.beep_time} />
+      </div>
+    );
+  }
+
+  if (!primary.beep_time) {
+    return (
+      <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
+        <Badge variant="statusNotStarted" className="gap-1">
+          ○ No beep yet
+        </Badge>
+        <span className="text-muted-foreground">
+          Audit screen needs this. Run detection or set manually.
+        </span>
+        <div className="ml-auto flex gap-1">
+          <Button size="sm" variant="default" onClick={() => detect(false)} disabled={busy}>
+            <RefreshCw />
+            Detect beep
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
+            <Pencil />
+            Set manually
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const isManual = primary.beep_source === "manual";
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
+      <Badge variant={isManual ? "statusComplete" : "statusInProgress"} className="gap-1">
+        <Check className="size-3" />
+        beep · {isManual ? "user" : "auto"}
+      </Badge>
+      <span className="font-mono tabular-nums">{primary.beep_time.toFixed(3)}s</span>
+      {primary.beep_peak_amplitude != null ? (
+        <span className="text-muted-foreground" title="Peak amplitude on the bandpassed envelope">
+          peak {primary.beep_peak_amplitude.toFixed(2)}
+        </span>
+      ) : null}
+      <div className="ml-auto flex gap-1">
+        <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
+          <Pencil />
+          Edit
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => detect(false)} disabled={busy}>
+          <RefreshCw />
+          Re-detect
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={clear}
+          disabled={busy}
+          title="Clear the beep timestamp (back to no-beep state)"
+        >
+          <Trash2 />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AudioVerifier({
+  stageNumber,
+  suspectedTime,
+}: {
+  stageNumber: number;
+  suspectedTime: number | null;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [available, setAvailable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(api.stageAudioUrl(stageNumber), { method: "HEAD" })
+      .then((r) => {
+        if (!cancelled) setAvailable(r.ok);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [stageNumber]);
+
+  useEffect(() => {
+    // Auto-seek the audio element near the suspected beep so the user can
+    // hit play and immediately hear the relevant slice.
+    const el = audioRef.current;
+    if (el && suspectedTime != null && Number.isFinite(suspectedTime)) {
+      const start = Math.max(0, suspectedTime - 0.5);
+      try {
+        el.currentTime = start;
+      } catch {
+        /* the metadata may not be loaded yet; the seek runs on load below */
+      }
+    }
+  }, [suspectedTime]);
+
+  if (available === null) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Volume2 className="size-3" />
+        Loading audio…
+      </div>
+    );
+  }
+  if (!available) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Volume2 className="size-3" />
+        Run "Detect beep" first to extract audio for verification.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Play className="size-3" />
+        Verify by ear (jumps to ~0.5s before the beep)
+      </div>
+      <audio
+        ref={audioRef}
+        src={api.stageAudioUrl(stageNumber)}
+        controls
+        preload="metadata"
+        onLoadedMetadata={() => {
+          const el = audioRef.current;
+          if (el && suspectedTime != null && Number.isFinite(suspectedTime)) {
+            el.currentTime = Math.max(0, suspectedTime - 0.5);
+          }
+        }}
+        className="w-full"
+      />
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -34,8 +34,9 @@ interface FolderPickerProps {
   onSelect: (path: string) => void;
   /** Optional callback for multi-file selection. When provided, video rows
    * gain a checkbox and the action button switches to "Use N files" when any
-   * files are selected. */
-  onSelectFiles?: (paths: string[]) => void;
+   * files are selected. The callback receives the selected files with their
+   * filesystem mtime so the parent can pre-fill date hints. */
+  onSelectFiles?: (files: { path: string; mtime: number | null }[]) => void;
   onCancel?: () => void;
   /** Render mode: inline (e.g. inside a card) vs. compact. */
   mode?: "inline" | "compact";
@@ -97,10 +98,10 @@ export function FolderPicker({
 
   const confirmFiles = () => {
     if (!path || selectedCount === 0) return;
-    const paths = videoEntries
+    const files = videoEntries
       .filter((e) => selectedFiles.has(e.name))
-      .map((e) => joinPath(path, e.name));
-    onSelectFiles!(paths);
+      .map((e) => ({ path: joinPath(path, e.name), mtime: e.mtime }));
+    onSelectFiles!(files);
   };
 
   return (

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -14,7 +14,7 @@
  *   - Keyboard navigable: Tab through, Enter on a row to drill in
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronRight,
   Clock,
@@ -295,8 +295,9 @@ function VideoRowMulti({
   onToggle: () => void;
   onProbed: (duration: number | null, thumbnail_url: string | null) => void;
 }) {
-  const [hover, setHover] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
   const [probing, setProbing] = useState(false);
+  const liRef = useRef<HTMLLIElement | null>(null);
 
   const ensureProbe = useCallback(async () => {
     if (entry.duration != null && entry.thumbnail_url != null) return;
@@ -314,12 +315,12 @@ function VideoRowMulti({
 
   return (
     <li
+      ref={liRef}
       onMouseEnter={() => {
-        setHover(true);
+        setRect(liRef.current?.getBoundingClientRect() ?? null);
         void ensureProbe();
       }}
-      onMouseLeave={() => setHover(false)}
-      className="relative"
+      onMouseLeave={() => setRect(null)}
     >
       <label
         className={cn(
@@ -340,21 +341,54 @@ function VideoRowMulti({
           <span className="truncate font-mono text-xs">{entry.name}</span>
         </span>
         <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground tabular-nums">
+          {entry.mtime != null ? <span>{formatMtime(entry.mtime)}</span> : null}
           {entry.duration != null ? <span>{formatDuration(entry.duration)}</span> : null}
           {entry.size_bytes != null ? <span>{formatBytes(entry.size_bytes)}</span> : null}
         </span>
       </label>
-      {hover && entry.thumbnail_url ? (
-        <div className="pointer-events-none absolute right-2 top-full z-10 mt-1 rounded-md border border-border bg-popover p-1 shadow-lg">
-          <img
-            src={entry.thumbnail_url}
-            alt={`${entry.name} thumbnail`}
-            className="h-32 rounded"
-          />
-        </div>
+      {rect && entry.thumbnail_url ? (
+        <ThumbnailFloat anchor={rect} src={entry.thumbnail_url} alt={entry.name} />
       ) : null}
     </li>
   );
+}
+
+function ThumbnailFloat({ anchor, src, alt }: { anchor: DOMRect; src: string; alt: string }) {
+  // Fixed positioning escapes the picker's overflow:auto clip so rows near
+  // the bottom of the list still render their preview. We anchor the
+  // thumbnail to the right edge of the row, flip it to the left if the
+  // viewport's right side wouldn't fit, and clamp the vertical position so
+  // it never paints off-screen.
+  const W = 320; // matches max-w used below
+  const H = 192; // h-48 -> 12rem -> 192px; rough cap to keep clamping math simple
+  const margin = 8;
+  const flipLeft = anchor.right + W + margin > window.innerWidth;
+  const left = flipLeft ? Math.max(margin, anchor.left - W - margin) : anchor.right + margin;
+  const desiredTop = anchor.top + anchor.height / 2 - H / 2;
+  const top = Math.max(margin, Math.min(window.innerHeight - H - margin, desiredTop));
+  return (
+    <div
+      role="presentation"
+      style={{ position: "fixed", top, left, width: W, zIndex: 50 }}
+      className="pointer-events-none rounded-md border border-border bg-popover p-1 shadow-xl"
+    >
+      <img src={src} alt={`${alt} thumbnail`} className="w-full rounded" />
+    </div>
+  );
+}
+
+function formatMtime(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const date = d.toLocaleDateString(undefined, {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${date} ${time}`;
 }
 
 function formatDuration(seconds: number): string {

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { ApiError, api, type FsListing } from "@/lib/api";
+import { ApiError, api, type FsEntry, type FsListing } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface FolderPickerProps {
@@ -55,21 +55,26 @@ export function FolderPicker({
   const [busy, setBusy] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
-  const load = useCallback(async (next?: string | null) => {
-    setBusy(true);
-    setError(null);
-    try {
-      const data = await api.listFolder(next ?? undefined);
-      setListing(data);
-      setPath(data.path);
-      // Reset multi-file selection when navigating to a new directory.
-      setSelectedFiles(new Set());
-    } catch (e) {
-      setError(e instanceof ApiError ? e.detail : e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  }, []);
+  const wantMetadata = onSelectFiles !== undefined;
+
+  const load = useCallback(
+    async (next?: string | null) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const data = await api.listFolder(next ?? undefined, { probe: wantMetadata });
+        setListing(data);
+        setPath(data.path);
+        // Reset multi-file selection when navigating to a new directory.
+        setSelectedFiles(new Set());
+      } catch (e) {
+        setError(e instanceof ApiError ? e.detail : e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [wantMetadata],
+  );
 
   useEffect(() => {
     void load(initialPath ?? null);
@@ -187,33 +192,33 @@ export function FolderPicker({
               {multiFileMode
                 ? videoEntries.map((entry) => {
                     const checked = selectedFiles.has(entry.name);
+                    const fullPath = path ? joinPath(path, entry.name) : entry.name;
                     return (
-                      <li key={`v-${entry.name}`}>
-                        <label
-                          className={cn(
-                            "flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent/40",
-                            checked && "bg-accent/30",
-                          )}
-                        >
-                          <span className="flex min-w-0 items-center gap-2">
-                            <input
-                              type="checkbox"
-                              className="size-4 accent-primary"
-                              checked={checked}
-                              onChange={() => toggleSelect(entry.name)}
-                              disabled={busy}
-                              aria-label={`Select ${entry.name}`}
-                            />
-                            <Film className="size-4 shrink-0 text-muted-foreground" />
-                            <span className="truncate font-mono text-xs">{entry.name}</span>
-                          </span>
-                          {entry.size_bytes != null ? (
-                            <span className="text-xs text-muted-foreground">
-                              {formatBytes(entry.size_bytes)}
-                            </span>
-                          ) : null}
-                        </label>
-                      </li>
+                      <VideoRowMulti
+                        key={`v-${entry.name}`}
+                        entry={entry}
+                        fullPath={fullPath}
+                        checked={checked}
+                        busy={busy}
+                        onToggle={() => toggleSelect(entry.name)}
+                        onProbed={(duration, thumbnail_url) => {
+                          // Patch the listing in-place so the row remembers
+                          // its on-demand probe result without forcing a
+                          // refresh.
+                          setListing((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  entries: prev.entries.map((e) =>
+                                    e.name === entry.name && e.kind === "video"
+                                      ? { ...e, duration, thumbnail_url }
+                                      : e,
+                                  ),
+                                }
+                              : prev,
+                          );
+                        }}
+                      />
                     );
                   })
                 : null}
@@ -273,6 +278,95 @@ export function FolderPicker({
       </div>
     </div>
   );
+}
+
+function VideoRowMulti({
+  entry,
+  fullPath,
+  checked,
+  busy,
+  onToggle,
+  onProbed,
+}: {
+  entry: FsEntry;
+  fullPath: string;
+  checked: boolean;
+  busy: boolean;
+  onToggle: () => void;
+  onProbed: (duration: number | null, thumbnail_url: string | null) => void;
+}) {
+  const [hover, setHover] = useState(false);
+  const [probing, setProbing] = useState(false);
+
+  const ensureProbe = useCallback(async () => {
+    if (entry.duration != null && entry.thumbnail_url != null) return;
+    if (probing) return;
+    setProbing(true);
+    try {
+      const r = await api.probeFile(fullPath);
+      onProbed(r.duration, r.thumbnail_url);
+    } catch {
+      // Best effort; leave fields null so the row still shows what it can.
+    } finally {
+      setProbing(false);
+    }
+  }, [entry.duration, entry.thumbnail_url, fullPath, onProbed, probing]);
+
+  return (
+    <li
+      onMouseEnter={() => {
+        setHover(true);
+        void ensureProbe();
+      }}
+      onMouseLeave={() => setHover(false)}
+      className="relative"
+    >
+      <label
+        className={cn(
+          "flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent/40",
+          checked && "bg-accent/30",
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={checked}
+            onChange={onToggle}
+            disabled={busy}
+            aria-label={`Select ${entry.name}`}
+          />
+          <Film className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-mono text-xs">{entry.name}</span>
+        </span>
+        <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground tabular-nums">
+          {entry.duration != null ? <span>{formatDuration(entry.duration)}</span> : null}
+          {entry.size_bytes != null ? <span>{formatBytes(entry.size_bytes)}</span> : null}
+        </span>
+      </label>
+      {hover && entry.thumbnail_url ? (
+        <div className="pointer-events-none absolute right-2 top-full z-10 mt-1 rounded-md border border-border bg-popover p-1 shadow-lg">
+          <img
+            src={entry.thumbnail_url}
+            alt={`${entry.name} thumbnail`}
+            className="h-32 rounded"
+          />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "?";
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  }
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 function formatBytes(bytes: number): string {

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -32,16 +32,27 @@ import { cn } from "@/lib/utils";
 interface FolderPickerProps {
   initialPath?: string | null;
   onSelect: (path: string) => void;
+  /** Optional callback for multi-file selection. When provided, video rows
+   * gain a checkbox and the action button switches to "Use N files" when any
+   * files are selected. */
+  onSelectFiles?: (paths: string[]) => void;
   onCancel?: () => void;
   /** Render mode: inline (e.g. inside a card) vs. compact. */
   mode?: "inline" | "compact";
 }
 
-export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" }: FolderPickerProps) {
+export function FolderPicker({
+  initialPath,
+  onSelect,
+  onSelectFiles,
+  onCancel,
+  mode = "inline",
+}: FolderPickerProps) {
   const [listing, setListing] = useState<FsListing | null>(null);
   const [path, setPath] = useState<string | null>(initialPath ?? null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
   const load = useCallback(async (next?: string | null) => {
     setBusy(true);
@@ -50,6 +61,8 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
       const data = await api.listFolder(next ?? undefined);
       setListing(data);
       setPath(data.path);
+      // Reset multi-file selection when navigating to a new directory.
+      setSelectedFiles(new Set());
     } catch (e) {
       setError(e instanceof ApiError ? e.detail : e instanceof Error ? e.message : String(e));
     } finally {
@@ -66,6 +79,29 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
   const dirEntries = listing?.entries.filter((e) => e.kind === "dir") ?? [];
   const videoEntries = listing?.entries.filter((e) => e.kind === "video") ?? [];
   const videosHere = videoEntries.length;
+  const multiFileMode = onSelectFiles !== undefined;
+  const selectedCount = selectedFiles.size;
+
+  const toggleSelect = (name: string) => {
+    setSelectedFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setSelectedFiles(new Set(videoEntries.map((e) => e.name)));
+  };
+
+  const confirmFiles = () => {
+    if (!path || selectedCount === 0) return;
+    const paths = videoEntries
+      .filter((e) => selectedFiles.has(e.name))
+      .map((e) => joinPath(path, e.name));
+    onSelectFiles!(paths);
+  };
 
   return (
     <div
@@ -119,18 +155,14 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
             </div>
           ) : error ? (
             <div className="p-4 text-sm text-destructive">{error}</div>
-          ) : !listing ? null : dirEntries.length === 0 ? (
-            <div className="p-4 text-sm text-muted-foreground">
-              {videosHere > 0
-                ? `No subfolders here. ${videosHere} video${videosHere === 1 ? "" : "s"} ready to scan.`
-                : "Empty folder."}
-            </div>
+          ) : !listing ? null : dirEntries.length === 0 && videoEntries.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground">Empty folder.</div>
           ) : (
-            <ul className="max-h-72 divide-y divide-border overflow-y-auto">
+            <ul className="max-h-80 divide-y divide-border overflow-y-auto">
               {dirEntries.map((entry) => {
                 const childPath = path ? joinPath(path, entry.name) : entry.name;
                 return (
-                  <li key={entry.name}>
+                  <li key={`d-${entry.name}`}>
                     <button
                       type="button"
                       className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
@@ -151,13 +183,46 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
                   </li>
                 );
               })}
+              {multiFileMode
+                ? videoEntries.map((entry) => {
+                    const checked = selectedFiles.has(entry.name);
+                    return (
+                      <li key={`v-${entry.name}`}>
+                        <label
+                          className={cn(
+                            "flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent/40",
+                            checked && "bg-accent/30",
+                          )}
+                        >
+                          <span className="flex min-w-0 items-center gap-2">
+                            <input
+                              type="checkbox"
+                              className="size-4 accent-primary"
+                              checked={checked}
+                              onChange={() => toggleSelect(entry.name)}
+                              disabled={busy}
+                              aria-label={`Select ${entry.name}`}
+                            />
+                            <Film className="size-4 shrink-0 text-muted-foreground" />
+                            <span className="truncate font-mono text-xs">{entry.name}</span>
+                          </span>
+                          {entry.size_bytes != null ? (
+                            <span className="text-xs text-muted-foreground">
+                              {formatBytes(entry.size_bytes)}
+                            </span>
+                          ) : null}
+                        </label>
+                      </li>
+                    );
+                  })
+                : null}
             </ul>
           )}
         </div>
       </div>
 
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {videosHere > 0 ? (
             <span className="inline-flex items-center gap-1">
               <Film className="size-3" />
@@ -166,6 +231,16 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
           ) : (
             <span>No videos directly here. Drill into a subfolder.</span>
           )}
+          {multiFileMode && videosHere > 0 ? (
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 underline-offset-2 hover:underline"
+              onClick={selectedCount === videosHere ? () => setSelectedFiles(new Set()) : selectAll}
+              disabled={busy}
+            >
+              {selectedCount === videosHere ? "Clear selection" : "Select all"}
+            </button>
+          ) : null}
         </div>
         <div className="flex gap-2">
           {onCancel ? (
@@ -173,23 +248,42 @@ export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" 
               Cancel
             </Button>
           ) : null}
-          <Button
-            type="button"
-            disabled={busy || !path || videosHere === 0}
-            onClick={() => path && onSelect(path)}
-            title={
-              videosHere === 0
-                ? "Select a folder that contains video files."
-                : `Use ${path}`
-            }
-          >
-            <FolderOpen />
-            Use this folder
-          </Button>
+          {multiFileMode && selectedCount > 0 ? (
+            <Button type="button" disabled={busy} onClick={confirmFiles}>
+              <FolderOpen />
+              Use {selectedCount} file{selectedCount === 1 ? "" : "s"}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              disabled={busy || !path || videosHere === 0}
+              onClick={() => path && onSelect(path)}
+              title={
+                videosHere === 0
+                  ? "Select a folder that contains video files, or drill in."
+                  : `Use ${path}`
+              }
+            >
+              <FolderOpen />
+              Use this folder
+            </Button>
+          )}
         </div>
       </div>
     </div>
   );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unit]}`;
 }
 
 function PathBar({

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -1,0 +1,269 @@
+/**
+ * FolderPicker — server-side directory browser for selecting a video folder.
+ *
+ * Uses GET /api/fs/list (server has full filesystem access; we don't try to
+ * use the browser's File System Access API because that doesn't expose
+ * server-side absolute paths needed for our symlink workflow).
+ *
+ * UX:
+ *   - Breadcrumb at top, click any segment to jump up
+ *   - Sidebar of bookmarks (last-scanned, ~/Movies, ~/Videos, ~/Downloads, home)
+ *   - Subdirectory list with video counts ("match-day · 7 videos")
+ *   - "Use this folder" confirms the current path
+ *   - Path input visible at top for keyboard / paste workflows
+ *   - Keyboard navigable: Tab through, Enter on a row to drill in
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ChevronRight,
+  Clock,
+  Film,
+  Folder,
+  FolderOpen,
+  Home,
+  Loader2,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ApiError, api, type FsListing } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface FolderPickerProps {
+  initialPath?: string | null;
+  onSelect: (path: string) => void;
+  onCancel?: () => void;
+  /** Render mode: inline (e.g. inside a card) vs. compact. */
+  mode?: "inline" | "compact";
+}
+
+export function FolderPicker({ initialPath, onSelect, onCancel, mode = "inline" }: FolderPickerProps) {
+  const [listing, setListing] = useState<FsListing | null>(null);
+  const [path, setPath] = useState<string | null>(initialPath ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async (next?: string | null) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const data = await api.listFolder(next ?? undefined);
+      setListing(data);
+      setPath(data.path);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.detail : e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(initialPath ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const breadcrumb = useMemo(() => buildBreadcrumb(path), [path]);
+  const dirEntries = listing?.entries.filter((e) => e.kind === "dir") ?? [];
+  const videoEntries = listing?.entries.filter((e) => e.kind === "video") ?? [];
+  const videosHere = videoEntries.length;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border border-border bg-card",
+        mode === "compact" ? "p-3" : "p-4",
+      )}
+    >
+      <PathBar path={path} onChange={(p) => void load(p)} disabled={busy} />
+
+      <div className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground">
+        {breadcrumb.map((seg, i) => (
+          <span key={`${seg.path}-${i}`} className="flex items-center gap-1">
+            {i > 0 ? <ChevronRight className="size-3" /> : null}
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 font-mono text-xs hover:bg-accent hover:text-accent-foreground"
+              onClick={() => void load(seg.path)}
+              disabled={busy}
+            >
+              {seg.label}
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[180px_1fr]">
+        <aside className="flex flex-col gap-1 text-sm">
+          {(listing?.suggested_starts ?? []).slice(0, 6).map((s, i) => (
+            <button
+              key={s}
+              type="button"
+              className={cn(
+                "flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                path === s && "bg-accent text-accent-foreground",
+              )}
+              onClick={() => void load(s)}
+              disabled={busy}
+              title={s}
+            >
+              {i === 0 ? <Clock className="size-3.5" /> : <Home className="size-3.5" />}
+              <span className="truncate text-xs">{s.split("/").filter(Boolean).pop() || "/"}</span>
+            </button>
+          ))}
+        </aside>
+
+        <div className="min-h-[12rem] rounded-md border border-border bg-background">
+          {busy && !listing ? (
+            <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="p-4 text-sm text-destructive">{error}</div>
+          ) : !listing ? null : dirEntries.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground">
+              {videosHere > 0
+                ? `No subfolders here. ${videosHere} video${videosHere === 1 ? "" : "s"} ready to scan.`
+                : "Empty folder."}
+            </div>
+          ) : (
+            <ul className="max-h-72 divide-y divide-border overflow-y-auto">
+              {dirEntries.map((entry) => {
+                const childPath = path ? joinPath(path, entry.name) : entry.name;
+                return (
+                  <li key={entry.name}>
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                      onClick={() => void load(childPath)}
+                      disabled={busy}
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <Folder className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{entry.name}</span>
+                      </span>
+                      {entry.video_count ? (
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <Film className="size-3" />
+                          {entry.video_count}
+                        </span>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs text-muted-foreground">
+          {videosHere > 0 ? (
+            <span className="inline-flex items-center gap-1">
+              <Film className="size-3" />
+              {videosHere} video{videosHere === 1 ? "" : "s"} in this folder
+            </span>
+          ) : (
+            <span>No videos directly here. Drill into a subfolder.</span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {onCancel ? (
+            <Button variant="ghost" type="button" onClick={onCancel} disabled={busy}>
+              Cancel
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            disabled={busy || !path || videosHere === 0}
+            onClick={() => path && onSelect(path)}
+            title={
+              videosHere === 0
+                ? "Select a folder that contains video files."
+                : `Use ${path}`
+            }
+          >
+            <FolderOpen />
+            Use this folder
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PathBar({
+  path,
+  onChange,
+  disabled,
+}: {
+  path: string | null;
+  onChange: (p: string) => void;
+  disabled: boolean;
+}) {
+  const [draft, setDraft] = useState(path ?? "");
+  useEffect(() => {
+    setDraft(path ?? "");
+  }, [path]);
+
+  return (
+    <form
+      className="flex gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (draft.trim()) onChange(draft.trim());
+      }}
+    >
+      <input
+        type="text"
+        className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 py-1 font-mono text-xs shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        placeholder="/path/to/folder"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={disabled}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        aria-label="Folder path"
+      />
+      <Button type="submit" variant="outline" size="sm" disabled={disabled || !draft.trim()}>
+        Go
+      </Button>
+    </form>
+  );
+}
+
+function buildBreadcrumb(path: string | null): { label: string; path: string }[] {
+  if (!path) return [];
+  if (path === "/") return [{ label: "/", path: "/" }];
+  // Windows paths come through as "C:\..." -- treat the drive as the root.
+  const isWin = /^[A-Za-z]:[\\/]/.test(path);
+  const segs: { label: string; path: string }[] = [];
+  if (isWin) {
+    const drive = path.slice(0, 2);
+    segs.push({ label: drive, path: drive + "\\" });
+    const rest = path.slice(3).split(/[\\/]/).filter(Boolean);
+    let acc = drive + "\\";
+    for (const part of rest) {
+      acc = acc.endsWith("\\") ? acc + part : acc + "\\" + part;
+      segs.push({ label: part, path: acc });
+    }
+    return segs;
+  }
+  // POSIX
+  segs.push({ label: "/", path: "/" });
+  const parts = path.split("/").filter(Boolean);
+  let acc = "";
+  for (const p of parts) {
+    acc = `${acc}/${p}`;
+    segs.push({ label: p, path: acc });
+  }
+  return segs;
+}
+
+function joinPath(base: string, child: string): string {
+  if (/^[A-Za-z]:[\\/]/.test(base)) {
+    return base.endsWith("\\") || base.endsWith("/") ? base + child : `${base}\\${child}`;
+  }
+  return base.endsWith("/") ? base + child : `${base}/${child}`;
+}

--- a/src/splitsmith/ui_static/src/components/MarkerGlyph.tsx
+++ b/src/splitsmith/ui_static/src/components/MarkerGlyph.tsx
@@ -1,0 +1,92 @@
+/**
+ * Audit-marker glyph -- color + shape, never color alone.
+ *
+ * Three states are distinguishable for color-blind users by shape, not just
+ * by color, satisfying WCAG 1.4.1 (Use of Color):
+ *
+ *   detected     filled triangle ▼ (default state, "pinned" feel)
+ *   rejected     outline triangle with strikethrough (visually "crossed out")
+ *   manual       filled diamond ◆ with dashed border (different shape entirely)
+ *
+ * Used in:
+ *   - /_design page (visual reference)
+ *   - audit screen waveform overlay (#15)
+ *   - badges and tables anywhere markers are referenced
+ */
+
+import { cn } from "@/lib/utils";
+
+export type MarkerKind = "detected" | "rejected" | "manual";
+
+interface MarkerGlyphProps {
+  kind: MarkerKind;
+  size?: number;
+  className?: string;
+  label?: string;
+}
+
+export function MarkerGlyph({ kind, size = 16, className, label }: MarkerGlyphProps) {
+  const colorVar = `var(--marker-${kind})`;
+  const aria = label ?? kind;
+  const half = size / 2;
+
+  if (kind === "manual") {
+    // Diamond rotated 45° with dashed border.
+    const inset = size * 0.1;
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={aria}
+        className={cn("inline-block shrink-0", className)}
+      >
+        <rect
+          x={inset}
+          y={inset}
+          width={size - inset * 2}
+          height={size - inset * 2}
+          fill={colorVar}
+          stroke={colorVar}
+          strokeWidth={1.5}
+          strokeDasharray="2,1.5"
+          transform={`rotate(45 ${half} ${half})`}
+        />
+      </svg>
+    );
+  }
+
+  // Triangle (filled = detected, outline = rejected).
+  const points = `${half},${size * 0.15} ${size * 0.92},${size * 0.85} ${size * 0.08},${size * 0.85}`;
+  const transform = `rotate(180 ${half} ${half})`;
+  const isOutline = kind === "rejected";
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={aria}
+      className={cn("inline-block shrink-0", className)}
+    >
+      <polygon
+        points={points}
+        transform={transform}
+        fill={isOutline ? "none" : colorVar}
+        stroke={colorVar}
+        strokeWidth={isOutline ? 1.5 : 0.5}
+      />
+      {isOutline ? (
+        <line
+          x1={size * 0.15}
+          y1={size * 0.5}
+          x2={size * 0.85}
+          y2={size * 0.5}
+          stroke={colorVar}
+          strokeWidth={1.5}
+        />
+      ) : null}
+    </svg>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/ThemeToggle.tsx
+++ b/src/splitsmith/ui_static/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/lib/theme";
+
+const NEXT: Record<"light" | "dark" | "system", "light" | "dark" | "system"> = {
+  light: "dark",
+  dark: "system",
+  system: "light",
+};
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const Icon = theme === "dark" ? Moon : theme === "light" ? Sun : Monitor;
+  const label =
+    theme === "dark"
+      ? "Switch to system theme"
+      : theme === "light"
+        ? "Switch to dark mode"
+        : "Switch to light mode";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={label}
+      title={label}
+      onClick={() => setTheme(NEXT[theme])}
+    >
+      <Icon />
+    </Button>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/ui/badge.tsx
+++ b/src/splitsmith/ui_static/src/components/ui/badge.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground",
+        outline: "text-foreground",
+        good: "border-transparent bg-split-good text-split-good-foreground",
+        ok: "border-transparent bg-split-ok text-split-ok-foreground",
+        slow: "border-transparent bg-split-slow text-split-slow-foreground",
+        transition:
+          "border-transparent bg-split-transition text-split-transition-foreground",
+        statusNotStarted:
+          "border-transparent bg-status-not-started/20 text-status-not-started",
+        statusInProgress:
+          "border-transparent bg-status-in-progress/20 text-status-in-progress",
+        statusComplete:
+          "border-transparent bg-status-complete/20 text-status-complete",
+        statusWarning:
+          "border-transparent bg-status-warning/20 text-status-warning",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/splitsmith/ui_static/src/components/ui/button.tsx
+++ b/src/splitsmith/ui_static/src/components/ui/button.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/splitsmith/ui_static/src/components/ui/card.tsx
+++ b/src/splitsmith/ui_static/src/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/src/splitsmith/ui_static/src/components/ui/skeleton.tsx
+++ b/src/splitsmith/ui_static/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -28,6 +28,7 @@ export interface StageEntry {
   scorecard_updated_at: string | null;
   videos: StageVideo[];
   skipped: boolean;
+  placeholder: boolean;
 }
 
 export interface MatchProject {
@@ -37,6 +38,7 @@ export interface MatchProject {
   updated_at: string;
   competitor_name: string | null;
   scoreboard_match_id: string | null;
+  match_date: string | null;
   stages: StageEntry[];
   unassigned_videos: StageVideo[];
   last_scanned_dir: string | null;
@@ -46,11 +48,30 @@ export interface MatchProject {
   exports_dir: string | null;
 }
 
+export interface PlaceholderStagesRequest {
+  stage_count: number;
+  match_name?: string | null;
+  match_date?: string | null;
+}
+
 export interface ProjectSettingsPatch {
   raw_dir?: string | null;
   audio_dir?: string | null;
   trimmed_dir?: string | null;
   exports_dir?: string | null;
+  confirm?: boolean;
+}
+
+export interface NonEmptyOldDir {
+  field: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir";
+  path: string;
+  file_count: number;
+}
+
+export interface NonEmptyOldDirsDetail {
+  code: "non_empty_old_dirs";
+  message: string;
+  dirs: NonEmptyOldDir[];
 }
 
 export interface ScanResponse {
@@ -80,6 +101,7 @@ class ApiError extends Error {
   constructor(
     public status: number,
     public detail: string,
+    public body: unknown = null,
   ) {
     super(`${status}: ${detail}`);
   }
@@ -104,15 +126,18 @@ async function request<T>(
   });
   if (!resp.ok) {
     let detail = resp.statusText;
+    let rawDetail: unknown = null;
     try {
       const body = await resp.json();
       if (body && typeof body === "object" && "detail" in body) {
-        detail = String((body as { detail: unknown }).detail);
+        rawDetail = (body as { detail: unknown }).detail;
+        detail =
+          typeof rawDetail === "string" ? rawDetail : JSON.stringify(rawDetail);
       }
     } catch {
       /* ignore */
     }
-    throw new ApiError(resp.status, detail);
+    throw new ApiError(resp.status, detail, rawDetail);
   }
   if (resp.status === 204) return undefined as T;
   return (await resp.json()) as T;
@@ -130,6 +155,12 @@ export const api = {
     request<MatchProject>("/api/scoreboard/import", {
       method: "POST",
       json: { data, overwrite },
+    }),
+
+  createPlaceholderStages: (req: PlaceholderStagesRequest) =>
+    request<MatchProject>("/api/project/placeholder-stages", {
+      method: "POST",
+      json: req,
     }),
 
   scanVideos: (sourceDir: string, autoAssignPrimary = true) =>

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1,0 +1,118 @@
+/**
+ * Typed client for the splitsmith UI backend.
+ *
+ * Mirrors the Pydantic models in src/splitsmith/ui/project.py and the
+ * endpoint surface in src/splitsmith/ui/server.py. When the backend grows,
+ * extend this file rather than scattering fetch() calls across the SPA.
+ */
+
+export type VideoRole = "primary" | "secondary" | "ignored";
+
+export interface StageVideo {
+  path: string;
+  role: VideoRole;
+  added_at: string;
+  processed: { beep: boolean; shot_detect: boolean; trim: boolean };
+  beep_time: number | null;
+  notes: string;
+}
+
+export interface StageEntry {
+  stage_number: number;
+  stage_name: string;
+  time_seconds: number;
+  scorecard_updated_at: string | null;
+  videos: StageVideo[];
+  skipped: boolean;
+}
+
+export interface MatchProject {
+  schema_version: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  competitor_name: string | null;
+  scoreboard_match_id: string | null;
+  stages: StageEntry[];
+  unassigned_videos: StageVideo[];
+}
+
+export interface ScanResponse {
+  registered: string[];
+  auto_assigned: Record<string, string>;
+  skipped: string[];
+}
+
+class ApiError extends Error {
+  constructor(
+    public status: number,
+    public detail: string,
+  ) {
+    super(`${status}: ${detail}`);
+  }
+}
+
+async function request<T>(
+  path: string,
+  init?: RequestInit & { json?: unknown },
+): Promise<T> {
+  const { json, ...rest } = init ?? {};
+  const headers: HeadersInit = {
+    Accept: "application/json",
+    ...(rest.headers ?? {}),
+  };
+  if (json !== undefined) {
+    (headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  const resp = await fetch(path, {
+    ...rest,
+    headers,
+    body: json !== undefined ? JSON.stringify(json) : rest.body,
+  });
+  if (!resp.ok) {
+    let detail = resp.statusText;
+    try {
+      const body = await resp.json();
+      if (body && typeof body === "object" && "detail" in body) {
+        detail = String((body as { detail: unknown }).detail);
+      }
+    } catch {
+      /* ignore */
+    }
+    throw new ApiError(resp.status, detail);
+  }
+  if (resp.status === 204) return undefined as T;
+  return (await resp.json()) as T;
+}
+
+export const api = {
+  getProject: () => request<MatchProject>("/api/project"),
+
+  importScoreboard: (data: unknown, overwrite = false) =>
+    request<MatchProject>("/api/scoreboard/import", {
+      method: "POST",
+      json: { data, overwrite },
+    }),
+
+  scanVideos: (sourceDir: string, autoAssignPrimary = true) =>
+    request<ScanResponse>("/api/videos/scan", {
+      method: "POST",
+      json: { source_dir: sourceDir, auto_assign_primary: autoAssignPrimary },
+    }),
+
+  moveAssignment: (
+    videoPath: string,
+    toStageNumber: number | null,
+    role: VideoRole = "secondary",
+  ) =>
+    request<MatchProject>("/api/assignments/move", {
+      method: "POST",
+      json: {
+        video_path: videoPath,
+        to_stage_number: toStageNumber,
+        role,
+      },
+    }),
+};
+
+export { ApiError };

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -40,6 +40,17 @@ export interface MatchProject {
   stages: StageEntry[];
   unassigned_videos: StageVideo[];
   last_scanned_dir: string | null;
+  raw_dir: string | null;
+  audio_dir: string | null;
+  trimmed_dir: string | null;
+  exports_dir: string | null;
+}
+
+export interface ProjectSettingsPatch {
+  raw_dir?: string | null;
+  audio_dir?: string | null;
+  trimmed_dir?: string | null;
+  exports_dir?: string | null;
 }
 
 export interface ScanResponse {
@@ -125,6 +136,18 @@ export const api = {
     request<ScanResponse>("/api/videos/scan", {
       method: "POST",
       json: { source_dir: sourceDir, auto_assign_primary: autoAssignPrimary },
+    }),
+
+  scanFiles: (sourcePaths: string[], autoAssignPrimary = true) =>
+    request<ScanResponse>("/api/videos/scan", {
+      method: "POST",
+      json: { source_paths: sourcePaths, auto_assign_primary: autoAssignPrimary },
+    }),
+
+  updateSettings: (patch: ProjectSettingsPatch) =>
+    request<MatchProject>("/api/project/settings", {
+      method: "POST",
+      json: patch,
     }),
 
   moveAssignment: (

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -35,12 +35,30 @@ export interface MatchProject {
   scoreboard_match_id: string | null;
   stages: StageEntry[];
   unassigned_videos: StageVideo[];
+  last_scanned_dir: string | null;
 }
 
 export interface ScanResponse {
   registered: string[];
   auto_assigned: Record<string, string>;
   skipped: string[];
+}
+
+export type FsEntryKind = "dir" | "video" | "file";
+
+export interface FsEntry {
+  name: string;
+  kind: FsEntryKind;
+  video_count: number | null;
+  size_bytes: number | null;
+  mtime: number | null;
+}
+
+export interface FsListing {
+  path: string;
+  parent: string | null;
+  entries: FsEntry[];
+  suggested_starts: string[];
 }
 
 class ApiError extends Error {
@@ -87,6 +105,11 @@ async function request<T>(
 
 export const api = {
   getProject: () => request<MatchProject>("/api/project"),
+
+  listFolder: (path?: string) => {
+    const qs = path ? `?path=${encodeURIComponent(path)}` : "";
+    return request<FsListing>(`/api/fs/list${qs}`);
+  },
 
   importScoreboard: (data: unknown, overwrite = false) =>
     request<MatchProject>("/api/scoreboard/import", {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -46,6 +46,8 @@ export interface MatchProject {
   audio_dir: string | null;
   trimmed_dir: string | null;
   exports_dir: string | null;
+  probes_dir: string | null;
+  thumbs_dir: string | null;
 }
 
 export interface PlaceholderStagesRequest {
@@ -59,11 +61,13 @@ export interface ProjectSettingsPatch {
   audio_dir?: string | null;
   trimmed_dir?: string | null;
   exports_dir?: string | null;
+  probes_dir?: string | null;
+  thumbs_dir?: string | null;
   confirm?: boolean;
 }
 
 export interface NonEmptyOldDir {
-  field: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir";
+  field: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir" | "probes_dir" | "thumbs_dir";
   path: string;
   file_count: number;
 }
@@ -88,6 +92,29 @@ export interface FsEntry {
   video_count: number | null;
   size_bytes: number | null;
   mtime: number | null;
+  duration: number | null;
+  thumbnail_url: string | null;
+}
+
+export interface FsProbeResponse {
+  duration: number | null;
+  thumbnail_url: string | null;
+}
+
+export interface RemovalPlan {
+  video_path: string;
+  raw_link_path: string;
+  audio_cache_path: string | null;
+  trimmed_cache_path: string | null;
+  audit_path: string | null;
+  was_primary: boolean;
+  stage_number: number | null;
+  audit_reset: boolean;
+}
+
+export interface RemoveVideoResponse {
+  project: MatchProject;
+  plan: RemovalPlan;
 }
 
 export interface FsListing {
@@ -146,10 +173,22 @@ async function request<T>(
 export const api = {
   getProject: () => request<MatchProject>("/api/project"),
 
-  listFolder: (path?: string) => {
-    const qs = path ? `?path=${encodeURIComponent(path)}` : "";
-    return request<FsListing>(`/api/fs/list${qs}`);
+  listFolder: (path?: string, opts?: { probe?: boolean }) => {
+    const params = new URLSearchParams();
+    if (path) params.set("path", path);
+    if (opts?.probe) params.set("probe", "true");
+    const qs = params.toString();
+    return request<FsListing>(`/api/fs/list${qs ? `?${qs}` : ""}`);
   },
+
+  probeFile: (path: string) =>
+    request<FsProbeResponse>(`/api/fs/probe?path=${encodeURIComponent(path)}`),
+
+  removeVideo: (videoPath: string, resetAudit = false) =>
+    request<RemoveVideoResponse>("/api/videos/remove", {
+      method: "POST",
+      json: { video_path: videoPath, reset_audit: resetAudit },
+    }),
 
   importScoreboard: (data: unknown, overwrite = false) =>
     request<MatchProject>("/api/scoreboard/import", {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -7,6 +7,7 @@
  */
 
 export type VideoRole = "primary" | "secondary" | "ignored";
+export type BeepSource = "auto" | "manual";
 
 export interface StageVideo {
   path: string;
@@ -14,6 +15,9 @@ export interface StageVideo {
   added_at: string;
   processed: { beep: boolean; shot_detect: boolean; trim: boolean };
   beep_time: number | null;
+  beep_source: BeepSource | null;
+  beep_peak_amplitude: number | null;
+  beep_duration_ms: number | null;
   notes: string;
 }
 
@@ -136,6 +140,20 @@ export const api = {
         role,
       },
     }),
+
+  detectBeep: (stageNumber: number, force = false) =>
+    request<MatchProject>(
+      `/api/stages/${stageNumber}/detect-beep${force ? "?force=true" : ""}`,
+      { method: "POST" },
+    ),
+
+  overrideBeep: (stageNumber: number, beepTime: number | null) =>
+    request<MatchProject>(`/api/stages/${stageNumber}/beep`, {
+      method: "POST",
+      json: { beep_time: beepTime },
+    }),
+
+  stageAudioUrl: (stageNumber: number) => `/api/stages/${stageNumber}/audio`,
 };
 
 export { ApiError };

--- a/src/splitsmith/ui_static/src/lib/theme.tsx
+++ b/src/splitsmith/ui_static/src/lib/theme.tsx
@@ -1,0 +1,88 @@
+/**
+ * Dark/light/system theme provider.
+ *
+ * Defaults to "system" (follows OS prefers-color-scheme). User selection is
+ * persisted in localStorage. Avoids the FOUC by writing the resolved class
+ * synchronously in <App> mount via a useLayoutEffect-equivalent pattern;
+ * for absolute zero flash a small inline script in index.html would help, but
+ * the production UI loads on localhost so the perceptible flash is minimal.
+ */
+
+import * as React from "react";
+
+type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "splitsmith.theme";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolved: "light" | "dark";
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null);
+
+function applyClass(resolved: "light" | "dark") {
+  const root = document.documentElement;
+  if (resolved === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+function resolveTheme(theme: Theme): "light" | "dark" {
+  if (theme !== "system") return theme;
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = React.useState<Theme>(() => {
+    if (typeof window === "undefined") return "system";
+    return (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? "system";
+  });
+  const [resolved, setResolved] = React.useState<"light" | "dark">(() =>
+    resolveTheme(theme)
+  );
+
+  // Apply class on theme change.
+  React.useLayoutEffect(() => {
+    const r = resolveTheme(theme);
+    setResolved(r);
+    applyClass(r);
+  }, [theme]);
+
+  // React to OS-level changes when theme === "system".
+  React.useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      const r = resolveTheme("system");
+      setResolved(r);
+      applyClass(r);
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = React.useCallback((t: Theme) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({ theme, resolved, setTheme }),
+    [theme, resolved, setTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within <ThemeProvider>");
+  return ctx;
+}

--- a/src/splitsmith/ui_static/src/lib/utils.ts
+++ b/src/splitsmith/ui_static/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/splitsmith/ui_static/src/main.tsx
+++ b/src/splitsmith/ui_static/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import "./styles/index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1,0 +1,40 @@
+import { Crosshair } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function Audit() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Audit</h1>
+        <p className="text-sm text-muted-foreground">
+          Multi-video audit screen. Implemented in{" "}
+          <a className="underline" href="https://github.com/mandakan/splitsmith/issues/15">
+            #15
+          </a>
+          . Depends on Sub 5 short-GOP trim (#16) for scrub-friendly playback.
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Crosshair className="size-5" />
+            Placeholder
+          </CardTitle>
+          <CardDescription>
+            The audit screen v2 replaces the existing <code>splitsmith review</code>{" "}
+            SPA inside this shell. Single playback source (video element drives
+            time), real-time scrubbing, multi-video viewing tabs.
+          </CardDescription>
+        </CardHeader>
+        <CardContent />
+      </Card>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Design.tsx
+++ b/src/splitsmith/ui_static/src/pages/Design.tsx
@@ -1,0 +1,332 @@
+/**
+ * /_design — the visual spec for the production UI.
+ *
+ * Per issue #12: "if a component renders correctly here, it renders correctly
+ * in the app." Render every token, every shadcn component, every custom
+ * component on a single scrollable page so visual QA is one page reload away.
+ */
+
+import { Crosshair, Plus, Save, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useTheme } from "@/lib/theme";
+
+const SHADCN_TOKENS = [
+  "background",
+  "foreground",
+  "card",
+  "popover",
+  "primary",
+  "secondary",
+  "muted",
+  "accent",
+  "destructive",
+  "border",
+  "input",
+  "ring",
+];
+
+const SPLIT_TOKENS = [
+  { name: "split-good", label: "Split ≤ 0.25s", fg: "split-good-foreground" },
+  { name: "split-ok", label: "Split 0.25–0.35s", fg: "split-ok-foreground" },
+  { name: "split-slow", label: "Split > 0.35s", fg: "split-slow-foreground" },
+  { name: "split-transition", label: "First / transition / reload", fg: "split-transition-foreground" },
+] as const;
+
+const STATUS_TOKENS = [
+  "status-not-started",
+  "status-in-progress",
+  "status-complete",
+  "status-warning",
+] as const;
+
+const MARKER_TOKENS = ["marker-detected", "marker-rejected", "marker-manual"] as const;
+
+export function Design() {
+  const { theme, resolved, setTheme } = useTheme();
+
+  return (
+    <div className="space-y-12 pb-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Design system</h1>
+        <p className="text-sm text-muted-foreground">
+          Live spec for splitsmith UI v1. Tokens, components, and patterns.
+          Mode: <Badge variant="outline">{theme}</Badge>{" "}
+          (resolved: <Badge variant="outline">{resolved}</Badge>).
+        </p>
+        <div className="flex gap-2 pt-2">
+          <Button size="sm" variant={theme === "light" ? "default" : "outline"} onClick={() => setTheme("light")}>
+            Light
+          </Button>
+          <Button size="sm" variant={theme === "dark" ? "default" : "outline"} onClick={() => setTheme("dark")}>
+            Dark
+          </Button>
+          <Button size="sm" variant={theme === "system" ? "default" : "outline"} onClick={() => setTheme("system")}>
+            System
+          </Button>
+        </div>
+      </header>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section
+        title="Color tokens — shadcn semantic"
+        description="The standard shadcn palette. Exposed as Tailwind utility classes (bg-primary, text-muted-foreground, etc.)."
+      >
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          {SHADCN_TOKENS.map((t) => (
+            <ColorSwatch key={t} name={t} />
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title="Color tokens — splits"
+        description="Match fcpxml_gen.py hex values. Same shot rendered green here is the same shot rendered green in Final Cut Pro."
+      >
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {SPLIT_TOKENS.map((t) => (
+            <div
+              key={t.name}
+              className={`rounded-lg border border-border p-4 bg-${t.name} text-${t.fg}`}
+              style={{ backgroundColor: `var(--${t.name})`, color: `var(--${t.fg})` }}
+            >
+              <div className="font-mono text-xs opacity-90">--{t.name}</div>
+              <div className="text-base font-semibold">{t.label}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title="Color tokens — status & markers"
+        description="Stage status and audit-marker colors. Used in the overview, ingest, and audit screens."
+      >
+        <div>
+          <h3 className="mb-2 text-sm font-medium">Status</h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {STATUS_TOKENS.map((t) => (
+              <ColorSwatch key={t} name={t} />
+            ))}
+          </div>
+        </div>
+        <div className="mt-6">
+          <h3 className="mb-2 text-sm font-medium">Markers</h3>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {MARKER_TOKENS.map((t) => (
+              <ColorSwatch key={t} name={t} />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Typography" description="Inter for sans, JetBrains Mono for time displays.">
+        <div className="space-y-2">
+          <p className="text-3xl font-semibold tracking-tight">3xl Heading — Inter</p>
+          <p className="text-2xl font-semibold tracking-tight">2xl Heading</p>
+          <p className="text-xl font-medium">xl Title</p>
+          <p className="text-lg">lg Subtitle</p>
+          <p className="text-base">Base body. The quick brown fox jumps over the lazy dog.</p>
+          <p className="text-sm text-muted-foreground">sm muted. Used for help text and captions.</p>
+          <p className="text-xs text-muted-foreground">xs muted. Used sparingly for timestamps and metadata.</p>
+          <p className="font-mono text-base tabular-nums">
+            00:14.732 — JetBrains Mono with tabular-nums
+          </p>
+          <p className="font-mono text-sm tabular-nums">
+            shot 7 / 14 · split 0.213s · confidence 0.624
+          </p>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Buttons" description="All variants and sizes.">
+        <div className="space-y-4">
+          <Row>
+            <Button>Default</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="destructive">Destructive</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="link">Link</Button>
+          </Row>
+          <Row>
+            <Button size="sm">Small</Button>
+            <Button>Default</Button>
+            <Button size="lg">Large</Button>
+            <Button size="icon" aria-label="Add">
+              <Plus />
+            </Button>
+            <Button size="icon" variant="destructive" aria-label="Delete">
+              <Trash2 />
+            </Button>
+          </Row>
+          <Row>
+            <Button>
+              <Save />
+              With icon
+            </Button>
+            <Button variant="outline">
+              <Crosshair />
+              With icon (outline)
+            </Button>
+            <Button disabled>Disabled</Button>
+          </Row>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Badges" description="Status, splits, and generic.">
+        <div className="space-y-4">
+          <Row>
+            <Badge>Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+            <Badge variant="outline">Outline</Badge>
+          </Row>
+          <Row>
+            <Badge variant="good">0.21s</Badge>
+            <Badge variant="ok">0.31s</Badge>
+            <Badge variant="slow">0.42s</Badge>
+            <Badge variant="transition">draw / 1.42s</Badge>
+          </Row>
+          <Row>
+            <Badge variant="statusNotStarted">Not started</Badge>
+            <Badge variant="statusInProgress">In progress</Badge>
+            <Badge variant="statusComplete">Complete</Badge>
+            <Badge variant="statusWarning">Needs attention</Badge>
+          </Row>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Cards" description="The default container pattern.">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Stage 3 — Per told me to do it</CardTitle>
+              <CardDescription>14.74s · 14 shots audited</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Primary video</span>
+                <span className="font-mono text-xs">VID_20260426_162417.mp4</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Beep</span>
+                <span className="font-mono tabular-nums">12.453s</span>
+              </div>
+              <div className="flex gap-2 pt-2">
+                <Badge variant="statusComplete">Audited</Badge>
+                <Badge variant="outline">2 angles</Badge>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Loading state</CardTitle>
+              <CardDescription>Skeleton lines for incoming data.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-4 w-2/3" />
+            </CardContent>
+          </Card>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Marker glyphs" description="Audit waveform markers, side-by-side for contrast checks.">
+        <div className="rounded-lg border border-border bg-muted/30 p-6">
+          <div className="flex items-end gap-8">
+            <Marker label="Detected" color="marker-detected" />
+            <Marker label="Manual" color="marker-manual" dashed />
+            <Marker label="Rejected" color="marker-rejected" rejected />
+          </div>
+        </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Motion" description="Hover transitions and reduced-motion behavior.">
+        <p className="text-sm text-muted-foreground">
+          Hover the buttons above. Transitions are 150ms ease-out. Respects{" "}
+          <code>prefers-reduced-motion</code>.
+        </p>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap items-center gap-2">{children}</div>;
+}
+
+function ColorSwatch({ name }: { name: string }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div
+        className="h-16 w-full"
+        style={{ backgroundColor: `var(--${name})` }}
+      />
+      <div className="px-3 py-2">
+        <div className="font-mono text-xs">--{name}</div>
+      </div>
+    </div>
+  );
+}
+
+function Marker({
+  label,
+  color,
+  dashed,
+  rejected,
+}: {
+  label: string;
+  color: string;
+  dashed?: boolean;
+  rejected?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="h-16 w-1.5 rounded-sm"
+        style={{
+          backgroundColor: `var(--${color})`,
+          opacity: rejected ? 0.5 : 1,
+          borderLeft: dashed ? "2px dashed currentColor" : undefined,
+          textDecoration: rejected ? "line-through" : undefined,
+        }}
+      />
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Design.tsx
+++ b/src/splitsmith/ui_static/src/pages/Design.tsx
@@ -6,8 +6,9 @@
  * component on a single scrollable page so visual QA is one page reload away.
  */
 
-import { Crosshair, Plus, Save, Trash2 } from "lucide-react";
+import { Check, Crosshair, Eye, Plus, Save, Trash2 } from "lucide-react";
 
+import { MarkerGlyph } from "@/components/MarkerGlyph";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,10 +37,30 @@ const SHADCN_TOKENS = [
 ];
 
 const SPLIT_TOKENS = [
-  { name: "split-good", label: "Split ≤ 0.25s", fg: "split-good-foreground" },
-  { name: "split-ok", label: "Split 0.25–0.35s", fg: "split-ok-foreground" },
-  { name: "split-slow", label: "Split > 0.35s", fg: "split-slow-foreground" },
-  { name: "split-transition", label: "First / transition / reload", fg: "split-transition-foreground" },
+  {
+    name: "split-good",
+    label: "Split ≤ 0.25s",
+    fg: "split-good-foreground",
+    note: "Okabe-Ito bluish green · 3.4:1 on white (AA UI)",
+  },
+  {
+    name: "split-ok",
+    label: "Split 0.25–0.35s",
+    fg: "split-ok-foreground",
+    note: "Okabe-Ito yellow · paired with dark fg for AA text",
+  },
+  {
+    name: "split-slow",
+    label: "Split > 0.35s",
+    fg: "split-slow-foreground",
+    note: "Okabe-Ito vermillion · 4.0:1 on white (AA UI)",
+  },
+  {
+    name: "split-transition",
+    label: "First / transition / reload",
+    fg: "split-transition-foreground",
+    note: "Okabe-Ito blue · 5.5:1 on white (AA text)",
+  },
 ] as const;
 
 const STATUS_TOKENS = [
@@ -89,18 +110,19 @@ export function Design() {
       </Section>
 
       <Section
-        title="Color tokens — splits"
-        description="Match fcpxml_gen.py hex values. Same shot rendered green here is the same shot rendered green in Final Cut Pro."
+        title="Color tokens — splits (Okabe-Ito, color-blind safe)"
+        description="Distinguishable under deuteranopia, protanopia, and tritanopia. fcpxml_gen.py emits band names ([GREEN]/[YELLOW]/[RED]/[BLUE]) as text only -- FCP renders marker color from FCP-side settings, so changing in-app palette has no effect on FCP output."
       >
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {SPLIT_TOKENS.map((t) => (
             <div
               key={t.name}
-              className={`rounded-lg border border-border p-4 bg-${t.name} text-${t.fg}`}
+              className="rounded-lg border border-border p-4"
               style={{ backgroundColor: `var(--${t.name})`, color: `var(--${t.fg})` }}
             >
-              <div className="font-mono text-xs opacity-90">--{t.name}</div>
+              <div className="font-mono text-xs opacity-80">--{t.name}</div>
               <div className="text-base font-semibold">{t.label}</div>
+              <div className="mt-1 text-xs opacity-80">{t.note}</div>
             </div>
           ))}
         </div>
@@ -199,10 +221,18 @@ export function Design() {
             <Badge variant="transition">draw / 1.42s</Badge>
           </Row>
           <Row>
-            <Badge variant="statusNotStarted">Not started</Badge>
-            <Badge variant="statusInProgress">In progress</Badge>
-            <Badge variant="statusComplete">Complete</Badge>
-            <Badge variant="statusWarning">Needs attention</Badge>
+            <Badge variant="statusNotStarted" className="gap-1">
+              ○ Not started
+            </Badge>
+            <Badge variant="statusInProgress" className="gap-1">
+              ◐ In progress
+            </Badge>
+            <Badge variant="statusComplete" className="gap-1">
+              ● Complete
+            </Badge>
+            <Badge variant="statusWarning" className="gap-1">
+              ▲ Needs attention
+            </Badge>
           </Row>
         </div>
       </Section>
@@ -245,14 +275,144 @@ export function Design() {
       </Section>
 
       {/* ------------------------------------------------------------------ */}
-      <Section title="Marker glyphs" description="Audit waveform markers, side-by-side for contrast checks.">
+      <Section
+        title="Marker glyphs — color + shape"
+        description="Audit waveform markers. Each state has a distinct shape so users with color vision deficiencies can tell them apart without color cues. WCAG 1.4.1 (Use of Color)."
+      >
         <div className="rounded-lg border border-border bg-muted/30 p-6">
-          <div className="flex items-end gap-8">
-            <Marker label="Detected" color="marker-detected" />
-            <Marker label="Manual" color="marker-manual" dashed />
-            <Marker label="Rejected" color="marker-rejected" rejected />
+          <div className="grid grid-cols-3 gap-6">
+            <MarkerSpec
+              kind="detected"
+              title="Detected"
+              note="Filled triangle. Detector candidate the user accepted. Default state."
+            />
+            <MarkerSpec
+              kind="rejected"
+              title="Rejected"
+              note="Outline triangle with strikethrough. Detector candidate the user dropped."
+            />
+            <MarkerSpec
+              kind="manual"
+              title="Manual"
+              note="Dashed diamond. User-added shot the detector missed."
+            />
           </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            All three shapes are recognisable at 12px and at 32px, in light and
+            dark mode, and under simulated deuteranopia / protanopia / tritanopia.
+          </p>
         </div>
+      </Section>
+
+      {/* ------------------------------------------------------------------ */}
+      <Section
+        title="Accessibility"
+        description="WCAG 2.2 Level AA target. The locked commitments and audit checklist for the production UI."
+      >
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Eye className="size-5" />
+                Color is never the only signal
+              </CardTitle>
+              <CardDescription>WCAG 1.4.1 Use of Color</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center gap-2">
+                <MarkerGlyph kind="detected" />
+                <span>Shape encodes meaning, color reinforces it.</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant="good" className="gap-1">
+                  <Check className="size-3" /> 0.21s
+                </Badge>
+                <span>Split badges pair color with the value (text).</span>
+              </div>
+              <p className="text-muted-foreground">
+                Status badges, marker glyphs, and split colors all carry a
+                non-color signal (icon, shape, or text).
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Color-blind safety — Okabe-Ito</CardTitle>
+              <CardDescription>
+                Empirically distinguishable across the three common
+                dichromacies.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
+                <li>
+                  <span className="text-foreground">Deuteranopia / -anomaly</span>{" "}
+                  (most common, ~6% of men): bluish green vs vermillion stay
+                  distinct.
+                </li>
+                <li>
+                  <span className="text-foreground">Protanopia / -anomaly</span>:
+                  same — vermillion shifts but still differs from bluish green.
+                </li>
+                <li>
+                  <span className="text-foreground">Tritanopia / -anomaly</span>{" "}
+                  (rare): yellow vs blue separation handled by the palette
+                  choice.
+                </li>
+                <li>
+                  <span className="text-foreground">Achromatopsia</span>{" "}
+                  (greyscale): rely on shapes + text labels.
+                </li>
+              </ul>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Contrast</CardTitle>
+              <CardDescription>WCAG 1.4.3 + 1.4.11</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                Body text ≥ 4.5:1 against background. UI components (icons,
+                borders, button outlines) ≥ 3:1.
+              </p>
+              <p>
+                Split colors meet at-least UI contrast against their containing
+                surface; foreground text on each split swatch is paired for
+                ≥ 4.5:1 (white on vermillion / blue / bluish green; near-black
+                on yellow).
+              </p>
+              <p>
+                shadcn semantic tokens are AA-clean by default in both light and
+                dark mode.
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Keyboard &amp; reduced motion</CardTitle>
+              <CardDescription>WCAG 2.1 + 2.3.3</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                Every interactive control reachable by Tab. Focus rings visible
+                in both light and dark mode (shadcn default).
+              </p>
+              <p>
+                <code>prefers-reduced-motion</code> reduces all transitions to
+                near-zero (see Motion section above).
+              </p>
+              <p>
+                Marker drag in the audit screen has keyboard equivalents
+                (arrows step, Enter accepts) — see #15.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Full audit checklist tracked separately. The Accessibility tracking
+          issue lists the per-screen items.
+        </p>
       </Section>
 
       {/* ------------------------------------------------------------------ */}
@@ -304,29 +464,26 @@ function ColorSwatch({ name }: { name: string }) {
   );
 }
 
-function Marker({
-  label,
-  color,
-  dashed,
-  rejected,
+function MarkerSpec({
+  kind,
+  title,
+  note,
 }: {
-  label: string;
-  color: string;
-  dashed?: boolean;
-  rejected?: boolean;
+  kind: "detected" | "rejected" | "manual";
+  title: string;
+  note: string;
 }) {
   return (
-    <div className="flex flex-col items-center gap-2">
-      <div
-        className="h-16 w-1.5 rounded-sm"
-        style={{
-          backgroundColor: `var(--${color})`,
-          opacity: rejected ? 0.5 : 1,
-          borderLeft: dashed ? "2px dashed currentColor" : undefined,
-          textDecoration: rejected ? "line-through" : undefined,
-        }}
-      />
-      <span className="text-xs text-muted-foreground">{label}</span>
+    <div className="flex flex-col items-center gap-2 text-center">
+      <div className="flex items-end gap-3">
+        <MarkerGlyph kind={kind} size={32} />
+        <MarkerGlyph kind={kind} size={20} />
+        <MarkerGlyph kind={kind} size={12} />
+      </div>
+      <div>
+        <div className="text-sm font-medium">{title}</div>
+        <div className="text-xs text-muted-foreground">{note}</div>
+      </div>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1,0 +1,40 @@
+import { FileBarChart } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function Export() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Analysis &amp; Export</h1>
+        <p className="text-sm text-muted-foreground">
+          Per-stage shot table, anomalies, output toggles, regenerate. Implemented in{" "}
+          <a className="underline" href="https://github.com/mandakan/splitsmith/issues/17">
+            #17
+          </a>
+          .
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileBarChart className="size-5" />
+            Placeholder
+          </CardTitle>
+          <CardDescription>
+            Wraps existing <code>csv_gen.py</code>, <code>fcpxml_gen.py</code>,{" "}
+            <code>report.py</code> with a UI; produces files identical to today's
+            CLI output.
+          </CardDescription>
+        </CardHeader>
+        <CardContent />
+      </Card>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -1,0 +1,84 @@
+import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Health {
+  status: string;
+  project_name: string;
+  project_root: string;
+  schema_version: number;
+}
+
+export function Home() {
+  const [health, setHealth] = useState<Health | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/health")
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(r.statusText))))
+      .then(setHealth)
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Match overview</h1>
+        <p className="text-sm text-muted-foreground">
+          Welcome. This is the v1 shell — ingest, audit and export screens
+          land in their own sub-issues (#13, #15, #17).
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Project</CardTitle>
+          <CardDescription>
+            Loaded from <code>project.json</code> at the path passed to{" "}
+            <code>splitsmith ui --project</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error ? (
+            <p className="text-sm text-destructive">Failed to load: {error}</p>
+          ) : !health ? (
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          ) : (
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1 text-sm">
+              <dt className="text-muted-foreground">Name</dt>
+              <dd className="font-medium">{health.project_name}</dd>
+              <dt className="text-muted-foreground">Root</dt>
+              <dd className="font-mono text-xs">{health.project_root}</dd>
+              <dt className="text-muted-foreground">Schema</dt>
+              <dd className="font-mono text-xs">v{health.schema_version}</dd>
+            </dl>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap gap-2">
+        <Button asChild>
+          <Link to="/ingest">Go to ingest</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link to="/audit">Open audit</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to="/_design">View design system</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -54,6 +54,10 @@ export function Ingest() {
   const [project, setProject] = useState<MatchProject | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<{
+    video: StageVideo;
+    stage: StageEntry | null;
+  } | null>(null);
 
   const reload = useCallback(async () => {
     try {
@@ -152,6 +156,20 @@ export function Ingest() {
     }
   };
 
+  const handleRemove = async (videoPath: string, resetAudit: boolean) => {
+    setBusy(true);
+    try {
+      const resp = await api.removeVideo(videoPath, resetAudit);
+      setProject(resp.project);
+      setRemoveTarget(null);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const move = async (videoPath: string, toStage: number | null, role: VideoRole) => {
     setBusy(true);
     try {
@@ -234,6 +252,7 @@ export function Ingest() {
             project={project}
             busy={busy}
             onAssign={(path, stage, role) => move(path, stage, role)}
+            onRemove={(video, stage) => setRemoveTarget({ video, stage })}
           />
           <StagesSection
             project={project}
@@ -242,8 +261,18 @@ export function Ingest() {
             setError={setError}
             onProjectUpdate={setProject}
             onMove={move}
+            onRemove={(video, stage) => setRemoveTarget({ video, stage })}
           />
         </>
+      ) : null}
+
+      {removeTarget ? (
+        <RemoveVideoDialog
+          target={removeTarget}
+          busy={busy}
+          onCancel={() => setRemoveTarget(null)}
+          onConfirm={(resetAudit) => handleRemove(removeTarget.video.path, resetAudit)}
+        />
       ) : null}
     </div>
   );
@@ -529,12 +558,20 @@ function SettingsSection({
   onProjectUpdate: (p: MatchProject) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [pickerFor, setPickerFor] = useState<null | "raw" | "audio" | "trimmed" | "exports">(null);
-  const fields: { key: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir"; label: string; help: string }[] = [
+  const [pickerFor, setPickerFor] = useState<
+    null | "raw" | "audio" | "trimmed" | "exports" | "probes" | "thumbs"
+  >(null);
+  const fields: {
+    key: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir" | "probes_dir" | "thumbs_dir";
+    label: string;
+    help: string;
+  }[] = [
     { key: "raw_dir", label: "Source video links", help: "Symlinks to source files (default: <project>/raw)." },
     { key: "audio_dir", label: "Audio cache", help: "Extracted WAVs (default: <project>/audio). Heavy intermediate; SSD-friendly." },
     { key: "trimmed_dir", label: "Trimmed clips", help: "Short-GOP MP4s used by the audit screen (default: <project>/trimmed)." },
     { key: "exports_dir", label: "Outputs", help: "CSV / FCPXML / report (default: <project>/exports)." },
+    { key: "probes_dir", label: "ffprobe cache", help: "Cached duration / codec metadata (default: <project>/probes)." },
+    { key: "thumbs_dir", label: "Thumbnail cache", help: "Cached preview JPGs (default: <project>/thumbs)." },
   ];
   const labelFor = (field: string) =>
     fields.find((f) => f.key === field)?.label ?? field;
@@ -635,7 +672,13 @@ function SettingsSection({
                       disabled={busy}
                       onClick={() =>
                         setPickerFor(
-                          key.replace("_dir", "") as "raw" | "audio" | "trimmed" | "exports",
+                          key.replace("_dir", "") as
+                            | "raw"
+                            | "audio"
+                            | "trimmed"
+                            | "exports"
+                            | "probes"
+                            | "thumbs",
                         )
                       }
                     >
@@ -684,10 +727,12 @@ function UnassignedSection({
   project,
   busy,
   onAssign,
+  onRemove,
 }: {
   project: MatchProject;
   busy: boolean;
   onAssign: (videoPath: string, stage: number | null, role: VideoRole) => void;
+  onRemove: (video: StageVideo, stage: StageEntry | null) => void;
 }) {
   if (project.unassigned_videos.length === 0) return null;
   return (
@@ -698,7 +743,9 @@ function UnassignedSection({
           Unassigned videos · {project.unassigned_videos.length}
         </CardTitle>
         <CardDescription>
-          Drag onto a stage, or use the menu to pick a stage.
+          Drag onto a stage, or use the menu to pick a stage. Trash removes the
+          video from the project (cache is cleared; the original source on USB
+          / external storage is never touched).
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2">
@@ -728,8 +775,9 @@ function UnassignedSection({
                 size="sm"
                 variant="ghost"
                 disabled={busy}
-                onClick={() => onAssign(v.path, null, "secondary")}
-                title="Mark as ignored (warmup, neighbour bay, etc.)"
+                onClick={() => onRemove(v, null)}
+                title="Remove from project"
+                aria-label={`Remove ${v.path}`}
               >
                 <Trash2 />
               </Button>
@@ -748,6 +796,7 @@ function StagesSection({
   setError,
   onProjectUpdate,
   onMove,
+  onRemove,
 }: {
   project: MatchProject;
   busy: boolean;
@@ -755,6 +804,7 @@ function StagesSection({
   setError: (msg: string | null) => void;
   onProjectUpdate: (next: MatchProject) => void;
   onMove: (path: string, stage: number | null, role: VideoRole) => void;
+  onRemove: (video: StageVideo, stage: StageEntry) => void;
 }) {
   if (project.stages.length === 0) return null;
 
@@ -785,6 +835,7 @@ function StagesSection({
             setError={setError}
             onProjectUpdate={onProjectUpdate}
             onMove={onMove}
+            onRemove={onRemove}
           />
         ))}
       </div>
@@ -801,6 +852,7 @@ function StageCard({
   setError,
   onProjectUpdate,
   onMove,
+  onRemove,
 }: {
   stage: StageEntry;
   allStages: StageEntry[];
@@ -810,6 +862,7 @@ function StageCard({
   setError: (msg: string | null) => void;
   onProjectUpdate: (next: MatchProject) => void;
   onMove: (path: string, stage: number | null, role: VideoRole) => void;
+  onRemove: (video: StageVideo, stage: StageEntry) => void;
 }) {
   const primary = stage.videos.find((v) => v.role === "primary");
   const secondaries = stage.videos.filter((v) => v.role === "secondary");
@@ -858,6 +911,7 @@ function StageCard({
                   busy={busy}
                   currentRole="primary"
                   onMove={onMove}
+                  onRemove={onRemove}
                 />
               }
             />
@@ -884,6 +938,7 @@ function StageCard({
                 busy={busy}
                 currentRole="secondary"
                 onMove={onMove}
+                onRemove={onRemove}
               />
             }
           />
@@ -905,6 +960,7 @@ function StageCard({
                 busy={busy}
                 currentRole="ignored"
                 onMove={onMove}
+                onRemove={onRemove}
               />
             }
           />
@@ -956,6 +1012,7 @@ function RoleActions({
   busy,
   currentRole,
   onMove,
+  onRemove,
 }: {
   video: StageVideo;
   stage: StageEntry;
@@ -963,6 +1020,7 @@ function RoleActions({
   busy: boolean;
   currentRole: VideoRole;
   onMove: (path: string, stage: number | null, role: VideoRole) => void;
+  onRemove: (video: StageVideo, stage: StageEntry) => void;
 }) {
   return (
     <>
@@ -1019,7 +1077,120 @@ function RoleActions({
             ))}
         </select>
       ) : null}
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={busy}
+        onClick={() => onRemove(video, stage)}
+        title="Remove from project (clears caches; source on disk is untouched)"
+        aria-label={`Remove ${video.path}`}
+      >
+        <Trash2 />
+      </Button>
     </>
+  );
+}
+
+function RemoveVideoDialog({
+  target,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  target: { video: StageVideo; stage: StageEntry | null };
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (resetAudit: boolean) => void;
+}) {
+  const { video, stage } = target;
+  const filename = video.path.split("/").pop() ?? video.path;
+  const isPrimary = video.role === "primary" && stage !== null;
+  const hasAudit = video.processed.beep || video.processed.shot_detect || video.processed.trim;
+  const offerAuditChoice = isPrimary && hasAudit;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="remove-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-4"
+      onClick={onCancel}
+    >
+      <Card
+        className="w-full max-w-lg shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle id="remove-dialog-title" className="flex items-center gap-2">
+            <Trash2 className="size-5" />
+            Remove video
+          </CardTitle>
+          <CardDescription>
+            <span className="font-mono text-xs">{filename}</span>
+            {stage ? (
+              <>
+                {" "}
+                from Stage {stage.stage_number}: {stage.stage_name}
+              </>
+            ) : (
+              " (unassigned)"
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p>
+            The symlink in the project's <code>raw/</code> folder is removed
+            and any cached audio / trimmed clip for this video is cleared.{" "}
+            <strong>The original source file is never touched.</strong>
+          </p>
+          {offerAuditChoice ? (
+            <div className="rounded-md border border-status-warning/40 bg-status-warning/10 p-3 text-xs">
+              <p className="mb-2 font-semibold">
+                Stage {stage!.stage_number} has audit data.
+              </p>
+              <p>
+                <em>Keep audit</em> preserves detected beep / shot times so you
+                can re-ingest a different file for this stage and pick up
+                where you left off.{" "}
+                <em>Reset audit</em> wipes the stage audit JSON and clears the
+                processed flags.
+              </p>
+            </div>
+          ) : null}
+          <div className="flex flex-wrap justify-end gap-2 pt-2">
+            <Button variant="ghost" disabled={busy} onClick={onCancel}>
+              Cancel
+            </Button>
+            {offerAuditChoice ? (
+              <>
+                <Button
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => onConfirm(false)}
+                >
+                  Remove, keep audit
+                </Button>
+                <Button
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => onConfirm(true)}
+                >
+                  Remove and reset audit
+                </Button>
+              </>
+            ) : (
+              <Button
+                variant="destructive"
+                disabled={busy}
+                onClick={() => onConfirm(false)}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -100,6 +100,19 @@ export function Ingest() {
     }
   };
 
+  const handleScanFiles = async (sourcePaths: string[]) => {
+    setBusy(true);
+    try {
+      await api.scanFiles(sourcePaths, true);
+      await reload();
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const move = async (videoPath: string, toStage: number | null, role: VideoRole) => {
     setBusy(true);
     try {
@@ -152,7 +165,12 @@ export function Ingest() {
         disabled={busy || !project || project.stages.length === 0}
         initialPath={project?.last_scanned_dir ?? null}
         onScan={handleScan}
+        onScanFiles={handleScanFiles}
       />
+
+      {project ? (
+        <SettingsSection project={project} busy={busy} setBusy={setBusy} setError={setError} onProjectUpdate={setProject} />
+      ) : null}
 
       {project ? (
         <>
@@ -223,10 +241,12 @@ function ScanSection({
   disabled,
   initialPath,
   onScan,
+  onScanFiles,
 }: {
   disabled: boolean;
   initialPath: string | null;
   onScan: (sourceDir: string) => void;
+  onScanFiles: (sourcePaths: string[]) => void;
 }) {
   const [open, setOpen] = useState(false);
   return (
@@ -234,12 +254,13 @@ function ScanSection({
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <FolderInput className="size-5" />
-          Scan video folder
+          Scan videos
         </CardTitle>
         <CardDescription>
-          Pick a folder containing the match's MP4/MOV files. Videos are
-          symlinked into <code>&lt;project&gt;/raw/</code> — nothing is uploaded.
-          Confident matches are auto-assigned as primary.
+          Pick a folder to scan in bulk, or check specific files (e.g. straight
+          off your camera over USB). Source files are <em>referenced via
+          symlink</em> — splitsmith never copies them. Confident timestamp
+          matches are auto-assigned as primary.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -247,7 +268,7 @@ function ScanSection({
           <div className="flex flex-wrap items-center gap-2">
             <Button disabled={disabled} onClick={() => setOpen(true)}>
               <FolderInput />
-              Browse for folder
+              Browse / pick files
             </Button>
             {initialPath ? (
               <>
@@ -272,6 +293,10 @@ function ScanSection({
               setOpen(false);
               onScan(p);
             }}
+            onSelectFiles={(paths) => {
+              setOpen(false);
+              onScanFiles(paths);
+            }}
             onCancel={() => setOpen(false)}
           />
         )}
@@ -281,6 +306,130 @@ function ScanSection({
           </p>
         ) : null}
       </CardContent>
+    </Card>
+  );
+}
+
+function SettingsSection({
+  project,
+  busy,
+  setBusy,
+  setError,
+  onProjectUpdate,
+}: {
+  project: MatchProject;
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+  onProjectUpdate: (p: MatchProject) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [pickerFor, setPickerFor] = useState<null | "raw" | "audio" | "trimmed" | "exports">(null);
+  const fields: { key: "raw_dir" | "audio_dir" | "trimmed_dir" | "exports_dir"; label: string; help: string }[] = [
+    { key: "raw_dir", label: "Source video links", help: "Symlinks to source files (default: <project>/raw)." },
+    { key: "audio_dir", label: "Audio cache", help: "Extracted WAVs (default: <project>/audio). Heavy intermediate; SSD-friendly." },
+    { key: "trimmed_dir", label: "Trimmed clips", help: "Short-GOP MP4s used by the audit screen (default: <project>/trimmed)." },
+    { key: "exports_dir", label: "Outputs", help: "CSV / FCPXML / report (default: <project>/exports)." },
+  ];
+  const update = async (patch: Partial<Record<typeof fields[number]["key"], string | null>>) => {
+    setBusy(true);
+    try {
+      const updated = await api.updateSettings(patch);
+      onProjectUpdate(updated);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="cursor-pointer" onClick={() => setExpanded((v) => !v)}>
+        <CardTitle className="flex items-center justify-between gap-2 text-base">
+          <span className="flex items-center gap-2">
+            <FolderInput className="size-4" />
+            Project storage
+          </span>
+          <span className="text-xs font-normal text-muted-foreground">
+            {expanded ? "Hide" : "Configure paths"}
+          </span>
+        </CardTitle>
+        <CardDescription>
+          Source videos are <em>never copied</em>; the project just references
+          them. Cache and outputs default to subfolders of the project root —
+          override them per project if you want heavy intermediates on a scratch
+          SSD or outputs next to your FCP library.
+        </CardDescription>
+      </CardHeader>
+      {expanded ? (
+        <CardContent className="space-y-3">
+          {fields.map(({ key, label, help }) => {
+            const current = project[key] ?? "";
+            return (
+              <div key={key} className="space-y-1">
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="font-medium">{label}</span>
+                  <span className="text-xs text-muted-foreground">{help}</span>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      defaultValue={current}
+                      placeholder={`<project>/${key.replace("_dir", "")}`}
+                      className="flex h-8 flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      disabled={busy}
+                      onBlur={(e) => {
+                        const value = e.target.value.trim();
+                        if (value === (project[key] ?? "")) return;
+                        void update({ [key]: value || "" } as never);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                      }}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() =>
+                        setPickerFor(
+                          key.replace("_dir", "") as "raw" | "audio" | "trimmed" | "exports",
+                        )
+                      }
+                    >
+                      Browse
+                    </Button>
+                    {current ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => void update({ [key]: "" } as never)}
+                        title="Reset to default (subfolder of project root)"
+                      >
+                        Reset
+                      </Button>
+                    ) : null}
+                  </div>
+                </label>
+              </div>
+            );
+          })}
+          {pickerFor ? (
+            <FolderPicker
+              initialPath={project[`${pickerFor}_dir` as keyof MatchProject] as string | null}
+              onSelect={(p) => {
+                void update({ [`${pickerFor}_dir`]: p } as never);
+                setPickerFor(null);
+              }}
+              onCancel={() => setPickerFor(null)}
+            />
+          ) : null}
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1,0 +1,37 @@
+import { FolderInput } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function Ingest() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Ingest</h1>
+        <p className="text-sm text-muted-foreground">
+          Drop videos, suggest stage matches, confirm assignments. Implemented
+          in <a className="underline" href="https://github.com/mandakan/splitsmith/issues/13">#13</a>.
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FolderInput className="size-5" />
+            Placeholder
+          </CardTitle>
+          <CardDescription>
+            The Sub 1 foundation lands the app shell + project model. The
+            ingest workflow (drop zone, stage cards, primary-video selection,
+            re-enterable adds for incremental ingest) is its own sub-issue.
+          </CardDescription>
+        </CardHeader>
+        <CardContent />
+      </Card>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1,5 +1,33 @@
-import { FolderInput } from "lucide-react";
+/**
+ * Ingest screen (#13).
+ *
+ * Lets the user:
+ *   1. Drop in a SSI Scoreboard JSON to populate the stage list
+ *   2. Scan a folder of videos -- the backend symlinks them into <project>/raw/
+ *      and runs video_match.py to suggest primary assignments
+ *   3. Reassign videos: make primary / secondary / ignored, or unassign
+ *
+ * Re-enterable: the ingest page is the persistent stage-assignment view, not
+ * a one-shot wizard. The user returns here to add more videos (e.g. friend's
+ * bay-cam dropped in days later) without losing audit work.
+ */
 
+import { useCallback, useEffect, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Crosshair,
+  FileJson,
+  FolderInput,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  Video as VideoIcon,
+  XCircle,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -7,31 +35,631 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ApiError, api, type MatchProject, type StageEntry, type StageVideo, type VideoRole } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 export function Ingest() {
+  const [project, setProject] = useState<MatchProject | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      setProject(await api.getProject());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const handleScoreboard = async (file: File) => {
+    setBusy(true);
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      const overwrite = (project?.stages.length ?? 0) > 0;
+      if (overwrite) {
+        const ok = window.confirm(
+          "This project already has stages. Importing will replace them and orphan any current video assignments. Continue?",
+        );
+        if (!ok) {
+          setBusy(false);
+          return;
+        }
+      }
+      const updated = await api.importScoreboard(data, overwrite);
+      setProject(updated);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleScan = async (sourceDir: string) => {
+    setBusy(true);
+    try {
+      await api.scanVideos(sourceDir, true);
+      await reload();
+      setError(null);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`Scan failed: ${e.detail}`);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const move = async (videoPath: string, toStage: number | null, role: VideoRole) => {
+    setBusy(true);
+    try {
+      const updated = await api.moveAssignment(videoPath, toStage, role);
+      setProject(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!project && !error) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-7 w-1/3" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-32" />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
-      <div>
+      <header className="space-y-1">
         <h1 className="text-2xl font-semibold tracking-tight">Ingest</h1>
         <p className="text-sm text-muted-foreground">
-          Drop videos, suggest stage matches, confirm assignments. Implemented
-          in <a className="underline" href="https://github.com/mandakan/splitsmith/issues/13">#13</a>.
+          Drop a scoreboard JSON, scan a folder of videos, confirm assignments. Returnable any time to add more videos to existing stages.
         </p>
-      </div>
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <FolderInput className="size-5" />
-            Placeholder
-          </CardTitle>
-          <CardDescription>
-            The Sub 1 foundation lands the app shell + project model. The
-            ingest workflow (drop zone, stage cards, primary-video selection,
-            re-enterable adds for incremental ingest) is its own sub-issue.
-          </CardDescription>
-        </CardHeader>
-        <CardContent />
-      </Card>
+      </header>
+
+      {error ? (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-2 text-sm text-destructive">
+              <AlertCircle className="size-4 shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <ScoreboardSection
+        project={project}
+        busy={busy}
+        onScoreboard={handleScoreboard}
+      />
+
+      <ScanSection
+        disabled={busy || !project || project.stages.length === 0}
+        onScan={handleScan}
+      />
+
+      {project ? (
+        <>
+          <UnassignedSection
+            project={project}
+            busy={busy}
+            onAssign={(path, stage, role) => move(path, stage, role)}
+          />
+          <StagesSection project={project} busy={busy} onMove={move} />
+        </>
+      ) : null}
     </div>
+  );
+}
+
+function ScoreboardSection({
+  project,
+  busy,
+  onScoreboard,
+}: {
+  project: MatchProject | null;
+  busy: boolean;
+  onScoreboard: (f: File) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileJson className="size-5" />
+          Scoreboard
+        </CardTitle>
+        <CardDescription>
+          {project?.stages.length
+            ? `${project.stages.length} stages loaded for ${project.competitor_name ?? "the primary competitor"}.`
+            : "No stages yet. Drop in an SSI Scoreboard JSON to load them."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <FileDropZone
+          accept=".json,application/json"
+          label={
+            project?.stages.length
+              ? "Replace scoreboard JSON (warns first)"
+              : "Drop or pick an SSI Scoreboard JSON"
+          }
+          icon={<FileJson className="size-5" />}
+          disabled={busy}
+          onFile={onScoreboard}
+        />
+        {project?.scoreboard_match_id ? (
+          <p className="text-xs text-muted-foreground">
+            Match id: <code>{project.scoreboard_match_id}</code>
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ScanSection({
+  disabled,
+  onScan,
+}: {
+  disabled: boolean;
+  onScan: (sourceDir: string) => void;
+}) {
+  const [path, setPath] = useState("");
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FolderInput className="size-5" />
+          Scan video folder
+        </CardTitle>
+        <CardDescription>
+          Path to a folder containing the match's MP4/MOV files. Videos are
+          symlinked into <code>&lt;project&gt;/raw/</code>; nothing is uploaded.
+          Confident matches are auto-assigned as primary.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          className="flex flex-col gap-2 sm:flex-row"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (path.trim()) onScan(path.trim());
+          }}
+        >
+          <input
+            type="text"
+            name="source_dir"
+            placeholder="/Users/me/match-day/videos"
+            className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            disabled={disabled}
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+          />
+          <Button type="submit" disabled={disabled || !path.trim()}>
+            <RefreshCw />
+            Scan
+          </Button>
+        </form>
+        {disabled ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Load a scoreboard first.
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function UnassignedSection({
+  project,
+  busy,
+  onAssign,
+}: {
+  project: MatchProject;
+  busy: boolean;
+  onAssign: (videoPath: string, stage: number | null, role: VideoRole) => void;
+}) {
+  if (project.unassigned_videos.length === 0) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <VideoIcon className="size-5" />
+          Unassigned videos · {project.unassigned_videos.length}
+        </CardTitle>
+        <CardDescription>
+          Drag onto a stage, or use the menu to pick a stage.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {project.unassigned_videos.map((v) => (
+          <div
+            key={v.path}
+            className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
+          >
+            <div className="flex items-center gap-2 font-mono text-xs">
+              <VideoIcon className="size-3.5 text-muted-foreground" />
+              {v.path}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {project.stages.map((s) => (
+                <Button
+                  key={s.stage_number}
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => onAssign(v.path, s.stage_number, "secondary")}
+                  title={`Assign to stage ${s.stage_number}: ${s.stage_name}`}
+                >
+                  → S{s.stage_number}
+                </Button>
+              ))}
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy}
+                onClick={() => onAssign(v.path, null, "secondary")}
+                title="Mark as ignored (warmup, neighbour bay, etc.)"
+              >
+                <Trash2 />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StagesSection({
+  project,
+  busy,
+  onMove,
+}: {
+  project: MatchProject;
+  busy: boolean;
+  onMove: (path: string, stage: number | null, role: VideoRole) => void;
+}) {
+  if (project.stages.length === 0) return null;
+
+  // Compute primary-conflict highlighting: a video appearing as primary on more
+  // than one stage. Belt-and-braces; the data model prevents this today, but
+  // surface it just in case some future flow allows it.
+  const primaryCounts = new Map<string, number>();
+  for (const s of project.stages) {
+    for (const v of s.videos) {
+      if (v.role === "primary") {
+        primaryCounts.set(v.path, (primaryCounts.get(v.path) ?? 0) + 1);
+      }
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {project.stages.map((s) => (
+          <StageCard
+            key={s.stage_number}
+            stage={s}
+            allStages={project.stages}
+            busy={busy}
+            primaryCounts={primaryCounts}
+            onMove={onMove}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function StageCard({
+  stage,
+  allStages,
+  busy,
+  primaryCounts,
+  onMove,
+}: {
+  stage: StageEntry;
+  allStages: StageEntry[];
+  busy: boolean;
+  primaryCounts: Map<string, number>;
+  onMove: (path: string, stage: number | null, role: VideoRole) => void;
+}) {
+  const primary = stage.videos.find((v) => v.role === "primary");
+  const secondaries = stage.videos.filter((v) => v.role === "secondary");
+  const ignored = stage.videos.filter((v) => v.role === "ignored");
+  const hasConflict = primary && (primaryCounts.get(primary.path) ?? 0) > 1;
+
+  return (
+    <Card className={cn(hasConflict && "border-status-warning")}>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <CardTitle className="text-base">
+              Stage {stage.stage_number}: {stage.stage_name}
+            </CardTitle>
+            <CardDescription className="font-mono tabular-nums">
+              {stage.time_seconds.toFixed(2)}s ·{" "}
+              {stage.scorecard_updated_at
+                ? new Date(stage.scorecard_updated_at).toLocaleString()
+                : "no scorecard time"}
+            </CardDescription>
+          </div>
+          <StatusGlyph stage={stage} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {stage.videos.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No videos assigned.</p>
+        ) : null}
+        {primary ? (
+          <VideoRow
+            video={primary}
+            badge={
+              <Badge
+                variant={hasConflict ? "statusWarning" : "statusInProgress"}
+                className="gap-1"
+              >
+                <Crosshair className="size-3" /> Primary
+              </Badge>
+            }
+            actions={
+              <RoleActions
+                video={primary}
+                stage={stage}
+                allStages={allStages}
+                busy={busy}
+                currentRole="primary"
+                onMove={onMove}
+              />
+            }
+          />
+        ) : null}
+        {secondaries.map((v) => (
+          <VideoRow
+            key={v.path}
+            video={v}
+            badge={<Badge variant="secondary">Secondary</Badge>}
+            actions={
+              <RoleActions
+                video={v}
+                stage={stage}
+                allStages={allStages}
+                busy={busy}
+                currentRole="secondary"
+                onMove={onMove}
+              />
+            }
+          />
+        ))}
+        {ignored.map((v) => (
+          <VideoRow
+            key={v.path}
+            video={v}
+            badge={
+              <Badge variant="outline" className="gap-1 opacity-70">
+                <XCircle className="size-3" /> Ignored
+              </Badge>
+            }
+            actions={
+              <RoleActions
+                video={v}
+                stage={stage}
+                allStages={allStages}
+                busy={busy}
+                currentRole="ignored"
+                onMove={onMove}
+              />
+            }
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function VideoRow({
+  video,
+  badge,
+  actions,
+}: {
+  video: StageVideo;
+  badge: React.ReactNode;
+  actions: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+      <div className="flex min-w-0 items-center gap-2 text-xs">
+        {badge}
+        <span className="truncate font-mono" title={video.path}>
+          {video.path.split("/").pop()}
+        </span>
+        {video.processed.beep ? (
+          <span
+            className="text-muted-foreground"
+            title={`beep at ${video.beep_time?.toFixed(3) ?? "?"}s`}
+          >
+            <CheckCircle2 className="size-3.5" />
+          </span>
+        ) : (
+          <Loader2
+            className="size-3.5 text-muted-foreground"
+            aria-label="beep detection pending"
+          />
+        )}
+      </div>
+      <div className="flex gap-1">{actions}</div>
+    </div>
+  );
+}
+
+function RoleActions({
+  video,
+  stage,
+  allStages,
+  busy,
+  currentRole,
+  onMove,
+}: {
+  video: StageVideo;
+  stage: StageEntry;
+  allStages: StageEntry[];
+  busy: boolean;
+  currentRole: VideoRole;
+  onMove: (path: string, stage: number | null, role: VideoRole) => void;
+}) {
+  return (
+    <>
+      {currentRole !== "primary" ? (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={() => onMove(video.path, stage.stage_number, "primary")}
+          title="Make primary (audit truth)"
+        >
+          Make primary
+        </Button>
+      ) : null}
+      {currentRole !== "ignored" ? (
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={() => onMove(video.path, stage.stage_number, "ignored")}
+          title="Mark as ignored (kept on stage but skipped by pipeline)"
+        >
+          Ignore
+        </Button>
+      ) : null}
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={busy}
+        onClick={() => onMove(video.path, null, "secondary")}
+        title="Unassign (move back to tray)"
+      >
+        Unassign
+      </Button>
+      {allStages.length > 1 ? (
+        <select
+          aria-label="Move to a different stage"
+          className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+          disabled={busy}
+          value=""
+          onChange={(e) => {
+            const next = e.target.value;
+            if (next === "") return;
+            onMove(video.path, Number(next), "secondary");
+          }}
+        >
+          <option value="">→ stage…</option>
+          {allStages
+            .filter((s) => s.stage_number !== stage.stage_number)
+            .map((s) => (
+              <option key={s.stage_number} value={s.stage_number}>
+                S{s.stage_number} — {s.stage_name}
+              </option>
+            ))}
+        </select>
+      ) : null}
+    </>
+  );
+}
+
+function StatusGlyph({ stage }: { stage: StageEntry }) {
+  if (stage.skipped) {
+    return (
+      <Badge variant="outline" className="gap-1">
+        <XCircle className="size-3" /> Skipped
+      </Badge>
+    );
+  }
+  if (!stage.videos.length) {
+    return (
+      <Badge variant="statusNotStarted" className="gap-1">
+        ○ No videos
+      </Badge>
+    );
+  }
+  if (stage.videos.find((v) => v.role === "primary")) {
+    return (
+      <Badge variant="statusComplete" className="gap-1">
+        <CheckCircle2 className="size-3" /> Ready
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="statusWarning" className="gap-1">
+      ▲ No primary
+    </Badge>
+  );
+}
+
+function FileDropZone({
+  accept,
+  label,
+  icon,
+  disabled,
+  onFile,
+}: {
+  accept: string;
+  label: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+  onFile: (f: File) => void;
+}) {
+  const [over, setOver] = useState(false);
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-muted/20 px-4 py-6 text-sm transition-colors",
+        over && "border-ring bg-muted/40",
+        disabled && "pointer-events-none opacity-50",
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setOver(false);
+        const file = e.dataTransfer.files?.[0];
+        if (file) onFile(file);
+      }}
+    >
+      {icon}
+      <span className="text-foreground">{label}</span>
+      <span className="text-xs text-muted-foreground">drag & drop, or click to browse</span>
+      <input
+        type="file"
+        accept={accept}
+        className="sr-only"
+        disabled={disabled}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onFile(file);
+          e.target.value = "";
+        }}
+      />
+    </label>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -20,12 +20,12 @@ import {
   FileJson,
   FolderInput,
   Loader2,
-  RefreshCw,
   Trash2,
   Video as VideoIcon,
   XCircle,
 } from "lucide-react";
 
+import { FolderPicker } from "@/components/FolderPicker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -149,6 +149,7 @@ export function Ingest() {
 
       <ScanSection
         disabled={busy || !project || project.stages.length === 0}
+        initialPath={project?.last_scanned_dir ?? null}
         onScan={handleScan}
       />
 
@@ -212,12 +213,14 @@ function ScoreboardSection({
 
 function ScanSection({
   disabled,
+  initialPath,
   onScan,
 }: {
   disabled: boolean;
+  initialPath: string | null;
   onScan: (sourceDir: string) => void;
 }) {
-  const [path, setPath] = useState("");
+  const [open, setOpen] = useState(false);
   return (
     <Card>
       <CardHeader>
@@ -226,44 +229,58 @@ function ScanSection({
           Scan video folder
         </CardTitle>
         <CardDescription>
-          Path to a folder containing the match's MP4/MOV files. Videos are
-          symlinked into <code>&lt;project&gt;/raw/</code>; nothing is uploaded.
+          Pick a folder containing the match's MP4/MOV files. Videos are
+          symlinked into <code>&lt;project&gt;/raw/</code> — nothing is uploaded.
           Confident matches are auto-assigned as primary.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form
-          className="flex flex-col gap-2 sm:flex-row"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (path.trim()) onScan(path.trim());
-          }}
-        >
-          <input
-            type="text"
-            name="source_dir"
-            placeholder="/Users/me/match-day/videos"
-            className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-            value={path}
-            onChange={(e) => setPath(e.target.value)}
-            disabled={disabled}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
+      <CardContent className="space-y-3">
+        {!open ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button disabled={disabled} onClick={() => setOpen(true)}>
+              <FolderInput />
+              Browse for folder
+            </Button>
+            {initialPath ? (
+              <>
+                <Button
+                  variant="outline"
+                  disabled={disabled}
+                  onClick={() => onScan(initialPath)}
+                  title={`Re-scan ${initialPath}`}
+                >
+                  Re-scan {shortPath(initialPath)}
+                </Button>
+                <span className="font-mono text-xs text-muted-foreground" title={initialPath}>
+                  last: {initialPath}
+                </span>
+              </>
+            ) : null}
+          </div>
+        ) : (
+          <FolderPicker
+            initialPath={initialPath}
+            onSelect={(p) => {
+              setOpen(false);
+              onScan(p);
+            }}
+            onCancel={() => setOpen(false)}
           />
-          <Button type="submit" disabled={disabled || !path.trim()}>
-            <RefreshCw />
-            Scan
-          </Button>
-        </form>
+        )}
         {disabled ? (
-          <p className="mt-2 text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground">
             Load a scoreboard first.
           </p>
         ) : null}
       </CardContent>
     </Card>
   );
+}
+
+function shortPath(p: string): string {
+  const parts = p.split("/").filter(Boolean);
+  if (parts.length <= 2) return p;
+  return `…/${parts.slice(-2).join("/")}`;
 }
 
 function UnassignedSection({

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -25,6 +25,7 @@ import {
   XCircle,
 } from "lucide-react";
 
+import { BeepSection } from "@/components/BeepSection";
 import { FolderPicker } from "@/components/FolderPicker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -160,7 +161,14 @@ export function Ingest() {
             busy={busy}
             onAssign={(path, stage, role) => move(path, stage, role)}
           />
-          <StagesSection project={project} busy={busy} onMove={move} />
+          <StagesSection
+            project={project}
+            busy={busy}
+            setBusy={setBusy}
+            setError={setError}
+            onProjectUpdate={setProject}
+            onMove={move}
+          />
         </>
       ) : null}
     </div>
@@ -347,10 +355,16 @@ function UnassignedSection({
 function StagesSection({
   project,
   busy,
+  setBusy,
+  setError,
+  onProjectUpdate,
   onMove,
 }: {
   project: MatchProject;
   busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+  onProjectUpdate: (next: MatchProject) => void;
   onMove: (path: string, stage: number | null, role: VideoRole) => void;
 }) {
   if (project.stages.length === 0) return null;
@@ -378,6 +392,9 @@ function StagesSection({
             allStages={project.stages}
             busy={busy}
             primaryCounts={primaryCounts}
+            setBusy={setBusy}
+            setError={setError}
+            onProjectUpdate={onProjectUpdate}
             onMove={onMove}
           />
         ))}
@@ -391,12 +408,18 @@ function StageCard({
   allStages,
   busy,
   primaryCounts,
+  setBusy,
+  setError,
+  onProjectUpdate,
   onMove,
 }: {
   stage: StageEntry;
   allStages: StageEntry[];
   busy: boolean;
   primaryCounts: Map<string, number>;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+  onProjectUpdate: (next: MatchProject) => void;
   onMove: (path: string, stage: number | null, role: VideoRole) => void;
 }) {
   const primary = stage.videos.find((v) => v.role === "primary");
@@ -427,27 +450,37 @@ function StageCard({
           <p className="text-sm text-muted-foreground">No videos assigned.</p>
         ) : null}
         {primary ? (
-          <VideoRow
-            video={primary}
-            badge={
-              <Badge
-                variant={hasConflict ? "statusWarning" : "statusInProgress"}
-                className="gap-1"
-              >
-                <Crosshair className="size-3" /> Primary
-              </Badge>
-            }
-            actions={
-              <RoleActions
-                video={primary}
-                stage={stage}
-                allStages={allStages}
-                busy={busy}
-                currentRole="primary"
-                onMove={onMove}
-              />
-            }
-          />
+          <>
+            <VideoRow
+              video={primary}
+              badge={
+                <Badge
+                  variant={hasConflict ? "statusWarning" : "statusInProgress"}
+                  className="gap-1"
+                >
+                  <Crosshair className="size-3" /> Primary
+                </Badge>
+              }
+              actions={
+                <RoleActions
+                  video={primary}
+                  stage={stage}
+                  allStages={allStages}
+                  busy={busy}
+                  currentRole="primary"
+                  onMove={onMove}
+                />
+              }
+            />
+            <BeepSection
+              stageNumber={stage.stage_number}
+              primary={primary}
+              busy={busy}
+              setBusy={setBusy}
+              setError={setError}
+              onProjectUpdate={onProjectUpdate}
+            />
+          </>
         ) : null}
         {secondaries.map((v) => (
           <VideoRow

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -15,11 +15,13 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   AlertCircle,
+  CalendarDays,
   CheckCircle2,
   Crosshair,
   FileJson,
   FolderInput,
   Loader2,
+  PlayCircle,
   Trash2,
   Video as VideoIcon,
   XCircle,
@@ -37,7 +39,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ApiError, api, type MatchProject, type StageEntry, type StageVideo, type VideoRole } from "@/lib/api";
+import {
+  ApiError,
+  api,
+  type MatchProject,
+  type NonEmptyOldDirsDetail,
+  type StageEntry,
+  type StageVideo,
+  type VideoRole,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 export function Ingest() {
@@ -63,10 +73,13 @@ export function Ingest() {
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      const overwrite = (project?.stages.length ?? 0) > 0;
+      // Real (non-placeholder) stages need explicit overwrite; placeholders
+      // are overlaid automatically without losing video assignments.
+      const realStages = (project?.stages ?? []).filter((s) => !s.placeholder);
+      const overwrite = realStages.length > 0;
       if (overwrite) {
         const ok = window.confirm(
-          "This project already has stages. Importing will replace them and orphan any current video assignments. Continue?",
+          "This project already has scoreboard-backed stages. Importing will replace them and orphan any current video assignments. Continue?",
         );
         if (!ok) {
           setBusy(false);
@@ -75,6 +88,32 @@ export function Ingest() {
       }
       const updated = await api.importScoreboard(data, overwrite);
       setProject(updated);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleStartFromVideos = async (
+    files: { path: string; mtime: number | null }[],
+    stageCount: number,
+    matchName: string | null,
+    matchDate: string | null,
+  ) => {
+    setBusy(true);
+    try {
+      await api.createPlaceholderStages({
+        stage_count: stageCount,
+        match_name: matchName,
+        match_date: matchDate,
+      });
+      await api.scanFiles(
+        files.map((f) => f.path),
+        false,
+      );
+      await reload();
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -140,7 +179,9 @@ export function Ingest() {
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold tracking-tight">Ingest</h1>
         <p className="text-sm text-muted-foreground">
-          Drop a scoreboard JSON, scan a folder of videos, confirm assignments. Returnable any time to add more videos to existing stages.
+          Bootstrap from a scoreboard JSON or just point at your videos -- a
+          real scoreboard can be uploaded later and will overlay onto the
+          placeholder stages without losing assignments.
         </p>
       </header>
 
@@ -155,11 +196,26 @@ export function Ingest() {
         </Card>
       ) : null}
 
-      <ScoreboardSection
-        project={project}
-        busy={busy}
-        onScoreboard={handleScoreboard}
-      />
+      {project && project.stages.length === 0 ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <ScoreboardSection
+            project={project}
+            busy={busy}
+            onScoreboard={handleScoreboard}
+          />
+          <StartFromVideosSection
+            project={project}
+            busy={busy}
+            onSubmit={handleStartFromVideos}
+          />
+        </div>
+      ) : (
+        <ScoreboardSection
+          project={project}
+          busy={busy}
+          onScoreboard={handleScoreboard}
+        />
+      )}
 
       <ScanSection
         disabled={busy || !project || project.stages.length === 0}
@@ -202,6 +258,19 @@ function ScoreboardSection({
   busy: boolean;
   onScoreboard: (f: File) => void;
 }) {
+  const stages = project?.stages ?? [];
+  const realCount = stages.filter((s) => !s.placeholder).length;
+  const placeholderCount = stages.filter((s) => s.placeholder).length;
+  const description = realCount
+    ? `${realCount} stages loaded for ${project!.competitor_name ?? "the primary competitor"}.`
+    : placeholderCount
+      ? `${placeholderCount} placeholder stages -- upload a real scoreboard to fill in names, competitor metadata, and timestamps.`
+      : "No stages yet. Drop in an SSI Scoreboard JSON to load them.";
+  const dropLabel = realCount
+    ? "Replace scoreboard JSON (warns first)"
+    : placeholderCount
+      ? "Upload scoreboard to overlay placeholders"
+      : "Drop or pick an SSI Scoreboard JSON";
   return (
     <Card>
       <CardHeader>
@@ -209,20 +278,12 @@ function ScoreboardSection({
           <FileJson className="size-5" />
           Scoreboard
         </CardTitle>
-        <CardDescription>
-          {project?.stages.length
-            ? `${project.stages.length} stages loaded for ${project.competitor_name ?? "the primary competitor"}.`
-            : "No stages yet. Drop in an SSI Scoreboard JSON to load them."}
-        </CardDescription>
+        <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         <FileDropZone
           accept=".json,application/json"
-          label={
-            project?.stages.length
-              ? "Replace scoreboard JSON (warns first)"
-              : "Drop or pick an SSI Scoreboard JSON"
-          }
+          label={dropLabel}
           icon={<FileJson className="size-5" />}
           disabled={busy}
           onFile={onScoreboard}
@@ -232,6 +293,150 @@ function ScoreboardSection({
             Match id: <code>{project.scoreboard_match_id}</code>
           </p>
         ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StartFromVideosSection({
+  project,
+  busy,
+  onSubmit,
+}: {
+  project: MatchProject;
+  busy: boolean;
+  onSubmit: (
+    files: { path: string; mtime: number | null }[],
+    stageCount: number,
+    matchName: string | null,
+    matchDate: string | null,
+  ) => void;
+}) {
+  const [picking, setPicking] = useState(false);
+  const [picked, setPicked] = useState<
+    { path: string; mtime: number | null }[] | null
+  >(null);
+  const [stageCount, setStageCount] = useState<number>(0);
+  const [matchName, setMatchName] = useState<string>(project.name);
+  const [matchDate, setMatchDate] = useState<string>("");
+
+  const beginPick = () => {
+    setPicking(true);
+  };
+
+  const onFilesChosen = (files: { path: string; mtime: number | null }[]) => {
+    setPicking(false);
+    setPicked(files);
+    setStageCount(files.length);
+    const earliest = files
+      .map((f) => f.mtime)
+      .filter((m): m is number => m !== null)
+      .sort((a, b) => a - b)[0];
+    if (earliest !== undefined) {
+      // mtime is seconds since epoch; toISOString().slice(0, 10) gives YYYY-MM-DD.
+      setMatchDate(new Date(earliest * 1000).toISOString().slice(0, 10));
+    } else {
+      setMatchDate(new Date().toISOString().slice(0, 10));
+    }
+  };
+
+  const submit = () => {
+    if (!picked || stageCount < 1) return;
+    onSubmit(
+      picked,
+      stageCount,
+      matchName.trim() || null,
+      matchDate || null,
+    );
+    setPicked(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <PlayCircle className="size-5" />
+          Start from videos
+        </CardTitle>
+        <CardDescription>
+          No scoreboard yet? Pick the videos you shot and tell splitsmith how
+          many stages you ran. Stage count and date are detected from the
+          files; you can adjust before continuing.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {picking ? (
+          <FolderPicker
+            initialPath={project.last_scanned_dir ?? null}
+            onSelect={() => {
+              /* not used: this card always wants files, not a folder. */
+            }}
+            onSelectFiles={onFilesChosen}
+            onCancel={() => setPicking(false)}
+          />
+        ) : picked ? (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              {picked.length} video{picked.length === 1 ? "" : "s"} selected.
+            </p>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium">Number of stages</span>
+              <span className="text-xs text-muted-foreground">
+                Defaulted to the number of files. Adjust if your camera split a
+                stage across multiple clips, or rolled across stages.
+              </span>
+              <input
+                type="number"
+                min={1}
+                value={stageCount}
+                onChange={(e) => setStageCount(Number(e.target.value))}
+                disabled={busy}
+                className="flex h-8 w-24 rounded-md border border-input bg-background px-2 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium">Match name</span>
+              <input
+                type="text"
+                value={matchName}
+                onChange={(e) => setMatchName(e.target.value)}
+                disabled={busy}
+                className="flex h-8 rounded-md border border-input bg-background px-2 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="flex items-center gap-1.5 font-medium">
+                <CalendarDays className="size-3.5" />
+                Match date
+              </span>
+              <input
+                type="date"
+                value={matchDate}
+                onChange={(e) => setMatchDate(e.target.value)}
+                disabled={busy}
+                className="flex h-8 w-44 rounded-md border border-input bg-background px-2 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <div className="flex gap-2">
+              <Button onClick={submit} disabled={busy || stageCount < 1}>
+                Create {stageCount || "?"} placeholder stage
+                {stageCount === 1 ? "" : "s"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setPicked(null)}
+                disabled={busy}
+              >
+                Back
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button onClick={beginPick} disabled={busy}>
+            <FolderInput />
+            Pick videos
+          </Button>
+        )}
       </CardContent>
     </Card>
   );
@@ -293,16 +498,16 @@ function ScanSection({
               setOpen(false);
               onScan(p);
             }}
-            onSelectFiles={(paths) => {
+            onSelectFiles={(files) => {
               setOpen(false);
-              onScanFiles(paths);
+              onScanFiles(files.map((f) => f.path));
             }}
             onCancel={() => setOpen(false)}
           />
         )}
         {disabled ? (
           <p className="text-xs text-muted-foreground">
-            Load a scoreboard first.
+            Bootstrap the project first (upload a scoreboard or start from videos).
           </p>
         ) : null}
       </CardContent>
@@ -331,6 +536,9 @@ function SettingsSection({
     { key: "trimmed_dir", label: "Trimmed clips", help: "Short-GOP MP4s used by the audit screen (default: <project>/trimmed)." },
     { key: "exports_dir", label: "Outputs", help: "CSV / FCPXML / report (default: <project>/exports)." },
   ];
+  const labelFor = (field: string) =>
+    fields.find((f) => f.key === field)?.label ?? field;
+
   const update = async (patch: Partial<Record<typeof fields[number]["key"], string | null>>) => {
     setBusy(true);
     try {
@@ -338,7 +546,39 @@ function SettingsSection({
       onProjectUpdate(updated);
       setError(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (
+        e instanceof ApiError &&
+        e.status === 409 &&
+        e.body &&
+        typeof e.body === "object" &&
+        (e.body as { code?: string }).code === "non_empty_old_dirs"
+      ) {
+        const detail = e.body as NonEmptyOldDirsDetail;
+        const lines = detail.dirs
+          .map(
+            (d) =>
+              `  - ${labelFor(d.field)}: ${d.path} (${d.file_count} item${d.file_count === 1 ? "" : "s"})`,
+          )
+          .join("\n");
+        const ok = window.confirm(
+          `The following directories contain files that will be left behind ` +
+            `(splitsmith does not migrate cache or exports between paths):\n\n${lines}\n\n` +
+            `Proceed anyway?`,
+        );
+        if (ok) {
+          try {
+            const updated = await api.updateSettings({ ...patch, confirm: true });
+            onProjectUpdate(updated);
+            setError(null);
+          } catch (e2) {
+            setError(e2 instanceof Error ? e2.message : String(e2));
+          }
+        } else {
+          setError(null);
+        }
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
     } finally {
       setBusy(false);
     }

--- a/src/splitsmith/ui_static/src/styles/index.css
+++ b/src/splitsmith/ui_static/src/styles/index.css
@@ -42,26 +42,31 @@
   --ring: oklch(0.708 0 0);
   --radius: 0.5rem;
 
-  /* Splitsmith split colors -- match fcpxml_gen.py */
-  --split-good: #00c853;
+  /* Splitsmith split colors -- Okabe-Ito-derived palette.
+   * Color-blind safe (deuteranopia / protanopia / tritanopia distinguishable).
+   * fcpxml_gen.py emits band names ([GREEN]/[YELLOW]/[RED]/[BLUE]) as text only;
+   * FCP renders marker colors from FCP-side settings, so changing these in-app
+   * has no effect on exported timelines.
+   * Always paired with shape encoding in markers (see Marker glyph). */
+  --split-good: #009e73;          /* bluish green; 3.4:1 on white, AA UI */
   --split-good-foreground: #ffffff;
-  --split-ok: #ffd600;
-  --split-ok-foreground: #000000;
-  --split-slow: #d50000;
+  --split-ok: #f0e442;             /* yellow; needs dark foreground */
+  --split-ok-foreground: #1a1a1a;
+  --split-slow: #d55e00;           /* vermillion; 4.0:1 on white, AA UI */
   --split-slow-foreground: #ffffff;
-  --split-transition: #2962ff;
+  --split-transition: #0072b2;     /* blue; 5.5:1 on white, AA normal text */
   --split-transition-foreground: #ffffff;
 
-  /* Stage status */
-  --status-not-started: oklch(0.65 0 0);
-  --status-in-progress: oklch(0.55 0.18 250);
-  --status-complete: oklch(0.55 0.16 145);
-  --status-warning: oklch(0.65 0.17 75);
+  /* Stage status -- Okabe-Ito derived */
+  --status-not-started: oklch(0.55 0 0);   /* neutral gray */
+  --status-in-progress: #0072b2;           /* blue */
+  --status-complete: #009e73;              /* bluish green */
+  --status-warning: #e69f00;               /* orange */
 
-  /* Audit markers */
-  --marker-detected: oklch(0.45 0.18 250);
-  --marker-rejected: oklch(0.7 0 0);
-  --marker-manual: oklch(0.65 0.17 75);
+  /* Audit markers -- color + shape (see <MarkerGlyph>) */
+  --marker-detected: #0072b2;              /* blue, filled triangle */
+  --marker-rejected: oklch(0.55 0 0);      /* neutral gray, outline + strike */
+  --marker-manual: #e69f00;                /* orange, dashed diamond */
 }
 
 .dark {
@@ -85,24 +90,24 @@
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);
 
-  /* Splitsmith split colors -- slight tweaks for dark-bg legibility */
-  --split-good: #1de87a;
-  --split-good-foreground: #00210d;
-  --split-ok: #ffe347;
-  --split-ok-foreground: #1f1500;
-  --split-slow: #ff5252;
-  --split-slow-foreground: #2a0000;
-  --split-transition: #5b8eff;
-  --split-transition-foreground: #001b4a;
+  /* Splitsmith split colors (dark mode) -- brighter Okabe-Ito for dark bg */
+  --split-good: #1fc78f;
+  --split-good-foreground: #00231a;
+  --split-ok: #f5e457;
+  --split-ok-foreground: #1f1c00;
+  --split-slow: #ff7733;
+  --split-slow-foreground: #2a0e00;
+  --split-transition: #4f9bd5;
+  --split-transition-foreground: #001a2a;
 
-  --status-not-started: oklch(0.55 0 0);
-  --status-in-progress: oklch(0.7 0.18 250);
-  --status-complete: oklch(0.7 0.18 145);
-  --status-warning: oklch(0.75 0.17 75);
+  --status-not-started: oklch(0.65 0 0);
+  --status-in-progress: #4f9bd5;
+  --status-complete: #1fc78f;
+  --status-warning: #ffae42;
 
-  --marker-detected: oklch(0.7 0.18 250);
-  --marker-rejected: oklch(0.5 0 0);
-  --marker-manual: oklch(0.75 0.17 75);
+  --marker-detected: #4f9bd5;
+  --marker-rejected: oklch(0.6 0 0);
+  --marker-manual: #ffae42;
 }
 
 /* ============================================================================

--- a/src/splitsmith/ui_static/src/styles/index.css
+++ b/src/splitsmith/ui_static/src/styles/index.css
@@ -1,0 +1,192 @@
+@import "tailwindcss";
+
+/* ============================================================================
+ * DESIGN TOKENS
+ * ----------------------------------------------------------------------------
+ * Issue #12 (Sub 1) locks the production-UI design system. Tokens live here
+ * as CSS variables, exposed to Tailwind via @theme. The /_design route
+ * renders them all.
+ *
+ * Three groups:
+ *   1. shadcn semantic tokens (background, foreground, primary, ...)
+ *   2. splitsmith-specific tokens (split-*, status-*, marker-*)
+ *   3. Typography + radius + motion
+ *
+ * Splitsmith colors that already appear in fcpxml_gen.py keep the same hex
+ * values so a shot rendered green in the audit UI is the same shot rendered
+ * green in Final Cut Pro.
+ * ========================================================================== */
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+:root {
+  /* shadcn semantic tokens (light mode) */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.5rem;
+
+  /* Splitsmith split colors -- match fcpxml_gen.py */
+  --split-good: #00c853;
+  --split-good-foreground: #ffffff;
+  --split-ok: #ffd600;
+  --split-ok-foreground: #000000;
+  --split-slow: #d50000;
+  --split-slow-foreground: #ffffff;
+  --split-transition: #2962ff;
+  --split-transition-foreground: #ffffff;
+
+  /* Stage status */
+  --status-not-started: oklch(0.65 0 0);
+  --status-in-progress: oklch(0.55 0.18 250);
+  --status-complete: oklch(0.55 0.16 145);
+  --status-warning: oklch(0.65 0.17 75);
+
+  /* Audit markers */
+  --marker-detected: oklch(0.45 0.18 250);
+  --marker-rejected: oklch(0.7 0 0);
+  --marker-manual: oklch(0.65 0.17 75);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.18 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.18 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.628 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+
+  /* Splitsmith split colors -- slight tweaks for dark-bg legibility */
+  --split-good: #1de87a;
+  --split-good-foreground: #00210d;
+  --split-ok: #ffe347;
+  --split-ok-foreground: #1f1500;
+  --split-slow: #ff5252;
+  --split-slow-foreground: #2a0000;
+  --split-transition: #5b8eff;
+  --split-transition-foreground: #001b4a;
+
+  --status-not-started: oklch(0.55 0 0);
+  --status-in-progress: oklch(0.7 0.18 250);
+  --status-complete: oklch(0.7 0.18 145);
+  --status-warning: oklch(0.75 0.17 75);
+
+  --marker-detected: oklch(0.7 0.18 250);
+  --marker-rejected: oklch(0.5 0 0);
+  --marker-manual: oklch(0.75 0.17 75);
+}
+
+/* ============================================================================
+ * @theme: expose tokens to Tailwind v4 utility classes
+ * ========================================================================== */
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-split-good: var(--split-good);
+  --color-split-good-foreground: var(--split-good-foreground);
+  --color-split-ok: var(--split-ok);
+  --color-split-ok-foreground: var(--split-ok-foreground);
+  --color-split-slow: var(--split-slow);
+  --color-split-slow-foreground: var(--split-slow-foreground);
+  --color-split-transition: var(--split-transition);
+  --color-split-transition-foreground: var(--split-transition-foreground);
+
+  --color-status-not-started: var(--status-not-started);
+  --color-status-in-progress: var(--status-in-progress);
+  --color-status-complete: var(--status-complete);
+  --color-status-warning: var(--status-warning);
+
+  --color-marker-detected: var(--marker-detected);
+  --color-marker-rejected: var(--marker-rejected);
+  --color-marker-manual: var(--marker-manual);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+/* ============================================================================
+ * Base
+ * ========================================================================== */
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-family: var(--font-sans);
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  }
+  /* All numeric columns/cells get tabular numerals so digits align. */
+  .tabular-nums,
+  .font-mono {
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+}

--- a/src/splitsmith/ui_static/tsconfig.app.json
+++ b/src/splitsmith/ui_static/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/src/splitsmith/ui_static/tsconfig.json
+++ b/src/splitsmith/ui_static/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/src/splitsmith/ui_static/tsconfig.node.json
+++ b/src/splitsmith/ui_static/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/splitsmith/ui_static/vite.config.ts
+++ b/src/splitsmith/ui_static/vite.config.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 5173,
+    // Proxy API calls to the FastAPI backend in dev mode.
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:5174",
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: true,
+  },
+});

--- a/src/splitsmith/video_probe.py
+++ b/src/splitsmith/video_probe.py
@@ -1,0 +1,147 @@
+"""ffprobe wrapper with mtime/size-keyed disk cache.
+
+Used by the production UI's folder picker so video rows can show duration
+alongside size + filename (issue #24). Caching keeps repeat listings of a
+USB-mounted directory cheap once the first scan completes.
+
+The cache key is ``sha1(absolute_path + mtime + size)`` truncated to 16 hex
+chars; any source-side change flips the key naturally, so cache invalidation
+is automatic. Stale cache entries are harmless leftovers -- they're never
+read (the lookup path always reflects current source state).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class ProbeError(RuntimeError):
+    """ffprobe failed or timed out."""
+
+
+class ProbeResult(BaseModel):
+    """Subset of ffprobe output we care about for the picker + tray."""
+
+    duration: float | None = None
+    width: int | None = None
+    height: int | None = None
+    codec: str | None = None
+
+
+def source_cache_key(path: Path) -> str:
+    """Return a short cache key for ``path`` based on its absolute path,
+    mtime, and size. Returns an empty string when the file can't be stat'd
+    (broken symlink etc.) so callers can skip caching cleanly."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return ""
+    payload = f"{path.resolve()}\n{stat.st_mtime}\n{stat.st_size}"
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def cached(path: Path, cache_dir: Path) -> ProbeResult | None:
+    """Look up a previously-cached probe for ``path``. Returns ``None`` on miss.
+
+    Reading is cheap: one stat to compute the key, one open for the JSON.
+    """
+    key = source_cache_key(path)
+    if not key:
+        return None
+    cache_file = cache_dir / f"{key}.json"
+    if not cache_file.exists():
+        return None
+    try:
+        return ProbeResult.model_validate_json(cache_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def probe(
+    path: Path,
+    *,
+    cache_dir: Path,
+    ffprobe_binary: str = "ffprobe",
+    timeout: float = 4.0,
+) -> ProbeResult:
+    """Probe ``path`` and persist the result under ``cache_dir``.
+
+    Caches on success; raises :class:`ProbeError` on failure (ffprobe missing,
+    non-zero exit, timeout, malformed output). The caller is responsible for
+    deciding whether a probe failure is worth surfacing -- the picker treats
+    ``ProbeError`` as "leave duration null and move on".
+    """
+    hit = cached(path, cache_dir)
+    if hit is not None:
+        return hit
+
+    if not shutil.which(ffprobe_binary):
+        raise ProbeError(f"ffprobe binary not found: {ffprobe_binary}")
+
+    cmd = [
+        ffprobe_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        "-select_streams",
+        "v:0",
+        str(path),
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProbeError(f"ffprobe timed out on {path}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise ProbeError(
+            f"ffprobe failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
+        ) from exc
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ProbeError(f"ffprobe returned invalid JSON for {path}") from exc
+
+    result = _parse(payload)
+    key = source_cache_key(path)
+    if key:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / f"{key}.json").write_text(
+            result.model_dump_json(indent=2) + "\n", encoding="utf-8"
+        )
+    return result
+
+
+def _parse(payload: dict) -> ProbeResult:
+    fmt = payload.get("format") or {}
+    streams = payload.get("streams") or []
+    video = streams[0] if streams else {}
+
+    duration_raw = fmt.get("duration") or video.get("duration")
+    duration: float | None
+    try:
+        duration = float(duration_raw) if duration_raw is not None else None
+    except (TypeError, ValueError):
+        duration = None
+
+    return ProbeResult(
+        duration=duration,
+        width=video.get("width"),
+        height=video.get("height"),
+        codec=video.get("codec_name"),
+    )

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,0 +1,107 @@
+"""Unit tests for ``splitsmith.thumbnail`` (ffmpeg mocked)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from splitsmith import thumbnail
+
+
+def _fake_completed() -> MagicMock:
+    completed = MagicMock(spec=subprocess.CompletedProcess)
+    completed.stdout = ""
+    completed.stderr = ""
+    completed.returncode = 0
+    return completed
+
+
+def _ffmpeg_writes_thumb(dest: Path) -> MagicMock:
+    """Return a side-effect that simulates ffmpeg writing the thumbnail file."""
+
+    def _run(cmd, *args, **kwargs):  # noqa: ANN001 ANN002 ANN003
+        out = Path(cmd[-1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg")
+        return _fake_completed()
+
+    return MagicMock(side_effect=_run)
+
+
+def test_ensure_extracts_and_caches(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "thumbs"
+
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", _ffmpeg_writes_thumb(tmp_path)) as run,
+    ):
+        first = thumbnail.ensure(source, cache_dir=cache_dir, duration=12.0)
+        # Cache hit: ffmpeg should not run again.
+        second = thumbnail.ensure(source, cache_dir=cache_dir, duration=12.0)
+
+    assert first.exists()
+    assert first.suffix == ".jpg"
+    assert first == second
+    assert run.call_count == 1
+
+
+def test_ensure_picks_short_t_for_short_clips(tmp_path: Path) -> None:
+    source = tmp_path / "short.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "thumbs"
+
+    captured: list[list[str]] = []
+
+    def _capture_cmd(cmd, *args, **kwargs):  # noqa: ANN001 ANN002 ANN003
+        captured.append(list(cmd))
+        Path(cmd[-1]).parent.mkdir(parents=True, exist_ok=True)
+        Path(cmd[-1]).write_bytes(b"x")
+        return _fake_completed()
+
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", side_effect=_capture_cmd),
+    ):
+        thumbnail.ensure(source, cache_dir=cache_dir, duration=2.0)
+
+    # duration=2.0 -> t = min(1.0, 2.0 * 0.1) = 0.2
+    assert captured, "ffmpeg should have been invoked"
+    args = captured[0]
+    ss_idx = args.index("-ss")
+    assert float(args[ss_idx + 1]) == pytest.approx(0.2)
+
+
+def test_ensure_raises_on_timeout(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch(
+            "splitsmith.thumbnail.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=6.0),
+        ),
+    ):
+        with pytest.raises(thumbnail.ThumbnailError, match="timed out"):
+            thumbnail.ensure(source, cache_dir=tmp_path / "t", duration=10.0)
+
+
+def test_ensure_raises_when_ffmpeg_produces_no_output(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", return_value=_fake_completed()),
+    ):
+        with pytest.raises(thumbnail.ThumbnailError, match="no output"):
+            thumbnail.ensure(source, cache_dir=tmp_path / "t", duration=10.0)
+
+
+def test_cached_returns_none_on_miss(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    assert thumbnail.cached(source, tmp_path / "thumbs") is None

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -105,6 +105,78 @@ def test_trim_rejects_negative_inputs(tmp_path: Path) -> None:
         trim_video(src, dst, beep_time=1.0, stage_time=1.0, buffer_seconds=-1.0, runner=runner)
 
 
+def test_trim_audit_mode_re_encodes_video_copies_audio(tmp_path: Path) -> None:
+    """Audit mode emits libx264 + short GOP video flags and stream-copies audio."""
+    src = _touch(tmp_path / "in.mp4")
+    dst = tmp_path / "out.mp4"
+    runner = _RecordingRunner()
+
+    trim_video(
+        src,
+        dst,
+        beep_time=10.0,
+        stage_time=15.0,
+        buffer_seconds=2.0,
+        mode="audit",
+        gop_frames=15,
+        crf=20,
+        preset="fast",
+        runner=runner,
+    )
+
+    cmd = runner.calls[0]
+    # Video re-encode.
+    assert cmd[cmd.index("-c:v") + 1] == "libx264"
+    assert cmd[cmd.index("-preset") + 1] == "fast"
+    assert cmd[cmd.index("-crf") + 1] == "20"
+    # Short GOP knobs.
+    assert cmd[cmd.index("-g") + 1] == "15"
+    assert cmd[cmd.index("-keyint_min") + 1] == "15"
+    # Disable I-frame insertion on scene change so GOP stays at exactly N.
+    assert cmd[cmd.index("-sc_threshold") + 1] == "0"
+    # Pixel format kept browser-friendly.
+    assert cmd[cmd.index("-pix_fmt") + 1] == "yuv420p"
+    # Audio is bit-exact -- detector input doesn't shift across modes.
+    assert cmd[cmd.index("-c:a") + 1] == "copy"
+    # No bare ``-c copy`` (which would override -c:v / -c:a).
+    assert "-c" not in cmd or cmd.index("-c") in (i for i in [-1] if False)
+
+
+def test_trim_lossless_is_default_and_unchanged(tmp_path: Path) -> None:
+    """Regression check: omitting mode keeps stream-copy behaviour byte-identical."""
+    src = _touch(tmp_path / "in.mp4")
+    dst = tmp_path / "out.mp4"
+    runner = _RecordingRunner()
+
+    trim_video(src, dst, beep_time=1.0, stage_time=1.0, runner=runner)
+
+    cmd = runner.calls[0]
+    # Stream copy.
+    assert cmd[cmd.index("-c") + 1] == "copy"
+    # No re-encode flags leak through.
+    assert "-c:v" not in cmd
+    assert "-crf" not in cmd
+    assert "-g" not in cmd
+
+
+def test_trim_rejects_unknown_mode(tmp_path: Path) -> None:
+    src = _touch(tmp_path / "in.mp4")
+    dst = tmp_path / "out.mp4"
+    runner = _RecordingRunner()
+    with pytest.raises(ValueError, match="mode must be"):
+        trim_video(src, dst, 1.0, 1.0, mode="bogus", runner=runner)  # type: ignore[arg-type]
+
+
+def test_trim_rejects_invalid_gop_or_crf(tmp_path: Path) -> None:
+    src = _touch(tmp_path / "in.mp4")
+    dst = tmp_path / "out.mp4"
+    runner = _RecordingRunner()
+    with pytest.raises(ValueError, match="gop_frames"):
+        trim_video(src, dst, 1.0, 1.0, gop_frames=0, runner=runner)
+    with pytest.raises(ValueError, match="crf"):
+        trim_video(src, dst, 1.0, 1.0, crf=99, runner=runner)
+
+
 def test_trim_raises_when_input_missing(tmp_path: Path) -> None:
     dst = tmp_path / "out.mp4"
     runner = _RecordingRunner()
@@ -165,3 +237,63 @@ def test_trim_integration_real_ffmpeg(tmp_path: Path, fixtures_dir: Path) -> Non
     actual = float(probe.stdout.strip())
     # Stream-copy with -ss before -i snaps to the nearest keyframe; allow generous slack.
     assert actual == pytest.approx(result.duration, abs=2.0)
+
+
+@pytest.mark.integration
+def test_trim_audit_mode_emits_short_gop(tmp_path: Path, fixtures_dir: Path) -> None:
+    """End-to-end: audit mode produces a clip with keyframes every <= 0.5s."""
+    src = fixtures_dir / "stage_sample.mp4"
+    if not src.exists():
+        pytest.skip(f"sample video not available at {src}")
+    dst = tmp_path / "trimmed_audit.mp4"
+
+    trim_video(
+        src,
+        dst,
+        beep_time=4.853,
+        stage_time=14.74,
+        buffer_seconds=2.0,
+        mode="audit",
+        gop_frames=15,
+        crf=20,
+        preset="ultrafast",  # faster encode for the test
+    )
+    assert dst.exists()
+
+    # ffprobe: list video frames with their pict_type and timestamp; assert
+    # the gap between consecutive I-frames never exceeds 0.5s.
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "frame=pict_type,best_effort_timestamp_time",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(dst),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    keyframe_times: list[float] = []
+    current_t: float | None = None
+    for line in probe.stdout.splitlines():
+        if line.startswith("best_effort_timestamp_time="):
+            current_t = float(line.split("=", 1)[1])
+        elif line.startswith("pict_type=") and line.endswith("=I"):
+            if current_t is not None:
+                keyframe_times.append(current_t)
+                current_t = None
+        elif line.startswith("pict_type="):
+            current_t = None
+
+    assert len(keyframe_times) >= 2, f"expected multiple keyframes, got {keyframe_times}"
+    gaps = [b - a for a, b in zip(keyframe_times, keyframe_times[1:], strict=False)]
+    assert max(gaps) <= 0.6, (
+        f"keyframe gaps exceed 0.5s tolerance: max={max(gaps):.3f}s, "
+        f"gaps={[round(g, 3) for g in gaps]}"
+    )

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -330,6 +330,157 @@ def test_import_scoreboard_refuses_overwrite_by_default(tmp_path: Path) -> None:
     assert project.stages[0].stage_name == "S2-different"
 
 
+def test_init_placeholder_stages_creates_n_stages(tmp_path: Path) -> None:
+    from datetime import date
+
+    root = tmp_path / "match-placeholder"
+    project = MatchProject.init(root, name="x")
+    project.init_placeholder_stages(
+        6,
+        match_name="Tällmilan Pre-Match",
+        match_date=date(2026, 4, 12),
+    )
+
+    assert project.name == "Tällmilan Pre-Match"
+    assert project.match_date == date(2026, 4, 12)
+    assert [s.stage_number for s in project.stages] == [1, 2, 3, 4, 5, 6]
+    assert all(s.placeholder for s in project.stages)
+    assert project.stages[0].stage_name == "Stage 1"
+    assert project.stages[0].scorecard_updated_at is None
+
+
+def test_init_placeholder_rejects_zero_or_negative(tmp_path: Path) -> None:
+    project = MatchProject.init(tmp_path / "match", name="x")
+    with pytest.raises(ValueError):
+        project.init_placeholder_stages(0)
+
+
+def test_init_placeholder_refuses_when_real_stages_exist(tmp_path: Path) -> None:
+    from splitsmith.ui.project import ScoreboardImportConflictError
+
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.import_scoreboard(
+        {
+            "match": {"id": "1", "name": "M"},
+            "competitors": [
+                {
+                    "competitor_id": 1,
+                    "name": "A",
+                    "stages": [
+                        {
+                            "stage_number": 1,
+                            "stage_name": "S1",
+                            "time_seconds": 10.0,
+                            "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    with pytest.raises(ScoreboardImportConflictError):
+        project.init_placeholder_stages(5)
+
+
+def test_init_placeholder_replaces_existing_placeholders_returning_videos(
+    tmp_path: Path,
+) -> None:
+    """Re-bootstrapping with a different stage count moves existing placeholder
+    videos back to unassigned so the user can re-bind."""
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.init_placeholder_stages(3)
+    project.stages[0].videos.append(StageVideo(path=Path("raw/clip.mp4"), role="primary"))
+
+    project.init_placeholder_stages(5)
+    assert len(project.stages) == 5
+    assert all(s.videos == [] for s in project.stages)
+    assert len(project.unassigned_videos) == 1
+    assert str(project.unassigned_videos[0].path) == "raw/clip.mp4"
+
+
+def test_import_scoreboard_overlays_placeholders_preserving_videos(tmp_path: Path) -> None:
+    """A scoreboard import on top of placeholders keeps assignments by stage_number."""
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.init_placeholder_stages(2)
+    project.stages[0].videos.append(StageVideo(path=Path("raw/v1.mp4"), role="primary"))
+    project.stages[1].videos.append(StageVideo(path=Path("raw/v2.mp4"), role="primary"))
+
+    project.import_scoreboard(
+        {
+            "match": {"id": "5", "name": "Real Match"},
+            "competitors": [
+                {
+                    "competitor_id": 1,
+                    "name": "A",
+                    "stages": [
+                        {
+                            "stage_number": 1,
+                            "stage_name": "Real S1",
+                            "time_seconds": 11.0,
+                            "scorecard_updated_at": "2026-04-01T00:00:00+00:00",
+                        },
+                        {
+                            "stage_number": 2,
+                            "stage_name": "Real S2",
+                            "time_seconds": 22.0,
+                            "scorecard_updated_at": "2026-04-01T00:00:00+00:00",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    assert project.name == "Real Match"
+    assert all(not s.placeholder for s in project.stages)
+    assert project.stages[0].stage_name == "Real S1"
+    assert len(project.stages[0].videos) == 1
+    assert str(project.stages[0].videos[0].path) == "raw/v1.mp4"
+    assert project.stages[0].videos[0].role == "primary"
+    assert len(project.stages[1].videos) == 1
+
+
+def test_import_scoreboard_overlay_drops_extras_to_unassigned(tmp_path: Path) -> None:
+    """When the scoreboard has fewer stages than placeholders, orphaned videos
+    move to unassigned_videos -- we never silently lose user data."""
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.init_placeholder_stages(3)
+    project.stages[2].videos.append(StageVideo(path=Path("raw/v3.mp4"), role="primary"))
+
+    project.import_scoreboard(
+        {
+            "match": {"id": "5", "name": "M"},
+            "competitors": [
+                {
+                    "competitor_id": 1,
+                    "name": "A",
+                    "stages": [
+                        {
+                            "stage_number": 1,
+                            "stage_name": "S1",
+                            "time_seconds": 10.0,
+                            "scorecard_updated_at": "2026-04-01T00:00:00+00:00",
+                        },
+                        {
+                            "stage_number": 2,
+                            "stage_name": "S2",
+                            "time_seconds": 20.0,
+                            "scorecard_updated_at": "2026-04-01T00:00:00+00:00",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    assert len(project.stages) == 2
+    assert len(project.unassigned_videos) == 1
+    assert str(project.unassigned_videos[0].path) == "raw/v3.mp4"
+    assert project.unassigned_videos[0].role == "secondary"
+
+
 def test_register_video_symlinks_into_raw(tmp_path: Path) -> None:
     """Registering a video creates a symlink in raw/ and adds to unassigned_videos."""
     root = tmp_path / "match-vid"

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -1,0 +1,270 @@
+"""Tests for the production UI's match-project model.
+
+Covers:
+- ``MatchProject.init`` creates the standard subdirectory layout
+- Round-trip: write -> read -> deep equality
+- Incremental write: adding a video to an existing project preserves prior state
+- Atomic write: an interrupted save never leaves a corrupt project.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from splitsmith.ui.project import (
+    PROJECT_FILE,
+    SCHEMA_VERSION,
+    SUBDIRS,
+    MatchProject,
+    StageEntry,
+    StageVideo,
+    atomic_write_json,
+)
+
+
+def test_init_creates_layout(tmp_path: Path) -> None:
+    project = MatchProject.init(tmp_path / "match-a", name="Match A")
+
+    assert project.name == "Match A"
+    assert project.schema_version == SCHEMA_VERSION
+    assert (tmp_path / "match-a" / PROJECT_FILE).exists()
+    for sub in SUBDIRS:
+        assert (tmp_path / "match-a" / sub).is_dir()
+
+
+def test_init_is_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "match-b"
+    first = MatchProject.init(root, name="Match B")
+    first.competitor_name = "Test Shooter"
+    first.save(root)
+
+    # Re-init must NOT clobber existing state.
+    second = MatchProject.init(root, name="Different Name")
+    assert second.name == "Match B"
+    assert second.competitor_name == "Test Shooter"
+
+
+def test_round_trip_preserves_full_project(tmp_path: Path) -> None:
+    root = tmp_path / "match-c"
+    project = MatchProject.init(root, name="Round Trip Match")
+    project.competitor_name = "Mathias"
+    project.scoreboard_match_id = "ssi-12345"
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="Per told me to do it",
+            time_seconds=14.74,
+            videos=[
+                StageVideo(
+                    path=Path("raw/VID_001.mp4"),
+                    role="primary",
+                    beep_time=12.453,
+                    processed={"beep": True, "shot_detect": True, "trim": True},
+                ),
+                StageVideo(
+                    path=Path("raw/VID_002.mp4"),
+                    role="secondary",
+                    beep_time=12.501,
+                    processed={"beep": True, "shot_detect": False, "trim": True},
+                    notes="bay cam from friend, added 2026-05-02",
+                ),
+            ],
+        ),
+        StageEntry(
+            stage_number=2,
+            stage_name="Speedy",
+            time_seconds=9.12,
+            videos=[],
+            skipped=True,
+        ),
+    ]
+    project.save(root)
+
+    reloaded = MatchProject.load(root)
+
+    # ``updated_at`` is bumped on save, so compare on the dumped form rather
+    # than direct equality of the live model. Drop ``updated_at`` for the
+    # comparison since both sides will have it set after save.
+    a = project.model_dump(mode="json")
+    b = reloaded.model_dump(mode="json")
+    a.pop("updated_at")
+    b.pop("updated_at")
+    assert a == b
+
+
+def test_incremental_add_video_preserves_prior_state(tmp_path: Path) -> None:
+    """The Sub 1 incremental-write test from issue #12.
+
+    Programmatically add a ``StageVideo`` to an existing project's stage,
+    write, re-read; the original state plus the new video must be preserved.
+    """
+    root = tmp_path / "match-incremental"
+    project = MatchProject.init(root, name="Incremental Match")
+    project.stages = [
+        StageEntry(
+            stage_number=3,
+            stage_name="Stage Three",
+            time_seconds=20.0,
+            videos=[
+                StageVideo(
+                    path=Path("raw/headcam.mp4"),
+                    role="primary",
+                    beep_time=15.0,
+                    processed={"beep": True, "shot_detect": True, "trim": True},
+                )
+            ],
+        )
+    ]
+    project.save(root)
+
+    # Day N: a friend sends bay-cam footage.
+    later = MatchProject.load(root)
+    later.stage(3).videos.append(
+        StageVideo(
+            path=Path("raw/baycam.mp4"),
+            role="secondary",
+            processed={"beep": False, "shot_detect": False, "trim": False},
+        )
+    )
+    later.save(root)
+
+    final = MatchProject.load(root)
+    stage = final.stage(3)
+    assert len(stage.videos) == 2
+    primary = stage.primary()
+    assert primary is not None
+    assert primary.path == Path("raw/headcam.mp4")
+    assert primary.beep_time == 15.0
+    assert primary.processed["shot_detect"] is True
+    secondary = stage.videos[1]
+    assert secondary.role == "secondary"
+    assert secondary.processed["shot_detect"] is False
+
+
+def test_atomic_write_no_partial_file_on_crash(tmp_path: Path) -> None:
+    """An exception mid-write must leave the destination either absent or a
+    fully-valid earlier version -- never a half-written file."""
+    target = tmp_path / "config.json"
+
+    # Start with a valid file the writer would otherwise overwrite.
+    target.write_text('{"version": 1}\n')
+
+    class BoomError(RuntimeError):
+        pass
+
+    def serializer_that_blows_up(obj: object) -> object:
+        raise BoomError("simulated failure mid-serialization")
+
+    with pytest.raises(BoomError):
+        # Force the json.dump path through ``default`` by passing an
+        # unserializable object plus our exploding default.
+        from splitsmith.ui import project as project_module
+
+        original_default = project_module._json_default
+        project_module._json_default = serializer_that_blows_up
+        try:
+            atomic_write_json(target, {"x": object()})
+        finally:
+            project_module._json_default = original_default
+
+    # Original file untouched.
+    assert json.loads(target.read_text()) == {"version": 1}
+    # No leftover .tmp file in the directory.
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".config.json.")]
+    assert leftovers == []
+
+
+def test_concurrent_saves_never_corrupt(tmp_path: Path) -> None:
+    """Hammer the project with parallel saves; the file is always a valid JSON
+    document corresponding to one of the writers' dumps."""
+    root = tmp_path / "match-concurrent"
+    MatchProject.init(root, name="Concurrent Match")
+
+    def bump(thread_id: int) -> None:
+        for i in range(20):
+            p = MatchProject.load(root)
+            p.competitor_name = f"thread-{thread_id}-iter-{i}"
+            p.save(root)
+
+    threads = [threading.Thread(target=bump, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Final state: file is valid JSON, parses as a MatchProject.
+    final = MatchProject.load(root)
+    assert final.competitor_name is not None
+    assert final.competitor_name.startswith("thread-")
+
+
+def test_stage_lookup_raises_for_missing(tmp_path: Path) -> None:
+    project = MatchProject.init(tmp_path / "match-d", name="Match D")
+    with pytest.raises(KeyError):
+        project.stage(99)
+
+
+def test_default_video_is_secondary(tmp_path: Path) -> None:
+    """First-time-added videos default to ``secondary``; primary designation is
+    explicit (handled by the ingest screen, not the data model)."""
+    v = StageVideo(path=Path("raw/v.mp4"))
+    assert v.role == "secondary"
+    assert v.processed == {"beep": False, "shot_detect": False, "trim": False}
+    assert v.beep_time is None
+
+
+def test_datetime_round_trips_as_iso8601(tmp_path: Path) -> None:
+    """The on-disk JSON uses ISO-8601 for datetimes; round-trip must be lossless."""
+    root = tmp_path / "match-dt"
+    project = MatchProject.init(root, name="DT Match")
+    project.save(root)
+
+    raw = json.loads((root / PROJECT_FILE).read_text())
+    # ISO-8601 is parseable.
+    parsed = datetime.fromisoformat(raw["created_at"])
+    assert parsed.tzinfo is not None  # we always store UTC
+
+
+def test_project_file_ends_with_newline(tmp_path: Path) -> None:
+    """File hygiene: a trailing newline keeps git diffs clean."""
+    root = tmp_path / "match-nl"
+    project = MatchProject.init(root, name="NL Match")
+    project.save(root)
+    contents = (root / PROJECT_FILE).read_text()
+    assert contents.endswith("\n")
+
+
+def test_atomic_write_uses_same_directory_for_tmp(tmp_path: Path) -> None:
+    """The temp file must live in the destination's directory so ``os.replace``
+    is atomic (cross-filesystem renames aren't)."""
+    target = tmp_path / "out.json"
+
+    seen_dirs: list[Path] = []
+    original_mkstemp = os.path.dirname  # placeholder so name exists
+
+    import tempfile as _tempfile
+
+    real_mkstemp = _tempfile.mkstemp
+
+    def spy(*args: object, **kwargs: object) -> tuple[int, str]:
+        if "dir" in kwargs:
+            seen_dirs.append(Path(str(kwargs["dir"])))
+        return real_mkstemp(*args, **kwargs)  # type: ignore[arg-type]
+
+    _tempfile.mkstemp = spy  # type: ignore[assignment]
+    try:
+        atomic_write_json(target, {"hello": "world"})
+    finally:
+        _tempfile.mkstemp = real_mkstemp  # type: ignore[assignment]
+
+    assert seen_dirs == [tmp_path]
+    assert json.loads(target.read_text()) == {"hello": "world"}
+
+    # Touch ``original_mkstemp`` so flake8 doesn't flag it; harmless.
+    _ = original_mkstemp

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -461,6 +461,52 @@ def test_auto_match_returns_suggestions_without_mutation(tmp_path: Path) -> None
     assert project.stages[0].videos == []
 
 
+def test_storage_paths_default_to_project_subdirs(tmp_path: Path) -> None:
+    root = tmp_path / "match-paths"
+    project = MatchProject.init(root, name="Paths Match")
+    assert project.raw_path(root) == root / "raw"
+    assert project.audio_path(root) == root / "audio"
+    assert project.trimmed_path(root) == root / "trimmed"
+    assert project.exports_path(root) == root / "exports"
+
+
+def test_storage_paths_relative_resolve_against_root(tmp_path: Path) -> None:
+    root = tmp_path / "match-relative"
+    project = MatchProject.init(root, name="Relative Match")
+    project.audio_dir = "cache/audio"
+    project.trimmed_dir = "cache/trimmed"
+    assert project.audio_path(root) == root / "cache" / "audio"
+    assert project.trimmed_path(root) == root / "cache" / "trimmed"
+
+
+def test_storage_paths_absolute_used_as_is(tmp_path: Path) -> None:
+    root = tmp_path / "match-absolute"
+    project = MatchProject.init(root, name="Absolute Match")
+    scratch = tmp_path / "scratch"
+    project.audio_dir = str(scratch / "audio")
+    project.trimmed_dir = str(scratch / "trimmed")
+    assert project.audio_path(root) == scratch / "audio"
+    assert project.trimmed_path(root) == scratch / "trimmed"
+
+
+def test_register_video_uses_configured_raw_dir(tmp_path: Path) -> None:
+    """When raw_dir points outside the project, the symlink lives there and
+    the StageVideo path is stored as absolute (since it's not under root)."""
+    root = tmp_path / "match-raw-config"
+    project = MatchProject.init(root, name="Raw Config Match")
+    external_raw = tmp_path / "external-raw"
+    project.raw_dir = str(external_raw)
+
+    src = tmp_path / "external" / "VID.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"")
+
+    video = project.register_video(src, root)
+    assert video.path.is_absolute()
+    assert (external_raw / "VID.mp4").exists()
+    assert (external_raw / "VID.mp4").resolve() == src
+
+
 def test_atomic_write_uses_same_directory_for_tmp(tmp_path: Path) -> None:
     """The temp file must live in the destination's directory so ``os.replace``
     is atomic (cross-filesystem renames aren't)."""

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -240,6 +240,227 @@ def test_project_file_ends_with_newline(tmp_path: Path) -> None:
     assert contents.endswith("\n")
 
 
+def test_import_scoreboard_populates_stages(tmp_path: Path) -> None:
+    """Dropping an SSI Scoreboard JSON populates stages, match name, and competitor."""
+    root = tmp_path / "match-import"
+    project = MatchProject.init(root, name="placeholder")
+
+    scoreboard = {
+        "match": {"id": "27046", "ct": "22", "name": "Blacksmith Handgun Open 2026"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Sample Shooter",
+                "division": "Production Optics",
+                "club": "Sample IPSC Club",
+                "stages": [
+                    {
+                        "stage_number": 2,  # intentionally out of order
+                        "stage_name": "100m",
+                        "time_seconds": 12.48,
+                        "scorecard_updated_at": "2026-04-12T12:03:32.729554+00:00",
+                    },
+                    {
+                        "stage_number": 1,
+                        "stage_name": "K-vallen",
+                        "time_seconds": 42.76,
+                        "scorecard_updated_at": "2026-04-12T11:29:28.833034+00:00",
+                    },
+                ],
+            }
+        ],
+    }
+    project.import_scoreboard(scoreboard)
+
+    assert project.name == "Blacksmith Handgun Open 2026"
+    assert project.scoreboard_match_id == "27046"
+    assert project.competitor_name == "Sample Shooter"
+    # Stages sorted by stage_number.
+    assert [s.stage_number for s in project.stages] == [1, 2]
+    assert project.stages[0].stage_name == "K-vallen"
+    assert project.stages[0].time_seconds == 42.76
+
+
+def test_import_scoreboard_refuses_overwrite_by_default(tmp_path: Path) -> None:
+    from splitsmith.ui.project import ScoreboardImportConflictError
+
+    root = tmp_path / "match-conflict"
+    project = MatchProject.init(root, name="x")
+    sb1 = {
+        "match": {"id": "1", "name": "First"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "A",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    project.import_scoreboard(sb1)
+
+    sb2 = {
+        "match": {"id": "2", "name": "Second"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "A",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S2-different",
+                        "time_seconds": 20.0,
+                        "scorecard_updated_at": "2026-02-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    with pytest.raises(ScoreboardImportConflictError):
+        project.import_scoreboard(sb2)
+
+    # Forced overwrite works.
+    project.import_scoreboard(sb2, overwrite=True)
+    assert project.stages[0].stage_name == "S2-different"
+
+
+def test_register_video_symlinks_into_raw(tmp_path: Path) -> None:
+    """Registering a video creates a symlink in raw/ and adds to unassigned_videos."""
+    root = tmp_path / "match-vid"
+    project = MatchProject.init(root, name="Vid Match")
+
+    source = tmp_path / "external" / "VID_001.mp4"
+    source.parent.mkdir()
+    source.write_bytes(b"\x00\x00\x00 ftypisom")  # any bytes; we don't probe in this test
+
+    video = project.register_video(source, root)
+
+    assert video.path == Path("raw") / "VID_001.mp4"
+    assert video.role == "secondary"
+    assert (root / "raw" / "VID_001.mp4").exists()
+    # Symlink resolves back to the source.
+    assert (root / "raw" / "VID_001.mp4").resolve() == source
+    assert len(project.unassigned_videos) == 1
+
+
+def test_register_video_is_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "match-idem"
+    project = MatchProject.init(root, name="Idempotent Match")
+    source = tmp_path / "external" / "VID_002.mp4"
+    source.parent.mkdir()
+    source.write_bytes(b"")
+
+    a = project.register_video(source, root)
+    b = project.register_video(source, root)
+    assert a.path == b.path
+    assert len(project.unassigned_videos) == 1
+
+
+def test_register_video_rejects_non_video(tmp_path: Path) -> None:
+    root = tmp_path / "match-bad"
+    project = MatchProject.init(root, name="Bad Match")
+    bad = tmp_path / "notes.txt"
+    bad.write_text("not a video")
+    with pytest.raises(ValueError):
+        project.register_video(bad, root)
+
+
+def test_assign_video_unassigned_to_stage_as_primary(tmp_path: Path) -> None:
+    root = tmp_path / "match-assign"
+    project = MatchProject.init(root, name="Assign Match")
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="A", time_seconds=10.0),
+    ]
+    src = tmp_path / "VID.mp4"
+    src.write_bytes(b"")
+    video = project.register_video(src, root)
+
+    project.assign_video(video.path, to_stage_number=1, role="primary")
+
+    assert len(project.unassigned_videos) == 0
+    assert len(project.stages[0].videos) == 1
+    assert project.stages[0].videos[0].role == "primary"
+
+
+def test_assign_video_demotes_existing_primary(tmp_path: Path) -> None:
+    root = tmp_path / "match-demote"
+    project = MatchProject.init(root, name="Demote Match")
+    src1 = tmp_path / "VID_a.mp4"
+    src2 = tmp_path / "VID_b.mp4"
+    src1.write_bytes(b"")
+    src2.write_bytes(b"")
+    project.stages = [StageEntry(stage_number=1, stage_name="A", time_seconds=10.0)]
+    v1 = project.register_video(src1, root)
+    v2 = project.register_video(src2, root)
+    project.assign_video(v1.path, to_stage_number=1, role="primary")
+    project.assign_video(v2.path, to_stage_number=1, role="primary")
+
+    stage = project.stages[0]
+    assert len(stage.videos) == 2
+    primaries = [v for v in stage.videos if v.role == "primary"]
+    secondaries = [v for v in stage.videos if v.role == "secondary"]
+    assert len(primaries) == 1
+    assert len(secondaries) == 1
+    # The newest assignment wins.
+    assert primaries[0].path == v2.path
+
+
+def test_assign_video_back_to_unassigned(tmp_path: Path) -> None:
+    root = tmp_path / "match-back"
+    project = MatchProject.init(root, name="Back Match")
+    project.stages = [StageEntry(stage_number=1, stage_name="A", time_seconds=10.0)]
+    src = tmp_path / "VID.mp4"
+    src.write_bytes(b"")
+    v = project.register_video(src, root)
+    project.assign_video(v.path, to_stage_number=1, role="primary")
+    project.assign_video(v.path, to_stage_number=None)
+
+    assert project.unassigned_videos[0].path == v.path
+    assert project.stages[0].videos == []
+
+
+def test_auto_match_returns_suggestions_without_mutation(tmp_path: Path) -> None:
+    """auto_match runs the heuristic and returns suggestions; project is unchanged."""
+    from datetime import UTC, datetime, timedelta
+
+    root = tmp_path / "match-auto"
+    project = MatchProject.init(root, name="Auto Match")
+    base = datetime.now(UTC).replace(microsecond=0)
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="A",
+            time_seconds=10.0,
+            scorecard_updated_at=base,
+        ),
+        StageEntry(
+            stage_number=2,
+            stage_name="B",
+            time_seconds=10.0,
+            scorecard_updated_at=base + timedelta(minutes=30),
+        ),
+    ]
+    src = tmp_path / "VID.mp4"
+    src.write_bytes(b"")
+    video = project.register_video(src, root)
+    # Set mtime so it lands in stage 1's window (scorecard - tolerance ≤ mtime ≤ scorecard).
+    target_ts = (base - timedelta(minutes=5)).timestamp()
+    os.utime(src, (target_ts, target_ts))
+
+    suggestions = project.auto_match(root)
+
+    assert suggestions == {1: video.path}
+    # No mutation -- the video is still unassigned.
+    assert len(project.unassigned_videos) == 1
+    assert project.stages[0].videos == []
+
+
 def test_atomic_write_uses_same_directory_for_tmp(tmp_path: Path) -> None:
     """The temp file must live in the destination's directory so ``os.replace``
     is atomic (cross-filesystem renames aren't)."""

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -481,6 +481,106 @@ def test_import_scoreboard_overlay_drops_extras_to_unassigned(tmp_path: Path) ->
     assert project.unassigned_videos[0].role == "secondary"
 
 
+def test_remove_video_unassigned_returns_plan(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    src = tmp_path / "ext" / "clip.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"fake")
+    video = project.register_video(src, root)
+
+    plan = project.remove_video(video.path, root)
+
+    assert project.find_video(video.path) is None
+    assert plan.was_primary is False
+    assert plan.stage_number is None
+    assert plan.audio_cache_path is None
+    assert plan.trimmed_cache_path is None
+    assert plan.audit_path is None
+    assert plan.raw_link_path == (root / "raw" / "clip.mp4")
+
+
+def test_remove_primary_includes_audio_and_trimmed_paths(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.import_scoreboard(
+        {
+            "match": {"id": "1", "name": "M"},
+            "competitors": [
+                {
+                    "competitor_id": 1,
+                    "name": "A",
+                    "stages": [
+                        {
+                            "stage_number": 1,
+                            "stage_name": "S1",
+                            "time_seconds": 10.0,
+                            "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    src = tmp_path / "ext" / "clip.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"fake")
+    video = project.register_video(src, root)
+    project.assign_video(video.path, to_stage_number=1, role="primary")
+    project.stages[0].videos[0].processed = {"beep": True, "shot_detect": True, "trim": True}
+
+    plan = project.remove_video(video.path, root)
+
+    assert plan.was_primary is True
+    assert plan.stage_number == 1
+    assert plan.audio_cache_path == (root / "audio" / "stage1_primary.wav")
+    assert plan.trimmed_cache_path == (root / "trimmed" / "stage1_trimmed.mp4")
+    assert plan.audit_path is None  # default: preserve audit
+    assert plan.audit_reset is False
+    assert project.stages[0].videos == []
+
+
+def test_remove_with_reset_audit_includes_audit_path(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    project.import_scoreboard(
+        {
+            "match": {"id": "1", "name": "M"},
+            "competitors": [
+                {
+                    "competitor_id": 1,
+                    "name": "A",
+                    "stages": [
+                        {
+                            "stage_number": 1,
+                            "stage_name": "S1",
+                            "time_seconds": 10.0,
+                            "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    src = tmp_path / "ext" / "clip.mp4"
+    src.parent.mkdir()
+    src.write_bytes(b"fake")
+    video = project.register_video(src, root)
+    project.assign_video(video.path, to_stage_number=1, role="primary")
+
+    plan = project.remove_video(video.path, root, reset_audit=True)
+
+    assert plan.audit_reset is True
+    assert plan.audit_path == (root / "audit" / "stage1.json")
+
+
+def test_remove_video_unknown_path_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="x")
+    with pytest.raises(KeyError):
+        project.remove_video(Path("raw/missing.mp4"), root)
+
+
 def test_register_video_symlinks_into_raw(tmp_path: Path) -> None:
     """Registering a video creates a symlink in raw/ and adds to unassigned_videos."""
     root = tmp_path / "match-vid"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -144,6 +144,50 @@ def test_import_scoreboard_409_on_conflict(tmp_path: Path) -> None:
     assert resp.status_code == 200
 
 
+def test_placeholder_stages_endpoint_creates_stages(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/project/placeholder-stages",
+        json={"stage_count": 5, "match_name": "Test Match", "match_date": "2026-04-12"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Test Match"
+    assert body["match_date"] == "2026-04-12"
+    assert len(body["stages"]) == 5
+    assert all(s["placeholder"] for s in body["stages"])
+
+
+def test_placeholder_stages_endpoint_409_when_real_stages_exist(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    # Real scoreboard import first.
+    sb = {
+        "match": {"id": "1", "name": "Real"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "A",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    resp = client.post(
+        "/api/project/placeholder-stages",
+        json={"stage_count": 5},
+    )
+    assert resp.status_code == 409
+
+
 def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
     """End-to-end test for the scan endpoint: create a stage, drop a video into a
     source folder with a matching mtime, scan, expect auto-assignment as primary."""
@@ -646,6 +690,56 @@ def test_settings_empty_string_clears_override(tmp_path: Path) -> None:
     )
     body = client.post("/api/project/settings", json={"audio_dir": ""}).json()
     assert body["audio_dir"] is None
+
+
+def test_settings_409_when_old_dir_non_empty(tmp_path: Path) -> None:
+    """Changing a path field must surface a 409 ``non_empty_old_dirs`` warning
+    when the old directory still has files -- splitsmith does not migrate."""
+    root = tmp_path / "match"
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    # Default audio_dir is <project>/audio. Drop a stray cache file there.
+    audio_default = root / "audio"
+    audio_default.mkdir(parents=True, exist_ok=True)
+    (audio_default / "stage_1.wav").write_bytes(b"fake")
+
+    new_audio = tmp_path / "scratch-audio"
+    resp = client.post(
+        "/api/project/settings",
+        json={"audio_dir": str(new_audio)},
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["code"] == "non_empty_old_dirs"
+    assert len(detail["dirs"]) == 1
+    assert detail["dirs"][0]["field"] == "audio_dir"
+    assert detail["dirs"][0]["path"] == str(audio_default)
+    assert detail["dirs"][0]["file_count"] == 1
+    # Project unchanged on disk.
+    assert MatchProject.load(root).audio_dir is None
+
+    # With confirm=true the change goes through, leaving old files behind.
+    resp = client.post(
+        "/api/project/settings",
+        json={"audio_dir": str(new_audio), "confirm": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["audio_dir"] == str(new_audio)
+    assert (audio_default / "stage_1.wav").exists()  # not migrated
+
+
+def test_settings_no_warning_when_old_dir_empty(tmp_path: Path) -> None:
+    """An empty old directory should not trigger the warning."""
+    root = tmp_path / "match"
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+    # Default <project>/audio doesn't even exist yet.
+    resp = client.post(
+        "/api/project/settings",
+        json={"audio_dir": str(tmp_path / "elsewhere")},
+    )
+    assert resp.status_code == 200
 
 
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -382,6 +382,173 @@ def test_scan_persists_last_scanned_dir(tmp_path: Path) -> None:
     assert project["last_scanned_dir"] == str(src_dir.resolve())
 
 
+def _seed_project_with_primary(tmp_path: Path) -> tuple[TestClient, Path]:
+    """Boot a server with one stage and a primary video assigned. Returns
+    ``(client, video_source_path)`` so the caller can mutate the source if
+    needed (e.g. to control mtime for video_match)."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="Beep Match")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "Beep Match"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Tester",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "Stage One",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    src = src_dir / "VID.mp4"
+    src.write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    return client, src
+
+
+def _stub_detect(monkeypatch, beep_time: float = 12.453) -> None:
+    """Replace audio_helpers.detect_primary_beep with a fast stub returning a
+    deterministic BeepDetection. The endpoint is otherwise wrapped around
+    ffmpeg + librosa, which we don't want to invoke from a unit test."""
+    from splitsmith.config import BeepDetection
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return BeepDetection(time=beep_time, peak_amplitude=0.42, duration_ms=320.0)
+
+    monkeypatch.setattr(audio_helpers, "detect_primary_beep", fake)
+
+
+def test_detect_beep_persists_auto_result(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453)
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 200
+    body = resp.json()
+    primary = body["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 12.453
+    assert primary["beep_source"] == "auto"
+    assert primary["beep_peak_amplitude"] == 0.42
+    assert primary["beep_duration_ms"] == 320.0
+    assert primary["processed"]["beep"] is True
+
+
+def test_detect_beep_409_over_manual_unless_forced(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    # User has already set a manual override.
+    client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    _stub_detect(monkeypatch, beep_time=99.0)
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 409
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 12.5
+    assert primary["beep_source"] == "manual"
+
+    # ?force=true replaces it.
+    resp = client.post("/api/stages/1/detect-beep?force=true")
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 99.0
+    assert primary["beep_source"] == "auto"
+
+
+def test_detect_beep_400_when_no_primary(tmp_path: Path) -> None:
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "Empty",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 400
+
+
+def test_override_beep_sets_manual_source(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 12.5
+    assert primary["beep_source"] == "manual"
+    assert primary["processed"]["beep"] is True
+
+
+def test_override_beep_clears_with_null(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=10.0)
+    client.post("/api/stages/1/detect-beep")
+
+    resp = client.post("/api/stages/1/beep", json={"beep_time": None})
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] is None
+    assert primary["beep_source"] is None
+    assert primary["processed"]["beep"] is False
+
+
+def test_override_beep_400_on_negative(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.post("/api/stages/1/beep", json={"beep_time": -1.0})
+    assert resp.status_code == 400
+
+
+def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
+    """The /audio endpoint asks the helper for the cached WAV; we stub the
+    helper to drop a small WAV file in place rather than running ffmpeg."""
+    client, _ = _seed_project_with_primary(tmp_path)
+
+    project_root = tmp_path / "match"
+    fake_wav = project_root / "audio" / "stage1_primary.wav"
+    fake_wav.parent.mkdir(parents=True, exist_ok=True)
+    # Minimal RIFF header + tiny data chunk; the test only checks that bytes flow.
+    fake_wav.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00" + b"\x00" * 16)
+
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake_ensure(root, n, source, **kwargs):  # type: ignore[no-untyped-def]
+        return fake_wav
+
+    monkeypatch.setattr(audio_helpers, "ensure_primary_audio", fake_ensure)
+
+    resp = client.get("/api/stages/1/audio")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/wav"
+    assert resp.content.startswith(b"RIFF")
+
+
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     """External edits to project.json must appear on the next request -- the
     server doesn't cache the model in memory."""

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -84,6 +84,212 @@ def test_spa_serves_index_html_when_built(tmp_path: Path) -> None:
     assert resp.status_code == 404
 
 
+def test_import_scoreboard_endpoint(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    sb = {
+        "match": {"id": "27046", "name": "Imported Match"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Tester",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    resp = client.post("/api/scoreboard/import", json={"data": sb})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Imported Match"
+    assert body["scoreboard_match_id"] == "27046"
+    assert body["competitor_name"] == "Tester"
+    assert len(body["stages"]) == 1
+
+
+def test_import_scoreboard_409_on_conflict(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    sb = {
+        "match": {"id": "1", "name": "First"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Tester",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    assert client.post("/api/scoreboard/import", json={"data": sb}).status_code == 200
+    resp = client.post("/api/scoreboard/import", json={"data": sb})
+    assert resp.status_code == 409
+
+    # overwrite=True succeeds.
+    resp = client.post("/api/scoreboard/import", json={"data": sb, "overwrite": True})
+    assert resp.status_code == 200
+
+
+def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
+    """End-to-end test for the scan endpoint: create a stage, drop a video into a
+    source folder with a matching mtime, scan, expect auto-assignment as primary."""
+    import os as _os
+    from datetime import datetime
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="Scan Match")
+    client = TestClient(app)
+
+    scorecard_iso = "2026-04-12T11:30:00+00:00"
+    scorecard_dt = datetime.fromisoformat(scorecard_iso)
+    sb = {
+        "match": {"id": "1", "name": "Scan Match Loaded"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Tester",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "First",
+                        "time_seconds": 12.0,
+                        "scorecard_updated_at": scorecard_iso,
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    vid = src_dir / "VID.mp4"
+    vid.write_bytes(b"")
+    target_ts = scorecard_dt.timestamp() - 60  # 1 minute before scorecard
+    _os.utime(vid, (target_ts, target_ts))
+
+    resp = client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["registered"] == ["raw/VID.mp4"]
+    assert body["auto_assigned"] == {"1": "raw/VID.mp4"}
+
+    # Verify project state.
+    project = client.get("/api/project").json()
+    assert project["stages"][0]["videos"][0]["role"] == "primary"
+    assert project["unassigned_videos"] == []
+
+
+def test_scan_videos_400_on_missing_dir(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post("/api/videos/scan", json={"source_dir": str(tmp_path / "does-not-exist")})
+    assert resp.status_code == 400
+
+
+def test_move_assignment_endpoint(tmp_path: Path) -> None:
+    """Set role to ignored, verify, then move back to a stage."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="Move Match")
+    client = TestClient(app)
+
+    # Set up: 1 stage, 1 video assigned as primary.
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "Tester",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "First",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    vid = src_dir / "VID.mp4"
+    vid.write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+
+    # Should have one unassigned video.
+    project = client.get("/api/project").json()
+    assert len(project["unassigned_videos"]) == 1
+
+    # Move to stage 1 as primary.
+    resp = client.post(
+        "/api/assignments/move",
+        json={
+            "video_path": "raw/VID.mp4",
+            "to_stage_number": 1,
+            "role": "primary",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["unassigned_videos"] == []
+    assert body["stages"][0]["videos"][0]["role"] == "primary"
+
+    # Mark as ignored (still on stage 1).
+    resp = client.post(
+        "/api/assignments/move",
+        json={
+            "video_path": "raw/VID.mp4",
+            "to_stage_number": 1,
+            "role": "ignored",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["stages"][0]["videos"][0]["role"] == "ignored"
+
+    # Back to unassigned.
+    resp = client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": None},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["stages"][0]["videos"] == []
+    assert len(body["unassigned_videos"]) == 1
+
+
+def test_move_assignment_404_on_unknown_video(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/nope.mp4", "to_stage_number": None},
+    )
+    assert resp.status_code == 404
+
+
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     """External edits to project.json must appear on the next request -- the
     server doesn't cache the model in memory."""

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -549,6 +549,105 @@ def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
     assert resp.content.startswith(b"RIFF")
 
 
+def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
+    """source_paths picks specific files (USB-cam workflow). Only the listed
+    files are registered, even if other videos sit in the same directory."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    keep1 = src_dir / "keep1.mp4"
+    keep2 = src_dir / "keep2.mp4"
+    skip = src_dir / "skip.mp4"
+    for f in (keep1, keep2, skip):
+        f.write_bytes(b"")
+
+    resp = client.post(
+        "/api/videos/scan",
+        json={
+            "source_paths": [str(keep1), str(keep2)],
+            "auto_assign_primary": False,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert sorted(body["registered"]) == ["raw/keep1.mp4", "raw/keep2.mp4"]
+    project = client.get("/api/project").json()
+    assert len(project["unassigned_videos"]) == 2
+    # last_scanned_dir set to the parent of the first picked file.
+    assert project["last_scanned_dir"] == str(src_dir.resolve())
+
+
+def test_scan_400_when_neither_source_dir_nor_paths(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post("/api/videos/scan", json={"auto_assign_primary": False})
+    assert resp.status_code == 400
+
+
+def test_scan_400_when_both_source_dir_and_paths(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(tmp_path), "source_paths": [str(tmp_path / "a.mp4")]},
+    )
+    assert resp.status_code == 400
+
+
+def test_settings_endpoint_persists_overrides(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/project/settings",
+        json={
+            "audio_dir": str(tmp_path / "scratch" / "audio"),
+            "trimmed_dir": str(tmp_path / "scratch" / "trimmed"),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["audio_dir"] == str(tmp_path / "scratch" / "audio")
+    assert body["trimmed_dir"] == str(tmp_path / "scratch" / "trimmed")
+    # raw_dir / exports_dir untouched.
+    assert body["raw_dir"] is None
+    assert body["exports_dir"] is None
+    # Directories were created.
+    assert (tmp_path / "scratch" / "audio").is_dir()
+    assert (tmp_path / "scratch" / "trimmed").is_dir()
+
+
+def test_settings_empty_string_clears_override(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    client.post(
+        "/api/project/settings",
+        json={"audio_dir": str(tmp_path / "audio-config")},
+    )
+    body = client.post("/api/project/settings", json={"audio_dir": ""}).json()
+    assert body["audio_dir"] is None
+
+
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     """External edits to project.json must appear on the next request -- the
     server doesn't cache the model in memory."""

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -290,6 +290,98 @@ def test_move_assignment_404_on_unknown_video(tmp_path: Path) -> None:
     assert resp.status_code == 404
 
 
+def test_fs_list_returns_directory_entries(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    listing_root = tmp_path / "browseable"
+    listing_root.mkdir()
+    (listing_root / "subdir-a").mkdir()
+    (listing_root / "subdir-b").mkdir()
+    (listing_root / "VID_1.mp4").write_bytes(b"")
+    (listing_root / "VID_2.mov").write_bytes(b"")
+    (listing_root / "notes.txt").write_text("hi")
+    (listing_root / ".hidden").mkdir()  # filtered out
+
+    resp = client.get("/api/fs/list", params={"path": str(listing_root)})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == str(listing_root.resolve())
+    assert body["parent"] == str(listing_root.parent.resolve())
+    names = {e["name"]: e for e in body["entries"]}
+    assert ".hidden" not in names
+    assert names["subdir-a"]["kind"] == "dir"
+    assert names["VID_1.mp4"]["kind"] == "video"
+    assert names["notes.txt"]["kind"] == "file"
+    # Directories sort first.
+    kinds = [e["kind"] for e in body["entries"]]
+    assert kinds.index("dir") < kinds.index("video")
+
+
+def test_fs_list_video_count_for_directories(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    parent = tmp_path / "p"
+    inner = parent / "match-day"
+    inner.mkdir(parents=True)
+    (inner / "v1.mp4").write_bytes(b"")
+    (inner / "v2.mov").write_bytes(b"")
+    (inner / "notes.txt").write_text("hi")
+
+    resp = client.get("/api/fs/list", params={"path": str(parent)})
+    assert resp.status_code == 200
+    entries = {e["name"]: e for e in resp.json()["entries"]}
+    assert entries["match-day"]["kind"] == "dir"
+    assert entries["match-day"]["video_count"] == 2
+
+
+def test_fs_list_default_path_uses_last_scanned_dir(tmp_path: Path) -> None:
+    """Saving last_scanned_dir on the project should change the default path."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+
+    seeded = tmp_path / "videos"
+    seeded.mkdir()
+    project = MatchProject.load(project_root)
+    project.last_scanned_dir = str(seeded.resolve())
+    project.save(project_root)
+
+    resp = client.get("/api/fs/list")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == str(seeded.resolve())
+    # The seeded dir is suggested first in bookmarks.
+    assert body["suggested_starts"][0] == str(seeded.resolve())
+
+
+def test_fs_list_404_on_missing_path(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.get("/api/fs/list", params={"path": str(tmp_path / "nope")})
+    assert resp.status_code == 404
+
+
+def test_scan_persists_last_scanned_dir(tmp_path: Path) -> None:
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "VID.mp4").write_bytes(b"")
+
+    resp = client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+    assert resp.status_code == 200
+
+    project = client.get("/api/project").json()
+    assert project["last_scanned_dir"] == str(src_dir.resolve())
+
+
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     """External edits to project.json must appear on the next request -- the
     server doesn't cache the model in memory."""

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
+from splitsmith.thumbnail import ThumbnailError
 from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
 from splitsmith.ui.server import create_app
+from splitsmith.video_probe import ProbeError, ProbeResult
 
 
 def test_health_returns_project_info(tmp_path: Path) -> None:
@@ -740,6 +743,307 @@ def test_settings_no_warning_when_old_dir_empty(tmp_path: Path) -> None:
         json={"audio_dir": str(tmp_path / "elsewhere")},
     )
     assert resp.status_code == 200
+
+
+def test_remove_video_unassigned(tmp_path: Path) -> None:
+    """Removing an unassigned video drops it from the project and unlinks
+    its symlink under raw_dir. The original source on USB / external storage
+    is never touched."""
+    root = tmp_path / "match"
+    src_dir = tmp_path / "ext"
+    src_dir.mkdir()
+    src = src_dir / "clip.mp4"
+    src.write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/videos/scan",
+        json={"source_paths": [str(src)], "auto_assign_primary": False},
+    )
+    assert resp.status_code == 200
+    registered_path = resp.json()["registered"][0]
+    raw_link = root / "raw" / "clip.mp4"
+    assert raw_link.is_symlink()
+
+    resp = client.post("/api/videos/remove", json={"video_path": registered_path})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan"]["was_primary"] is False
+    assert body["project"]["unassigned_videos"] == []
+    assert not raw_link.exists()
+    assert src.exists(), "original source must never be touched"
+
+
+def test_remove_primary_clears_caches_and_keeps_audit(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src_dir = tmp_path / "ext"
+    src_dir.mkdir()
+    src = src_dir / "clip.mp4"
+    src.write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "M"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "A",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post(
+        "/api/videos/scan",
+        json={"source_paths": [str(src)], "auto_assign_primary": False},
+    )
+    project = MatchProject.load(root)
+    project.assign_video(Path("raw/clip.mp4"), to_stage_number=1, role="primary")
+    # Simulate processed state: write fake cached files audit/audio/trimmed.
+    audio_cache = root / "audio" / "stage1_primary.wav"
+    audio_cache.parent.mkdir(parents=True, exist_ok=True)
+    audio_cache.write_bytes(b"wav")
+    trimmed_cache = root / "trimmed" / "stage1_trimmed.mp4"
+    trimmed_cache.parent.mkdir(parents=True, exist_ok=True)
+    trimmed_cache.write_bytes(b"mp4")
+    audit = root / "audit" / "stage1.json"
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text("{}")
+    project.stages[0].videos[0].processed = {
+        "beep": True,
+        "shot_detect": True,
+        "trim": True,
+    }
+    project.save(root)
+
+    resp = client.post(
+        "/api/videos/remove",
+        json={"video_path": "raw/clip.mp4"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan"]["was_primary"] is True
+    assert body["plan"]["audit_reset"] is False
+    assert not audio_cache.exists()
+    assert not trimmed_cache.exists()
+    assert audit.exists(), "audit JSON must be preserved by default"
+
+
+def test_remove_primary_with_reset_audit_clears_audit(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src_dir = tmp_path / "ext"
+    src_dir.mkdir()
+    src = src_dir / "clip.mp4"
+    src.write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "M"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "A",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post(
+        "/api/videos/scan",
+        json={"source_paths": [str(src)], "auto_assign_primary": False},
+    )
+    project = MatchProject.load(root)
+    project.assign_video(Path("raw/clip.mp4"), to_stage_number=1, role="primary")
+    project.save(root)
+    audit = root / "audit" / "stage1.json"
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text("{}")
+
+    resp = client.post(
+        "/api/videos/remove",
+        json={"video_path": "raw/clip.mp4", "reset_audit": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["plan"]["audit_reset"] is True
+    assert not audit.exists()
+
+
+def test_remove_video_404_when_unknown(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    resp = client.post(
+        "/api/videos/remove",
+        json={"video_path": "raw/no-such.mp4"},
+    )
+    assert resp.status_code == 404
+
+
+def test_fs_list_probe_populates_duration_and_thumbnail(tmp_path: Path) -> None:
+    """When ``probe=true`` is passed, video entries get duration + thumbnail."""
+    root = tmp_path / "match"
+    folder = tmp_path / "videos"
+    folder.mkdir()
+    clip = folder / "clip.mp4"
+    clip.write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    def _fake_probe(path: Path, *, cache_dir: Path, **kwargs):  # noqa: ANN001
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return ProbeResult(duration=12.5, width=1920, height=1080, codec="h264")
+
+    def _fake_thumb(source: Path, *, cache_dir: Path, **kwargs):  # noqa: ANN001
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        from splitsmith.video_probe import source_cache_key
+
+        dest = cache_dir / f"{source_cache_key(source)}.jpg"
+        dest.write_bytes(b"\xff\xd8\xff")
+        return dest
+
+    with (
+        patch("splitsmith.ui.server.video_probe.probe", side_effect=_fake_probe),
+        patch("splitsmith.ui.server.thumbnail_helpers.ensure", side_effect=_fake_thumb),
+    ):
+        resp = client.get(f"/api/fs/list?path={folder}&probe=true")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    [entry] = body["entries"]
+    assert entry["kind"] == "video"
+    assert entry["duration"] == 12.5
+    assert entry["thumbnail_url"].startswith("/api/thumbnails/")
+
+
+def test_fs_probe_endpoint_runs_on_demand(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    def _fake_probe(path: Path, *, cache_dir: Path, **kwargs):  # noqa: ANN001
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return ProbeResult(duration=8.0)
+
+    def _fake_thumb(source: Path, *, cache_dir: Path, **kwargs):  # noqa: ANN001
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        from splitsmith.video_probe import source_cache_key
+
+        dest = cache_dir / f"{source_cache_key(source)}.jpg"
+        dest.write_bytes(b"\xff")
+        return dest
+
+    with (
+        patch("splitsmith.ui.server.video_probe.probe", side_effect=_fake_probe),
+        patch("splitsmith.ui.server.thumbnail_helpers.ensure", side_effect=_fake_thumb),
+    ):
+        resp = client.get(f"/api/fs/probe?path={clip}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["duration"] == 8.0
+    assert body["thumbnail_url"].startswith("/api/thumbnails/")
+
+
+def test_thumbnail_endpoint_serves_cached(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    thumbs_dir = root / "thumbs"
+    thumbs_dir.mkdir(parents=True, exist_ok=True)
+    (thumbs_dir / "abc123.jpg").write_bytes(b"\xff\xd8\xff jpeg")
+
+    resp = client.get("/api/thumbnails/abc123.jpg")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/jpeg")
+
+    resp_404 = client.get("/api/thumbnails/missing.jpg")
+    assert resp_404.status_code == 404
+
+
+def test_thumbnail_endpoint_rejects_path_traversal(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    # Slashes in the path component aren't possible thanks to FastAPI's
+    # path matcher, but '..' as a key should be rejected by our shape check.
+    resp = client.get("/api/thumbnails/..jpg")
+    assert resp.status_code == 400
+
+
+def test_fs_list_probe_skipped_when_falsy(tmp_path: Path) -> None:
+    """Without ?probe=true and without cached results, video entries should
+    have null duration / thumbnail and probe / ensure must not run."""
+    root = tmp_path / "match"
+    folder = tmp_path / "videos"
+    folder.mkdir()
+    (folder / "clip.mp4").write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    with (
+        patch(
+            "splitsmith.ui.server.video_probe.probe",
+            side_effect=AssertionError("probe must not run"),
+        ),
+        patch(
+            "splitsmith.ui.server.thumbnail_helpers.ensure",
+            side_effect=AssertionError("thumb must not run"),
+        ),
+    ):
+        resp = client.get(f"/api/fs/list?path={folder}")
+
+    assert resp.status_code == 200
+    [entry] = resp.json()["entries"]
+    assert entry["duration"] is None
+    assert entry["thumbnail_url"] is None
+
+
+def test_fs_list_probe_failure_swallowed(tmp_path: Path) -> None:
+    """A probe failure must not break the listing; the entry just gets nulls."""
+    root = tmp_path / "match"
+    folder = tmp_path / "videos"
+    folder.mkdir()
+    (folder / "clip.mp4").write_bytes(b"fake")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    with (
+        patch(
+            "splitsmith.ui.server.video_probe.probe",
+            side_effect=ProbeError("boom"),
+        ),
+        patch(
+            "splitsmith.ui.server.thumbnail_helpers.ensure",
+            side_effect=ThumbnailError("thumb fails too"),
+        ),
+    ):
+        resp = client.get(f"/api/fs/list?path={folder}&probe=true")
+
+    assert resp.status_code == 200
+    [entry] = resp.json()["entries"]
+    assert entry["duration"] is None
 
 
 def test_external_edit_visible_without_restart(tmp_path: Path) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,100 @@
+"""Tests for the production UI's FastAPI backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+from splitsmith.ui.server import create_app
+
+
+def test_health_returns_project_info(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="Test Match")
+    client = TestClient(app)
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["project_name"] == "Test Match"
+    assert body["schema_version"] == 1
+
+
+def test_get_project_returns_full_dump(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="Get Project Match")
+    project.competitor_name = "API Tester"
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=5.0)],
+        )
+    ]
+    project.save(root)
+
+    app = create_app(project_root=root, project_name="ignored, project already exists")
+    client = TestClient(app)
+
+    resp = client.get("/api/project")
+    assert resp.status_code == 200
+    body = resp.json()
+    # The project name from disk wins, not the create_app argument.
+    assert body["name"] == "Get Project Match"
+    assert body["competitor_name"] == "API Tester"
+    assert len(body["stages"]) == 1
+    assert body["stages"][0]["videos"][0]["role"] == "primary"
+
+
+def test_spa_serves_index_html_when_built(tmp_path: Path) -> None:
+    """When ui_static/dist is built (the post-`npm run build` state), `/`
+    must serve the SPA's index.html so the browser bootstraps the React app.
+
+    Skipped automatically if the dev hasn't built the SPA yet; CI builds it
+    before running tests, so the post-build path is the one we care about
+    asserting against."""
+    from splitsmith.ui.server import STATIC_DIR
+
+    if not (STATIC_DIR / "index.html").exists():
+        import pytest as _pytest
+
+        _pytest.skip("SPA not built; run `pnpm build` in src/splitsmith/ui_static/")
+
+    app = create_app(project_root=tmp_path / "match", project_name="SPA Match")
+    client = TestClient(app)
+
+    # The /api/health route always works.
+    assert client.get("/api/health").status_code == 200
+
+    # SPA index for the root.
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b'<div id="root"></div>' in resp.content
+
+    # SPA fallback for unknown client routes (so React Router can handle them).
+    resp = client.get("/some/deep/route")
+    assert resp.status_code == 200
+    assert b'<div id="root"></div>' in resp.content
+
+    # API routes still return 404 from the fallback rather than the SPA.
+    resp = client.get("/api/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
+    """External edits to project.json must appear on the next request -- the
+    server doesn't cache the model in memory."""
+    root = tmp_path / "match"
+    app = create_app(project_root=root, project_name="External Edit Match")
+    client = TestClient(app)
+
+    assert client.get("/api/project").json()["competitor_name"] is None
+
+    project = MatchProject.load(root)
+    project.competitor_name = "Edited Externally"
+    project.save(root)
+
+    assert client.get("/api/project").json()["competitor_name"] == "Edited Externally"

--- a/tests/test_video_probe.py
+++ b/tests/test_video_probe.py
@@ -1,0 +1,139 @@
+"""Unit tests for ``splitsmith.video_probe``.
+
+ffprobe is mocked in these unit tests so they run without depending on
+ffmpeg being installed and without paying its startup cost. An end-to-end
+integration test that hits the real binary lives separately and is gated
+behind ``@pytest.mark.integration``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from splitsmith import video_probe
+
+
+def _fake_ffprobe_output(duration: float, width: int = 1920, height: int = 1080) -> str:
+    return json.dumps(
+        {
+            "format": {"duration": str(duration)},
+            "streams": [
+                {
+                    "codec_name": "h264",
+                    "width": width,
+                    "height": height,
+                    "duration": str(duration),
+                }
+            ],
+        }
+    )
+
+
+def _fake_completed(stdout: str) -> MagicMock:
+    completed = MagicMock(spec=subprocess.CompletedProcess)
+    completed.stdout = stdout
+    completed.stderr = ""
+    completed.returncode = 0
+    return completed
+
+
+def test_probe_caches_result(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "probes"
+
+    with (
+        patch("splitsmith.video_probe.shutil.which", return_value="/usr/bin/ffprobe"),
+        patch(
+            "splitsmith.video_probe.subprocess.run",
+            return_value=_fake_completed(_fake_ffprobe_output(12.5)),
+        ) as run,
+    ):
+        first = video_probe.probe(source, cache_dir=cache_dir)
+        # Second call should hit the cache -- subprocess.run not invoked again.
+        second = video_probe.probe(source, cache_dir=cache_dir)
+
+    assert first.duration == pytest.approx(12.5)
+    assert first.width == 1920
+    assert first.codec == "h264"
+    assert second == first
+    assert run.call_count == 1
+    assert (cache_dir / f"{video_probe.source_cache_key(source)}.json").exists()
+
+
+def test_cached_returns_none_on_miss(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "probes"
+    assert video_probe.cached(source, cache_dir) is None
+
+
+def test_probe_invalidates_on_mtime_change(tmp_path: Path) -> None:
+    """Mutating the source flips the cache key; we re-run ffprobe."""
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"original")
+    cache_dir = tmp_path / "probes"
+
+    with (
+        patch("splitsmith.video_probe.shutil.which", return_value="/usr/bin/ffprobe"),
+        patch(
+            "splitsmith.video_probe.subprocess.run",
+            side_effect=[
+                _fake_completed(_fake_ffprobe_output(10.0)),
+                _fake_completed(_fake_ffprobe_output(20.0)),
+            ],
+        ) as run,
+    ):
+        first = video_probe.probe(source, cache_dir=cache_dir)
+        # Re-write with a different size to flip mtime + size in the key.
+        source.write_bytes(b"changed-significantly")
+        second = video_probe.probe(source, cache_dir=cache_dir)
+
+    assert first.duration == pytest.approx(10.0)
+    assert second.duration == pytest.approx(20.0)
+    assert run.call_count == 2
+
+
+def test_probe_raises_on_timeout(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with (
+        patch("splitsmith.video_probe.shutil.which", return_value="/usr/bin/ffprobe"),
+        patch(
+            "splitsmith.video_probe.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffprobe", timeout=4.0),
+        ),
+    ):
+        with pytest.raises(video_probe.ProbeError, match="timed out"):
+            video_probe.probe(source, cache_dir=tmp_path / "p")
+
+
+def test_probe_raises_on_nonzero_exit(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with (
+        patch("splitsmith.video_probe.shutil.which", return_value="/usr/bin/ffprobe"),
+        patch(
+            "splitsmith.video_probe.subprocess.run",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd="ffprobe", stderr="bad"),
+        ),
+    ):
+        with pytest.raises(video_probe.ProbeError, match="exit 1"):
+            video_probe.probe(source, cache_dir=tmp_path / "p")
+
+
+def test_probe_raises_when_binary_missing(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with patch("splitsmith.video_probe.shutil.which", return_value=None):
+        with pytest.raises(video_probe.ProbeError, match="not found"):
+            video_probe.probe(source, cache_dir=tmp_path / "p")
+
+
+def test_source_cache_key_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    assert video_probe.source_cache_key(tmp_path / "no-such.mp4") == ""

--- a/uv.lock
+++ b/uv.lock
@@ -609,6 +609,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -727,6 +743,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -1935,6 +1987,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2400,6 +2461,7 @@ name = "splitsmith"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "librosa" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -2408,6 +2470,7 @@ dependencies = [
     { name = "scipy" },
     { name = "soundfile" },
     { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -2425,6 +2488,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "librosa", specifier = ">=0.10.2" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
@@ -2433,6 +2497,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13.0" },
     { name = "soundfile", specifier = ">=0.12.1" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2480,6 +2545,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/ae/e3707f6c1bc6f7aa0df600ba8075bfb8a19252140cd595335be60e25f9ee/standard_sunau-3.13.0-py3-none-any.whl", hash = "sha256:53af624a9529c41062f4c2fd33837f297f3baa196b0cfceffea6555654602622", size = 7364, upload-time = "2024-10-30T16:01:28.003Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -2737,4 +2815,212 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
Implements issue #12 (Sub 1 / Foundation) of the production UI v1 roadmap:

- src/splitsmith/ui/project.py: MatchProject Pydantic model. A "match" is the
  persistence unit; the project directory IS the match. Per-video role
  (primary / secondary / ignored) and processed flags drive incremental
  ingest -- adding a secondary later only runs beep + trim, never invalidates
  the primary's audit. atomic_write_json (temp + Path.replace) makes saves
  crash-safe.

- src/splitsmith/ui/server.py: FastAPI app. /api/health and /api/project
  endpoints. SPA fallback serves the built ui_static/dist for any non-API
  route so the React router can handle deep links.

- splitsmith ui CLI subcommand: boots the server bound to a project path and
  opens the browser. Project initialised on first run, resumed on subsequent.

- src/splitsmith/ui_static/: React 19 + Vite 6 + Tailwind v4 + shadcn-style
  components. App shell with sidebar nav and four routes (Home, Ingest,
  Audit, Export) plus /_design as the living visual spec.

- Design tokens locked: shadcn semantic tokens plus splitsmith-specific
  --split-good/-ok/-slow/-transition (matching fcpxml_gen.py hex values),
  --status-* and --marker-* tokens, dark/light variants for all. Inter
  for sans, JetBrains Mono for time displays with tabular numerics.

- Dark/light/system theme toggle, persisted to localStorage, defaulting to
  prefers-color-scheme.

- 15 new tests: round-trip, incremental write (the headline acceptance
  criterion from #12), atomic write under crash, concurrent saves, SPA
  served by FastAPI when dist exists. Full suite: 118 passed, 3 skipped,
  no regression on existing splitsmith review.

The existing review_static/ vanilla-JS SPA stays in place for fixture
audits per the locked v1 contract -- folding it into the new UI is a
separate follow-up.

https://claude.ai/code/session_01Y8f6igyYH5ARtyxiCMLDk3