### PR TITLE
Analysis & Export screen + per-stage generate (closes #17)

### DIFF
--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -172,17 +172,13 @@ def export_stage(
     or ``write_fcpxml`` is set.
     """
     if not audit_path.exists():
-        raise StageExportError(
-            f"no audit JSON at {audit_path}; finish auditing this stage first"
-        )
+        raise StageExportError(f"no audit JSON at {audit_path}; finish auditing this stage first")
     try:
         audit_data = json.loads(audit_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise StageExportError(f"failed to read audit JSON {audit_path}: {exc}") from exc
 
-    shots = audit_shots_to_engine_shots(
-        audit_data, beep_time_in_source=beep_time_in_source
-    )
+    shots = audit_shots_to_engine_shots(audit_data, beep_time_in_source=beep_time_in_source)
     if not shots:
         raise StageExportError(
             f"audit JSON {audit_path} has no shots in shots[]; nothing to export"

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .. import csv_gen, fcpxml_gen, report
+from .. import csv_gen, fcpxml_gen, report, trim
 from ..config import Config, ReportFiles, Shot, StageAnalysis, StageData
 
 
@@ -28,13 +28,15 @@ from ..config import Config, ReportFiles, Shot, StageAnalysis, StageData
 class StageExportRequest:
     """One stage's export job: which artefacts to write.
 
-    The trimmed video is not regenerated here -- it lives at
-    ``<project>/trimmed/stage<N>_<slug>.mp4`` from the audit-mode trim and
-    is referenced as-is. The FCPXML is only written when that file exists,
-    matching the CLI's ``_process_one`` behaviour.
+    The lossless trim is part of the export -- it's the archival deliverable
+    that ships to FCP, distinct from the audit-mode short-GOP scrub copy
+    that lives in ``<project>/trimmed/``. The FCPXML references the lossless
+    trim, mirroring ``splitsmith single``: the SPA's exports are
+    byte-comparable with the CLI's for the same audit data.
     """
 
     stage_number: int
+    write_trim: bool = True
     write_csv: bool = True
     write_fcpxml: bool = True
     write_report: bool = True
@@ -45,10 +47,10 @@ class StageExportResult:
     """Paths produced (or skipped) by :func:`export_stage`."""
 
     stage_number: int
+    trimmed_video_path: Path | None
     csv_path: Path | None
     fcpxml_path: Path | None
     report_path: Path | None
-    trimmed_video_path: Path | None
     shots_written: int
     anomalies: list[str]
 
@@ -145,18 +147,29 @@ def export_stage(
     request: StageExportRequest,
     audit_path: Path,
     exports_dir: Path,
-    trimmed_video_path: Path | None,
+    source_video_path: Path | None,
     stage_data: StageData,
     beep_time_in_source: float,
+    pre_buffer_seconds: float,
+    post_buffer_seconds: float,
     config: Config,
 ) -> StageExportResult:
     """Run the export for one stage. Pure orchestration over the engine
     modules; never re-detects.
 
+    Produces (subject to the request flags):
+      - ``stage<N>_<slug>_trimmed.mp4`` -- lossless stream-copy trim of the
+        source, matching ``splitsmith single``. This is the FCP-bound
+        deliverable, distinct from the audit-mode short-GOP scrub copy in
+        ``<project>/trimmed/``.
+      - ``stage<N>_<slug>_splits.csv``
+      - ``stage<N>_<slug>.fcpxml`` (references the lossless trim above)
+      - ``stage<N>_<slug>_report.txt``
+
     ``audit_path`` must exist and contain at least one shot. ``exports_dir``
-    is created if missing. The trimmed video is required for FCPXML (the
-    timeline references it) -- when missing the FCPXML step is skipped
-    rather than failing the whole export.
+    is created if missing. ``source_video_path`` is the primary's source
+    file (resolved through any symlink); it is required when ``write_trim``
+    or ``write_fcpxml`` is set.
     """
     if not audit_path.exists():
         raise StageExportError(
@@ -178,52 +191,129 @@ def export_stage(
     exports_dir.mkdir(parents=True, exist_ok=True)
     base = f"stage{stage_data.stage_number}_{_slugify(stage_data.stage_name)}"
 
+    skip_reasons: list[str] = []
+
+    # Source-reachability is the most common reason an export degrades:
+    # the project stores symlinks to a USB drive that's not plugged in.
+    # Build one shared, specific message so the user gets the same hint
+    # regardless of which artefact tripped over the missing source.
+    source_missing = source_video_path is None or not source_video_path.exists()
+    missing_msg: str | None = None
+    if source_missing and (request.write_trim or request.write_fcpxml):
+        if source_video_path is None:
+            missing_msg = (
+                "source video is not registered for this stage; assign a "
+                "primary on the Ingest screen first."
+            )
+        else:
+            missing_msg = (
+                f"source video not reachable: {source_video_path}. If it lives "
+                "on external storage (USB drive, SD card), reconnect and "
+                "re-run Generate. CSV and report still wrote -- they only "
+                "need the audit JSON."
+            )
+
+    # Lossless trim into exports/. Always reference *this* file from FCPXML
+    # so SPA-produced output lines up with ``splitsmith single``. The
+    # audit-mode short-GOP file in <project>/trimmed/ is a scrub cache,
+    # not an export.
+    trimmed_path: Path | None = None
+    if request.write_trim:
+        if source_missing:
+            assert missing_msg is not None  # populated above
+            skip_reasons.append(f"trim not written: {missing_msg}")
+            # If a prior run left a lossless trim, surface it -- the user
+            # has *something* to ship while the source is unreachable.
+            stale = exports_dir / f"{base}_trimmed.mp4"
+            if stale.exists():
+                trimmed_path = stale
+        else:
+            assert source_video_path is not None  # narrowed by source_missing
+            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+            try:
+                trim.trim_video(
+                    source_video_path,
+                    trimmed_path,
+                    beep_time=beep_time_in_source,
+                    stage_time=stage_data.time_seconds,
+                    pre_buffer_seconds=pre_buffer_seconds,
+                    post_buffer_seconds=post_buffer_seconds,
+                    mode="lossless",
+                    overwrite=True,
+                )
+            except (trim.FFmpegError, FileNotFoundError, RuntimeError) as exc:
+                # Don't fail the whole export -- CSV / report are still
+                # useful even if ffmpeg blew up. Surface as anomaly.
+                skip_reasons.append(f"trim not written: {exc}")
+                trimmed_path = None
+                if (exports_dir / f"{base}_trimmed.mp4").exists():
+                    # Stale artefact from a prior run -- still reference it
+                    # from FCPXML so the user gets *something* usable.
+                    trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+
     csv_path: Path | None = None
     if request.write_csv:
         csv_path = exports_dir / f"{base}_splits.csv"
         csv_gen.write_splits_csv(shots, csv_path)
 
     fcpxml_path: Path | None = None
-    fcpxml_skipped_reason: str | None = None
     if request.write_fcpxml:
-        if trimmed_video_path is None or not trimmed_video_path.exists():
-            fcpxml_skipped_reason = (
-                "no trimmed clip on disk; trim the stage from the audit screen first"
-            )
+        # FCPXML needs a video to reference. Prefer the lossless trim we
+        # just produced; fall back to a stale lossless trim from a prior
+        # export if it exists; only as a last resort look for a lossless
+        # trim independent of this run.
+        fcp_video: Path | None = None
+        candidate = exports_dir / f"{base}_trimmed.mp4"
+        if trimmed_path is not None and trimmed_path.exists():
+            fcp_video = trimmed_path
+        elif candidate.exists():
+            fcp_video = candidate
+
+        if fcp_video is None:
+            if missing_msg:
+                # The trim couldn't run because the source is unreachable.
+                # Surface that as the FCPXML reason too -- avoids the user
+                # chasing two separate "no lossless trim" messages.
+                skip_reasons.append(f"fcpxml not written: {missing_msg}")
+            else:
+                skip_reasons.append(
+                    "fcpxml not written: no lossless trim in exports/. "
+                    "Re-run Generate with the Trim toggle enabled."
+                )
         else:
             fcpxml_path = exports_dir / f"{base}.fcpxml"
-            meta = fcpxml_gen.probe_video(trimmed_video_path)
-            # Beep offset *within the trimmed clip*: comes from the audit
-            # JSON (``beep_time``), which the audit pipeline writes as
-            # ``beep_in_clip`` -- not the source beep. Fall back to the
-            # configured trim buffer if missing (matches the CLI default).
-            audit_beep_in_clip = audit_data.get("beep_time")
-            beep_offset_in_clip = (
-                float(audit_beep_in_clip)
-                if isinstance(audit_beep_in_clip, (int, float))
-                else config.output.trim_buffer_seconds
-            )
-            fcpxml_gen.generate_fcpxml(
-                video_path=trimmed_video_path,
-                video=meta,
-                shots=shots,
-                beep_offset_seconds=beep_offset_in_clip,
-                output_path=fcpxml_path,
-                project_name=base,
-                config=config.output,
-            )
+            try:
+                meta = fcpxml_gen.probe_video(fcp_video)
+                # Beep offset within the lossless trim: the trim cut at
+                # ``beep_time - pre_buffer`` from source, so the beep lives
+                # ``pre_buffer`` seconds into the clip.
+                fcpxml_gen.generate_fcpxml(
+                    video_path=fcp_video,
+                    video=meta,
+                    shots=shots,
+                    beep_offset_seconds=pre_buffer_seconds,
+                    output_path=fcpxml_path,
+                    project_name=base,
+                    config=config.output,
+                )
+            except (fcpxml_gen.FFprobeError, OSError) as exc:
+                skip_reasons.append(f"fcpxml not written: {exc}")
+                fcpxml_path = None
 
     anomalies = report.detect_anomalies(shots, beep_time_in_source, stage_data.time_seconds)
-    files = ReportFiles(
-        video=trimmed_video_path if trimmed_video_path and trimmed_video_path.exists() else None,
-        csv=csv_path,
-        fcpxml=fcpxml_path,
-    )
+    if skip_reasons:
+        anomalies = [*anomalies, *skip_reasons]
+
     report_path: Path | None = None
     if request.write_report:
+        files = ReportFiles(
+            video=trimmed_path if trimmed_path and trimmed_path.exists() else None,
+            csv=csv_path,
+            fcpxml=fcpxml_path,
+        )
         analysis = StageAnalysis(
             stage=stage_data,
-            video_path=trimmed_video_path or Path(),
+            video_path=trimmed_path or source_video_path or Path(),
             beep_time=beep_time_in_source,
             shots=shots,
             anomalies=anomalies,
@@ -236,20 +326,14 @@ def export_stage(
             color_thresholds=config.output.split_color_thresholds,
         )
 
-    if fcpxml_skipped_reason and request.write_fcpxml:
-        # Surface as an anomaly so the report lists it without failing the
-        # whole export. The SPA also reads the StageExportResult and shows
-        # the user; this keeps the file-side artefact aligned.
-        anomalies = [*anomalies, f"FCPXML not written: {fcpxml_skipped_reason}"]
-
     return StageExportResult(
         stage_number=stage_data.stage_number,
+        trimmed_video_path=(
+            trimmed_path if trimmed_path is not None and trimmed_path.exists() else None
+        ),
         csv_path=csv_path,
         fcpxml_path=fcpxml_path,
         report_path=report_path,
-        trimmed_video_path=trimmed_video_path
-        if trimmed_video_path and trimmed_video_path.exists()
-        else None,
         shots_written=len(shots),
         anomalies=anomalies,
     )

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -1,0 +1,265 @@
+"""Per-stage export pipeline for the production UI (issue #17).
+
+The Audit screen produces a per-stage audit JSON at
+``<project>/audit/stage<N>.json`` whose ``shots[]`` is the user's source of
+truth. This module is a thin orchestrator that converts that JSON into the
+existing engine's :class:`Shot` records and calls the unchanged
+:mod:`csv_gen`, :mod:`fcpxml_gen`, and :mod:`report` writers so the
+production UI's exports are byte-comparable with ``splitsmith single``
+output for the same audit data.
+
+Pure of detection: never re-runs beep / shot detection. The whole point of
+the production UI is that the user-audited shots are the truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .. import csv_gen, fcpxml_gen, report
+from ..config import Config, ReportFiles, Shot, StageAnalysis, StageData
+
+
+@dataclass(frozen=True)
+class StageExportRequest:
+    """One stage's export job: which artefacts to write.
+
+    The trimmed video is not regenerated here -- it lives at
+    ``<project>/trimmed/stage<N>_<slug>.mp4`` from the audit-mode trim and
+    is referenced as-is. The FCPXML is only written when that file exists,
+    matching the CLI's ``_process_one`` behaviour.
+    """
+
+    stage_number: int
+    write_csv: bool = True
+    write_fcpxml: bool = True
+    write_report: bool = True
+
+
+@dataclass(frozen=True)
+class StageExportResult:
+    """Paths produced (or skipped) by :func:`export_stage`."""
+
+    stage_number: int
+    csv_path: Path | None
+    fcpxml_path: Path | None
+    report_path: Path | None
+    trimmed_video_path: Path | None
+    shots_written: int
+    anomalies: list[str]
+
+
+class StageExportError(RuntimeError):
+    """Raised when the audit JSON is missing / malformed / lacks the data
+    needed to produce an export. Endpoints surface this as a 400."""
+
+
+def audit_shots_to_engine_shots(
+    audit_data: dict[str, Any],
+    *,
+    beep_time_in_source: float,
+) -> list[Shot]:
+    """Convert the audit JSON's ``shots[]`` to engine :class:`Shot` records.
+
+    ``beep_time_in_source`` is the beep position in the source video's
+    timeline (seconds from start). Audit ``shots[].time`` is clip-local;
+    we never use it directly here -- the engine wants ``time_absolute`` in
+    the source, which is ``beep_time_in_source + time_from_beep``.
+
+    ``peak_amplitude`` and ``confidence`` are looked up from the candidate
+    pool (``_candidates_pending_audit.candidates``) by ``candidate_number``
+    when present; otherwise default to 0.0 (manually-added shots that
+    weren't tied to a detector candidate).
+
+    Splits: shot 1's split is the draw (= ``time_from_beep``); shot N>1 is
+    the difference between successive ``time_from_beep`` values. This
+    mirrors :func:`csv_gen.write_splits_csv`'s expectations from the CLI.
+    """
+    raw_shots = audit_data.get("shots") or []
+    if not isinstance(raw_shots, list) or not raw_shots:
+        return []
+
+    candidates_block = audit_data.get("_candidates_pending_audit") or {}
+    candidates = candidates_block.get("candidates") if isinstance(candidates_block, dict) else None
+    by_cand: dict[int, dict[str, Any]] = {}
+    if isinstance(candidates, list):
+        for c in candidates:
+            num = c.get("candidate_number") if isinstance(c, dict) else None
+            if isinstance(num, int):
+                by_cand[num] = c
+
+    # Sort by shot_number so the output is deterministic regardless of the
+    # JSON's row order. Audits saved by the SPA preserve order, but external
+    # tools (audit-apply) write append-style, so don't trust order.
+    ordered = sorted(raw_shots, key=lambda s: s.get("shot_number", 0))
+
+    out: list[Shot] = []
+    prev_time_from_beep: float | None = None
+    for raw in ordered:
+        if not isinstance(raw, dict):
+            continue
+        ms = raw.get("ms_after_beep")
+        if ms is None:
+            continue
+        time_from_beep = float(ms) / 1000.0
+        time_absolute = beep_time_in_source + time_from_beep
+        cand_num = raw.get("candidate_number")
+        cand = by_cand.get(cand_num) if isinstance(cand_num, int) else None
+        peak = float(cand.get("peak_amplitude", 0.0)) if isinstance(cand, dict) else 0.0
+        conf = (
+            float(cand.get("confidence", 0.0))
+            if isinstance(cand, dict) and cand.get("confidence") is not None
+            else 0.0
+        )
+        # Clamp confidence to the model's [0, 1] domain in case the
+        # candidate carries a raw classifier score that escaped the band.
+        conf = max(0.0, min(1.0, conf))
+        notes_raw = raw.get("notes")
+        notes = str(notes_raw) if isinstance(notes_raw, str) else ""
+        shot_number = int(raw.get("shot_number", len(out) + 1))
+        if prev_time_from_beep is None:
+            split = time_from_beep  # draw
+        else:
+            split = time_from_beep - prev_time_from_beep
+        prev_time_from_beep = time_from_beep
+        out.append(
+            Shot(
+                shot_number=shot_number,
+                time_absolute=time_absolute,
+                time_from_beep=time_from_beep,
+                split=split,
+                peak_amplitude=peak,
+                confidence=conf,
+                notes=notes,
+            )
+        )
+    return out
+
+
+def export_stage(
+    *,
+    request: StageExportRequest,
+    audit_path: Path,
+    exports_dir: Path,
+    trimmed_video_path: Path | None,
+    stage_data: StageData,
+    beep_time_in_source: float,
+    config: Config,
+) -> StageExportResult:
+    """Run the export for one stage. Pure orchestration over the engine
+    modules; never re-detects.
+
+    ``audit_path`` must exist and contain at least one shot. ``exports_dir``
+    is created if missing. The trimmed video is required for FCPXML (the
+    timeline references it) -- when missing the FCPXML step is skipped
+    rather than failing the whole export.
+    """
+    if not audit_path.exists():
+        raise StageExportError(
+            f"no audit JSON at {audit_path}; finish auditing this stage first"
+        )
+    try:
+        audit_data = json.loads(audit_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StageExportError(f"failed to read audit JSON {audit_path}: {exc}") from exc
+
+    shots = audit_shots_to_engine_shots(
+        audit_data, beep_time_in_source=beep_time_in_source
+    )
+    if not shots:
+        raise StageExportError(
+            f"audit JSON {audit_path} has no shots in shots[]; nothing to export"
+        )
+
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    base = f"stage{stage_data.stage_number}_{_slugify(stage_data.stage_name)}"
+
+    csv_path: Path | None = None
+    if request.write_csv:
+        csv_path = exports_dir / f"{base}_splits.csv"
+        csv_gen.write_splits_csv(shots, csv_path)
+
+    fcpxml_path: Path | None = None
+    fcpxml_skipped_reason: str | None = None
+    if request.write_fcpxml:
+        if trimmed_video_path is None or not trimmed_video_path.exists():
+            fcpxml_skipped_reason = (
+                "no trimmed clip on disk; trim the stage from the audit screen first"
+            )
+        else:
+            fcpxml_path = exports_dir / f"{base}.fcpxml"
+            meta = fcpxml_gen.probe_video(trimmed_video_path)
+            # Beep offset *within the trimmed clip*: comes from the audit
+            # JSON (``beep_time``), which the audit pipeline writes as
+            # ``beep_in_clip`` -- not the source beep. Fall back to the
+            # configured trim buffer if missing (matches the CLI default).
+            audit_beep_in_clip = audit_data.get("beep_time")
+            beep_offset_in_clip = (
+                float(audit_beep_in_clip)
+                if isinstance(audit_beep_in_clip, (int, float))
+                else config.output.trim_buffer_seconds
+            )
+            fcpxml_gen.generate_fcpxml(
+                video_path=trimmed_video_path,
+                video=meta,
+                shots=shots,
+                beep_offset_seconds=beep_offset_in_clip,
+                output_path=fcpxml_path,
+                project_name=base,
+                config=config.output,
+            )
+
+    anomalies = report.detect_anomalies(shots, beep_time_in_source, stage_data.time_seconds)
+    files = ReportFiles(
+        video=trimmed_video_path if trimmed_video_path and trimmed_video_path.exists() else None,
+        csv=csv_path,
+        fcpxml=fcpxml_path,
+    )
+    report_path: Path | None = None
+    if request.write_report:
+        analysis = StageAnalysis(
+            stage=stage_data,
+            video_path=trimmed_video_path or Path(),
+            beep_time=beep_time_in_source,
+            shots=shots,
+            anomalies=anomalies,
+        )
+        report_path = exports_dir / f"{base}_report.txt"
+        report.write_report(
+            analysis,
+            files,
+            report_path,
+            color_thresholds=config.output.split_color_thresholds,
+        )
+
+    if fcpxml_skipped_reason and request.write_fcpxml:
+        # Surface as an anomaly so the report lists it without failing the
+        # whole export. The SPA also reads the StageExportResult and shows
+        # the user; this keeps the file-side artefact aligned.
+        anomalies = [*anomalies, f"FCPXML not written: {fcpxml_skipped_reason}"]
+
+    return StageExportResult(
+        stage_number=stage_data.stage_number,
+        csv_path=csv_path,
+        fcpxml_path=fcpxml_path,
+        report_path=report_path,
+        trimmed_video_path=trimmed_video_path
+        if trimmed_video_path and trimmed_video_path.exists()
+        else None,
+        shots_written=len(shots),
+        anomalies=anomalies,
+    )
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(name: str) -> str:
+    """Filesystem-friendly slug. Mirrors the CLI's ``_slugify`` exactly so
+    exports have identical names whether produced via the CLI or the
+    production UI -- byte-comparable filenames are part of the AC."""
+    return _SLUG_RE.sub("-", name.lower()).strip("-") or "stage"

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -155,15 +155,32 @@ class StageExportStatus(BaseModel):
     has_primary: bool
     primary_processed: dict[str, bool]
     audit_shot_count: int
-    pending_candidate_count: int
+    # Size of the detector's full candidate pool (``_candidates_pending_audit.
+    # candidates`` in the audit JSON). NOT "pending"; once shot detection has
+    # run, every candidate is either in ``shots[]`` (kept) or implicitly
+    # rejected. The SPA renders this as "X shots audited from Y candidates"
+    # so the math makes sense at a glance.
+    total_candidate_count: int
     audit_path: Path | None
+    # The video reference the SPA renders. Prefers the lossless trim under
+    # ``exports/``; falls back to the audit-mode short-GOP copy from
+    # ``trimmed/`` only when no lossless trim exists yet, so the user
+    # always has *something* trimmed to inspect. ``lossless_trim_present``
+    # disambiguates "this is the deliverable" vs "this is the scrub cache".
     trimmed_video_path: Path | None
+    lossless_trim_present: bool = False
     csv_path: Path | None
     fcpxml_path: Path | None
     report_path: Path | None
     has_exports: bool
     last_export_at: datetime | None
     ready_to_export: bool
+    # Whether the primary's source video resolves to a present file.
+    # ``False`` typically means the symlink under ``raw/`` is dangling
+    # because external storage is disconnected; the SPA badges the row
+    # so the user knows Generate will degrade (CSV/report only) without
+    # having to click first. ``None`` when the stage has no primary.
+    source_reachable: bool | None = None
 
 
 class StageMatchWindow(BaseModel):
@@ -368,7 +385,7 @@ class MatchProject(BaseModel):
             primary = stage.primary()
             audit_file = audit_dir / f"stage{stage.stage_number}.json"
             shot_count = 0
-            pending_count = 0
+            total_candidates = 0
             if audit_file.exists():
                 try:
                     raw = json.loads(audit_file.read_text(encoding="utf-8"))
@@ -383,23 +400,35 @@ class MatchProject(BaseModel):
                 if isinstance(cand_block, dict):
                     cands = cand_block.get("candidates")
                     if isinstance(cands, list):
-                        pending_count = len(cands)
+                        total_candidates = len(cands)
 
             base = f"stage{stage.stage_number}_{exports_mod._slugify(stage.stage_name)}"
             csv_p = exports_dir / f"{base}_splits.csv"
             fcpxml_p = exports_dir / f"{base}.fcpxml"
             report_p = exports_dir / f"{base}_report.txt"
-            trimmed_p = trimmed_dir / f"stage{stage.stage_number}_trimmed.mp4"
+            # The "trimmed video" surfaced to the Export screen is the
+            # lossless trim in exports/ (the FCP-bound deliverable), not
+            # the audit-mode short-GOP scrub copy in <project>/trimmed/.
+            # Reference trimmed_dir only when the lossless one is missing
+            # so the row at least shows the user *something* trimmed.
+            lossless_trim_p = exports_dir / f"{base}_trimmed.mp4"
+            audit_trim_p = trimmed_dir / f"stage{stage.stage_number}_trimmed.mp4"
+            trimmed_p = (
+                lossless_trim_p
+                if lossless_trim_p.exists()
+                else (audit_trim_p if audit_trim_p.exists() else lossless_trim_p)
+            )
 
             csv_exists = csv_p.exists()
             fcpxml_exists = fcpxml_p.exists()
             report_exists = report_p.exists()
-            has_exports = csv_exists or fcpxml_exists or report_exists
+            trim_exists = lossless_trim_p.exists()
+            has_exports = csv_exists or fcpxml_exists or report_exists or trim_exists
             last_export_at: datetime | None = None
             if has_exports:
                 mtimes = [
                     p.stat().st_mtime
-                    for p in (csv_p, fcpxml_p, report_p)
+                    for p in (csv_p, fcpxml_p, report_p, lossless_trim_p)
                     if p.exists()
                 ]
                 if mtimes:
@@ -417,6 +446,13 @@ class MatchProject(BaseModel):
                 and processed.get("shot_detect", False)
                 and shot_count > 0
             )
+            source_reachable: bool | None = None
+            if primary is not None:
+                try:
+                    src = self.resolve_video_path(root, primary.path)
+                    source_reachable = src.exists()
+                except OSError:
+                    source_reachable = False
 
             out.append(
                 StageExportStatus(
@@ -426,15 +462,17 @@ class MatchProject(BaseModel):
                     has_primary=primary is not None,
                     primary_processed=processed,
                     audit_shot_count=shot_count,
-                    pending_candidate_count=pending_count,
+                    total_candidate_count=total_candidates,
                     audit_path=audit_file if audit_file.exists() else None,
                     trimmed_video_path=trimmed_p if trimmed_p.exists() else None,
                     csv_path=csv_p if csv_exists else None,
                     fcpxml_path=fcpxml_p if fcpxml_exists else None,
                     report_path=report_p if report_exists else None,
+                    lossless_trim_present=trim_exists,
                     has_exports=has_exports,
                     last_export_at=last_export_at,
                     ready_to_export=ready_to_export,
+                    source_reachable=source_reachable,
                 )
             )
         return out

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -394,9 +394,7 @@ class MatchProject(BaseModel):
                 shots = raw.get("shots") if isinstance(raw, dict) else None
                 if isinstance(shots, list):
                     shot_count = len(shots)
-                cand_block = (
-                    raw.get("_candidates_pending_audit") if isinstance(raw, dict) else None
-                )
+                cand_block = raw.get("_candidates_pending_audit") if isinstance(raw, dict) else None
                 if isinstance(cand_block, dict):
                     cands = cand_block.get("candidates")
                     if isinstance(cands, list):
@@ -477,9 +475,7 @@ class MatchProject(BaseModel):
             )
         return out
 
-    def match_analysis(
-        self, *, config: VideoMatchConfig | None = None
-    ) -> MatchAnalysis:
+    def match_analysis(self, *, config: VideoMatchConfig | None = None) -> MatchAnalysis:
         """Run the canonical match heuristic over the project's stored
         timestamps and return per-stage windows + per-video classifications.
 
@@ -507,9 +503,7 @@ class MatchProject(BaseModel):
                 scorecard_updated_at=s.scorecard_updated_at,
                 tolerance_minutes=cfg.tolerance_minutes,
                 lower=(
-                    video_match.match_window(
-                        s.scorecard_updated_at, cfg.tolerance_minutes
-                    )[0]
+                    video_match.match_window(s.scorecard_updated_at, cfg.tolerance_minutes)[0]
                     if s.scorecard_updated_at is not None
                     else None
                 ),
@@ -734,9 +728,7 @@ class MatchProject(BaseModel):
             video = existing[1]
             if video.match_timestamp is None:
                 try:
-                    video.match_timestamp = video_match.video_timestamp(
-                        source, prefer_ctime=True
-                    )
+                    video.match_timestamp = video_match.video_timestamp(source, prefer_ctime=True)
                 except OSError:
                     pass
             return video
@@ -862,9 +854,7 @@ class MatchProject(BaseModel):
         # was already on this stage, it gets pulled out and re-attached; the
         # old primary is demoted inside assign_video. New primary's processed
         # flags are reset because the audio source changed.
-        new_primary = self.assign_video(
-            path, to_stage_number=stage_number, role="primary"
-        )
+        new_primary = self.assign_video(path, to_stage_number=stage_number, role="primary")
         new_primary.processed = {"beep": False, "shot_detect": False, "trim": False}
         new_primary.beep_time = None
         new_primary.beep_source = None

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -139,6 +139,33 @@ class RemovalPlan(BaseModel):
     audit_reset: bool = False  # caller-facing flag: did we wipe stage audit?
 
 
+class StageExportStatus(BaseModel):
+    """Per-stage audit + export status for the Analysis & Export overview.
+
+    Inferred (no explicit "Done" button per the v1 contract): a stage is
+    ``ready_to_export`` when its primary has run beep + trim + shot detect
+    and the audit JSON has at least one shot. ``has_exports`` flips when
+    the user has clicked Generate at least once for this stage; the SPA
+    uses it to badge stages with stale exports vs. fresh ones.
+    """
+
+    stage_number: int
+    stage_name: str
+    skipped: bool
+    has_primary: bool
+    primary_processed: dict[str, bool]
+    audit_shot_count: int
+    pending_candidate_count: int
+    audit_path: Path | None
+    trimmed_video_path: Path | None
+    csv_path: Path | None
+    fcpxml_path: Path | None
+    report_path: Path | None
+    has_exports: bool
+    last_export_at: datetime | None
+    ready_to_export: bool
+
+
 class StageMatchWindow(BaseModel):
     """One stage's match window for the SPA timeline (issue #13).
 
@@ -321,6 +348,95 @@ class MatchProject(BaseModel):
         out: list[StageVideo] = list(self.unassigned_videos)
         for s in self.stages:
             out.extend(s.videos)
+        return out
+
+    def export_overview(self, root: Path) -> list[StageExportStatus]:
+        """Per-stage audit + export status for the Analysis & Export screen.
+
+        Pure: stat-only inspection of the audit/exports directories; never
+        re-runs detection. The returned list mirrors :attr:`stages` order so
+        the SPA can iterate cards directly.
+        """
+        from . import exports as exports_mod  # local: avoid import cycle
+
+        audit_dir = self.audit_path(root)
+        exports_dir = self.exports_path(root)
+        trimmed_dir = self.trimmed_path(root)
+
+        out: list[StageExportStatus] = []
+        for stage in self.stages:
+            primary = stage.primary()
+            audit_file = audit_dir / f"stage{stage.stage_number}.json"
+            shot_count = 0
+            pending_count = 0
+            if audit_file.exists():
+                try:
+                    raw = json.loads(audit_file.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    raw = {}
+                shots = raw.get("shots") if isinstance(raw, dict) else None
+                if isinstance(shots, list):
+                    shot_count = len(shots)
+                cand_block = (
+                    raw.get("_candidates_pending_audit") if isinstance(raw, dict) else None
+                )
+                if isinstance(cand_block, dict):
+                    cands = cand_block.get("candidates")
+                    if isinstance(cands, list):
+                        pending_count = len(cands)
+
+            base = f"stage{stage.stage_number}_{exports_mod._slugify(stage.stage_name)}"
+            csv_p = exports_dir / f"{base}_splits.csv"
+            fcpxml_p = exports_dir / f"{base}.fcpxml"
+            report_p = exports_dir / f"{base}_report.txt"
+            trimmed_p = trimmed_dir / f"stage{stage.stage_number}_trimmed.mp4"
+
+            csv_exists = csv_p.exists()
+            fcpxml_exists = fcpxml_p.exists()
+            report_exists = report_p.exists()
+            has_exports = csv_exists or fcpxml_exists or report_exists
+            last_export_at: datetime | None = None
+            if has_exports:
+                mtimes = [
+                    p.stat().st_mtime
+                    for p in (csv_p, fcpxml_p, report_p)
+                    if p.exists()
+                ]
+                if mtimes:
+                    last_export_at = datetime.fromtimestamp(max(mtimes), tz=UTC)
+
+            processed = (
+                dict(primary.processed)
+                if primary is not None
+                else {"beep": False, "shot_detect": False, "trim": False}
+            )
+            ready_to_export = (
+                primary is not None
+                and processed.get("beep", False)
+                and processed.get("trim", False)
+                and processed.get("shot_detect", False)
+                and shot_count > 0
+            )
+
+            out.append(
+                StageExportStatus(
+                    stage_number=stage.stage_number,
+                    stage_name=stage.stage_name,
+                    skipped=stage.skipped,
+                    has_primary=primary is not None,
+                    primary_processed=processed,
+                    audit_shot_count=shot_count,
+                    pending_candidate_count=pending_count,
+                    audit_path=audit_file if audit_file.exists() else None,
+                    trimmed_video_path=trimmed_p if trimmed_p.exists() else None,
+                    csv_path=csv_p if csv_exists else None,
+                    fcpxml_path=fcpxml_p if fcpxml_exists else None,
+                    report_path=report_p if report_exists else None,
+                    has_exports=has_exports,
+                    last_export_at=last_export_at,
+                    ready_to_export=ready_to_export,
+                )
+            )
         return out
 
     def match_analysis(

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1860,8 +1860,19 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
 
     @app.post("/api/stages/{stage_number}/export")
     def export_stage(stage_number: int, req: ExportStageRequest) -> JSONResponse:
-        """Run the per-stage export: CSV / FCPXML / report. Idempotent --
-        re-running overwrites prior artefacts in place.
+        """Submit a per-stage export job.
+
+        Wraps the ``export_helpers.export_stage`` orchestrator (lossless trim
+        + CSV + FCPXML + report) in a JobRegistry entry so the SPA's
+        JobsPanel surfaces progress alongside detect-beep / trim /
+        shot-detect. Returns a Job snapshot; the SPA polls
+        ``/api/jobs/{id}`` until status leaves running, then re-fetches
+        ``/api/exports/overview`` to refresh paths and ``last_export_at``.
+
+        Pre-flight validations (stage exists, primary present, beep ready,
+        source reachable, scoreboard not placeholder) still raise HTTP
+        errors up front so the SPA can show a clear error before queueing
+        a useless job.
         """
         project = state.load()
         try:
@@ -1877,19 +1888,6 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                     "finish ingest + audit before exporting"
                 ),
             )
-
-        audit_dir = project.audit_path(state.project_root)
-        audit_file = audit_dir / f"stage{stage_number}.json"
-        exports_dir = project.exports_path(state.project_root)
-        # The export pipeline runs a lossless trim from the *source* video
-        # (the symlink under raw_dir resolves through). The audit-mode
-        # short-GOP file in <project>/trimmed/ is a scrub cache and is
-        # never used as the FCP-bound deliverable.
-        source_video = project.resolve_video_path(state.project_root, primary.path)
-
-        # Build the engine StageData from the stored stage. ``time_seconds``
-        # must be > 0 for the report's anomaly checks to make sense; reject
-        # placeholder stages that never got real scoreboard data.
         if stage.time_seconds <= 0 or stage.scorecard_updated_at is None:
             raise HTTPException(
                 status_code=400,
@@ -1898,14 +1896,61 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                     "scoreboard before exporting"
                 ),
             )
+        # Source-reachability surfaces as a structured 424 so the SPA
+        # renders the same "reconnect external storage" message used
+        # elsewhere -- even if the user only wants CSV/report (those would
+        # still work, but the explicit 424 lets them re-try after
+        # reconnecting rather than hunting for the partial degradation
+        # message in the per-row anomaly list).
+        if req.write_trim or req.write_fcpxml:
+            _ensure_source_reachable(
+                stage_number, project.resolve_video_path(state.project_root, primary.path)
+            )
+
+        existing = state.jobs.find_active(kind="export", stage_number=stage_number)
+        if existing is not None:
+            return JSONResponse(existing.model_dump(mode="json"))
+        job = state.jobs.submit(
+            kind="export",
+            stage_number=stage_number,
+            fn=lambda h, n=stage_number, r=req: _run_export_for_stage(h, n, r),
+        )
+        return JSONResponse(job.model_dump(mode="json"))
+
+    def _run_export_for_stage(
+        handle: JobHandle, stage_number: int, req: ExportStageRequest
+    ) -> None:
+        """Worker for /api/stages/{n}/export. Phases mirror the user's
+        mental model so the JobsPanel message is meaningful."""
         from ..config import StageData as EngineStageData
 
+        handle.update(progress=0.05, message="Loading project...")
+        proj = state.load()
+        stg = proj.stage(stage_number)
+        prim = stg.primary()
+        if prim is None or prim.beep_time is None:
+            raise RuntimeError("primary or beep disappeared mid-flight")
+
+        audit_file = proj.audit_path(state.project_root) / f"stage{stage_number}.json"
+        exports_dir = proj.exports_path(state.project_root)
+        source_video = proj.resolve_video_path(state.project_root, prim.path)
         engine_stage = EngineStageData(
-            stage_number=stage.stage_number,
-            stage_name=stage.stage_name,
-            time_seconds=stage.time_seconds,
-            scorecard_updated_at=stage.scorecard_updated_at,
+            stage_number=stg.stage_number,
+            stage_name=stg.stage_name,
+            time_seconds=stg.time_seconds,
+            scorecard_updated_at=stg.scorecard_updated_at,
         )
+
+        # Phase progress is approximate; trim dominates wall time when the
+        # source is large, so we hold at 0.4 through the trim phase and
+        # then jump on the small writers.
+        if req.write_trim:
+            handle.update(progress=0.15, message="Trimming source (lossless stream copy)...")
+        elif req.write_fcpxml:
+            handle.update(progress=0.15, message="Reading audit + preparing FCPXML...")
+        else:
+            handle.update(progress=0.15, message="Reading audit JSON...")
+        handle.check_cancel()
 
         try:
             result = export_helpers.export_stage(
@@ -1920,30 +1965,39 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 exports_dir=exports_dir,
                 source_video_path=source_video if source_video.exists() else None,
                 stage_data=engine_stage,
-                beep_time_in_source=primary.beep_time,
-                pre_buffer_seconds=project.trim_pre_buffer_seconds,
-                post_buffer_seconds=project.trim_post_buffer_seconds,
+                beep_time_in_source=prim.beep_time,
+                pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                post_buffer_seconds=proj.trim_post_buffer_seconds,
                 config=Config(),
             )
         except export_helpers.StageExportError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            # Surface as a job failure with the exporter's own message so
+            # the JobsPanel row reads "audit JSON has no shots in shots[]"
+            # rather than a stack trace.
+            raise RuntimeError(str(exc)) from exc
 
-        # Touch updated_at so the overview's last_export_at reflects this run.
-        project.updated_at = datetime.now(UTC)
-        project.save(state.project_root)
-        return JSONResponse(
-            {
-                "stage_number": result.stage_number,
-                "csv_path": str(result.csv_path) if result.csv_path else None,
-                "fcpxml_path": str(result.fcpxml_path) if result.fcpxml_path else None,
-                "report_path": str(result.report_path) if result.report_path else None,
-                "trimmed_video_path": (
-                    str(result.trimmed_video_path) if result.trimmed_video_path else None
-                ),
-                "shots_written": result.shots_written,
-                "anomalies": result.anomalies,
-            }
-        )
+        handle.update(progress=0.95, message="Saving project...")
+        proj.updated_at = datetime.now(UTC)
+        proj.save(state.project_root)
+
+        # Final message summarises what shipped + flags any skipped
+        # artefacts (FCPXML without a trim, etc). The full list lives in
+        # the report.txt; the user can Reveal it for details.
+        bits: list[str] = []
+        if result.trimmed_video_path is not None:
+            bits.append("trim")
+        if result.csv_path is not None:
+            bits.append("csv")
+        if result.fcpxml_path is not None:
+            bits.append("fcpxml")
+        if result.report_path is not None:
+            bits.append("report")
+        summary = ", ".join(bits) if bits else "nothing written"
+        if result.anomalies:
+            n = len(result.anomalies)
+            word = "anomaly" if n == 1 else "anomalies"
+            summary += f" ({n} {word} -- see report.txt)"
+        handle.update(progress=1.0, message=f"Done: {summary}")
 
     @app.post("/api/files/reveal")
     def reveal_file(req: RevealRequest) -> JSONResponse:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -96,7 +96,7 @@ def _ensure_source_reachable(stage_number: int | None, source: Path) -> None:
             "stage_number": stage_number,
             "path": str(source),
             "message": (
-                f"Source video"
+                "Source video"
                 + (f" for stage {stage_number}" if stage_number is not None else "")
                 + f" is not reachable: {source}. If it lives on external "
                 f"storage (USB drive, SD card), reconnect and try again."
@@ -1576,9 +1576,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             served_path = project.resolve_video_path(state.project_root, video.path).resolve()
             # Same structured shape as detect-beep / trim / preview so
             # the SPA's "reconnect external storage" surface is uniform.
-            _ensure_source_reachable(
-                stage.stage_number if stage is not None else None, served_path
-            )
+            _ensure_source_reachable(stage.stage_number if stage is not None else None, served_path)
 
         media_type = (
             "video/mp4" if served_path.suffix.lower() == ".mp4" else "application/octet-stream"

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -47,6 +47,7 @@ import json
 import logging
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -64,7 +65,9 @@ from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
+from ..config import Config
 from . import audio as audio_helpers
+from . import exports as export_helpers
 from .jobs import Job, JobCancelled, JobHandle, JobRegistry
 from .project import (
     VIDEO_EXTENSIONS,
@@ -326,6 +329,32 @@ class BeepSelectRequest(BaseModel):
     """
 
     time: float
+
+
+class ExportStageRequest(BaseModel):
+    """Body for POST /api/stages/{n}/export.
+
+    Each toggle defaults True; turning one off skips that artefact while
+    leaving the others on. The trimmed video itself is never regenerated
+    here -- it lives at ``<project>/trimmed/stage<N>_trimmed.mp4`` from the
+    audit-mode trim and is referenced as-is.
+    """
+
+    write_csv: bool = True
+    write_fcpxml: bool = True
+    write_report: bool = True
+
+
+class RevealRequest(BaseModel):
+    """Body for POST /api/files/reveal.
+
+    Opens the OS file manager at ``path``'s parent, selecting the file when
+    the platform supports it (``open -R`` on macOS). The path must resolve
+    inside the project root for safety -- we don't expose a generic shell
+    out.
+    """
+
+    path: str
 
 
 class SwapPrimaryRequest(BaseModel):
@@ -1776,6 +1805,136 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
+
+    @app.get("/api/exports/overview")
+    def export_overview() -> JSONResponse:
+        """Match-overview payload for the Analysis & Export screen.
+
+        Returns one row per stage with audit + export status (shot count,
+        pending candidates, file paths, last export time, ready-to-export
+        flag). Pure stat: no detection, no rewriting of audit JSON.
+        """
+        project = state.load()
+        rows = project.export_overview(state.project_root)
+        return JSONResponse({"stages": [r.model_dump(mode="json") for r in rows]})
+
+    @app.post("/api/stages/{stage_number}/export")
+    def export_stage(stage_number: int, req: ExportStageRequest) -> JSONResponse:
+        """Run the per-stage export: CSV / FCPXML / report. Idempotent --
+        re-running overwrites prior artefacts in place.
+        """
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        primary = stage.primary()
+        if primary is None or primary.beep_time is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"stage {stage_number} has no primary or no beep yet; "
+                    "finish ingest + audit before exporting"
+                ),
+            )
+
+        audit_dir = project.audit_path(state.project_root)
+        audit_file = audit_dir / f"stage{stage_number}.json"
+        exports_dir = project.exports_path(state.project_root)
+        trimmed_dir = project.trimmed_path(state.project_root)
+        trimmed_video = trimmed_dir / f"stage{stage_number}_trimmed.mp4"
+
+        # Build the engine StageData from the stored stage. ``time_seconds``
+        # must be > 0 for the report's anomaly checks to make sense; reject
+        # placeholder stages that never got real scoreboard data.
+        if stage.time_seconds <= 0 or stage.scorecard_updated_at is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"stage {stage_number} is a placeholder; import a real "
+                    "scoreboard before exporting"
+                ),
+            )
+        from ..config import StageData as EngineStageData
+
+        engine_stage = EngineStageData(
+            stage_number=stage.stage_number,
+            stage_name=stage.stage_name,
+            time_seconds=stage.time_seconds,
+            scorecard_updated_at=stage.scorecard_updated_at,
+        )
+
+        try:
+            result = export_helpers.export_stage(
+                request=export_helpers.StageExportRequest(
+                    stage_number=stage_number,
+                    write_csv=req.write_csv,
+                    write_fcpxml=req.write_fcpxml,
+                    write_report=req.write_report,
+                ),
+                audit_path=audit_file,
+                exports_dir=exports_dir,
+                trimmed_video_path=trimmed_video if trimmed_video.exists() else None,
+                stage_data=engine_stage,
+                beep_time_in_source=primary.beep_time,
+                config=Config(),
+            )
+        except export_helpers.StageExportError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        # Touch updated_at so the overview's last_export_at reflects this run.
+        project.updated_at = datetime.now(UTC)
+        project.save(state.project_root)
+        return JSONResponse(
+            {
+                "stage_number": result.stage_number,
+                "csv_path": str(result.csv_path) if result.csv_path else None,
+                "fcpxml_path": str(result.fcpxml_path) if result.fcpxml_path else None,
+                "report_path": str(result.report_path) if result.report_path else None,
+                "trimmed_video_path": (
+                    str(result.trimmed_video_path) if result.trimmed_video_path else None
+                ),
+                "shots_written": result.shots_written,
+                "anomalies": result.anomalies,
+            }
+        )
+
+    @app.post("/api/files/reveal")
+    def reveal_file(req: RevealRequest) -> JSONResponse:
+        """Reveal a file in the OS file manager.
+
+        Restricted to paths inside the current project root so the endpoint
+        can never be coerced into opening arbitrary locations. macOS uses
+        ``open -R`` (selects the file in Finder); Linux uses ``xdg-open``
+        on the parent dir; Windows uses ``explorer /select``.
+        """
+        target = Path(req.path).expanduser()
+        try:
+            resolved = target.resolve(strict=True)
+        except (OSError, FileNotFoundError) as exc:
+            raise HTTPException(status_code=404, detail=f"not found: {target}") from exc
+        try:
+            resolved.relative_to(state.project_root.resolve())
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="reveal path must be inside the project root",
+            ) from exc
+        try:
+            if sys.platform == "darwin":
+                subprocess.run(["open", "-R", str(resolved)], check=False)
+            elif sys.platform.startswith("win"):
+                subprocess.run(["explorer", f"/select,{resolved}"], check=False)
+            else:
+                # xdg-open doesn't support file selection; opening the parent
+                # is the closest cross-distro behaviour.
+                parent = resolved.parent if resolved.is_file() else resolved
+                subprocess.run(["xdg-open", str(parent)], check=False)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=500, detail=f"failed to launch file manager: {exc}"
+            ) from exc
+        return JSONResponse({"revealed": str(resolved)})
 
     @app.post("/api/stages/{stage_number}/skip")
     def set_stage_skipped(stage_number: int, req: SkipStageRequest) -> JSONResponse:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -77,6 +77,34 @@ from .project import (
 )
 
 
