### PR TITLE
beep: ranked candidates picker + click-to-set waveform (closes #22)

### DIFF
--- a/src/splitsmith/beep_detect.py
+++ b/src/splitsmith/beep_detect.py
@@ -51,7 +51,7 @@ import numpy as np
 import soundfile as sf
 from scipy.signal import butter, hilbert, sosfiltfilt
 
-from .config import BeepDetectConfig, BeepDetection
+from .config import BeepCandidate, BeepDetectConfig, BeepDetection
 
 # Rise-foot leading-edge parameters. Same definition as shot_detect (the
 # burst's own peak is the reference, so detection is insensitive to gain /
@@ -160,14 +160,30 @@ def detect_beep(
             f"{config.freq_max_hz}] Hz"
         )
 
-    run_start, run_end, run_peak, _score = max(candidates, key=lambda c: c[3])
+    # Rank by silence-preference score (highest first). Compute the rise-foot
+    # leading edge for every candidate so the UI can show alternatives without
+    # a second pass.
+    ranked = sorted(candidates, key=lambda c: c[3], reverse=True)
+    ranked_models: list[BeepCandidate] = []
+    for run_start, run_end, run_peak, score in ranked:
+        leading_idx = _rise_foot_leading_edge(env, run_start, run_end)
+        ranked_models.append(
+            BeepCandidate(
+                time=leading_idx / sample_rate,
+                score=score,
+                peak_amplitude=run_peak,
+                duration_ms=(run_end - run_start) * 1000.0 / sample_rate,
+            )
+        )
 
-    leading_idx = _rise_foot_leading_edge(env, run_start, run_end)
-
+    top_n = config.top_n_candidates if config.top_n_candidates > 0 else 1
+    surfaced = ranked_models[:top_n]
+    winner = ranked_models[0]
     return BeepDetection(
-        time=leading_idx / sample_rate,
-        peak_amplitude=run_peak,
-        duration_ms=(run_end - run_start) * 1000.0 / sample_rate,
+        time=winner.time,
+        peak_amplitude=winner.peak_amplitude,
+        duration_ms=winner.duration_ms,
+        candidates=surfaced,
     )
 
 

--- a/src/splitsmith/config.py
+++ b/src/splitsmith/config.py
@@ -39,12 +39,33 @@ class StageAnalysis(BaseModel):
     anomalies: list[str] = Field(default_factory=list)
 
 
+class BeepCandidate(BaseModel):
+    """One ranked beep candidate from ``beep_detect``.
+
+    Surfaced to the production UI so the user can pick a different candidate
+    when the auto-winner is wrong (issue #22). The score is silence-preference
+    (``run_peak / pre_window_mean``); higher = stronger candidate.
+    """
+
+    time: float
+    score: float
+    peak_amplitude: float
+    duration_ms: float
+
+
 class BeepDetection(BaseModel):
-    """Result of running beep_detect on a clip; carries diagnostics for the audit report."""
+    """Result of running beep_detect on a clip; carries diagnostics for the audit report.
+
+    ``candidates`` holds the top-N silence-preference-ranked candidates with
+    ``candidates[0]`` matching ``time``/``peak_amplitude``/``duration_ms``.
+    The list is empty for callers that don't request alternatives (kept
+    optional for backwards compatibility with on-disk audit JSON).
+    """
 
     time: float
     peak_amplitude: float
     duration_ms: float
+    candidates: list[BeepCandidate] = Field(default_factory=list)
 
 
 class TrimResult(BaseModel):
@@ -144,6 +165,11 @@ class BeepDetectConfig(BaseModel):
     # alone. Capping the search avoids that failure mode entirely. Override per
     # video in YAML if your recording is longer-leading.
     search_window_s: float = 30.0
+    # Number of ranked candidates to surface alongside the auto-winner.
+    # The production UI shows these as "other candidates" so the user can
+    # pick the right one without typing a timestamp by hand (issue #22).
+    # ``0`` returns just the winner (legacy behaviour).
+    top_n_candidates: int = 5
 
 
 class ShotDetectConfig(BaseModel):

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from ..config import StageData, VideoMatchConfig
+from ..config import BeepCandidate, StageData, VideoMatchConfig
 from ..video_match import match_videos_to_stages
 
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
@@ -75,6 +75,11 @@ class StageVideo(BaseModel):
     # surfaced in the UI to help the user judge auto-detection confidence.
     beep_peak_amplitude: float | None = None
     beep_duration_ms: float | None = None
+    # Ranked alternative candidates from the most recent auto-detection run
+    # (silence-preference score, descending). The production UI offers these
+    # as one-click alternatives to the auto-winner so the user rarely has to
+    # type a timestamp by hand. Cleared on manual override / clear (issue #22).
+    beep_candidates: list[BeepCandidate] = Field(default_factory=list)
     notes: str = ""
 
 
@@ -579,6 +584,7 @@ class MatchProject(BaseModel):
                     v.beep_source = None
                     v.beep_peak_amplitude = None
                     v.beep_duration_ms = None
+                    v.beep_candidates = []
 
         return RemovalPlan(
             video_path=video.path,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -783,12 +783,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         # cutoff is conservative -- noise events fall well below, real
         # shots typically land >= 0.4. The user can flip individuals
         # afterward; ``reset=true`` re-runs this seeding from scratch.
-        SEED_KEEP_CONFIDENCE = 0.3
+        seed_keep_confidence = 0.3
         if reset:
             existing_json["shots"] = []
         seeded_shots = False
         if not existing_json.get("shots"):
-            kept = [c for c in candidates if (c.get("confidence") or 0.0) >= SEED_KEEP_CONFIDENCE]
+            kept = [c for c in candidates if (c.get("confidence") or 0.0) >= seed_keep_confidence]
             existing_json["shots"] = [
                 {
                     "shot_number": i,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -236,6 +236,20 @@ class BeepOverrideRequest(BaseModel):
     beep_time: float | None  # None clears the override
 
 
+class BeepSelectRequest(BaseModel):
+    """Body for POST /api/stages/{n}/beep/select.
+
+    ``time`` is matched against ``primary.beep_candidates`` within 1 ms.
+    Time-based addressing (rather than an index into the list) is robust
+    against the SPA holding a stale candidate snapshot when a concurrent
+    trim job re-persists the project: the user picked a *time*, so the
+    server should honour that exact pick regardless of where it lands in
+    the current list.
+    """
+
+    time: float
+
+
 class RemoveVideoRequest(BaseModel):
     """Body for POST /api/videos/remove (#24).
 
@@ -566,6 +580,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             prim.beep_source = "auto"
             prim.beep_peak_amplitude = beep.peak_amplitude
             prim.beep_duration_ms = beep.duration_ms
+            prim.beep_candidates = list(beep.candidates)
             prim.processed["beep"] = True
 
             trimmed_ok = False
@@ -890,6 +905,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             primary.beep_source = None
             primary.beep_peak_amplitude = None
             primary.beep_duration_ms = None
+            primary.beep_candidates = []
             primary.processed["beep"] = False
             primary.processed["trim"] = False
             primary.processed["shot_detect"] = False
@@ -902,6 +918,10 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             # Diagnostics from a previous auto-detect are no longer authoritative.
             primary.beep_peak_amplitude = None
             primary.beep_duration_ms = None
+            # Manual time wins over the ranked-candidate list -- drop it so
+            # the UI doesn't keep offering a different "auto" pick that
+            # contradicts what the user just typed.
+            primary.beep_candidates = []
             # New beep -> previous trim was cut around the wrong window.
             # processed.trim flips back so the SPA prompts re-trim.
             primary.processed["trim"] = False
@@ -917,6 +937,77 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         if (
             req.beep_time is not None
             and stage.time_seconds > 0
+            and state.jobs.find_active(kind="trim", stage_number=stage_number) is None
+        ):
+            state.jobs.submit(
+                kind="trim",
+                stage_number=stage_number,
+                fn=lambda h, n=stage_number: _run_trim_for_stage(h, n),
+            )
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/beep/select")
+    def select_beep_candidate(
+        stage_number: int, req: BeepSelectRequest
+    ) -> JSONResponse:
+        """Promote one of the ranked auto-detected candidates as authoritative.
+
+        Lets the user fix a wrong auto-pick without typing a timestamp.
+        Re-uses the auto-detect provenance because the time still came from
+        the detector -- we only changed which candidate the project trusts.
+        Triggers a re-trim like the manual override path so the cached
+        audit clip lines up with the new beep.
+        """
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"stage {stage_number} has no primary video",
+            )
+        if not primary.beep_candidates:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"stage {stage_number} has no candidate list yet; run "
+                    "detect-beep first"
+                ),
+            )
+        # Match by time within 1 ms. Round-tripping floats through JSON +
+        # pydantic preserves the value but a strict equality check is
+        # fragile, so we use the same epsilon the SPA uses to pick the
+        # active row.
+        match_eps = 1e-3
+        chosen = None
+        for c in primary.beep_candidates:
+            if abs(c.time - req.time) <= match_eps:
+                chosen = c
+                break
+        if chosen is None:
+            available = ", ".join(f"{c.time:.3f}" for c in primary.beep_candidates)
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"no candidate within {match_eps * 1000:.0f} ms of "
+                    f"{req.time:.3f}s; available: [{available}]"
+                ),
+            )
+        primary.beep_time = chosen.time
+        primary.beep_source = "auto"
+        primary.beep_peak_amplitude = chosen.peak_amplitude
+        primary.beep_duration_ms = chosen.duration_ms
+        primary.processed["beep"] = True
+        primary.processed["trim"] = False
+        primary.processed["shot_detect"] = False
+
+        audio_helpers.invalidate_audit_trim(state.project_root, stage_number, project=project)
+        project.save(state.project_root)
+        if (
+            stage.time_seconds > 0
             and state.jobs.find_active(kind="trim", stage_number=stage_number) is None
         ):
             state.jobs.submit(
@@ -955,14 +1046,16 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     @app.get("/api/stages/{stage_number}/beep-preview")
-    def stage_beep_preview(stage_number: int) -> FileResponse:
-        """Serve a tiny MP4 around the primary's detected beep (#27).
+    def stage_beep_preview(
+        stage_number: int, t: float | None = None
+    ) -> FileResponse:
+        """Serve a tiny MP4 around a beep timestamp (#27, #22).
 
-        Lets the Ingest screen render an inline preview right after
-        detection runs so the user can eyeball "did the detector land on
-        the right beep?" without jumping into the audit screen. Cache
-        keys on (source mtime/size, beep_time, duration), so a re-detect
-        or manual override naturally regenerates the clip.
+        Default center is the primary's persisted ``beep_time``. The
+        optional ``t`` query param overrides it so the BeepCandidates
+        picker (#22) can preview alternative ranked candidates without
+        promoting them first. Cache keys on (source mtime/size, center
+        time, duration), so each distinct ``t`` gets its own cached clip.
         """
         project = state.load()
         try:
@@ -975,11 +1068,14 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=404,
                 detail=f"stage {stage_number} has no primary video",
             )
-        if primary.beep_time is None:
+        center = t if t is not None else primary.beep_time
+        if center is None:
             raise HTTPException(
                 status_code=404,
                 detail=f"stage {stage_number} has no beep_time yet",
             )
+        if center < 0:
+            raise HTTPException(status_code=400, detail="t must be >= 0")
         source = project.resolve_video_path(state.project_root, primary.path)
         if not source.is_file():
             raise HTTPException(
@@ -991,7 +1087,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             clip = thumbnail_helpers.ensure_clip(
                 source,
                 cache_dir=thumbs_dir,
-                center_time=float(primary.beep_time),
+                center_time=float(center),
                 duration_s=1.0,
                 width=480,
             )

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -14,13 +14,33 @@
  * waveform-based correction inline with the audit waveform.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Check, Loader2, Pencil, Play, RefreshCw, Sparkles, Trash2, Volume2 } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Pencil,
+  Play,
+  RefreshCw,
+  Sparkles,
+  Trash2,
+  Volume2,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ApiError, api, type Job, type MatchProject, type StageVideo } from "@/lib/api";
+import { Waveform } from "@/components/Waveform";
+import {
+  ApiError,
+  api,
+  type BeepCandidate,
+  type Job,
+  type MatchProject,
+  type PeaksResult,
+  type StageVideo,
+} from "@/lib/api";
 
 interface Props {
   stageNumber: number;
@@ -145,7 +165,22 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
     }
   };
 
+  const selectCandidate = async (time: number) => {
+    setBusy(true);
+    try {
+      const updated = await api.selectBeepCandidate(stageNumber, time);
+      onProjectUpdate(updated);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   if (editing) {
+    const draftSourceTime = Number(draft);
+    const draftValid = Number.isFinite(draftSourceTime) && draftSourceTime >= 0;
     return (
       <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm">
         <div className="flex flex-wrap items-end gap-2">
@@ -171,7 +206,16 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
             Cancel
           </Button>
         </div>
-        <AudioVerifier stageNumber={stageNumber} suspectedTime={Number(draft) || primary.beep_time} />
+        <BeepWaveformPicker
+          stageNumber={stageNumber}
+          primaryBeepTime={primary.beep_time}
+          draftSourceTime={draftValid ? draftSourceTime : null}
+          onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
+        />
+        <AudioVerifier
+          stageNumber={stageNumber}
+          suspectedTime={draftValid ? draftSourceTime : primary.beep_time}
+        />
       </div>
     );
   }
@@ -238,11 +282,329 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
           </Button>
         </div>
       </div>
+      <BeepCandidates
+        stageNumber={stageNumber}
+        candidates={primary.beep_candidates}
+        currentTime={primary.beep_time}
+        busy={busy}
+        onSelect={selectCandidate}
+      />
       <BeepPreview
         stageNumber={stageNumber}
         beepTime={primary.beep_time}
       />
     </div>
+  );
+}
+
+/** Click-to-set waveform inside the manual-edit panel.
+ *
+ *  The /audio + /peaks endpoints serve the **trimmed** audit clip when one
+ *  exists (cut around the previously-detected beep) and the **full**
+ *  primary WAV otherwise. Time on the waveform is therefore "local clip
+ *  time", not source time. We translate using the offset
+ *  ``primary.beep_time - peaks.beep_time``: in the trimmed case this is
+ *  exactly the trim window's start; in the untrimmed case both sides are
+ *  the same number so the offset is zero. */
+function BeepWaveformPicker({
+  stageNumber,
+  primaryBeepTime,
+  draftSourceTime,
+  onPick,
+}: {
+  stageNumber: number;
+  primaryBeepTime: number | null;
+  draftSourceTime: number | null;
+  onPick: (sourceTime: number) => void;
+}) {
+  const [peaks, setPeaks] = useState<PeaksResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+  // Local clip time in seconds; drives the waveform's playhead while the
+  // user drags. Initialised to the existing primary beep position so the
+  // playhead doesn't snap to 0 on open.
+  const [localTime, setLocalTime] = useState<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setUnavailable(false);
+    api
+      .getStagePeaks(stageNumber)
+      .then((p) => {
+        if (cancelled) return;
+        setPeaks(p);
+        // Seed the playhead at the served clip's beep marker if we have
+        // one, otherwise at zero.
+        setLocalTime(p.beep_time ?? 0);
+      })
+      .catch(() => {
+        if (!cancelled) setUnavailable(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [stageNumber]);
+
+  const offset = useMemo(() => {
+    // primary.beep_time and peaks.beep_time are both expressed as the same
+    // physical instant (the beep). Their difference is the trim window's
+    // start time in source coordinates; zero when the audio is the full
+    // source. Falls back to 0 when either side is unset.
+    if (primaryBeepTime == null || !peaks || peaks.beep_time == null) return 0;
+    return primaryBeepTime - peaks.beep_time;
+  }, [primaryBeepTime, peaks]);
+
+  // Keep the visual playhead in sync with the numeric draft when the user
+  // types in the input directly.
+  useEffect(() => {
+    if (!peaks || draftSourceTime == null) return;
+    const local = draftSourceTime - offset;
+    if (local >= 0 && local <= peaks.duration) {
+      setLocalTime(local);
+    }
+  }, [draftSourceTime, peaks, offset]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" aria-hidden />
+        Loading waveform...
+      </div>
+    );
+  }
+  if (unavailable || !peaks) {
+    // No audio cached yet (the user has never run detect-beep on this
+    // stage). The numeric input + AudioVerifier hint below cover this case.
+    return null;
+  }
+
+  const handleScrub = (t: number) => {
+    setLocalTime(t);
+  };
+  const handleScrubEnd = () => {
+    onPick(localTime + offset);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs text-muted-foreground">
+        Drag the waveform to set the beep time (releases snap to source seconds)
+      </div>
+      <Waveform
+        peaks={peaks.peaks}
+        duration={peaks.duration}
+        currentTime={localTime}
+        onScrub={handleScrub}
+        onScrubEnd={handleScrubEnd}
+        beepTime={peaks.beep_time}
+        height={80}
+        ariaLabel={`Beep editor waveform for stage ${stageNumber}`}
+      />
+    </div>
+  );
+}
+
+function BeepCandidates({
+  stageNumber,
+  candidates,
+  currentTime,
+  busy,
+  onSelect,
+}: {
+  stageNumber: number;
+  candidates: BeepCandidate[];
+  currentTime: number | null;
+  busy: boolean;
+  onSelect: (time: number) => void | Promise<void>;
+}) {
+  // Never bother showing a picker when the detector only returned the winner
+  // (no real choice for the user to make). For projects that predate #22 the
+  // list is just empty -- next detect-beep run repopulates it.
+  const hasAlternatives = candidates.length > 1;
+  const [open, setOpen] = useState(false);
+  if (!hasAlternatives) return null;
+
+  // The "currently promoted" candidate is the one whose time matches
+  // primary.beep_time. We compare with a small epsilon because the value
+  // round-trips through JSON. Falls back to index 0 (the auto-winner).
+  const activeIndex = (() => {
+    if (currentTime == null) return -1;
+    let best = -1;
+    let bestDelta = Infinity;
+    candidates.forEach((c, i) => {
+      const d = Math.abs(c.time - currentTime);
+      if (d < bestDelta) {
+        bestDelta = d;
+        best = i;
+      }
+    });
+    return bestDelta <= 1e-3 ? best : -1;
+  })();
+
+  // Single shared preview slot under the candidate list. Holding one
+  // <video> for the whole list keeps the layout predictable and avoids
+  // the SPA stacking 5 different aspect-ratio thumbnails when the user
+  // explores alternatives.
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const [previewError, setPreviewError] = useState(false);
+  useEffect(() => {
+    setPreviewError(false);
+  }, [previewIndex, stageNumber]);
+  // If candidates change underneath us (re-detect, override) drop a stale
+  // preview index.
+  useEffect(() => {
+    if (previewIndex != null && previewIndex >= candidates.length) {
+      setPreviewIndex(null);
+    }
+  }, [candidates.length, previewIndex]);
+
+  return (
+    <div className="rounded-md border border-border/40 bg-background/40">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+        aria-expanded={open}
+        aria-controls={`beep-candidates-${stageNumber}`}
+        title="Silence-preference ranked; pick a different one if the auto-winner is wrong"
+      >
+        {open ? (
+          <ChevronDown className="size-3" aria-hidden />
+        ) : (
+          <ChevronRight className="size-3" aria-hidden />
+        )}
+        <span>
+          {candidates.length - 1} alternate
+          {candidates.length - 1 === 1 ? "" : "s"}
+        </span>
+      </button>
+      {open ? (
+        <>
+          <ul
+            id={`beep-candidates-${stageNumber}`}
+            className="divide-y divide-border/40 border-t border-border/40"
+          >
+            {candidates.map((c, i) => (
+              <CandidateRow
+                key={`${c.time.toFixed(6)}-${i}`}
+                candidate={c}
+                index={i}
+                isActive={i === activeIndex}
+                isPreviewing={i === previewIndex}
+                busy={busy}
+                onTogglePreview={() =>
+                  setPreviewIndex((cur) => (cur === i ? null : i))
+                }
+                onSelect={() => onSelect(c.time)}
+              />
+            ))}
+          </ul>
+          {previewIndex != null && candidates[previewIndex] ? (
+            <div className="border-t border-border/40 p-2">
+              <div className="mb-1 text-xs text-muted-foreground">
+                Preview #{previewIndex + 1} -- {candidates[previewIndex].time.toFixed(3)}s
+              </div>
+              {previewError ? (
+                <div className="flex items-center gap-1 rounded-md border border-dashed border-border/60 bg-background/40 px-2 py-1 text-xs text-muted-foreground">
+                  <Sparkles className="size-3" />
+                  Preview unavailable (no cached clip yet)
+                </div>
+              ) : (
+                <video
+                  key={`${stageNumber}:${candidates[previewIndex].time.toFixed(3)}`}
+                  src={api.stageBeepPreviewUrl(
+                    stageNumber,
+                    candidates[previewIndex].time,
+                  )}
+                  className="aspect-video w-full max-w-sm rounded-md border border-border/60 bg-black object-contain"
+                  playsInline
+                  controls
+                  autoPlay
+                  preload="metadata"
+                  aria-label={`Preview for candidate ${previewIndex + 1}`}
+                  onError={() => setPreviewError(true)}
+                />
+              )}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function CandidateRow({
+  candidate,
+  index,
+  isActive,
+  isPreviewing,
+  busy,
+  onTogglePreview,
+  onSelect,
+}: {
+  candidate: BeepCandidate;
+  index: number;
+  isActive: boolean;
+  isPreviewing: boolean;
+  busy: boolean;
+  onTogglePreview: () => void;
+  onSelect: () => void | Promise<void>;
+}) {
+  // Two-line layout to fit narrow stage cards: top line is the headline
+  // (rank + time + actions); bottom line is muted diagnostics. Buttons
+  // are icon-only with title tooltips so the row never grows wider than
+  // the card.
+  return (
+    <li
+      className={`px-2 py-1.5 text-xs ${isActive ? "bg-muted/40" : ""}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="w-5 shrink-0 text-muted-foreground tabular-nums">
+          #{index + 1}
+        </span>
+        <span className="font-mono tabular-nums">{candidate.time.toFixed(3)}s</span>
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onTogglePreview}
+            aria-pressed={isPreviewing}
+            aria-label={isPreviewing ? "Hide preview" : "Preview"}
+            title={isPreviewing ? "Hide preview" : "Preview a 1 s clip"}
+            className="size-7"
+          >
+            <Play className="size-3.5" />
+          </Button>
+          {isActive ? (
+            <Badge variant="statusComplete" className="gap-1" title="Currently promoted">
+              <Check className="size-3" />
+              Selected
+            </Badge>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onSelect}
+              disabled={busy}
+              title={`Promote ${candidate.time.toFixed(3)}s as the beep`}
+            >
+              Use this
+            </Button>
+          )}
+        </div>
+      </div>
+      <div
+        className="mt-0.5 pl-7 text-[11px] text-muted-foreground"
+        title={`Silence-preference score: ${candidate.score.toFixed(2)} (run peak / pre-window mean). Peak amplitude on the bandpassed envelope: ${candidate.peak_amplitude.toFixed(3)}. Duration: ${candidate.duration_ms.toFixed(0)} ms.`}
+      >
+        score {candidate.score.toFixed(1)} &middot; peak {candidate.peak_amplitude.toFixed(2)}{" "}
+        &middot; {Math.round(candidate.duration_ms)} ms
+      </div>
+    </li>
   );
 }
 

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -9,6 +9,17 @@
 export type VideoRole = "primary" | "secondary" | "ignored";
 export type BeepSource = "auto" | "manual";
 
+/** One ranked beep candidate emitted by ``detect-beep`` (issue #22).
+ *  ``score`` is silence-preference (run_peak / pre-window mean); higher =
+ *  more confident. ``beep_candidates[0]`` matches the promoted ``beep_time``
+ *  on the parent ``StageVideo``. */
+export interface BeepCandidate {
+  time: number;
+  score: number;
+  peak_amplitude: number;
+  duration_ms: number;
+}
+
 export interface StageVideo {
   path: string;
   role: VideoRole;
@@ -18,6 +29,9 @@ export interface StageVideo {
   beep_source: BeepSource | null;
   beep_peak_amplitude: number | null;
   beep_duration_ms: number | null;
+  /** Ranked alternative candidates from the most recent auto-detection run.
+   *  Empty when the project predates issue #22 or after a manual override. */
+  beep_candidates: BeepCandidate[];
   notes: string;
 }
 
@@ -327,6 +341,17 @@ export const api = {
       json: { beep_time: beepTime },
     }),
 
+  /** Promote one of the ranked auto-detected candidates as authoritative.
+   *  ``time`` is matched against ``primary.beep_candidates`` within 1 ms,
+   *  so the SPA can hold a slightly stale snapshot without breaking the
+   *  click. The server keeps the candidate list intact so the user can
+   *  switch again without re-running detection, and re-fires the trim job. */
+  selectBeepCandidate: (stageNumber: number, time: number) =>
+    request<MatchProject>(`/api/stages/${stageNumber}/beep/select`, {
+      method: "POST",
+      json: { time },
+    }),
+
   /** Submit an audit-mode short-GOP trim job. Returns a Job snapshot;
    *  idempotent on the worker side -- when the cached MP4 is fresh the
    *  job completes near-instantly without re-encoding. */
@@ -369,10 +394,11 @@ export const api = {
 
   stageAudioUrl: (stageNumber: number) => `/api/stages/${stageNumber}/audio`,
 
-  /** URL for a tiny MP4 around the detected beep (#27). The server keys
-   *  the cache on the source's mtime+size and the beep_time, so the URL
-   *  needs ``beepTime`` as a cache-busting query param: a re-detect
-   *  flips beep_time and the SPA must re-fetch a freshly-encoded clip. */
+  /** URL for a tiny MP4 around a beep timestamp (#27, #22). ``t`` is
+   *  passed to the server (which centres the clip there) AND ms-rounded
+   *  into the cache key, so each distinct ``t`` gets its own MP4. The
+   *  candidate picker uses this with arbitrary candidate times; the
+   *  default flow passes ``primary.beep_time``. */
   stageBeepPreviewUrl: (stageNumber: number, beepTime: number) =>
     `/api/stages/${stageNumber}/beep-preview?t=${beepTime.toFixed(3)}`,
 

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -877,7 +877,12 @@ function StagesSection({
   return (
     <section className="space-y-3">
       <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {/* Cards carry a beep section + stage-move dropdown + multiple
+          video previews; squeezing them into 3 columns at the xl
+          breakpoint (1280px viewport, ~992px content width after the
+          240px sidebar) clipped controls. Push 2-col to lg and 3-col
+          to 2xl so each card has room to breathe. */}
+      <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
         {project.stages.map((s) => (
           <StageCard
             key={s.stage_number}

--- a/tests/test_beep_detect.py
+++ b/tests/test_beep_detect.py
@@ -64,6 +64,52 @@ def test_detect_beep_synthetic_clean_tone() -> None:
     assert 250.0 <= result.duration_ms <= 350.0
 
 
+def test_detect_beep_returns_ranked_candidates() -> None:
+    """Two synthetic beeps in one buffer; candidates should be sorted by
+    silence-preference score (descending) and the winner should match
+    candidates[0]."""
+    sr = 48000
+    rng = np.random.default_rng(7)
+    audio = (rng.standard_normal(sr * 6) * 0.001).astype(np.float32)
+
+    def _stamp(at_s: float, amp: float, dur_s: float = 0.300) -> None:
+        n = int(sr * dur_s)
+        t = np.arange(n) / sr
+        audio[int(sr * at_s) : int(sr * at_s) + n] += (
+            amp * np.sin(2 * np.pi * 3000 * t).astype(np.float32)
+        )
+
+    _stamp(1.0, 0.6)  # the "real" beep -- preceded by ~1 s of silence
+    _stamp(3.0, 0.4)  # competing transient further into the clip
+
+    result = detect_beep(audio, sr, BeepDetectConfig())
+    assert len(result.candidates) >= 2
+    # Sorted by score, descending.
+    scores = [c.score for c in result.candidates]
+    assert scores == sorted(scores, reverse=True)
+    # Winner == candidates[0].
+    assert result.time == pytest.approx(result.candidates[0].time, abs=1e-9)
+    assert result.peak_amplitude == pytest.approx(
+        result.candidates[0].peak_amplitude, abs=1e-9
+    )
+    assert result.duration_ms == pytest.approx(
+        result.candidates[0].duration_ms, abs=1e-9
+    )
+
+
+def test_detect_beep_top_n_zero_returns_only_winner() -> None:
+    sr = 48000
+    rng = np.random.default_rng(11)
+    audio = (rng.standard_normal(sr * 3) * 0.001).astype(np.float32)
+    n = int(sr * 0.300)
+    t = np.arange(n) / sr
+    audio[sr : sr + n] += 0.6 * np.sin(2 * np.pi * 3000 * t).astype(np.float32)
+
+    cfg = BeepDetectConfig(top_n_candidates=0)
+    result = detect_beep(audio, sr, cfg)
+    assert len(result.candidates) == 1
+
+
 def test_detect_beep_rejects_2d_input() -> None:
     sr = 48000
     audio = np.zeros((sr, 2), dtype=np.float32)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -490,15 +490,26 @@ def _seed_project_with_primary(tmp_path: Path) -> tuple[TestClient, Path]:
     return client, src
 
 
-def _stub_detect(monkeypatch, beep_time: float = 12.453) -> None:
+def _stub_detect(
+    monkeypatch,
+    beep_time: float = 12.453,
+    *,
+    candidates: list | None = None,
+) -> None:
     """Replace audio_helpers.detect_primary_beep with a fast stub returning a
     deterministic BeepDetection. The endpoint is otherwise wrapped around
     ffmpeg + librosa, which we don't want to invoke from a unit test."""
-    from splitsmith.config import BeepDetection
+    from splitsmith.config import BeepCandidate, BeepDetection
     from splitsmith.ui import audio as audio_helpers
 
     def fake(*args, **kwargs):  # type: ignore[no-untyped-def]
-        return BeepDetection(time=beep_time, peak_amplitude=0.42, duration_ms=320.0)
+        cands: list[BeepCandidate] = candidates or []
+        return BeepDetection(
+            time=beep_time,
+            peak_amplitude=0.42,
+            duration_ms=320.0,
+            candidates=cands,
+        )
 
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", fake)
 
@@ -598,6 +609,101 @@ def test_override_beep_400_on_negative(tmp_path: Path) -> None:
     assert resp.status_code == 400
 
 
+def _three_candidates() -> list:
+    from splitsmith.config import BeepCandidate
+
+    return [
+        BeepCandidate(time=12.453, score=18.0, peak_amplitude=0.42, duration_ms=320.0),
+        BeepCandidate(time=8.100, score=9.0, peak_amplitude=0.30, duration_ms=180.0),
+        BeepCandidate(time=27.500, score=4.5, peak_amplitude=0.55, duration_ms=210.0),
+    ]
+
+
+def test_detect_beep_persists_candidate_list(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 200
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert len(primary["beep_candidates"]) == 3
+    assert primary["beep_candidates"][0]["time"] == 12.453
+    assert primary["beep_candidates"][1]["time"] == 8.100
+
+
+def test_select_beep_candidate_promotes_alternate(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
+    final = _wait_for_job(
+        client, client.post("/api/stages/1/detect-beep").json()["id"]
+    )
+    assert final["status"] == "succeeded"
+
+    resp = client.post("/api/stages/1/beep/select", json={"time": 8.100})
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 8.100
+    assert primary["beep_source"] == "auto"
+    assert primary["beep_peak_amplitude"] == 0.30
+    assert primary["beep_duration_ms"] == 180.0
+    # Selecting an alternate keeps the candidate list intact so the user
+    # can switch again without re-running detection.
+    assert len(primary["beep_candidates"]) == 3
+    # New beep -> previous trim is stale.
+    assert primary["processed"]["trim"] is False
+
+
+def test_select_beep_candidate_tolerates_sub_ms_drift(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The SPA may send a slightly-rounded time (3 decimals) while the
+    server still has the full-precision candidate. The 1 ms tolerance
+    keeps the click working."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
+    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+
+    resp = client.post("/api/stages/1/beep/select", json={"time": 8.1004})
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 8.100
+
+
+def test_select_beep_candidate_400_when_no_candidates(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.post("/api/stages/1/beep/select", json={"time": 0.0})
+    assert resp.status_code == 400
+
+
+def test_select_beep_candidate_400_when_time_no_match(
+    tmp_path: Path, monkeypatch
+) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
+    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+
+    resp = client.post("/api/stages/1/beep/select", json={"time": 99.999})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    # The server lists what's available so the user can copy a real time.
+    assert "12.453" in detail
+    assert "8.100" in detail
+
+
+def test_manual_override_clears_candidate_list(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
+    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+
+    resp = client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    assert resp.status_code == 200
+    primary = resp.json()["stages"][0]["videos"][0]
+    assert primary["beep_source"] == "manual"
+    assert primary["beep_candidates"] == []
+
+
 def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
     """The /audio endpoint asks the helper for the cached WAV; we stub the
     helper to drop a small WAV file in place rather than running ffmpeg."""
@@ -663,6 +769,58 @@ def test_beep_preview_serves_cached_clip(tmp_path: Path, monkeypatch) -> None:
     assert captured["center_time"] == pytest.approx(12.5)
     assert captured["duration_s"] == pytest.approx(1.0)
     assert Path(captured["source"]).name == src.name
+
+
+def test_beep_preview_t_query_overrides_center(tmp_path: Path, monkeypatch) -> None:
+    """``?t=<seconds>`` re-centres the preview clip on an arbitrary time
+    (used by the candidate picker before the user has committed a choice).
+    """
+    client, src = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 12.5
+    project.save(project_root)
+
+    thumbs_dir = project_root / "thumbs"
+    thumbs_dir.mkdir(parents=True, exist_ok=True)
+    fake_clip = thumbs_dir / "fake_t27500_d1000.mp4"
+    fake_clip.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-mp4")
+
+    captured: dict = {}
+
+    def fake_ensure_clip(source, *, cache_dir, center_time, duration_s=1.0, **kwargs):  # type: ignore[no-untyped-def]
+        captured["center_time"] = center_time
+        return fake_clip
+
+    from splitsmith.ui import server as server_module
+
+    monkeypatch.setattr(
+        server_module.thumbnail_helpers, "ensure_clip", fake_ensure_clip
+    )
+
+    resp = client.get("/api/stages/1/beep-preview?t=27.5")
+    assert resp.status_code == 200
+    assert captured["center_time"] == pytest.approx(27.5)
+    # primary.beep_time is unchanged.
+    after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert after["beep_time"] == 12.5
+    # ``src`` is the seeded source video; sanity-check it exists.
+    assert src.exists()
+
+
+def test_beep_preview_400_on_negative_t(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.save(project_root)
+
+    resp = client.get("/api/stages/1/beep-preview?t=-1")
+    assert resp.status_code == 400
 
 
 def test_beep_preview_404_when_no_beep(tmp_path: Path) -> None:
@@ -894,6 +1052,7 @@ def test_detect_beep_auto_trims(tmp_path: Path, monkeypatch) -> None:
         time = 6.5
         peak_amplitude = 0.42
         duration_ms = 110.0
+        candidates: list = []
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "x.wav")
     (tmp_path / "x.wav").write_bytes(b"\x00")
@@ -945,6 +1104,7 @@ def test_detect_beep_skips_trim_when_stage_time_zero(tmp_path: Path, monkeypatch
         time = 4.0
         peak_amplitude = 0.5
         duration_ms = 100.0
+        candidates: list = []
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "y.wav")
     (tmp_path / "y.wav").write_bytes(b"\x00")
@@ -1277,6 +1437,7 @@ def test_jobs_endpoints_list_and_get(tmp_path: Path, monkeypatch) -> None:
         time = 1.0
         peak_amplitude = 0.5
         duration_ms = 80.0
+        candidates: list = []
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "z.wav")
     (tmp_path / "z.wav").write_bytes(b"\x00")


### PR DESCRIPTION
Closes #22.

The auto-detector frequently picks the wrong silence-preference candidate (steel rings, neighbour-bay beeps, distant timer chirps). Rather than throwing more signal-processing at the problem, this surfaces the detector's top-N ranking to the user and gives them three escalating ways to fix it: pick a different candidate, set a time on the waveform, or type the seconds directly.

## Backend
- ``BeepDetectConfig.top_n_candidates`` (default 5). ``detect_beep`` now ranks every silence-preference candidate, computes a rise-foot leading edge for each, and returns them on ``BeepDetection.candidates``. Winner stays at index 0 and matches the legacy ``time`` / ``peak_amplitude`` / ``duration_ms`` fields, so existing callers don't change behaviour.
- ``StageVideo.beep_candidates`` persists the list with the project. Cleared on manual override / clear / video removal; kept on candidate-select so the user can switch again without re-running detection.
- **New** ``POST /api/stages/{n}/beep/select`` matches by ``time`` within 1 ms tolerance -- robust against stale SPA snapshots if a concurrent trim job re-saves the project mid-click. 400 detail enumerates available times when no candidate matches.
- **Extended** ``GET /api/stages/{n}/beep-preview?t=<seconds>``: re-centre the 1 s preview clip on an arbitrary time so candidate previews actually differ. Cache key already keys on ``center_time`` (rounded to ms), so each candidate gets its own cached MP4.

## Frontend
- New ``BeepCandidates`` panel under the auto/manual badge: a collapsed ``N alternates`` disclosure -> compact two-line rows (rank + time + actions on top; ``score / peak / ms`` muted below). One shared ``<video aspect-video object-contain>`` preview slot below the list -- click another row's Preview to switch.
- New ``BeepWaveformPicker`` inside the manual-edit panel: fetches ``/peaks``, renders the audit waveform, and on scrub-end translates clip-local time back to source time using the ``primary.beep_time - peaks.beep_time`` offset (zero when audio is the full source). Numeric input + audio scrubber + waveform stay in sync; the user can type, drag, or click to set the beep.
- Candidate ``Preview`` switched from ``<a target=_blank>`` (which sometimes downloaded the MP4 instead of playing it) to inline ``<video autoplay>``.
- Stage grid breakpoints bumped: ``md:grid-cols-2 xl:grid-cols-3`` -> ``lg:grid-cols-2 2xl:grid-cols-3``. The xl tier collapsed cards to ~325 px after the 240 px sidebar, clipping the beep section and stage-move dropdown; 2-col on 1280-1440 px laptops gives ~488 px per card.

## Acceptance criteria from #22

- [x] ``POST /detect-beep`` runs detection on a stage's primary and persists the result with ``beep_source=auto``
- [x] ``POST /beep`` accepts a manual override and persists with ``beep_source=manual``
- [x] ``GET /audio`` serves the primary's cached WAV with Range support
- [x] Per-stage card surfaces beep status (none / auto / manual) with edit + re-detect actions
- [x] Manual override survives subsequent auto-detect attempts unless ``force=true``
- [x] Tests cover detect, override, 409 on auto-over-manual without force, audio served with valid WAV, no UI regression

This PR adds the things that turned up while using #22 in anger:

- [x] Candidate picker so the user doesn't have to type a timestamp when the detector landed one slot off
- [x] Click-to-set waveform inside the manual-edit panel as the last-resort fallback
- [x] Inline candidate preview that plays instead of downloading
- [x] Card layout that doesn't clip controls

## Test plan

- [x] ``uv run pytest`` -- 255 tests, all green
- [x] ``tsc --noEmit`` clean
- [ ] Manual UI smoke: detect-beep on a stage with a known wrong auto-pick, expand alternates, Preview a few, Use this on the right one, verify trim re-runs against the new beep
- [ ] Manual UI smoke: edit panel -- type a time, drag the waveform, confirm the input + audio scrubber stay in sync; Apply persists to ``beep_source=manual``
- [ ] Verify candidate previews are distinct MP4s (different ``?t=``) and play inline rather than downloading

## Notes for reviewers

- No on-disk schema bump. Pydantic populates ``beep_candidates`` with ``[]`` for projects that predate this PR; the SPA hides the picker when the list is empty, and the next ``detect-beep`` run repopulates it.
- ``select`` matches by time, not index, specifically because the obvious index-based design failed in testing -- a concurrent trim job persisted the project between the SPA's snapshot and the click, and the index pointed at a different candidate than the user thought they were promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)