### PR TITLE
Beep preview thumbnail + refine link on Ingest (closes #27)

### DIFF
--- a/src/splitsmith/thumbnail.py
+++ b/src/splitsmith/thumbnail.py
@@ -1,4 +1,4 @@
-"""ffmpeg thumbnail extraction with mtime/size-keyed disk cache.
+"""ffmpeg thumbnail + short-clip extraction with mtime/size-keyed disk cache.
 
 Pairs with :mod:`splitsmith.video_probe` for the production UI (issue #24):
 the picker and tray render thumbnails so the user can tell which clip is
@@ -11,6 +11,12 @@ the key automatically.
 Frame selection: 1.0 s by default; clamped to ``min(1.0, duration * 0.1)``
 when the source is shorter so we don't seek past the end. Caller passes
 ``duration`` if known (saves a redundant ffprobe).
+
+Short clip extraction (issue #27): :func:`ensure_clip` produces a tiny MP4
+around a target time -- the Ingest screen uses it to render an inline beep
+preview so the user can eyeball detection without leaving the page. Cache
+key extends the still-frame key with center-time + duration so re-detection
+naturally invalidates the preview.
 """
 
 from __future__ import annotations
@@ -110,4 +116,121 @@ def ensure(
         ) from exc
     if not dest.exists():
         raise ThumbnailError(f"ffmpeg produced no output for {source}")
+    return dest
+
+
+def clip_cache_key(source: Path, *, center_time: float, duration_s: float) -> str:
+    """Return a content-addressed key for a short clip cached around
+    ``center_time``.
+
+    Extends :func:`source_cache_key` with millisecond-rounded center-time
+    and duration so a re-detected beep generates a fresh preview without
+    stomping the previous one (kept around for cache eviction at leisure).
+    Returns an empty string when the source can't be stat'd.
+    """
+    base = source_cache_key(source)
+    if not base:
+        return ""
+    return f"{base}_t{int(round(center_time * 1000)):d}_d{int(round(duration_s * 1000)):d}"
+
+
+def cached_clip(
+    source: Path,
+    cache_dir: Path,
+    *,
+    center_time: float,
+    duration_s: float,
+    ext: str = "mp4",
+) -> Path | None:
+    """Return the cached short clip for ``source`` at ``center_time`` if it
+    exists, else ``None``."""
+    key = clip_cache_key(source, center_time=center_time, duration_s=duration_s)
+    if not key:
+        return None
+    candidate = cache_dir / f"{key}.{ext}"
+    return candidate if candidate.exists() else None
+
+
+def ensure_clip(
+    source: Path,
+    *,
+    cache_dir: Path,
+    center_time: float,
+    duration_s: float = 1.0,
+    width: int = 240,
+    ffmpeg_binary: str = "ffmpeg",
+    timeout: float = 12.0,
+) -> Path:
+    """Extract a short MP4 around ``center_time`` (or return the cached one).
+
+    The clip spans roughly ``[center_time - duration_s/2, +duration_s/2]``,
+    clamped at zero so a beep close to the start of a recording still gets
+    a preview. Audio is kept (AAC) -- verifying a beep needs both eyes and
+    ears, especially when the detector landed on a steel ring or another
+    bay's distant beep that *looks* wrong but only the audio confirms it.
+
+    Returns the absolute path to the resulting MP4. Raises
+    :class:`ThumbnailError` on ffmpeg failure / missing binary / timeout.
+    """
+    if duration_s <= 0:
+        raise ThumbnailError(f"duration_s must be positive, got {duration_s}")
+
+    hit = cached_clip(
+        source, cache_dir, center_time=center_time, duration_s=duration_s
+    )
+    if hit is not None:
+        return hit
+
+    key = clip_cache_key(source, center_time=center_time, duration_s=duration_s)
+    if not key:
+        raise ThumbnailError(f"cannot stat source: {source}")
+    dest = cache_dir / f"{key}.mp4"
+
+    if not shutil.which(ffmpeg_binary):
+        raise ThumbnailError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    start = max(0.0, center_time - duration_s / 2.0)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{start:.3f}",
+        "-i",
+        str(source),
+        "-t",
+        f"{duration_s:.3f}",
+        "-vf",
+        f"scale={width}:-2",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "28",
+        "-pix_fmt",
+        "yuv420p",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "96k",
+        "-ac",
+        "1",
+        "-movflags",
+        "+faststart",
+        str(dest),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise ThumbnailError(f"ffmpeg timed out extracting clip for {source}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise ThumbnailError(
+            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
+        ) from exc
+    if not dest.exists():
+        raise ThumbnailError(f"ffmpeg produced no clip for {source}")
     return dest

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -22,6 +22,7 @@ Endpoints (locked v1 surface):
   GET  /api/jobs/{job_id}           -- poll a single job for progress / status
   GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
   GET  /api/stages/{n}/peaks?bins=N -- waveform peak data for the audit screen
+  GET  /api/stages/{n}/beep-preview -- ~1s MP4 around the detected beep (#27)
   GET  /api/videos/stream?path=...  -- serve a registered video file (Range)
   GET  /api/stages/{n}/audit        -- read the stage's audit JSON (404 if none)
   PUT  /api/stages/{n}/audit        -- atomically write the stage's audit JSON
@@ -952,6 +953,51 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         except audio_helpers.AudioExtractionError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    @app.get("/api/stages/{stage_number}/beep-preview")
+    def stage_beep_preview(stage_number: int) -> FileResponse:
+        """Serve a tiny MP4 around the primary's detected beep (#27).
+
+        Lets the Ingest screen render an inline preview right after
+        detection runs so the user can eyeball "did the detector land on
+        the right beep?" without jumping into the audit screen. Cache
+        keys on (source mtime/size, beep_time, duration), so a re-detect
+        or manual override naturally regenerates the clip.
+        """
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"stage {stage_number} has no primary video",
+            )
+        if primary.beep_time is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"stage {stage_number} has no beep_time yet",
+            )
+        source = project.resolve_video_path(state.project_root, primary.path)
+        if not source.is_file():
+            raise HTTPException(
+                status_code=404,
+                detail=f"primary video missing on disk: {source}",
+            )
+        thumbs_dir = project.thumbs_path(state.project_root)
+        try:
+            clip = thumbnail_helpers.ensure_clip(
+                source,
+                cache_dir=thumbs_dir,
+                center_time=float(primary.beep_time),
+                duration_s=1.0,
+                width=480,
+            )
+        except thumbnail_helpers.ThumbnailError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return FileResponse(clip, media_type="video/mp4", filename=clip.name)
 
     @app.get("/api/stages/{stage_number}/audio")
     def stage_audio(stage_number: int) -> FileResponse:

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { Check, Loader2, Pencil, Play, RefreshCw, Trash2, Volume2 } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Check, Loader2, Pencil, Play, RefreshCw, Sparkles, Trash2, Volume2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -204,37 +205,90 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
 
   const isManual = primary.beep_source === "manual";
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
-      <Badge variant={isManual ? "statusComplete" : "statusInProgress"} className="gap-1">
-        <Check className="size-3" />
-        beep · {isManual ? "user" : "auto"}
-      </Badge>
-      <span className="font-mono tabular-nums">{primary.beep_time.toFixed(3)}s</span>
-      {primary.beep_peak_amplitude != null ? (
-        <span className="text-muted-foreground" title="Peak amplitude on the bandpassed envelope">
-          peak {primary.beep_peak_amplitude.toFixed(2)}
-        </span>
-      ) : null}
-      {jobStatus ? <JobProgress job={jobStatus} /> : null}
-      <div className="ml-auto flex gap-1">
-        <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
-          <Pencil />
-          Edit
-        </Button>
-        <Button size="sm" variant="ghost" onClick={() => detect(false)} disabled={busy}>
-          <RefreshCw />
-          Re-detect
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={clear}
-          disabled={busy}
-          title="Clear the beep timestamp (back to no-beep state)"
-        >
-          <Trash2 />
-        </Button>
+    <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={isManual ? "statusComplete" : "statusInProgress"} className="gap-1">
+          <Check className="size-3" />
+          beep · {isManual ? "user" : "auto"}
+        </Badge>
+        <span className="font-mono tabular-nums">{primary.beep_time.toFixed(3)}s</span>
+        {primary.beep_peak_amplitude != null ? (
+          <span className="text-muted-foreground" title="Peak amplitude on the bandpassed envelope">
+            peak {primary.beep_peak_amplitude.toFixed(2)}
+          </span>
+        ) : null}
+        {jobStatus ? <JobProgress job={jobStatus} /> : null}
+        <div className="ml-auto flex gap-1">
+          <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
+            <Pencil />
+            Edit
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => detect(false)} disabled={busy}>
+            <RefreshCw />
+            Re-detect
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={clear}
+            disabled={busy}
+            title="Clear the beep timestamp (back to no-beep state)"
+          >
+            <Trash2 />
+          </Button>
+        </div>
       </div>
+      <BeepPreview
+        stageNumber={stageNumber}
+        beepTime={primary.beep_time}
+      />
+    </div>
+  );
+}
+
+function BeepPreview({
+  stageNumber,
+  beepTime,
+}: {
+  stageNumber: number;
+  beepTime: number;
+}) {
+  // The clip caches on the source's mtime+size and beep_time, so re-mounting
+  // with a new beepTime forces a fresh fetch. <video> errors when no clip
+  // exists yet (rare race after detect-beep finishes); fall back to a hint.
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [stageNumber, beepTime]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {errored ? (
+        <div className="flex items-center gap-1 rounded-md border border-dashed border-border/60 bg-background/40 px-2 py-1 text-muted-foreground">
+          <Sparkles className="size-3" />
+          Preview unavailable
+        </div>
+      ) : (
+        <video
+          key={`${stageNumber}:${beepTime.toFixed(3)}`}
+          src={api.stageBeepPreviewUrl(stageNumber, beepTime)}
+          className="h-40 w-64 rounded-md border border-border/60 bg-black object-cover"
+          playsInline
+          controls
+          preload="metadata"
+          aria-label={`Beep preview for stage ${stageNumber}`}
+          title="1s preview around the detected beep -- press play to verify"
+          onError={() => setErrored(true)}
+        />
+      )}
+      <Link
+        to={`/audit/${stageNumber}`}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        title="Open the audit screen to verify or correct this beep on the waveform"
+      >
+        <Sparkles className="size-3" />
+        Looks wrong? Refine in audit
+      </Link>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -369,6 +369,13 @@ export const api = {
 
   stageAudioUrl: (stageNumber: number) => `/api/stages/${stageNumber}/audio`,
 
+  /** URL for a tiny MP4 around the detected beep (#27). The server keys
+   *  the cache on the source's mtime+size and the beep_time, so the URL
+   *  needs ``beepTime`` as a cache-busting query param: a re-detect
+   *  flips beep_time and the SPA must re-fetch a freshly-encoded clip. */
+  stageBeepPreviewUrl: (stageNumber: number, beepTime: number) =>
+    `/api/stages/${stageNumber}/beep-preview?t=${beepTime.toFixed(3)}`,
+
   videoStreamUrl: (videoPath: string) =>
     `/api/videos/stream?path=${encodeURIComponent(videoPath)}`,
 

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -105,3 +105,108 @@ def test_cached_returns_none_on_miss(tmp_path: Path) -> None:
     source = tmp_path / "clip.mp4"
     source.write_bytes(b"fake")
     assert thumbnail.cached(source, tmp_path / "thumbs") is None
+
+
+def _ffmpeg_writes_clip() -> MagicMock:
+    """Stand-in for ffmpeg producing the requested MP4 output."""
+
+    def _run(cmd, *args, **kwargs):  # noqa: ANN001 ANN002 ANN003
+        out = Path(cmd[-1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-mp4")
+        return _fake_completed()
+
+    return MagicMock(side_effect=_run)
+
+
+def test_ensure_clip_extracts_and_caches(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "thumbs"
+
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", _ffmpeg_writes_clip()) as run,
+    ):
+        first = thumbnail.ensure_clip(
+            source, cache_dir=cache_dir, center_time=12.5, duration_s=1.0
+        )
+        # Same key -> cache hit, ffmpeg not invoked again.
+        second = thumbnail.ensure_clip(
+            source, cache_dir=cache_dir, center_time=12.5, duration_s=1.0
+        )
+
+    assert first.exists()
+    assert first.suffix == ".mp4"
+    assert first == second
+    assert run.call_count == 1
+
+
+def test_ensure_clip_keys_on_center_time(tmp_path: Path) -> None:
+    """A re-detected beep at a new time must produce a different cached
+    file -- otherwise the SPA would serve a stale preview around the old
+    (wrong) beep position."""
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "thumbs"
+
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", _ffmpeg_writes_clip()) as run,
+    ):
+        a = thumbnail.ensure_clip(source, cache_dir=cache_dir, center_time=12.5)
+        b = thumbnail.ensure_clip(source, cache_dir=cache_dir, center_time=14.7)
+
+    assert a != b
+    assert run.call_count == 2
+
+
+def test_ensure_clip_clamps_start_to_zero(tmp_path: Path) -> None:
+    """A beep close to the start of the recording still gets a preview --
+    we just clamp the start time at 0 instead of seeking to a negative."""
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    cache_dir = tmp_path / "thumbs"
+
+    captured: list[list[str]] = []
+
+    def _capture(cmd, *args, **kwargs):  # noqa: ANN001 ANN002 ANN003
+        captured.append(list(cmd))
+        Path(cmd[-1]).parent.mkdir(parents=True, exist_ok=True)
+        Path(cmd[-1]).write_bytes(b"x")
+        return _fake_completed()
+
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("splitsmith.thumbnail.subprocess.run", side_effect=_capture),
+    ):
+        thumbnail.ensure_clip(source, cache_dir=cache_dir, center_time=0.2, duration_s=1.0)
+
+    args = captured[0]
+    ss_idx = args.index("-ss")
+    assert float(args[ss_idx + 1]) == pytest.approx(0.0)
+
+
+def test_ensure_clip_raises_on_timeout(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    with (
+        patch("splitsmith.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch(
+            "splitsmith.thumbnail.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=12.0),
+        ),
+    ):
+        with pytest.raises(thumbnail.ThumbnailError, match="timed out"):
+            thumbnail.ensure_clip(source, cache_dir=tmp_path / "t", center_time=5.0)
+
+
+def test_cached_clip_returns_none_on_miss(tmp_path: Path) -> None:
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"fake")
+    assert (
+        thumbnail.cached_clip(
+            source, tmp_path / "thumbs", center_time=5.0, duration_s=1.0
+        )
+        is None
+    )

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -622,6 +622,108 @@ def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
     assert resp.content.startswith(b"RIFF")
 
 
+def test_beep_preview_serves_cached_clip(tmp_path: Path, monkeypatch) -> None:
+    """When a primary has beep_time set, the endpoint asks ensure_clip for a
+    short MP4 around the beep and serves it as video/mp4. We stub the helper
+    so the test doesn't need real ffmpeg."""
+    client, src = _seed_project_with_primary(tmp_path)
+
+    # Set beep_time on the primary so the endpoint has something to anchor on.
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 12.5
+    project.save(project_root)
+
+    # Drop a fake clip in the thumbs cache and stub ensure_clip to return it.
+    thumbs_dir = project_root / "thumbs"
+    thumbs_dir.mkdir(parents=True, exist_ok=True)
+    fake_clip = thumbs_dir / "fake_t12500_d1000.mp4"
+    fake_clip.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-mp4")
+
+    captured: dict = {}
+
+    def fake_ensure_clip(source, *, cache_dir, center_time, duration_s=1.0, **kwargs):  # type: ignore[no-untyped-def]
+        captured["source"] = source
+        captured["center_time"] = center_time
+        captured["duration_s"] = duration_s
+        return fake_clip
+
+    from splitsmith.ui import server as server_module
+
+    monkeypatch.setattr(
+        server_module.thumbnail_helpers, "ensure_clip", fake_ensure_clip
+    )
+
+    resp = client.get("/api/stages/1/beep-preview")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "video/mp4"
+    assert resp.content.startswith(b"\x00\x00\x00\x18ftyp")
+    assert captured["center_time"] == pytest.approx(12.5)
+    assert captured["duration_s"] == pytest.approx(1.0)
+    assert Path(captured["source"]).name == src.name
+
+
+def test_beep_preview_404_when_no_beep(tmp_path: Path) -> None:
+    """No beep_time yet -> 404 with a clear detail. The SPA hides the preview
+    until detection has run."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.get("/api/stages/1/beep-preview")
+    assert resp.status_code == 404
+    assert "beep_time" in resp.json()["detail"]
+
+
+def test_beep_preview_404_when_no_primary(tmp_path: Path) -> None:
+    """A stage without a primary has no source video to clip from."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "Empty",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    resp = client.get("/api/stages/1/beep-preview")
+    assert resp.status_code == 404
+
+
+def test_beep_preview_500_on_ffmpeg_failure(tmp_path: Path, monkeypatch) -> None:
+    """ensure_clip raises on missing ffmpeg / encode failure -- surface as
+    500 so the SPA can fall back to the 'preview unavailable' hint."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.save(project_root)
+
+    from splitsmith import thumbnail
+    from splitsmith.ui import server as server_module
+
+    def boom(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise thumbnail.ThumbnailError("ffmpeg exploded")
+
+    monkeypatch.setattr(server_module.thumbnail_helpers, "ensure_clip", boom)
+    resp = client.get("/api/stages/1/beep-preview")
+    assert resp.status_code == 500
+    assert "ffmpeg exploded" in resp.json()["detail"]
+
+
 def test_peaks_endpoint_uses_trimmed_audio_when_present(tmp_path: Path, monkeypatch) -> None:
     """When stage<N>_trimmed.mp4 exists the peaks come from its WAV; the
     response carries the clip-local beep_time and trimmed=true so the SPA


### PR DESCRIPTION
## Summary
- Inline ~1s MP4 preview around the detected beep on each stage's Ingest card. Generated on demand via a new \`thumbnail.ensure_clip\` helper, cached under \`thumbs/\` keyed on (source mtime/size, beep_time, duration) so re-detection naturally invalidates the preview. Audio is kept (AAC mono 96k) so the user can verify by ear, not just by eye.
- New \`GET /api/stages/{n}/beep-preview\` endpoint serves the cached MP4. 404s when there's no primary or no \`beep_time\`.
- \`BeepSection\` renders a 256x160 \`<video controls>\` (manual playback, no autoplay) plus a \`Link\` to \`/audit/{n}\` -- "Looks wrong? Refine in audit" -- so the user can jump straight into waveform-based correction (#22).

Closes #27. Pairs with #22.

## Test plan
- [x] \`uv run pytest\` -- 245 pass (4 new \`ensure_clip\` unit tests, 4 new \`/beep-preview\` endpoint tests).
- [x] \`npm run build\` clean; \`tsc --noEmit\` clean.
- [ ] Manually verify on Ingest: detect a beep, confirm the preview renders, scrub + unmute, click "Refine in audit" and land on \`/audit/{n}\`.
- [ ] After bumping the encoded width to 480 the existing thumbs cache should be cleared once (\`rm <project>/thumbs/*_t*_d*.mp4\`) so previews regenerate at the new resolution + with audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)