+def _ensure_source_reachable(stage_number: int | None, source: Path) -> None:
+    """Raise a structured 424 when ``source`` doesn't exist on disk.
+
+    The SPA reads ``detail.code == "source_unreachable"`` to render a
+    uniform "reconnect the USB / SD card" message wherever a source-bound
+    operation is invoked (detect-beep, audit-mode trim, beep preview,
+    video stream, export). Callers handle the "no primary" check with
+    their endpoint-specific status code before calling this -- the helper
+    only handles the upstream-dependency-offline case.
+    """
+    if source.exists():
+        return
+    raise HTTPException(
+        status_code=424,
+        detail={
+            "code": "source_unreachable",
+            "stage_number": stage_number,
+            "path": str(source),
+            "message": (
+                f"Source video"
+                + (f" for stage {stage_number}" if stage_number is not None else "")
+                + f" is not reachable: {source}. If it lives on external "
+                f"storage (USB drive, SD card), reconnect and try again."
+            ),
+        },
+    )
+
+
 def _cancellable_runner(handle: JobHandle):
     """Build a ``trim.Runner`` that registers ffmpeg with the job for cancel.
 
@@ -335,11 +363,13 @@ class ExportStageRequest(BaseModel):
     """Body for POST /api/stages/{n}/export.
 
     Each toggle defaults True; turning one off skips that artefact while
