### PR TITLE
audit: marker UX fixes + auto-progress on K (#38, #39, #40)

### DIFF
--- a/src/splitsmith/ui_static/src/components/HelpOverlay.tsx
+++ b/src/splitsmith/ui_static/src/components/HelpOverlay.tsx
@@ -46,7 +46,7 @@ function sections(mode: HelpMode): Section[] {
     { keys: ["Shift", "M"], desc: "Previous kept shot" },
     { keys: ["N"], desc: "Next marker (any kind)" },
     { keys: ["Shift", "N"], desc: "Previous marker (any kind)" },
-    { keys: ["K"], desc: "Toggle current shot keep / reject (manual: delete)" },
+    { keys: ["K"], desc: "Toggle keep / reject (manual: delete); auto-advances if enabled" },
     { keys: ["Delete"], desc: "Delete focused manual marker" },
     { keys: ["Alt", "←", "→"], desc: "Nudge selected marker (10.7 ms)" },
     { keys: ["Alt", "Shift", "←", "→"], desc: "Nudge selected marker (1 ms)" },

--- a/src/splitsmith/ui_static/src/components/MarkerLayer.tsx
+++ b/src/splitsmith/ui_static/src/components/MarkerLayer.tsx
@@ -22,7 +22,7 @@
  * through to the waveform. Each marker re-enables pointer-events for itself.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { MarkerGlyph, type MarkerKind } from "@/components/MarkerGlyph";
 import { cn } from "@/lib/utils";
@@ -33,6 +33,17 @@ import { cn } from "@/lib/utils";
  *  and land on the 1 ms grid. */
 export const DETECTOR_RESOLUTION_S = 0.0107;
 const FINE_NUDGE_S = 0.001;
+
+/** Pointer travel (in CSS pixels) before a press is treated as a drag rather
+ *  than a click. Trackpad clicks routinely register a few stray pixels of
+ *  motion; without this threshold those clicks accidentally moved the marker.
+ *  6px matches the de-facto threshold in FCP / Logic / most native UIs. */
+const DRAG_THRESHOLD_PX = 6;
+
+/** Idle window after the last keyboard nudge before the burst is committed
+ *  as a single undo entry. 350 ms is long enough to chord arrow taps without
+ *  splitting them, short enough that the Cmd+Z right after feels responsive. */
+const NUDGE_COMMIT_IDLE_MS = 350;
 
 export interface AuditMarker {
   id: string;
@@ -53,7 +64,19 @@ export interface MarkerLayerProps {
   onFocusChange: (id: string | null) => void;
   onClick: (marker: AuditMarker) => void;
   onDelete: (marker: AuditMarker) => void;
+  /** Live time update during a drag or nudge. Parent should mutate state
+   *  for visual feedback but NOT push to its undo stack -- intermediate
+   *  positions are noise. Use ``onTimeChangeBegin`` / ``onTimeChangeCommit``
+   *  to bracket the gesture and snapshot the from/to once. */
   onTimeChange: (id: string, time: number) => void;
+  /** Called once at the start of a drag (or first keyboard nudge in a
+   *  burst). Parent records the marker's pre-edit time so the
+   *  matching commit can produce a single from->to undo entry. */
+  onTimeChangeBegin?: (id: string) => void;
+  /** Called once at the end of a drag (pointerup / pointercancel) or at
+   *  the end of a keyboard nudge burst. Parent pushes the bracketed
+   *  edit to its undo stack and audit_events log. */
+  onTimeChangeCommit?: (id: string, time: number) => void;
   /** Categories to render. Hiding ``rejected`` while saving keeps the
    *  rejected markers in the model -- they just don't render. The save
    *  flow still serializes them via the audit JSON. */
@@ -68,14 +91,53 @@ export function MarkerLayer({
   onClick,
   onDelete,
   onTimeChange,
+  onTimeChangeBegin,
+  onTimeChangeCommit,
   visibleKinds,
 }: MarkerLayerProps) {
   if (duration <= 0) return null;
 
-  // Drag state lives here so re-renders driven by external time updates
-  // don't reset the active drag.
-  const [draggingId, setDraggingId] = useState<string | null>(null);
-  const dragRef = useRef<{ pointerId: number; element: HTMLButtonElement } | null>(null);
+  // Drag state lives in a ref so re-renders driven by external time
+  // updates don't reset the active drag. ``moved`` only flips once the
+  // cursor crosses DRAG_THRESHOLD_PX -- before that, the gesture is
+  // still ambiguous and pointerup will fire as a click.
+  const dragRef = useRef<{
+    pointerId: number;
+    element: HTMLButtonElement;
+    startX: number;
+    startY: number;
+    moved: boolean;
+  } | null>(null);
+
+  // Keyboard-nudge burst tracking: the first arrow key in a burst calls
+  // onTimeChangeBegin; subsequent keys within NUDGE_COMMIT_IDLE_MS just
+  // update live. The trailing-edge timer commits one bracketed entry.
+  const nudgeRef = useRef<{
+    id: string;
+    lastTime: number;
+    timer: number;
+  } | null>(null);
+
+  const flushNudge = useCallback(() => {
+    const n = nudgeRef.current;
+    if (!n) return;
+    window.clearTimeout(n.timer);
+    nudgeRef.current = null;
+    onTimeChangeCommit?.(n.id, n.lastTime);
+  }, [onTimeChangeCommit]);
+
+  // If the focused marker changes mid-burst, commit before the new marker
+  // starts its own burst so the two don't merge into one undo entry.
+  useEffect(() => {
+    const n = nudgeRef.current;
+    if (n && n.id !== focusedId) flushNudge();
+  }, [focusedId, flushNudge]);
+
+  // Final flush on unmount (stage switch, etc.) so a half-typed burst
+  // doesn't disappear without producing an audit event.
+  useEffect(() => {
+    return () => flushNudge();
+  }, [flushNudge]);
 
   // Markers in time order so Tab moves left-to-right naturally. Filtered
   // categories are dropped entirely so they don't intercept pointer events
@@ -108,8 +170,13 @@ export function MarkerLayer({
       e.preventDefault();
       const el = e.currentTarget;
       el.setPointerCapture(e.pointerId);
-      dragRef.current = { pointerId: e.pointerId, element: el };
-      setDraggingId(marker.id);
+      dragRef.current = {
+        pointerId: e.pointerId,
+        element: el,
+        startX: e.clientX,
+        startY: e.clientY,
+        moved: false,
+      };
       onFocusChange(marker.id);
     },
     [onFocusChange],
@@ -117,35 +184,46 @@ export function MarkerLayer({
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>, marker: AuditMarker) => {
-      if (dragRef.current?.pointerId !== e.pointerId) return;
+      const drag = dragRef.current;
+      if (drag?.pointerId !== e.pointerId) return;
+      if (!drag.moved) {
+        const dx = e.clientX - drag.startX;
+        const dy = e.clientY - drag.startY;
+        if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return;
+        drag.moved = true;
+        // Drag committed past the threshold: tell the parent to snapshot
+        // the pre-edit time. Subsequent onTimeChange calls are visual
+        // only; the matching commit on pointerup brackets the gesture.
+        onTimeChangeBegin?.(marker.id);
+      }
       const parent = e.currentTarget.parentElement;
       if (!parent) return;
       const rect = parent.getBoundingClientRect();
       const t = snap(timeFromClientX(e.clientX, rect), e.shiftKey);
       onTimeChange(marker.id, t);
     },
-    [snap, timeFromClientX, onTimeChange],
+    [snap, timeFromClientX, onTimeChange, onTimeChangeBegin],
   );
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>, marker: AuditMarker) => {
-      if (dragRef.current?.pointerId !== e.pointerId) return;
+      const drag = dragRef.current;
+      if (drag?.pointerId !== e.pointerId) return;
       const el = e.currentTarget;
       if (el.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId);
+      const moved = drag.moved;
       dragRef.current = null;
-      // If the pointer didn't actually move, treat as a click.
-      const moved = draggingId === marker.id;
-      setDraggingId(null);
       if (!moved) {
         onClick(marker);
+        return;
       }
-      // Track 'click vs drag' more carefully via pointer movement deltas would
-      // be nicer, but the simpler heuristic above feels right in practice:
-      // setDraggingId fires on pointerdown so this branch is essentially
-      // "you pressed -> we set drag -> you released". A lightly clicked drag
-      // snaps to the same time it started; harmless.
+      // Commit the drag: parent reads the marker's current time from its
+      // own state (it's been updating live during pointermove) and pushes
+      // a single from->to undo entry plus one audit_events row.
+      const live = markers.find((m) => m.id === marker.id);
+      onTimeChangeCommit?.(marker.id, live?.time ?? marker.time);
     },
-    [draggingId, onClick],
+    [onClick, onTimeChangeCommit, markers],
   );
 
   const handleKeyDown = useCallback(
@@ -156,25 +234,48 @@ export function MarkerLayer({
           e.preventDefault();
           const dir = e.key === "ArrowRight" ? 1 : -1;
           const step = e.shiftKey ? FINE_NUDGE_S : DETECTOR_RESOLUTION_S;
-          const next = Math.max(0, Math.min(duration, marker.time + dir * step));
-          onTimeChange(marker.id, snap(next, e.shiftKey));
+          const next = snap(
+            Math.max(0, Math.min(duration, marker.time + dir * step)),
+            e.shiftKey,
+          );
+          // First key in a burst -> open the bracket. Subsequent keys
+          // just refresh the trailing-edge timer.
+          if (nudgeRef.current?.id !== marker.id) {
+            flushNudge();
+            onTimeChangeBegin?.(marker.id);
+            nudgeRef.current = {
+              id: marker.id,
+              lastTime: next,
+              timer: window.setTimeout(flushNudge, NUDGE_COMMIT_IDLE_MS),
+            };
+          } else {
+            window.clearTimeout(nudgeRef.current.timer);
+            nudgeRef.current.lastTime = next;
+            nudgeRef.current.timer = window.setTimeout(
+              flushNudge,
+              NUDGE_COMMIT_IDLE_MS,
+            );
+          }
+          onTimeChange(marker.id, next);
           return;
         }
         case "Enter":
         case " ":
           e.preventDefault();
+          flushNudge();
           onClick(marker);
           return;
         case "Delete":
         case "Backspace":
           e.preventDefault();
+          flushNudge();
           onDelete(marker);
           return;
         default:
           return;
       }
     },
-    [duration, onClick, onDelete, onTimeChange, snap],
+    [duration, onClick, onDelete, onTimeChange, onTimeChangeBegin, snap, flushNudge],
   );
 
   // Whenever focus moves to a marker, keep ARIA in sync.

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -31,6 +31,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   CheckCircle2,
+  ChevronsRight,
   Crosshair,
   HelpCircle,
   ListChecks,
@@ -81,6 +82,7 @@ import { cn } from "@/lib/utils";
 
 const PEAK_BINS = 1500;
 const MAX_UNDO = 50;
+const K_AUTO_PROGRESS_KEY = "splitsmith.audit.k_auto_progress";
 
 export function Audit() {
   const { stage: stageParam } = useParams();
@@ -123,6 +125,19 @@ export function Audit() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [activeVideoIndex, setActiveVideoIndex] = useState(0);
   const [loopMode, setLoopMode] = useState(false);
+  // Auto-advance to the next visible marker after K toggles a candidate.
+  // Default on (FCP-style "mark and move"); persisted across sessions
+  // because the user audits in long flow blocks and shouldn't have to
+  // re-enable it every reload.
+  const [kAutoProgress, setKAutoProgress] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    const v = window.localStorage.getItem(K_AUTO_PROGRESS_KEY);
+    return v == null ? true : v === "1";
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(K_AUTO_PROGRESS_KEY, kAutoProgress ? "1" : "0");
+  }, [kAutoProgress]);
   // Anchor for loop-to-start semantics: the audit-timeline position
   // playback last started from (or where the user last scrubbed). On
   // pause / end-of-clip while loopMode is on, the playhead snaps back
@@ -456,38 +471,68 @@ export function Audit() {
     [markers, mutate, recordEvent],
   );
 
-  const handleMarkerTimeChange = useCallback(
-    (id: string, time: number) => {
-      // Drag-during-pointer-move calls this many times. Coalesce by replacing
-      // the head of the undo stack on the same id while a drag is active --
-      // simplest: only push to undo when the time actually differs from the
-      // current snapshot. Here we use an inline check.
-      setMarkers((prev) => {
-        const target = prev.find((x) => x.id === id);
-        if (target && target.time !== time) {
-          // One event per drag commit (rAF-coalesced). Aggregating
-          // pointer-move ticks into a single event would need extra
-          // glue; the log stays useful even with a few entries per drag.
-          sessionEventsRef.current.push({
-            ts: new Date().toISOString(),
-            kind: "marker_time_changed",
-            payload: { id, from_time: target.time, to_time: time },
-          });
-          isDirtyRef.current = true;
-        }
-        const nextList = prev.map((x) => (x.id === id ? { ...x, time } : x));
-        if (
-          undoStackRef.current.length === 0 ||
-          undoStackRef.current[undoStackRef.current.length - 1] !== prev
-        ) {
-          undoStackRef.current.push(prev);
-          if (undoStackRef.current.length > MAX_UNDO) undoStackRef.current.shift();
-        }
-        return nextList;
-      });
-    },
-    [],
+  // Drag / nudge gestures are bracketed by the MarkerLayer:
+  //   onTimeChangeBegin -> snapshot the pre-edit markers list
+  //   onTimeChange      -> live-mutate state for visual feedback (no undo push)
+  //   onTimeChangeCommit-> push exactly one undo entry + one audit event
+  //
+  // editingSnapshotRef holds the markers snapshot taken at Begin so the
+  // Commit can recover the pre-edit time without depending on the React
+  // state at the moment of the closure.
+  const editingSnapshotRef = useRef<{
+    id: string;
+    fromMarkers: AuditMarker[];
+    fromTime: number;
+  } | null>(null);
+
+  const handleMarkerTimeChange = useCallback((id: string, time: number) => {
+    // Live update for visual feedback only. Undo push happens at Commit.
+    setMarkers((prev) => prev.map((x) => (x.id === id ? { ...x, time } : x)));
+    isDirtyRef.current = true;
+  }, []);
+
+  const handleMarkerTimeChangeBegin = useCallback((id: string) => {
+    setMarkers((prev) => {
+      const target = prev.find((x) => x.id === id);
+      editingSnapshotRef.current = {
+        id,
+        fromMarkers: prev,
+        fromTime: target?.time ?? 0,
+      };
+      return prev;
+    });
+  }, []);
+
+  const handleMarkerTimeChangeCommit = useCallback((id: string, time: number) => {
+    const snap = editingSnapshotRef.current;
+    editingSnapshotRef.current = null;
+    if (!snap || snap.id !== id) return;
+    if (snap.fromTime === time) return; // no-op gesture; don't dirty undo
+    undoStackRef.current.push(snap.fromMarkers);
+    if (undoStackRef.current.length > MAX_UNDO) undoStackRef.current.shift();
+    sessionEventsRef.current.push({
+      ts: new Date().toISOString(),
+      kind: "marker_time_changed",
+      payload: { id, from_time: snap.fromTime, to_time: time },
+    });
+    isDirtyRef.current = true;
+  }, []);
+
+  // Alt+Arrow nudge burst (page-level handler -- fires whether or not a
+  // marker has DOM focus). Uses the same begin/commit bracketing so a
+  // run of nudges produces one undo entry. Mirror of MarkerLayer's
+  // keyboard burst tracking; lives here because the page-level handler
+  // can't see MarkerLayer's internal state.
+  const altNudgeRef = useRef<{ id: string; lastTime: number; timer: number } | null>(
+    null,
   );
+  const flushAltNudge = useCallback(() => {
+    const n = altNudgeRef.current;
+    if (!n) return;
+    window.clearTimeout(n.timer);
+    altNudgeRef.current = null;
+    handleMarkerTimeChangeCommit(n.id, n.lastTime);
+  }, [handleMarkerTimeChangeCommit]);
 
   const handleAddManual = useCallback(
     (time: number) => {
@@ -554,51 +599,81 @@ export function Audit() {
   const stepShot = useCallback(
     (delta: number) => {
       if (keptShots.length === 0) return;
-      const next = Math.min(Math.max(currentShotIndex + delta, 0), keptShots.length - 1);
+      // Anchor on the focused marker (#39): if focus is on a kept shot,
+      // step from there. Otherwise use currentShotIndex as a fallback.
+      // This way, after K rejects the focused marker, M / Shift+M land
+      // on the correct neighbour in the post-mutation list instead of
+      // skipping one because the integer index now addresses i+2.
+      let anchor = currentShotIndex;
+      if (focusedMarkerId) {
+        const idx = keptShots.findIndex((k) => k.id === focusedMarkerId);
+        if (idx >= 0) anchor = idx;
+        // Focus is on a non-kept marker (e.g., just-rejected). Walk to
+        // the kept shot at-or-just-before the playhead so +1 lands on
+        // the next kept after currentTime.
+        else {
+          let preceding = -1;
+          for (let i = 0; i < keptShots.length; i++) {
+            if (keptShots[i].time <= currentTime) preceding = i;
+            else break;
+          }
+          // delta>0: start one step *before* the next kept marker so
+          // anchor+1 lands on it. delta<0: start at the next kept marker
+          // so anchor-1 lands on the preceding one.
+          anchor = delta > 0 ? preceding : Math.max(0, preceding + 1);
+        }
+      }
+      const next = Math.min(Math.max(anchor + delta, 0), keptShots.length - 1);
       setCurrentShotIndex(next);
       setFocusedMarkerId(keptShots[next].id);
       handleScrub(keptShots[next].time);
     },
-    [keptShots, currentShotIndex, handleScrub],
+    [keptShots, currentShotIndex, focusedMarkerId, currentTime, handleScrub],
   );
 
-  // All markers in time order (detected + rejected + manual). The N
-  // shortcut walks this list so the user can revisit a rejected marker
-  // and toggle it back to kept without touching the mouse. M only
-  // visits kept shots (the "real" sequence the export will use).
-  const allMarkersSorted = useMemo(
-    () => markers.slice().sort((a, b) => a.time - b.time || a.id.localeCompare(b.id)),
-    [markers],
+  const visibleKinds = useMemo(() => visibleKindsFromFilters(filters), [filters]);
+
+  // Markers in time order, filtered to currently-visible kinds. N and
+  // K-auto-progress walk this list -- a marker that's filtered out of
+  // view shouldn't be a navigation target either, otherwise the
+  // playhead jumps to a marker the user can't see.
+  const visibleMarkersSorted = useMemo(
+    () =>
+      markers
+        .filter((m) => visibleKinds.has(m.kind))
+        .slice()
+        .sort((a, b) => a.time - b.time || a.id.localeCompare(b.id)),
+    [markers, visibleKinds],
   );
 
   const stepAnyMarker = useCallback(
     (delta: number) => {
-      if (allMarkersSorted.length === 0) return;
+      if (visibleMarkersSorted.length === 0) return;
       // Anchor: focused marker -> use its index; otherwise pick the
       // marker at-or-just-before the playhead so forward stepping lands
       // on the next one and back-stepping lands on the previous.
       let curIdx = -1;
       if (focusedMarkerId) {
-        curIdx = allMarkersSorted.findIndex((m) => m.id === focusedMarkerId);
+        curIdx = visibleMarkersSorted.findIndex((m) => m.id === focusedMarkerId);
       }
       if (curIdx < 0) {
-        for (let i = 0; i < allMarkersSorted.length; i++) {
-          if (allMarkersSorted[i].time <= currentTime) curIdx = i;
+        for (let i = 0; i < visibleMarkersSorted.length; i++) {
+          if (visibleMarkersSorted[i].time <= currentTime) curIdx = i;
           else break;
         }
         if (curIdx < 0) curIdx = delta > 0 ? -1 : 0;
       }
       const nextIdx = Math.min(
         Math.max(curIdx + delta, 0),
-        allMarkersSorted.length - 1,
+        visibleMarkersSorted.length - 1,
       );
-      const target = allMarkersSorted[nextIdx];
+      const target = visibleMarkersSorted[nextIdx];
       setFocusedMarkerId(target.id);
       handleScrub(target.time);
       const keptIdx = keptShots.findIndex((k) => k.id === target.id);
       if (keptIdx >= 0) setCurrentShotIndex(keptIdx);
     },
-    [allMarkersSorted, focusedMarkerId, currentTime, handleScrub, keptShots],
+    [visibleMarkersSorted, focusedMarkerId, currentTime, handleScrub, keptShots],
   );
 
   const jumpToMarker = useCallback(
@@ -612,7 +687,6 @@ export function Audit() {
     [handleScrub, keptShots],
   );
 
-  const visibleKinds = useMemo(() => visibleKindsFromFilters(filters), [filters]);
   const pixelsPerSecond = useMemo(
     () => zoomToPixelsPerSecond(zoom, waveformViewport, peaks?.duration ?? 0),
     [zoom, waveformViewport, peaks],
@@ -756,6 +830,20 @@ export function Audit() {
         const step = e.shiftKey ? 0.001 : 0.0107;
         const dur = peaks?.duration ?? target.time + step;
         const next = Math.min(dur, Math.max(0, target.time + dir * step));
+        // Burst-coalesce so Cmd+Z reverses the entire burst, not each tap.
+        if (altNudgeRef.current?.id !== target.id) {
+          flushAltNudge();
+          handleMarkerTimeChangeBegin(target.id);
+          altNudgeRef.current = {
+            id: target.id,
+            lastTime: next,
+            timer: window.setTimeout(flushAltNudge, 350),
+          };
+        } else {
+          window.clearTimeout(altNudgeRef.current.timer);
+          altNudgeRef.current.lastTime = next;
+          altNudgeRef.current.timer = window.setTimeout(flushAltNudge, 350);
+        }
         handleMarkerTimeChange(target.id, next);
         handleScrub(next);
         return;
@@ -807,6 +895,13 @@ export function Audit() {
             // K on a manual marker actually does something useful.
             if (target.kind === "manual") handleMarkerDelete(target);
             else handleMarkerClick(target);
+            // Auto-progress: walk the visible marker list (filters
+            // respected) so the user can rip through K-K-K without
+            // moving the mouse. stepAnyMarker anchors on the focused
+            // marker, which is the one we just toggled -- so +1 lands
+            // on the next visible marker even though kept/rejected
+            // membership shifted underneath us.
+            if (kAutoProgress) stepAnyMarker(1);
           }
           return;
         }
@@ -839,11 +934,20 @@ export function Audit() {
     handleMarkerClick,
     handleMarkerDelete,
     handleMarkerTimeChange,
+    handleMarkerTimeChangeBegin,
+    flushAltNudge,
     focusedMarkerId,
     markers,
     keptShots,
     currentShotIndex,
+    kAutoProgress,
   ]);
+
+  // Stage switch / unmount: flush any pending nudge bracket so the
+  // commit doesn't fire after the markers list has been swapped out.
+  useEffect(() => {
+    return () => flushAltNudge();
+  }, [stageNumber, flushAltNudge]);
 
   const videoSrc = activeVideo ? api.videoStreamUrl(activeVideo.path) : "";
 
@@ -1023,6 +1127,8 @@ export function Audit() {
                       onClick={handleMarkerClick}
                       onDelete={handleMarkerDelete}
                       onTimeChange={handleMarkerTimeChange}
+                      onTimeChangeBegin={handleMarkerTimeChangeBegin}
+                      onTimeChangeCommit={handleMarkerTimeChangeCommit}
                       visibleKinds={visibleKinds}
                     />
                   </Waveform>
@@ -1049,6 +1155,24 @@ export function Audit() {
                     aria-label={loopMode ? "Loop on (R)" : "Loop off (R)"}
                   >
                     <Repeat className="size-4" />
+                  </Button>
+                  <Button
+                    variant={kAutoProgress ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setKAutoProgress((v) => !v)}
+                    aria-pressed={kAutoProgress}
+                    title={
+                      kAutoProgress
+                        ? "Auto-advance to next marker after K (on)"
+                        : "Auto-advance to next marker after K (off)"
+                    }
+                    aria-label={
+                      kAutoProgress
+                        ? "Auto-progress on K is on"
+                        : "Auto-progress on K is off"
+                    }
+                  >
+                    <ChevronsRight className="size-4" />
                   </Button>
                   <span className="font-mono text-muted-foreground">
                     {formatTime(currentTime)} / {formatTime(peaks.duration)}


### PR DESCRIPTION
## Summary
- **#40 drag-vs-click**: 6px drag threshold in `MarkerLayer`. A press whose pointer travel stays under threshold is a click; only a clear drag moves the marker. Matches FCP / Logic conventions.
- **#39 M-then-K-then-M skip**: `stepShot` now anchors on `focusedMarkerId` (with playhead fallback when the focused marker dropped out of `keptShots`) so navigation isn't fooled by list mutations. `stepAnyMarker` also gained filter-awareness so N never lands on a marker hidden by the current filter.
- **#38 drag pollutes undo stack**: gestures are bracketed by `onTimeChangeBegin` / `onTimeChangeCommit`. Pointer drags and keyboard nudge bursts each produce **one** undo entry plus one `marker_time_changed` audit event, instead of dozens. Page-level `Alt+Arrow` mirrors the same coalescing via a 350ms idle timer.
- **New: auto-progress on K** (default on, persisted to `localStorage`). After K toggles a candidate, the playhead advances to the next visible marker so the user can K-K-K through the timeline. Toggle button next to Loop; documented in the help overlay.

## Test plan
- [ ] Trackpad-click a marker -- focuses + toggles, doesn't move it.
- [ ] Drag a marker past 6px -- moves with snap as before.
- [ ] M to a kept marker, K to reject, M again -- lands on the next kept (no skip).
- [ ] Drag a marker, then Cmd+Z -- one press restores the original time.
- [ ] Alt+Right several times in a row, then Cmd+Z -- one press restores the original time.
- [ ] Filter rejected out, press N -- never lands on a rejected marker.
- [ ] K through a stage with auto-progress on -- playhead advances each press.
- [ ] Toggle auto-progress off, K -- no advance. Reload -- toggle remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)