-    leaving the others on. The trimmed video itself is never regenerated
-    here -- it lives at ``<project>/trimmed/stage<N>_trimmed.mp4`` from the
-    audit-mode trim and is referenced as-is.
+    leaving the others on. ``write_trim`` produces the lossless stream-copy
+    trim into ``<project>/exports/`` -- distinct from the audit-mode
+    short-GOP scrub copy in ``<project>/trimmed/``. The FCPXML always
+    references the lossless trim so SPA exports match ``splitsmith single``.
     """
 
+    write_trim: bool = True
     write_csv: bool = True
     write_fcpxml: bool = True
     write_report: bool = True
@@ -693,6 +723,13 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
+        # Reachability pre-flight: surface the same structured 424 the
+        # export pipeline uses, so the SPA renders a consistent "reconnect
+        # external storage" message regardless of which screen kicked
+        # off the work.
+        _ensure_source_reachable(
+            stage_number, project.resolve_video_path(state.project_root, primary.path)
+        )
         if primary.beep_source == "manual" and not force:
             raise HTTPException(
                 status_code=409,
@@ -783,6 +820,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
+        # Same source-reachability pre-flight as detect-beep: a 424 with
+        # ``code: "source_unreachable"`` so the SPA can surface a uniform
+        # "reconnect external storage" message before any job is queued.
+        _ensure_source_reachable(
+            stage_number, project.resolve_video_path(state.project_root, primary.path)
+        )
         if primary.beep_time is None:
             raise HTTPException(
                 status_code=400,
@@ -1257,6 +1300,11 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=404,
                 detail=f"stage {stage_number} has no primary video",
             )
+        # Reuse the structured 424 path so the SPA gets a uniform
+        # "reconnect external storage" message regardless of which surface
+        # invoked the preview.
+        source = project.resolve_video_path(state.project_root, primary.path)
+        _ensure_source_reachable(stage_number, source)
         center = t if t is not None else primary.beep_time
         if center is None:
             raise HTTPException(
@@ -1265,12 +1313,6 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             )
         if center < 0:
             raise HTTPException(status_code=400, detail="t must be >= 0")
-        source = project.resolve_video_path(state.project_root, primary.path)
-        if not source.is_file():
-            raise HTTPException(
-                status_code=404,
-                detail=f"primary video missing on disk: {source}",
-            )
         thumbs_dir = project.thumbs_path(state.project_root)
         try:
             clip = thumbnail_helpers.ensure_clip(
@@ -1532,11 +1574,11 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 served_path = trimmed.resolve()
         if served_path is None:
             served_path = project.resolve_video_path(state.project_root, video.path).resolve()
-            if not served_path.is_file():
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"video missing on disk: {served_path}",
-                )
+            # Same structured shape as detect-beep / trim / preview so
+            # the SPA's "reconnect external storage" surface is uniform.
+            _ensure_source_reachable(
+                stage.stage_number if stage is not None else None, served_path
+            )
 
         media_type = (
             "video/mp4" if served_path.suffix.lower() == ".mp4" else "application/octet-stream"
@@ -1841,8 +1883,11 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         audit_dir = project.audit_path(state.project_root)
         audit_file = audit_dir / f"stage{stage_number}.json"
         exports_dir = project.exports_path(state.project_root)
-        trimmed_dir = project.trimmed_path(state.project_root)
-        trimmed_video = trimmed_dir / f"stage{stage_number}_trimmed.mp4"
+        # The export pipeline runs a lossless trim from the *source* video
+        # (the symlink under raw_dir resolves through). The audit-mode
+        # short-GOP file in <project>/trimmed/ is a scrub cache and is
+        # never used as the FCP-bound deliverable.
+        source_video = project.resolve_video_path(state.project_root, primary.path)
 
         # Build the engine StageData from the stored stage. ``time_seconds``
         # must be > 0 for the report's anomaly checks to make sense; reject
@@ -1868,15 +1913,18 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             result = export_helpers.export_stage(
                 request=export_helpers.StageExportRequest(
                     stage_number=stage_number,
+                    write_trim=req.write_trim,
                     write_csv=req.write_csv,
                     write_fcpxml=req.write_fcpxml,
                     write_report=req.write_report,
                 ),
                 audit_path=audit_file,
                 exports_dir=exports_dir,
-                trimmed_video_path=trimmed_video if trimmed_video.exists() else None,
+                source_video_path=source_video if source_video.exists() else None,
                 stage_data=engine_stage,
                 beep_time_in_source=primary.beep_time,
+                pre_buffer_seconds=project.trim_pre_buffer_seconds,
+                post_buffer_seconds=project.trim_post_buffer_seconds,
                 config=Config(),
             )
         except export_helpers.StageExportError as exc:

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -35,6 +35,7 @@ import { Waveform } from "@/components/Waveform";
 import {
   ApiError,
   api,
+  asSourceUnreachable,
   type BeepCandidate,
   type Job,
   type MatchProject,
@@ -119,7 +120,15 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
         );
         if (ok) await detect(true);
       } else {
-        setError(e instanceof Error ? e.message : String(e));
+        // Source-unreachable (424) gets the same friendly wording the
+        // Export page shows, so the user sees one consistent
+        // "reconnect external storage" message everywhere.
+        const unreachable = asSourceUnreachable(e);
+        if (unreachable) {
+          setError(unreachable.message);
+        } else {
+          setError(e instanceof Error ? e.message : String(e));
+        }
       }
     } finally {
       setJobStatus(null);

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -164,7 +164,9 @@ export interface MatchAnalysis {
 
 /** Per-stage status row for the Analysis & Export overview (#17).
  *  Mirrors splitsmith.ui.project.StageExportStatus. The SPA renders one
- *  card per row; ``ready_to_export`` decides whether Generate is enabled. */
+ *  card per row; ``ready_to_export`` decides whether Generate is enabled.
+ *  ``source_reachable`` flags the dangling-symlink case (USB unplugged) so
+ *  the row can warn before the user clicks Generate. */
 export interface StageExportStatus {
   stage_number: number;
   stage_name: string;
@@ -172,15 +174,20 @@ export interface StageExportStatus {
   has_primary: boolean;
   primary_processed: { beep: boolean; shot_detect: boolean; trim: boolean };
   audit_shot_count: number;
-  pending_candidate_count: number;
+  /** Size of the detector's candidate pool. NOT "pending" -- once shot
+   *  detection has run, every candidate is kept (in shots[]) or rejected
+   *  (not in shots[]). Render as "X shots audited from Y candidates". */
+  total_candidate_count: number;
   audit_path: string | null;
   trimmed_video_path: string | null;
+  lossless_trim_present: boolean;
   csv_path: string | null;
   fcpxml_path: string | null;
   report_path: string | null;
   has_exports: boolean;
   last_export_at: string | null;
   ready_to_export: boolean;
+  source_reachable: boolean | null;
 }
 
 export interface ExportOverview {
@@ -188,6 +195,7 @@ export interface ExportOverview {
 }
 
 export interface ExportStageRequestPayload {
+  write_trim?: boolean;
   write_csv?: boolean;
   write_fcpxml?: boolean;
   write_report?: boolean;
@@ -195,10 +203,10 @@ export interface ExportStageRequestPayload {
 
 export interface ExportStageResult {
   stage_number: number;
+  trimmed_video_path: string | null;
   csv_path: string | null;
   fcpxml_path: string | null;
   report_path: string | null;
-  trimmed_video_path: string | null;
   shots_written: number;
   anomalies: string[];
 }
@@ -305,6 +313,30 @@ export interface Job {
   updated_at: string;
   started_at: string | null;
   finished_at: string | null;
+}
+
+/** Structured error payload emitted by source-bound endpoints (detect-beep,
+ *  trim, beep-preview, video stream, export) when the primary's source file
+ *  is not reachable on disk -- typically because external storage is
+ *  unplugged. Status code is 424 (Failed Dependency); ``code`` is the
+ *  discriminator the SPA matches on. */
+export interface SourceUnreachableDetail {
+  code: "source_unreachable";
+  stage_number: number | null;
+  path: string;
+  message: string;
+}
+
+/** Pull a SourceUnreachableDetail out of an ApiError if the body matches.
+ *  Returns null otherwise so callers can fall through to generic display. */
+export function asSourceUnreachable(err: unknown): SourceUnreachableDetail | null {
+  if (!(err instanceof ApiError)) return null;
+  if (err.status !== 424) return null;
+  const body = err.body;
+  if (!body || typeof body !== "object") return null;
+  const code = (body as { code?: unknown }).code;
+  if (code !== "source_unreachable") return null;
+  return body as SourceUnreachableDetail;
 }
 
 class ApiError extends Error {
@@ -565,6 +597,7 @@ export const api = {
     request<ExportStageResult>(`/api/stages/${stageNumber}/export`, {
       method: "POST",
       json: {
+        write_trim: opts.write_trim ?? true,
         write_csv: opts.write_csv ?? true,
         write_fcpxml: opts.write_fcpxml ?? true,
         write_report: opts.write_report ?? true,

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -162,6 +162,47 @@ export interface MatchAnalysis {
   videos: VideoMatchAnalysisEntry[];
 }
 
+/** Per-stage status row for the Analysis & Export overview (#17).
+ *  Mirrors splitsmith.ui.project.StageExportStatus. The SPA renders one
+ *  card per row; ``ready_to_export`` decides whether Generate is enabled. */
+export interface StageExportStatus {
+  stage_number: number;
+  stage_name: string;
+  skipped: boolean;
+  has_primary: boolean;
+  primary_processed: { beep: boolean; shot_detect: boolean; trim: boolean };
+  audit_shot_count: number;
+  pending_candidate_count: number;
+  audit_path: string | null;
+  trimmed_video_path: string | null;
+  csv_path: string | null;
+  fcpxml_path: string | null;
+  report_path: string | null;
+  has_exports: boolean;
+  last_export_at: string | null;
+  ready_to_export: boolean;
+}
+
+export interface ExportOverview {
+  stages: StageExportStatus[];
+}
+
+export interface ExportStageRequestPayload {
+  write_csv?: boolean;
+  write_fcpxml?: boolean;
+  write_report?: boolean;
+}
+
+export interface ExportStageResult {
+  stage_number: number;
+  csv_path: string | null;
+  fcpxml_path: string | null;
+  report_path: string | null;
+  trimmed_video_path: string | null;
+  shots_written: number;
+  anomalies: string[];
+}
+
 export interface RemovalPlan {
   video_path: string;
   raw_link_path: string;
@@ -218,6 +259,10 @@ export interface AuditShot {
   time: number;
   ms_after_beep: number;
   source?: "detected" | "manual";
+  /** Free-text user note ("draw", "reload", "transition", ...). Persisted
+   *  in the per-stage audit JSON and rendered in the splits CSV. Optional
+   *  for backwards compatibility with audit JSONs written before #17. */
+  notes?: string;
 }
 
 export interface AuditEvent {
@@ -510,6 +555,29 @@ export const api = {
     request<StageAudit>(`/api/stages/${stageNumber}/audit`, {
       method: "PUT",
       json: payload,
+    }),
+
+  /** Match-overview payload for the Analysis & Export screen. */
+  getExportOverview: () => request<ExportOverview>("/api/exports/overview"),
+
+  /** Run a stage export. Idempotent; re-running overwrites in place. */
+  exportStage: (stageNumber: number, opts: ExportStageRequestPayload = {}) =>
+    request<ExportStageResult>(`/api/stages/${stageNumber}/export`, {
+      method: "POST",
+      json: {
+        write_csv: opts.write_csv ?? true,
+        write_fcpxml: opts.write_fcpxml ?? true,
+        write_report: opts.write_report ?? true,
+      },
+    }),
+
+  /** Open the OS file manager at ``path`` (selecting the file on macOS /
+   *  Windows; opening the parent dir on Linux). The backend rejects paths
+   *  outside the project root. */
+  revealFile: (path: string) =>
+    request<{ revealed: string }>("/api/files/reveal", {
+      method: "POST",
+      json: { path },
     }),
 
   // -----------------------------------------------------------------------

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -592,9 +592,14 @@ export const api = {
   /** Match-overview payload for the Analysis & Export screen. */
   getExportOverview: () => request<ExportOverview>("/api/exports/overview"),
 
-  /** Run a stage export. Idempotent; re-running overwrites in place. */
+  /** Submit a stage export job. Returns a Job snapshot; poll
+   *  ``/api/jobs/{id}`` (or {@link api.pollJob}) until it leaves the
+   *  running state, then re-fetch the export overview to see updated
+   *  paths + ``last_export_at``. Idempotent on the worker side: the
+   *  registry dedupes by (kind, stage_number) so double-clicking
+   *  Generate returns the in-flight job instead of stacking. */
   exportStage: (stageNumber: number, opts: ExportStageRequestPayload = {}) =>
-    request<ExportStageResult>(`/api/stages/${stageNumber}/export`, {
+    request<Job>(`/api/stages/${stageNumber}/export`, {
       method: "POST",
       json: {
         write_trim: opts.write_trim ?? true,

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -43,7 +43,7 @@ import {
   api,
   asSourceUnreachable,
   type ExportOverview,
-  type ExportStageResult,
+  type Job,
   type MatchProject,
   type StageAudit,
   type StageExportStatus,
@@ -252,23 +252,61 @@ function StageActions({
   const [csv, setCsv] = useState(true);
   const [fcpxml, setFcpxml] = useState(true);
   const [reportFlag, setReportFlag] = useState(true);
-  const [busy, setBusy] = useState(false);
-  const [lastResult, setLastResult] = useState<ExportStageResult | null>(null);
+  const [job, setJob] = useState<Job | null>(null);
 
   const sourceUnreachable = row.has_primary && row.source_reachable === false;
   const willDegrade = sourceUnreachable && (trim || fcpxml);
+  const busy = job?.status === "pending" || job?.status === "running";
+
+  // Resume an in-flight export job after a page reload, so the JobsPanel
+  // (sidebar) and this row stay consistent.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listJobs()
+      .then(async (jobs) => {
+        if (cancelled) return;
+        const active = jobs.find(
+          (j) =>
+            j.kind === "export" &&
+            j.stage_number === row.stage_number &&
+            (j.status === "pending" || j.status === "running"),
+        );
+        if (!active) return;
+        setJob(active);
+        const final = await api.pollJob(active.id, (j) => {
+          if (!cancelled) setJob(j);
+        });
+        if (cancelled) return;
+        if (final.status === "failed") {
+          onError(final.error ?? "Export failed");
+        }
+        await onChanged();
+      })
+      .catch(() => {
+        // Best effort; jobs endpoint occasionally hiccups during reload.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [row.stage_number, onChanged, onError]);
 
   const generate = async () => {
-    setBusy(true);
+    onError(null);
     try {
-      const r = await api.exportStage(row.stage_number, {
+      const submitted = await api.exportStage(row.stage_number, {
         write_trim: trim,
         write_csv: csv,
         write_fcpxml: fcpxml,
         write_report: reportFlag,
       });
-      setLastResult(r);
-      onError(null);
+      setJob(submitted);
+      const final = await api.pollJob(submitted.id, setJob);
+      if (final.status === "failed") {
+        onError(final.error ?? "Export failed");
+      } else if (final.status === "cancelled") {
+        onError("Export cancelled");
+      }
       await onChanged();
     } catch (e) {
       // Source-unreachable: surface the structured message so the user
@@ -287,7 +325,10 @@ function StageActions({
         );
       }
     } finally {
-      setBusy(false);
+      // Clear the local job snapshot a moment after completion so the
+      // row's UI returns to its idle state. The JobsPanel still keeps
+      // the terminal entry in its history.
+      setTimeout(() => setJob(null), 1500);
     }
   };
 
@@ -387,17 +428,16 @@ function StageActions({
 
       <FileLinks row={row} onReveal={reveal} />
 
-      {lastResult && lastResult.anomalies.length > 0 ? (
-        <div className="rounded-md border border-status-warning/40 bg-status-warning/5 p-3 text-xs">
-          <div className="mb-1 flex items-center gap-1 font-medium">
-            <AlertCircle className="size-3.5" />
-            Anomalies from latest export
-          </div>
-          <ul className="ml-5 list-disc space-y-0.5 text-muted-foreground">
-            {lastResult.anomalies.map((a, i) => (
-              <li key={i}>{a}</li>
-            ))}
-          </ul>
+      {job ? (
+        <div className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
+          {job.status === "succeeded" ? (
+            <CheckCircle2 className="size-3.5 text-status-success" />
+          ) : job.status === "failed" || job.status === "cancelled" ? (
+            <AlertCircle className="size-3.5 text-status-warning" />
+          ) : (
+            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+          )}
+          <span className="text-muted-foreground">{job.message ?? job.status}</span>
         </div>
       ) : null}
     </div>

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -322,7 +322,7 @@ function StageActions({
           {row.has_exports ? "Re-generate" : "Generate"}
         </Button>
         <Button asChild size="sm" variant="outline" title="Open audit screen for this stage">
-          <Link to={`/audit?stage=${row.stage_number}`}>
+          <Link to={`/audit/${row.stage_number}`}>
             <PlayCircle className="size-4" />
             Audit
           </Link>
@@ -474,7 +474,7 @@ function StageShotTable({
         Audit JSON exists but no shots yet.{" "}
         <Link
           className="text-foreground underline"
-          to={`/audit?stage=${row.stage_number}`}
+          to={`/audit/${row.stage_number}`}
         >
           Open audit screen
         </Link>

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1,5 +1,35 @@
-import { FileBarChart } from "lucide-react";
+/**
+ * Analysis & Export screen (#17).
+ *
+ * Match overview at the top: project name, audit progress (X / N stages),
+ * a row per stage with audit + export status. Click a stage to drill into
+ * its analysis: editable shot table, anomalies, output toggles, and a
+ * Generate button that wraps csv_gen / fcpxml_gen / report.write_report
+ * via /api/stages/{n}/export.
+ *
+ * Notes editing is inline; saves write back to the audit JSON via the
+ * existing /api/stages/{n}/audit endpoint, so the same notes flow through
+ * to the splits CSV on the next Generate.
+ */
 
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  FileBarChart,
+  FileText,
+  FolderOpen,
+  Loader2,
+  PlayCircle,
+  RefreshCw,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -7,34 +37,499 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ApiError,
+  api,
+  type ExportOverview,
+  type ExportStageResult,
+  type MatchProject,
+  type StageAudit,
+  type StageExportStatus,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 export function Export() {
+  const [project, setProject] = useState<MatchProject | null>(null);
+  const [overview, setOverview] = useState<ExportOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      const [proj, ov] = await Promise.all([
+        api.getProject(),
+        api.getExportOverview(),
+      ]);
+      setProject(proj);
+      setOverview(ov);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  if (!project && !error) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-7 w-1/3" />
+        <Skeleton className="h-32" />
+      </div>
+    );
+  }
+
+  const total = (overview?.stages ?? []).filter((s) => !s.skipped).length;
+  const ready = (overview?.stages ?? []).filter(
+    (s) => !s.skipped && s.ready_to_export,
+  ).length;
+  const exported = (overview?.stages ?? []).filter(
+    (s) => !s.skipped && s.has_exports,
+  ).length;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Analysis &amp; Export</h1>
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Analysis &amp; Export
+        </h1>
         <p className="text-sm text-muted-foreground">
-          Per-stage shot table, anomalies, output toggles, regenerate. Implemented in{" "}
-          <a className="underline" href="https://github.com/mandakan/splitsmith/issues/17">
-            #17
-          </a>
-          .
+          Per-stage shot review and CSV / FCPXML / report generation. Outputs
+          are written to <code>{project?.exports_dir ?? "<project>/exports"}</code>;
+          re-running overwrites in place.
         </p>
-      </div>
+      </header>
+
+      {error ? (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-2 text-sm text-destructive">
+              <AlertCircle className="size-4 shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
             <FileBarChart className="size-5" />
-            Placeholder
+            {project?.name ?? "Match"}
           </CardTitle>
-          <CardDescription>
-            Wraps existing <code>csv_gen.py</code>, <code>fcpxml_gen.py</code>,{" "}
-            <code>report.py</code> with a UI; produces files identical to today's
-            CLI output.
+          <CardDescription className="space-x-4 tabular-nums">
+            <span>
+              {ready} / {total} stages ready
+            </span>
+            <span className="text-muted-foreground">
+              {exported} / {total} have exports
+            </span>
+            {project?.match_date ? (
+              <span className="text-muted-foreground">
+                {project.match_date}
+              </span>
+            ) : null}
           </CardDescription>
         </CardHeader>
-        <CardContent />
       </Card>
+
+      <div className="space-y-3">
+        {(overview?.stages ?? []).map((row) => (
+          <StageRow
+            key={row.stage_number}
+            row={row}
+            onChanged={reload}
+            onError={setError}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StageRow({
+  row,
+  onChanged,
+  onError,
+}: {
+  row: StageExportStatus;
+  onChanged: () => Promise<void>;
+  onError: (msg: string | null) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <Card className={cn(row.skipped && "opacity-60")}>
+      <CardHeader
+        className="cursor-pointer pb-3"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-start gap-2">
+            {expanded ? (
+              <ChevronDown className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            )}
+            <div>
+              <CardTitle className="text-base">
+                Stage {row.stage_number}: {row.stage_name}
+              </CardTitle>
+              <CardDescription className="font-mono tabular-nums">
+                {row.audit_shot_count} shot{row.audit_shot_count === 1 ? "" : "s"} audited
+                {row.pending_candidate_count > 0
+                  ? ` -- ${row.pending_candidate_count} candidate${row.pending_candidate_count === 1 ? "" : "s"} pending`
+                  : ""}
+                {row.last_export_at
+                  ? ` -- last export ${new Date(row.last_export_at).toLocaleString()}`
+                  : ""}
+              </CardDescription>
+            </div>
+          </div>
+          <StatusBadge row={row} />
+        </div>
+      </CardHeader>
+      {expanded ? (
+        <CardContent className="space-y-4 pt-0">
+          <StageActions row={row} onChanged={onChanged} onError={onError} />
+          <StageShotTable row={row} onChanged={onChanged} onError={onError} />
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+function StatusBadge({ row }: { row: StageExportStatus }) {
+  if (row.skipped) {
+    return <Badge variant="outline">Skipped</Badge>;
+  }
+  if (!row.has_primary) {
+    return <Badge variant="statusNotStarted">No primary</Badge>;
+  }
+  if (row.ready_to_export && row.has_exports) {
+    return (
+      <Badge variant="statusComplete" className="gap-1">
+        <CheckCircle2 className="size-3" /> Exported
+      </Badge>
+    );
+  }
+  if (row.ready_to_export) {
+    return (
+      <Badge variant="statusInProgress" className="gap-1">
+        Ready
+      </Badge>
+    );
+  }
+  if (row.audit_shot_count > 0 || row.pending_candidate_count > 0) {
+    return <Badge variant="statusInProgress">Auditing</Badge>;
+  }
+  return <Badge variant="statusNotStarted">Not started</Badge>;
+}
+
+function StageActions({
+  row,
+  onChanged,
+  onError,
+}: {
+  row: StageExportStatus;
+  onChanged: () => Promise<void>;
+  onError: (msg: string | null) => void;
+}) {
+  const [csv, setCsv] = useState(true);
+  const [fcpxml, setFcpxml] = useState(true);
+  const [reportFlag, setReportFlag] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [lastResult, setLastResult] = useState<ExportStageResult | null>(null);
+
+  const generate = async () => {
+    setBusy(true);
+    try {
+      const r = await api.exportStage(row.stage_number, {
+        write_csv: csv,
+        write_fcpxml: fcpxml,
+        write_report: reportFlag,
+      });
+      setLastResult(r);
+      onError(null);
+      await onChanged();
+    } catch (e) {
+      onError(
+        e instanceof ApiError
+          ? `Generate failed: ${e.detail}`
+          : e instanceof Error
+            ? e.message
+            : String(e),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reveal = async (path: string | null) => {
+    if (!path) return;
+    try {
+      await api.revealFile(path);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={csv}
+            disabled={busy}
+            onChange={(e) => setCsv(e.target.checked)}
+          />
+          CSV
+        </label>
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={fcpxml}
+            disabled={busy}
+            onChange={(e) => setFcpxml(e.target.checked)}
+          />
+          FCPXML
+        </label>
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={reportFlag}
+            disabled={busy}
+            onChange={(e) => setReportFlag(e.target.checked)}
+          />
+          Report
+        </label>
+        <Button
+          size="sm"
+          onClick={generate}
+          disabled={busy || !row.ready_to_export || (!csv && !fcpxml && !reportFlag)}
+          title={
+            row.ready_to_export
+              ? "Write the selected artefacts (overwrites if present)"
+              : "Finish the audit first -- need at least one shot in the audit JSON"
+          }
+        >
+          {busy ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+          {row.has_exports ? "Re-generate" : "Generate"}
+        </Button>
+        <Button asChild size="sm" variant="outline" title="Open audit screen for this stage">
+          <Link to={`/audit?stage=${row.stage_number}`}>
+            <PlayCircle className="size-4" />
+            Audit
+          </Link>
+        </Button>
+      </div>
+
+      <FileLinks row={row} onReveal={reveal} />
+
+      {lastResult && lastResult.anomalies.length > 0 ? (
+        <div className="rounded-md border border-status-warning/40 bg-status-warning/5 p-3 text-xs">
+          <div className="mb-1 flex items-center gap-1 font-medium">
+            <AlertCircle className="size-3.5" />
+            Anomalies from latest export
+          </div>
+          <ul className="ml-5 list-disc space-y-0.5 text-muted-foreground">
+            {lastResult.anomalies.map((a, i) => (
+              <li key={i}>{a}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FileLinks({
+  row,
+  onReveal,
+}: {
+  row: StageExportStatus;
+  onReveal: (path: string | null) => void;
+}) {
+  const items: { label: string; path: string | null }[] = [
+    { label: "Trimmed MP4", path: row.trimmed_video_path },
+    { label: "Splits CSV", path: row.csv_path },
+    { label: "FCPXML", path: row.fcpxml_path },
+    { label: "Report", path: row.report_path },
+  ];
+  return (
+    <div className="space-y-1 text-xs">
+      {items.map(({ label, path }) => (
+        <div
+          key={label}
+          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            {label === "Report" ? (
+              <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <FileBarChart className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="font-medium">{label}:</span>
+            <span
+              className={cn(
+                "truncate font-mono",
+                !path && "text-muted-foreground italic",
+              )}
+              title={path ?? "(not yet generated)"}
+            >
+              {path ?? "(not yet generated)"}
+            </span>
+          </div>
+          {path ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 px-2"
+              onClick={() => onReveal(path)}
+              title="Reveal in OS file manager"
+            >
+              <FolderOpen className="size-3.5" />
+            </Button>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StageShotTable({
+  row,
+  onChanged,
+  onError,
+}: {
+  row: StageExportStatus;
+  onChanged: () => Promise<void>;
+  onError: (msg: string | null) => void;
+}) {
+  const [audit, setAudit] = useState<StageAudit | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const a = await api.getStageAudit(row.stage_number);
+      setAudit(a);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [row.stage_number, onError]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return <Skeleton className="h-32" />;
+  }
+  if (!audit) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No audit JSON yet. Open the audit screen for this stage to start.
+      </p>
+    );
+  }
+
+  const sortedShots = [...audit.shots].sort((a, b) => a.shot_number - b.shot_number);
+  const splits = sortedShots.map((s, i, arr) => {
+    if (i === 0) return s.ms_after_beep / 1000;
+    return (s.ms_after_beep - arr[i - 1].ms_after_beep) / 1000;
+  });
+
+  const saveNote = async (shotNumber: number, value: string) => {
+    if (!audit) return;
+    const next: StageAudit = {
+      ...audit,
+      shots: audit.shots.map((s) =>
+        s.shot_number === shotNumber ? { ...s, notes: value } : s,
+      ),
+    };
+    try {
+      const saved = await api.saveStageAudit(row.stage_number, next);
+      setAudit(saved);
+      onError(null);
+      // The overview's last_export_at doesn't move on note edit, but the
+      // notes flow into the next CSV regen -- keep the row's status fresh
+      // anyway in case the caller cares.
+      void onChanged();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  if (sortedShots.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Audit JSON exists but no shots yet.{" "}
+        <Link
+          className="text-foreground underline"
+          to={`/audit?stage=${row.stage_number}`}
+        >
+          Open audit screen
+        </Link>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs tabular-nums">
+        <thead>
+          <tr className="border-b border-border/60 text-left text-muted-foreground">
+            <th className="px-2 py-1 text-right">#</th>
+            <th className="px-2 py-1 text-right">t (s)</th>
+            <th className="px-2 py-1 text-right">split (s)</th>
+            <th className="px-2 py-1">notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedShots.map((s, i) => (
+            <tr
+              key={s.shot_number}
+              className="border-b border-border/30 hover:bg-accent/20"
+            >
+              <td className="px-2 py-1 text-right">{s.shot_number}</td>
+              <td className="px-2 py-1 text-right font-mono">
+                {(s.ms_after_beep / 1000).toFixed(3)}
+              </td>
+              <td className="px-2 py-1 text-right font-mono">
+                {splits[i].toFixed(3)}
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="text"
+                  defaultValue={s.notes ?? ""}
+                  placeholder="--"
+                  className="h-6 w-full rounded border border-input bg-background px-1.5 py-0.5 font-mono text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  onBlur={(e) => {
+                    const value = e.target.value;
+                    if ((s.notes ?? "") !== value) void saveNote(s.shot_number, value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                  }}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+        <ExternalLink className="size-3" />
+        Notes save on blur or Enter; flow into the next CSV regen.
+      </p>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -41,6 +41,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   ApiError,
   api,
+  asSourceUnreachable,
   type ExportOverview,
   type ExportStageResult,
   type MatchProject,
@@ -177,9 +178,13 @@ function StageRow({
                 Stage {row.stage_number}: {row.stage_name}
               </CardTitle>
               <CardDescription className="font-mono tabular-nums">
+                {/* Math: 61 shots audited from 91 candidates means 61
+                    were kept, 91 - 61 = 30 were rejected. Every candidate
+                    is decided once shot detection has run -- nothing is
+                    "pending" in the audit_events sense. */}
                 {row.audit_shot_count} shot{row.audit_shot_count === 1 ? "" : "s"} audited
-                {row.pending_candidate_count > 0
-                  ? ` -- ${row.pending_candidate_count} candidate${row.pending_candidate_count === 1 ? "" : "s"} pending`
+                {row.total_candidate_count > 0
+                  ? ` from ${row.total_candidate_count} candidate${row.total_candidate_count === 1 ? "" : "s"}`
                   : ""}
                 {row.last_export_at
                   ? ` -- last export ${new Date(row.last_export_at).toLocaleString()}`
@@ -207,6 +212,13 @@ function StatusBadge({ row }: { row: StageExportStatus }) {
   if (!row.has_primary) {
     return <Badge variant="statusNotStarted">No primary</Badge>;
   }
+  if (row.source_reachable === false) {
+    return (
+      <Badge variant="statusWarning" className="gap-1">
+        <AlertCircle className="size-3" /> Source missing
+      </Badge>
+    );
+  }
   if (row.ready_to_export && row.has_exports) {
     return (
       <Badge variant="statusComplete" className="gap-1">
@@ -221,7 +233,7 @@ function StatusBadge({ row }: { row: StageExportStatus }) {
       </Badge>
     );
   }
-  if (row.audit_shot_count > 0 || row.pending_candidate_count > 0) {
+  if (row.audit_shot_count > 0 || row.total_candidate_count > 0) {
     return <Badge variant="statusInProgress">Auditing</Badge>;
   }
   return <Badge variant="statusNotStarted">Not started</Badge>;
@@ -236,16 +248,21 @@ function StageActions({
   onChanged: () => Promise<void>;
   onError: (msg: string | null) => void;
 }) {
+  const [trim, setTrim] = useState(true);
   const [csv, setCsv] = useState(true);
   const [fcpxml, setFcpxml] = useState(true);
   const [reportFlag, setReportFlag] = useState(true);
   const [busy, setBusy] = useState(false);
   const [lastResult, setLastResult] = useState<ExportStageResult | null>(null);
 
+  const sourceUnreachable = row.has_primary && row.source_reachable === false;
+  const willDegrade = sourceUnreachable && (trim || fcpxml);
+
   const generate = async () => {
     setBusy(true);
     try {
       const r = await api.exportStage(row.stage_number, {
+        write_trim: trim,
         write_csv: csv,
         write_fcpxml: fcpxml,
         write_report: reportFlag,
@@ -254,13 +271,21 @@ function StageActions({
       onError(null);
       await onChanged();
     } catch (e) {
-      onError(
-        e instanceof ApiError
-          ? `Generate failed: ${e.detail}`
-          : e instanceof Error
-            ? e.message
-            : String(e),
-      );
+      // Source-unreachable: surface the structured message so the user
+      // gets the same wording across detect-beep, trim, beep preview,
+      // and export.
+      const unreachable = asSourceUnreachable(e);
+      if (unreachable) {
+        onError(unreachable.message);
+      } else {
+        onError(
+          e instanceof ApiError
+            ? `Generate failed: ${e.detail}`
+            : e instanceof Error
+              ? e.message
+              : String(e),
+        );
+      }
     } finally {
       setBusy(false);
     }
@@ -277,7 +302,31 @@ function StageActions({
 
   return (
     <div className="space-y-3">
+      {sourceUnreachable ? (
+        <div className="rounded-md border border-status-warning/40 bg-status-warning/5 p-3 text-xs">
+          <div className="mb-1 flex items-center gap-1 font-medium">
+            <AlertCircle className="size-3.5 text-status-warning" />
+            Source video not reachable
+          </div>
+          <p className="text-muted-foreground">
+            The primary's symlink is dangling -- typically because the USB
+            drive / SD card is unplugged. CSV and report can still be
+            generated from the audit JSON. Reconnect the source to produce
+            a fresh trim and FCPXML.
+          </p>
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center gap-3 text-sm">
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={trim}
+            disabled={busy}
+            onChange={(e) => setTrim(e.target.checked)}
+          />
+          Trim (lossless MP4)
+        </label>
         <label className="flex items-center gap-1.5">
           <input
             type="checkbox"
@@ -311,10 +360,17 @@ function StageActions({
         <Button
           size="sm"
           onClick={generate}
-          disabled={busy || !row.ready_to_export || (!csv && !fcpxml && !reportFlag)}
+          disabled={
+            busy ||
+            !row.ready_to_export ||
+            (!trim && !csv && !fcpxml && !reportFlag)
+          }
           title={
             row.ready_to_export
-              ? "Write the selected artefacts (overwrites if present)"
+              ? willDegrade
+                ? "Source is unreachable; trim and FCPXML will be skipped, " +
+                  "CSV/report will still write."
+                : "Write the selected artefacts (overwrites if present)"
               : "Finish the audit first -- need at least one shot in the audit JSON"
           }
         >
@@ -355,8 +411,16 @@ function FileLinks({
   row: StageExportStatus;
   onReveal: (path: string | null) => void;
 }) {
+  // Only call out the lossless trim as the deliverable. The audit-mode
+  // short-GOP scrub copy in <project>/trimmed/ is a cache file and isn't
+  // meant to ship to FCP, so we don't surface it here -- the row falls
+  // back to "(not yet generated)" until the user hits Generate with the
+  // Trim toggle on.
   const items: { label: string; path: string | null }[] = [
-    { label: "Trimmed MP4", path: row.trimmed_video_path },
+    {
+      label: "Trim (lossless MP4)",
+      path: row.lossless_trim_present ? row.trimmed_video_path : null,
+    },
     { label: "Splits CSV", path: row.csv_path },
     { label: "FCPXML", path: row.fcpxml_path },
     { label: "Report", path: row.report_path },

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -132,11 +132,17 @@ def test_export_stage_writes_csv_and_report(tmp_path: Path) -> None:
 
     result = exports_mod.export_stage(
         request=exports_mod.StageExportRequest(
-            stage_number=1, write_csv=True, write_fcpxml=False, write_report=True
+            stage_number=1,
+            write_trim=False,
+            write_csv=True,
+            write_fcpxml=False,
+            write_report=True,
         ),
         audit_path=audit_path,
         exports_dir=exports_dir,
-        trimmed_video_path=None,
+        source_video_path=None,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
         stage_data=StageData(
             stage_number=1,
             stage_name="Stage 1 -- H1",
@@ -174,7 +180,9 @@ def test_export_stage_refuses_missing_audit(tmp_path: Path) -> None:
             request=exports_mod.StageExportRequest(stage_number=1),
             audit_path=tmp_path / "missing.json",
             exports_dir=tmp_path / "exports",
-            trimmed_video_path=None,
+            source_video_path=None,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
             stage_data=StageData(
                 stage_number=1,
                 stage_name="S",
@@ -194,7 +202,9 @@ def test_export_stage_refuses_empty_shots(tmp_path: Path) -> None:
             request=exports_mod.StageExportRequest(stage_number=1),
             audit_path=audit_path,
             exports_dir=tmp_path / "exports",
-            trimmed_video_path=None,
+            source_video_path=None,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
             stage_data=StageData(
                 stage_number=1,
                 stage_name="S",
@@ -206,9 +216,10 @@ def test_export_stage_refuses_empty_shots(tmp_path: Path) -> None:
         )
 
 
-def test_export_stage_skips_fcpxml_without_trimmed_video(tmp_path: Path) -> None:
-    """No trimmed clip on disk -> FCPXML is skipped with an anomaly,
-    but CSV / report still write."""
+def test_export_stage_skips_trim_and_fcpxml_when_source_unreachable(tmp_path: Path) -> None:
+    """Source video missing (USB unplugged) -> trim and FCPXML skip with a
+    helpful anomaly, but CSV / report still write so the user gets the
+    audit data even when external storage is offline."""
     audit_path = tmp_path / "stage1.json"
     audit_path.write_text(
         json.dumps(
@@ -223,11 +234,17 @@ def test_export_stage_skips_fcpxml_without_trimmed_video(tmp_path: Path) -> None
 
     result = exports_mod.export_stage(
         request=exports_mod.StageExportRequest(
-            stage_number=1, write_csv=True, write_fcpxml=True, write_report=True
+            stage_number=1,
+            write_trim=True,
+            write_csv=True,
+            write_fcpxml=True,
+            write_report=True,
         ),
         audit_path=audit_path,
         exports_dir=tmp_path / "exports",
-        trimmed_video_path=None,
+        source_video_path=None,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
         stage_data=StageData(
             stage_number=1,
             stage_name="S",
@@ -239,8 +256,13 @@ def test_export_stage_skips_fcpxml_without_trimmed_video(tmp_path: Path) -> None
     )
 
     assert result.csv_path and result.csv_path.exists()
+    assert result.report_path and result.report_path.exists()
+    assert result.trimmed_video_path is None
     assert result.fcpxml_path is None
-    assert any("FCPXML not written" in a for a in result.anomalies)
+    # Both the trim-skip and fcpxml-skip messages should reference the
+    # source-unreachable cause, not raw ffmpeg errors.
+    assert any("trim not written" in a for a in result.anomalies)
+    assert any("fcpxml not written" in a for a in result.anomalies)
 
 
 def test_slugify_matches_cli_format() -> None:
@@ -289,5 +311,14 @@ def test_export_overview_status(tmp_path: Path) -> None:
     row = overview[0]
     assert row.has_primary
     assert row.audit_shot_count == 1
+    # Total candidate pool from the detector. NOT "pending" -- once shot
+    # detection has run, every candidate is kept (in shots[]) or rejected.
+    # The fixture ships 2 candidates; only 1 was promoted to a shot, so
+    # 1 was implicitly rejected.
+    assert row.total_candidate_count == 2
     assert row.ready_to_export is True
     assert row.has_exports is False
+    # source_reachable is False -- the test fixture's primary path
+    # ``raw/a.mp4`` doesn't exist on disk, mirroring the "USB unplugged"
+    # case the SPA badges with "Source missing".
+    assert row.source_reachable is False

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -181,8 +181,8 @@ def test_export_stage_refuses_missing_audit(tmp_path: Path) -> None:
             audit_path=tmp_path / "missing.json",
             exports_dir=tmp_path / "exports",
             source_video_path=None,
-        pre_buffer_seconds=5.0,
-        post_buffer_seconds=5.0,
+            pre_buffer_seconds=5.0,
+            post_buffer_seconds=5.0,
             stage_data=StageData(
                 stage_number=1,
                 stage_name="S",
@@ -203,8 +203,8 @@ def test_export_stage_refuses_empty_shots(tmp_path: Path) -> None:
             audit_path=audit_path,
             exports_dir=tmp_path / "exports",
             source_video_path=None,
-        pre_buffer_seconds=5.0,
-        post_buffer_seconds=5.0,
+            pre_buffer_seconds=5.0,
+            post_buffer_seconds=5.0,
             stage_data=StageData(
                 stage_number=1,
                 stage_name="S",

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -1,0 +1,293 @@
+"""Tests for the UI export pipeline (issue #17).
+
+Covers the audit-JSON -> engine-Shot conversion, slug parity with the CLI,
+and the orchestrator's failure modes (missing audit, no shots).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from splitsmith.config import Config, StageData
+from splitsmith.ui import exports as exports_mod
+
+
+def _audit_payload(shots: list[dict] | None = None, beep_in_clip: float = 5.0) -> dict:
+    return {
+        "stage_number": 1,
+        "stage_name": "Stage 1 -- H1",
+        "stage_time_seconds": 8.0,
+        "beep_time": beep_in_clip,
+        "shots": shots if shots is not None else [],
+        "_candidates_pending_audit": {
+            "candidates": [
+                {
+                    "candidate_number": 1,
+                    "time": 5.5,
+                    "ms_after_beep": 500,
+                    "peak_amplitude": 0.7,
+                    "confidence": 0.9,
+                },
+                {
+                    "candidate_number": 2,
+                    "time": 5.9,
+                    "ms_after_beep": 900,
+                    "peak_amplitude": 0.6,
+                    "confidence": 0.85,
+                },
+            ]
+        },
+    }
+
+
+def test_audit_shots_to_engine_shots_computes_splits() -> None:
+    """Shot 1's split is the draw (= time_from_beep); shot N>1 is the diff
+    against the previous shot's time_from_beep. Mirrors the CLI's csv_gen
+    expectations."""
+    payload = _audit_payload(
+        shots=[
+            {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+            {"shot_number": 2, "candidate_number": 2, "time": 5.9, "ms_after_beep": 900},
+        ]
+    )
+    shots = exports_mod.audit_shots_to_engine_shots(payload, beep_time_in_source=10.0)
+    assert [s.shot_number for s in shots] == [1, 2]
+    # First shot's split == draw == time_from_beep.
+    assert shots[0].split == pytest.approx(0.5)
+    assert shots[1].split == pytest.approx(0.4)
+    # Engine time_absolute == beep_time_in_source + time_from_beep.
+    assert shots[0].time_absolute == pytest.approx(10.5)
+    assert shots[1].time_absolute == pytest.approx(10.9)
+    # Peak / confidence lifted from the candidate by candidate_number.
+    assert shots[0].peak_amplitude == pytest.approx(0.7)
+    assert shots[0].confidence == pytest.approx(0.9)
+
+
+def test_audit_shots_to_engine_shots_orders_by_shot_number() -> None:
+    """Shots are sorted by shot_number even if the JSON stores them out of
+    order (audit-apply writes append-style; tools may reorder)."""
+    payload = _audit_payload(
+        shots=[
+            {"shot_number": 2, "candidate_number": 2, "time": 5.9, "ms_after_beep": 900},
+            {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+        ]
+    )
+    shots = exports_mod.audit_shots_to_engine_shots(payload, beep_time_in_source=10.0)
+    assert [s.shot_number for s in shots] == [1, 2]
+
+
+def test_audit_shots_to_engine_shots_handles_manual_shot_without_candidate() -> None:
+    """A manually-added shot has candidate_number=None; we still emit the
+    shot but with peak/confidence defaults."""
+    payload = _audit_payload(
+        shots=[
+            {"shot_number": 1, "candidate_number": None, "time": 5.5, "ms_after_beep": 500},
+        ]
+    )
+    shots = exports_mod.audit_shots_to_engine_shots(payload, beep_time_in_source=10.0)
+    assert len(shots) == 1
+    assert shots[0].peak_amplitude == 0.0
+    assert shots[0].confidence == 0.0
+
+
+def test_audit_shots_to_engine_shots_preserves_notes() -> None:
+    payload = _audit_payload(
+        shots=[
+            {
+                "shot_number": 1,
+                "candidate_number": 1,
+                "time": 5.5,
+                "ms_after_beep": 500,
+                "notes": "draw",
+            },
+        ]
+    )
+    shots = exports_mod.audit_shots_to_engine_shots(payload, beep_time_in_source=10.0)
+    assert shots[0].notes == "draw"
+
+
+def test_export_stage_writes_csv_and_report(tmp_path: Path) -> None:
+    """End-to-end: drop a real audit JSON, get a CSV byte-for-byte
+    consistent with the CLI's output for the same shots."""
+    audit_path = tmp_path / "audit" / "stage1.json"
+    audit_path.parent.mkdir(parents=True)
+    audit_path.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                    {"shot_number": 2, "candidate_number": 2, "time": 5.9, "ms_after_beep": 900},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    exports_dir = tmp_path / "exports"
+
+    result = exports_mod.export_stage(
+        request=exports_mod.StageExportRequest(
+            stage_number=1, write_csv=True, write_fcpxml=False, write_report=True
+        ),
+        audit_path=audit_path,
+        exports_dir=exports_dir,
+        trimmed_video_path=None,
+        stage_data=StageData(
+            stage_number=1,
+            stage_name="Stage 1 -- H1",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ),
+        beep_time_in_source=10.0,
+        config=Config(),
+    )
+
+    assert result.shots_written == 2
+    assert result.csv_path is not None
+    assert result.csv_path.exists()
+    assert result.report_path is not None
+    assert result.report_path.exists()
+    # CSV name must match the CLI slug.
+    assert result.csv_path.name == "stage1_stage-1-h1_splits.csv"
+    # CSV content sanity.
+    rows = list(csv.reader(result.csv_path.open()))
+    assert rows[0] == [
+        "shot_number",
+        "time_from_start",
+        "split",
+        "peak_amplitude",
+        "confidence",
+        "notes",
+    ]
+    assert rows[1][0] == "1"
+    assert rows[2][0] == "2"
+
+
+def test_export_stage_refuses_missing_audit(tmp_path: Path) -> None:
+    with pytest.raises(exports_mod.StageExportError):
+        exports_mod.export_stage(
+            request=exports_mod.StageExportRequest(stage_number=1),
+            audit_path=tmp_path / "missing.json",
+            exports_dir=tmp_path / "exports",
+            trimmed_video_path=None,
+            stage_data=StageData(
+                stage_number=1,
+                stage_name="S",
+                time_seconds=8.0,
+                scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+            ),
+            beep_time_in_source=10.0,
+            config=Config(),
+        )
+
+
+def test_export_stage_refuses_empty_shots(tmp_path: Path) -> None:
+    audit_path = tmp_path / "stage1.json"
+    audit_path.write_text(json.dumps(_audit_payload(shots=[])), encoding="utf-8")
+    with pytest.raises(exports_mod.StageExportError):
+        exports_mod.export_stage(
+            request=exports_mod.StageExportRequest(stage_number=1),
+            audit_path=audit_path,
+            exports_dir=tmp_path / "exports",
+            trimmed_video_path=None,
+            stage_data=StageData(
+                stage_number=1,
+                stage_name="S",
+                time_seconds=8.0,
+                scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+            ),
+            beep_time_in_source=10.0,
+            config=Config(),
+        )
+
+
+def test_export_stage_skips_fcpxml_without_trimmed_video(tmp_path: Path) -> None:
+    """No trimmed clip on disk -> FCPXML is skipped with an anomaly,
+    but CSV / report still write."""
+    audit_path = tmp_path / "stage1.json"
+    audit_path.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    result = exports_mod.export_stage(
+        request=exports_mod.StageExportRequest(
+            stage_number=1, write_csv=True, write_fcpxml=True, write_report=True
+        ),
+        audit_path=audit_path,
+        exports_dir=tmp_path / "exports",
+        trimmed_video_path=None,
+        stage_data=StageData(
+            stage_number=1,
+            stage_name="S",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ),
+        beep_time_in_source=10.0,
+        config=Config(),
+    )
+
+    assert result.csv_path and result.csv_path.exists()
+    assert result.fcpxml_path is None
+    assert any("FCPXML not written" in a for a in result.anomalies)
+
+
+def test_slugify_matches_cli_format() -> None:
+    """Filename slug parity: same shape as cli._slugify so exports
+    produced via the SPA and via the CLI are byte-comparable."""
+    assert exports_mod._slugify("Stage 1 -- H1") == "stage-1-h1"
+    assert exports_mod._slugify("All Symbols!@#") == "all-symbols"
+    assert exports_mod._slugify("") == "stage"
+
+
+def test_export_overview_status(tmp_path: Path) -> None:
+    """The MatchProject.export_overview reports per-stage status correctly."""
+    from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.stages.append(
+        StageEntry(
+            stage_number=1,
+            stage_name="Stage 1",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        )
+    )
+    project.stages[0].videos.append(
+        StageVideo(
+            path=Path("raw/a.mp4"),
+            role="primary",
+            beep_time=1.0,
+            processed={"beep": True, "shot_detect": True, "trim": True},
+        )
+    )
+    audit = root / "audit" / "stage1.json"
+    audit.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+    overview = project.export_overview(root)
+    assert len(overview) == 1
+    row = overview[0]
+    assert row.has_primary
+    assert row.audit_shot_count == 1
+    assert row.ready_to_export is True
+    assert row.has_exports is False

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -791,12 +791,8 @@ def test_atomic_write_uses_same_directory_for_tmp(tmp_path: Path) -> None:
 def test_swap_primary_no_audit_no_warning(tmp_path: Path) -> None:
     """primary_swap_warns is False when no audit JSON exists."""
     project = MatchProject.init(tmp_path / "m", name="m")
-    project.stages.append(
-        StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0)
-    )
-    project.stages[0].videos.append(
-        StageVideo(path=Path("raw/a.mp4"), role="primary")
-    )
+    project.stages.append(StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0))
+    project.stages[0].videos.append(StageVideo(path=Path("raw/a.mp4"), role="primary"))
     assert project.primary_swap_warns(tmp_path / "m", stage_number=1) is False
 
 
@@ -804,16 +800,16 @@ def test_swap_primary_warns_when_shots_audited(tmp_path: Path) -> None:
     """primary_swap_warns is True when audit JSON has at least one shot."""
     root = tmp_path / "m"
     project = MatchProject.init(root, name="m")
-    project.stages.append(
-        StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0)
-    )
+    project.stages.append(StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0))
     audit = root / "audit" / "stage1.json"
     audit.write_text(
         json.dumps(
             {
                 "stage_number": 1,
                 "stage_name": "S1",
-                "shots": [{"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}],
+                "shots": [
+                    {"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}
+                ],
             }
         )
     )
@@ -826,9 +822,7 @@ def test_swap_primary_does_not_warn_for_pending_candidates_only(tmp_path: Path) 
     a fresh candidate list anyway."""
     root = tmp_path / "m"
     project = MatchProject.init(root, name="m")
-    project.stages.append(
-        StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0)
-    )
+    project.stages.append(StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0))
     audit = root / "audit" / "stage1.json"
     audit.write_text(
         json.dumps(
@@ -836,7 +830,9 @@ def test_swap_primary_does_not_warn_for_pending_candidates_only(tmp_path: Path) 
                 "stage_number": 1,
                 "stage_name": "S1",
                 "shots": [],
-                "_candidates_pending_audit": {"candidates": [{"candidate_number": 1, "time": 1.0, "ms_after_beep": 0}]},
+                "_candidates_pending_audit": {
+                    "candidates": [{"candidate_number": 1, "time": 1.0, "ms_after_beep": 0}]
+                },
             }
         )
     )
@@ -848,9 +844,7 @@ def test_swap_primary_backs_up_audit_and_clears_processed(tmp_path: Path) -> Non
     clears the new primary's processed flags so detection re-runs."""
     root = tmp_path / "m"
     project = MatchProject.init(root, name="m")
-    project.stages.append(
-        StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0)
-    )
+    project.stages.append(StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0))
     project.stages[0].videos.append(
         StageVideo(
             path=Path("raw/a.mp4"),
@@ -866,7 +860,9 @@ def test_swap_primary_backs_up_audit_and_clears_processed(tmp_path: Path) -> Non
             {
                 "stage_number": 1,
                 "stage_name": "S1",
-                "shots": [{"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}],
+                "shots": [
+                    {"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}
+                ],
             }
         )
     )
@@ -890,9 +886,7 @@ def test_swap_primary_backs_up_audit_and_clears_processed(tmp_path: Path) -> Non
 def test_swap_primary_skips_backup_when_no_audit(tmp_path: Path) -> None:
     root = tmp_path / "m"
     project = MatchProject.init(root, name="m")
-    project.stages.append(
-        StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0)
-    )
+    project.stages.append(StageEntry(stage_number=1, stage_name="S1", time_seconds=10.0))
     project.stages[0].videos.append(StageVideo(path=Path("raw/a.mp4"), role="primary"))
     project.stages[0].videos.append(StageVideo(path=Path("raw/b.mp4"), role="secondary"))
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1807,8 +1807,12 @@ def test_stream_video_404_on_unregistered_path(tmp_path: Path) -> None:
     assert "not registered" in resp.json()["detail"]
 
 
-def test_stream_video_404_when_target_missing(tmp_path: Path) -> None:
-    """Registered path that no longer exists on disk surfaces as 404."""
+def test_stream_video_424_when_target_missing(tmp_path: Path) -> None:
+    """Registered path that no longer exists on disk surfaces as 424
+    (Failed Dependency) with a structured detail. The SPA reads
+    ``detail.code == "source_unreachable"`` to render a consistent
+    "reconnect the USB / SD card" message across detect-beep, trim,
+    beep preview, video stream, and export."""
     client, _ = _seed_project_with_primary(tmp_path)
     project = MatchProject.load(tmp_path / "match")
     primary = project.stages[0].primary()
@@ -1817,8 +1821,10 @@ def test_stream_video_404_when_target_missing(tmp_path: Path) -> None:
     if resolved.exists() or resolved.is_symlink():
         resolved.unlink()
     resp = client.get(f"/api/videos/stream?path={primary.path}")
-    assert resp.status_code == 404
-    assert "missing" in resp.json()["detail"]
+    assert resp.status_code == 424
+    body = resp.json()
+    assert body["detail"]["code"] == "source_unreachable"
+    assert "not reachable" in body["detail"]["message"]
 
 
 def test_peaks_endpoint_rejects_extreme_bins(tmp_path: Path) -> None:

--- a/tests/test_video_match.py
+++ b/tests/test_video_match.py
@@ -199,11 +199,13 @@ def test_match_window_is_asymmetric() -> None:
 
 
 def test_classify_video_against_stages_in_window() -> None:
-    from splitsmith.video_match import classify_video_against_stages
     from splitsmith.config import StageData
+    from splitsmith.video_match import classify_video_against_stages
 
     sc = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
-    stages = [StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)]
+    stages = [
+        StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)
+    ]
     cls, hits = classify_video_against_stages(
         sc - timedelta(minutes=5), stages, tolerance_minutes=15
     )
@@ -212,8 +214,8 @@ def test_classify_video_against_stages_in_window() -> None:
 
 
 def test_classify_video_against_stages_contested() -> None:
-    from splitsmith.video_match import classify_video_against_stages
     from splitsmith.config import StageData
+    from splitsmith.video_match import classify_video_against_stages
 
     # Two stages whose windows overlap.
     sc1 = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
@@ -231,15 +233,15 @@ def test_classify_video_against_stages_contested() -> None:
 
 
 def test_classify_video_against_stages_orphan() -> None:
-    from splitsmith.video_match import classify_video_against_stages
     from splitsmith.config import StageData
+    from splitsmith.video_match import classify_video_against_stages
 
     sc = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
-    stages = [StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)]
+    stages = [
+        StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)
+    ]
     # Way before any window.
-    cls, hits = classify_video_against_stages(
-        sc - timedelta(hours=3), stages, tolerance_minutes=15
-    )
+    cls, hits = classify_video_against_stages(sc - timedelta(hours=3), stages, tolerance_minutes=15)
     assert cls == "orphan"
     assert hits == []
 


### PR DESCRIPTION
Sub 6 of #11. Replaces the placeholder Export page with the v1 production surface.

## Summary

- **Match overview**: project name, audit-progress counts, one row per stage with audit + export status (not started / auditing / ready / exported / skipped).
- **Per-stage analysis** (drill-down on click): editable shot table (#, time, split, notes), output toggles (CSV / FCPXML / report -- all on by default), Generate button, reveal-in-finder per file.
- **Notes editing** flows through the existing audit JSON writer (with ``.bak``), so notes land in the next CSV regen.
- **Re-generate** overwrites the artefacts in place.
- **Reveal-in-finder** uses ``open -R`` on macOS, ``explorer /select`` on Windows, ``xdg-open`` on Linux. Restricted to paths inside the project root.

## Architecture

- New ``src/splitsmith/ui/exports.py`` orchestrates the per-stage export by reading the audit JSON, converting ``shots[]`` to engine ``Shot`` records (splits computed from successive ``ms_after_beep``; peak / confidence lifted from the candidate pool by ``candidate_number``; manual shots default to 0.0), and calling the unchanged ``csv_gen``, ``fcpxml_gen``, and ``report`` writers.
- **Slug parity** with the CLI's ``_slugify`` is part of the AC: the same audit produces byte-comparable filenames whether the user runs ``splitsmith single`` or clicks Generate.
- **Audit status** (per the v1 "no Done button" decision) is inferred: ``has_primary && processed.beep && processed.trim && processed.shot_detect && audit_shot_count > 0`` -> ``ready_to_export``.

## New endpoints

- ``GET /api/exports/overview`` -- per-stage status payload for the SPA.
- ``POST /api/stages/{n}/export`` -- run the generate pipeline.
- ``POST /api/files/reveal`` -- platform-aware reveal-in-finder, scoped to the project root.

## Test plan

- [x] ``uv run pytest tests/`` (306 passed, +10 new)
- [x] ``npx tsc --noEmit`` and ``npx vite build``
- [ ] Browser smoke: open Export tab; overview shows match name + counts; expand a stage with audit data; edit a note + blur; Generate writes CSV/FCPXML/report; Re-generate overwrites; Reveal opens Finder
- [ ] Browser smoke: Generate on a stage without a trimmed clip writes CSV+report and surfaces the FCPXML-skip anomaly
- [ ] Compare output against ``splitsmith single`` for the same audit -- CSV byte-comparable, FCPXML structurally identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)