### PR TITLE
ingest: per-video beep so secondaries can sync to the primary

### DIFF
--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -4,12 +4,15 @@ The CLI does this inline in ``cli.py:_extract_or_load_audio`` (caching the WAV
 next to the source video). The production UI prefers project-local caching so
 the project directory stays self-contained:
 
-  <project>/audio/stage<N>_primary.wav   -- extracted from the full source
-  <project>/audio/stage<N>_audit.wav     -- extracted from the trimmed MP4
+  <project>/audio/stage<N>_primary.wav            -- primary WAV (legacy name)
+  <project>/audio/stage<N>_cam_<video_id>.wav     -- non-primary WAV (per video)
+  <project>/audio/stage<N>_audit.wav              -- primary's audit WAV
+  <project>/audio/stage<N>_cam_<video_id>_audit.wav -- secondary's audit WAV
 
 The audit screen (#15) prefers the audit WAV when a trimmed clip exists,
-falling back to the full primary WAV. The cache is invalidated when its
-source's mtime changes.
+falling back to the full WAV. Caches are invalidated when their source's
+mtime changes. Per-video keys live alongside the legacy primary names so
+existing primary caches survive the rollout to multi-camera ingest.
 """
 
 from __future__ import annotations
@@ -22,7 +25,7 @@ from pathlib import Path
 
 from .. import beep_detect
 from ..config import BeepDetectConfig, BeepDetection
-from .project import MatchProject
+from .project import MatchProject, StageVideo
 
 # Standard trim buffer (config.OutputConfig.trim_buffer_seconds default).
 # Used to derive the beep's position inside a trimmed clip when no trim
@@ -49,6 +52,26 @@ class AuditAudioResult:
 
 class AudioExtractionError(RuntimeError):
     """ffmpeg or ffprobe failed during audio extraction."""
+
+
+def video_audio_path(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    *,
+    project: MatchProject | None = None,
+) -> Path:
+    """Resolve the cached audio-WAV path for ``video`` on ``stage_number``.
+
+    Filename rules:
+      - primary -> ``stage<N>_primary.wav`` (legacy; preserved so existing
+        caches survive the introduction of multi-cam beep workflows)
+      - non-primary -> ``stage<N>_cam_<video_id>.wav`` (per-video)
+    """
+    audio_dir = project.audio_path(project_root) if project else project_root / "audio"
+    if video.role == "primary":
+        return audio_dir / f"stage{stage_number}_primary.wav"
+    return audio_dir / f"stage{stage_number}_cam_{video.video_id}.wav"
 
 
 def primary_audio_path(
@@ -120,6 +143,91 @@ def ensure_primary_audio(
     return audio_path
 
 
+def ensure_video_audio(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    source_video: Path,
+    *,
+    sample_rate: int = 48000,
+    ffmpeg_binary: str = "ffmpeg",
+    project: MatchProject | None = None,
+) -> Path:
+    """Extract a mono WAV for ``video`` if not already cached.
+
+    For the primary, delegates to :func:`ensure_primary_audio` so the
+    legacy ``stage<N>_primary.wav`` cache + monkeypatch points keep
+    working. Non-primary cameras land at
+    ``<audio_dir>/stage<N>_cam_<video_id>.wav`` and run their own
+    extraction. Re-extracts when the source mtime is newer than cache.
+    """
+    if video.role == "primary":
+        return ensure_primary_audio(
+            project_root,
+            stage_number,
+            source_video,
+            sample_rate=sample_rate,
+            ffmpeg_binary=ffmpeg_binary,
+            project=project,
+        )
+    audio_path = video_audio_path(project_root, stage_number, video, project=project)
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+
+    src_resolved = source_video.resolve()
+    if not src_resolved.exists():
+        raise FileNotFoundError(f"video missing on disk: {src_resolved}")
+
+    if audio_path.exists() and audio_path.stat().st_mtime >= src_resolved.stat().st_mtime:
+        return audio_path
+
+    if not shutil.which(ffmpeg_binary):
+        raise AudioExtractionError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(src_resolved),
+        "-ac",
+        "1",
+        "-ar",
+        str(sample_rate),
+        "-vn",
+        str(audio_path),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        raise AudioExtractionError(
+            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
+        ) from exc
+    return audio_path
+
+
+def trimmed_video_path(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    *,
+    project: MatchProject,
+) -> Path:
+    """Resolve the cached audit-mode short-GOP MP4 for ``video`` on a stage.
+
+    Primary keeps the legacy ``stage<N>_trimmed.mp4`` filename; non-primary
+    cameras get ``stage<N>_cam_<video_id>_trimmed.mp4`` so each angle has its
+    own scrub clip cut around its own beep.
+    """
+    if video.role == "primary":
+        return project.trimmed_path(project_root) / f"stage{stage_number}_trimmed.mp4"
+    return (
+        project.trimmed_path(project_root)
+        / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
+    )
+
+
 def trimmed_primary_path(project_root: Path, stage_number: int, *, project: MatchProject) -> Path:
     """Resolve the cached short-GOP trimmed MP4 path for a stage's primary."""
     return project.trimmed_path(project_root) / f"stage{stage_number}_trimmed.mp4"
@@ -131,9 +239,23 @@ def audit_audio_path(
     *,
     project: MatchProject,
 ) -> Path:
-    """Cache path for the audit WAV (extracted from the trimmed MP4)."""
+    """Cache path for the primary's audit WAV (extracted from the trimmed MP4)."""
     audio_dir = project.audio_path(project_root)
     return audio_dir / f"stage{stage_number}_audit.wav"
+
+
+def video_audit_audio_path(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    *,
+    project: MatchProject,
+) -> Path:
+    """Cache path for ``video``'s audit WAV (extracted from its trimmed MP4)."""
+    if video.role == "primary":
+        return audit_audio_path(project_root, stage_number, project=project)
+    audio_dir = project.audio_path(project_root)
+    return audio_dir / f"stage{stage_number}_cam_{video.video_id}_audit.wav"
 
 
 def ensure_audit_audio(
@@ -242,15 +364,21 @@ def _current_trim_params(
     }
 
 
-def invalidate_audit_trim(project_root: Path, stage_number: int, *, project: MatchProject) -> None:
-    """Delete the cached trim, audit WAV, and params sidecar.
+def invalidate_video_audit_trim(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    *,
+    project: MatchProject,
+) -> None:
+    """Delete the cached trim, audit WAV, and params sidecar for ``video``.
 
     Called after beep_time changes (manual override) or stage_time changes
     (scoreboard re-import) so the next trim job runs from scratch instead
     of trusting a now-stale cache. Idempotent if any file is missing.
     """
-    output = trimmed_primary_path(project_root, stage_number, project=project)
-    wav = audit_audio_path(project_root, stage_number, project=project)
+    output = trimmed_video_path(project_root, stage_number, video, project=project)
+    wav = video_audit_audio_path(project_root, stage_number, video, project=project)
     params = trim_params_path(output)
     partial = output.with_name(f"{output.stem}.partial{output.suffix}")
     for p in (output, wav, params, partial):
@@ -261,48 +389,71 @@ def invalidate_audit_trim(project_root: Path, stage_number: int, *, project: Mat
             pass
 
 
-def ensure_audit_trim(
+def invalidate_audit_trim(project_root: Path, stage_number: int, *, project: MatchProject) -> None:
+    """Backward-compat shim: invalidate the primary's audit trim.
+
+    Equivalent to :func:`invalidate_video_audit_trim` with the stage's
+    primary. Synthesizes a primary-role ``StageVideo`` so the legacy code
+    path in callers that don't have the live model handy still works.
+    """
+    invalidate_video_audit_trim(
+        project_root,
+        stage_number,
+        StageVideo(path=Path("primary"), role="primary"),
+        project=project,
+    )
+
+
+def ensure_video_audit_trim(
     project_root: Path,
     stage_number: int,
-    primary_source: Path,
-    primary_beep_time: float,
+    video: StageVideo,
+    source: Path,
+    beep_time: float,
     stage_time_seconds: float,
     *,
     project: MatchProject,
     ffmpeg_binary: str = "ffmpeg",
     runner: object | None = None,
 ) -> Path:
-    """Produce ``stage<N>_trimmed.mp4`` for the audit screen if not cached.
+    """Produce the audit-mode short-GOP trim for ``video`` if not cached.
 
-    Re-encodes the primary's source with a short GOP (Sub 5 / #16 audit
-    mode) so the audit screen scrubs frame-accurately. The trim window is
-    ``[max(0, beep - pre_buffer), beep + stage_time + post_buffer]``.
+    Generic over role: primary delegates to :func:`ensure_audit_trim` so
+    legacy filename caching + monkeypatch surfaces keep working;
+    secondaries run the same trim pipeline against their per-video output
+    path. The trim window is ``[max(0, beep - pre_buffer), beep +
+    stage_time + post_buffer]`` -- same shape for both roles.
 
-    Cache key is the source mtime *and* a sidecar params JSON: when the
+    Cache key is the source mtime *and* a sidecar params JSON; when the
     beep, stage time, or buffer settings change, the next call sees a
-    params mismatch and re-trims even though the source file is
-    untouched. Without that the user could fix a wrong beep, click "Trim
-    now", and still get the old trim served back.
-
-    Returns the path to the trimmed MP4. Raises ``AudioExtractionError`` on
-    ffmpeg failure (kept under the same error type the audio helpers
-    already raise so the endpoint can map them with one ``except``).
+    params mismatch and re-trims even though the source file is untouched.
     """
+    if video.role == "primary":
+        return ensure_audit_trim(
+            project_root,
+            stage_number,
+            source,
+            beep_time,
+            stage_time_seconds,
+            project=project,
+            ffmpeg_binary=ffmpeg_binary,
+            runner=runner,
+        )
     from .. import trim as trim_module
 
-    output = trimmed_primary_path(project_root, stage_number, project=project)
+    output = trimmed_video_path(project_root, stage_number, video, project=project)
     output.parent.mkdir(parents=True, exist_ok=True)
     partial = output.with_name(f"{output.stem}.partial{output.suffix}")
     params_file = trim_params_path(output)
     current_params = _current_trim_params(
-        primary_beep_time=primary_beep_time,
+        primary_beep_time=beep_time,
         stage_time_seconds=stage_time_seconds,
         project=project,
     )
 
-    src_resolved = primary_source.resolve()
+    src_resolved = source.resolve()
     if not src_resolved.exists():
-        raise FileNotFoundError(f"primary video missing on disk: {src_resolved}")
+        raise FileNotFoundError(f"video missing on disk: {src_resolved}")
 
     cache_hit = (
         output.exists()
@@ -332,7 +483,7 @@ def ensure_audit_trim(
     trim_kwargs: dict[str, object] = {
         "input_path": src_resolved,
         "output_path": partial,
-        "beep_time": primary_beep_time,
+        "beep_time": beep_time,
         "stage_time": stage_time_seconds,
         "pre_buffer_seconds": project.trim_pre_buffer_seconds,
         "post_buffer_seconds": project.trim_post_buffer_seconds,
@@ -347,6 +498,97 @@ def ensure_audit_trim(
         trim_module.trim_video(**trim_kwargs)
     except trim_module.FFmpegError as exc:
         # ffmpeg may have written some bytes before bailing; delete them.
+        if partial.exists():
+            partial.unlink()
+        raise AudioExtractionError(str(exc)) from exc
+
+    partial.replace(output)
+    params_file.write_text(json.dumps(current_params, indent=2) + "\n", encoding="utf-8")
+    return output
+
+
+def ensure_audit_trim(
+    project_root: Path,
+    stage_number: int,
+    primary_source: Path,
+    primary_beep_time: float,
+    stage_time_seconds: float,
+    *,
+    project: MatchProject,
+    ffmpeg_binary: str = "ffmpeg",
+    runner: object | None = None,
+) -> Path:
+    """Produce ``stage<N>_trimmed.mp4`` for the audit screen if not cached.
+
+    Re-encodes the primary's source with a short GOP (Sub 5 / #16 audit
+    mode) so the audit screen scrubs frame-accurately. The trim window is
+    ``[max(0, beep - pre_buffer), beep + stage_time + post_buffer]``.
+
+    Cache key is the source mtime *and* a sidecar params JSON: when the
+    beep, stage time, or buffer settings change, the next call sees a
+    params mismatch and re-trims even though the source file is
+    untouched. Without that the user could fix a wrong beep, click "Trim
+    now", and still get the old trim served back.
+
+    Returns the path to the trimmed MP4. Raises ``AudioExtractionError``
+    on ffmpeg failure (kept under the same error type the audio helpers
+    already raise so the endpoint can map them with one ``except``).
+    """
+    from .. import trim as trim_module
+
+    output = trimmed_primary_path(project_root, stage_number, project=project)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    partial = output.with_name(f"{output.stem}.partial{output.suffix}")
+    params_file = trim_params_path(output)
+    current_params = _current_trim_params(
+        primary_beep_time=primary_beep_time,
+        stage_time_seconds=stage_time_seconds,
+        project=project,
+    )
+
+    src_resolved = primary_source.resolve()
+    if not src_resolved.exists():
+        raise FileNotFoundError(f"primary video missing on disk: {src_resolved}")
+
+    cache_hit = (
+        output.exists()
+        and output.stat().st_mtime >= src_resolved.stat().st_mtime
+        and params_file.exists()
+    )
+    if cache_hit:
+        try:
+            existing_params = json.loads(params_file.read_text(encoding="utf-8"))
+            if existing_params == current_params:
+                if partial.exists():
+                    partial.unlink()
+                return output
+        except (OSError, ValueError):
+            pass
+
+    for p in (output, partial, params_file):
+        if p.exists():
+            p.unlink()
+
+    encoder = trim_module.select_audit_encoder(
+        project.trim_audit_encoder, ffmpeg_binary=ffmpeg_binary
+    )
+    trim_kwargs: dict[str, object] = {
+        "input_path": src_resolved,
+        "output_path": partial,
+        "beep_time": primary_beep_time,
+        "stage_time": stage_time_seconds,
+        "pre_buffer_seconds": project.trim_pre_buffer_seconds,
+        "post_buffer_seconds": project.trim_post_buffer_seconds,
+        "mode": "audit",
+        "video_encoder": encoder,
+        "ffmpeg_binary": ffmpeg_binary,
+        "overwrite": True,
+    }
+    if runner is not None:
+        trim_kwargs["runner"] = runner
+    try:
+        trim_module.trim_video(**trim_kwargs)
+    except trim_module.FFmpegError as exc:
         if partial.exists():
             partial.unlink()
         raise AudioExtractionError(str(exc)) from exc
@@ -375,6 +617,46 @@ def detect_primary_beep(
         project_root,
         stage_number,
         source_video,
+        ffmpeg_binary=ffmpeg_binary,
+        project=project,
+    )
+    audio, sr = beep_detect.load_audio(audio_path)
+    cfg = config or BeepDetectConfig()
+    return beep_detect.detect_beep(audio, sr, cfg)
+
+
+def detect_video_beep(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    source: Path,
+    *,
+    config: BeepDetectConfig | None = None,
+    ffmpeg_binary: str = "ffmpeg",
+    project: MatchProject | None = None,
+) -> BeepDetection:
+    """Run ``beep_detect.detect_beep`` against ``video``'s cached audio.
+
+    Generic over role: primary delegates to :func:`detect_primary_beep`
+    so existing monkeypatches + cache filenames keep working;
+    non-primary cameras run the same detector against the per-video
+    audio cache (``stage<N>_cam_<video_id>.wav``). Caller persists the
+    fields onto ``video``.
+    """
+    if video.role == "primary":
+        return detect_primary_beep(
+            project_root,
+            stage_number,
+            source,
+            config=config,
+            ffmpeg_binary=ffmpeg_binary,
+            project=project,
+        )
+    audio_path = ensure_video_audio(
+        project_root,
+        stage_number,
+        video,
+        source,
         ffmpeg_binary=ffmpeg_binary,
         project=project,
     )

--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -223,8 +223,7 @@ def trimmed_video_path(
     if video.role == "primary":
         return project.trimmed_path(project_root) / f"stage{stage_number}_trimmed.mp4"
     return (
-        project.trimmed_path(project_root)
-        / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
+        project.trimmed_path(project_root) / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
     )
 
 

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -54,6 +54,18 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 
+class _Unset:
+    """Sentinel for ``find_active``'s optional ``video_id`` filter.
+
+    ``None`` is a valid match (stage-level jobs have ``video_id=None``); we
+    need a third state for "caller didn't pass it" so legacy primary-only
+    dedupe queries stay role-agnostic.
+    """
+
+
+_UNSET = _Unset()
+
+
 class JobStatus(StrEnum):
     """Job lifecycle states.
 
@@ -90,6 +102,11 @@ class Job(BaseModel):
     id: str
     kind: str  # "detect_beep" | "trim" | etc; used for SPA copy + filtering
     stage_number: int | None = None
+    # Targets a specific ``StageVideo`` when the operation is per-video
+    # (multi-cam beep detect / trim). ``None`` for stage-level jobs that
+    # are intrinsically primary-bound (shot_detect, export). The SPA
+    # disambiguates concurrent per-camera jobs in JobsPanel by this id.
+    video_id: str | None = None
     status: JobStatus
     progress: float | None = None  # 0..1 when known
     message: str | None = None  # human-readable phase, e.g. "Extracting audio..."
@@ -202,6 +219,7 @@ class JobRegistry:
         kind: str,
         fn: Callable[[JobHandle], None],
         stage_number: int | None = None,
+        video_id: str | None = None,
     ) -> Job:
         """Schedule ``fn`` to run on the thread pool.
 
@@ -213,6 +231,7 @@ class JobRegistry:
             id=uuid.uuid4().hex,
             kind=kind,
             stage_number=stage_number,
+            video_id=video_id,
             status=JobStatus.PENDING,
             created_at=now,
             updated_at=now,
@@ -273,12 +292,23 @@ class JobRegistry:
                 logger.warning("cancel: terminate() failed for job %s", job_id, exc_info=True)
         return snapshot
 
-    def find_active(self, *, kind: str, stage_number: int | None = None) -> Job | None:
-        """Return the first PENDING/RUNNING job matching ``(kind, stage_number)``.
+    def find_active(
+        self,
+        *,
+        kind: str,
+        stage_number: int | None = None,
+        video_id: str | None | _Unset = _UNSET,
+    ) -> Job | None:
+        """Return the first PENDING/RUNNING job matching the keys.
 
         Used to dedupe submissions: a second click of "Trim now" while the
         first job is still running should adopt the existing job instead
         of spawning a parallel ffmpeg that races on the same output file.
+
+        ``video_id`` is matched only when explicitly passed; legacy callers
+        that don't know about per-video jobs keep their previous behaviour
+        of "match on (kind, stage_number)" so a stage-level shot_detect
+        dedupe still works against a video_id-less submission.
         """
         with self._lock:
             for jid in self._order:
@@ -288,6 +318,8 @@ class JobRegistry:
                 if j.status not in (JobStatus.PENDING, JobStatus.RUNNING):
                     continue
                 if j.kind != kind or j.stage_number != stage_number:
+                    continue
+                if not isinstance(video_id, _Unset) and j.video_id != video_id:
                     continue
                 return j.model_copy(deep=True)
             return None

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -23,6 +23,7 @@ is the foundation that makes incremental ingest safe.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -31,7 +32,7 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from .. import video_match
 from ..config import BeepCandidate, StageData, VideoMatchConfig
@@ -91,6 +92,22 @@ class StageVideo(BaseModel):
     beep_candidates: list[BeepCandidate] = Field(default_factory=list)
     notes: str = ""
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def video_id(self) -> str:
+        """Stable URL-safe identifier derived from ``path``.
+
+        Used by per-video API endpoints (``/api/stages/{n}/videos/{video_id}/...``)
+        and by per-video cache filenames (audio WAV, trimmed MP4) so each video
+        on a stage gets its own cache slot. Hash is a 12-char blake2s digest of
+        the stored path string -- stable across restarts, project reloads, and
+        re-registration of the same source.
+
+        Surfaced as a computed field on the wire so the SPA can route
+        per-video requests without re-implementing the hash client-side.
+        """
+        return hashlib.blake2s(str(self.path).encode("utf-8"), digest_size=6).hexdigest()
+
 
 class StageEntry(BaseModel):
     """A stage in the match: scoreboard data + assigned videos + audit status."""
@@ -112,6 +129,18 @@ class StageEntry(BaseModel):
         """Return the primary video, or ``None`` if no video is the primary yet."""
         for v in self.videos:
             if v.role == "primary":
+                return v
+        return None
+
+    def find_video_by_id(self, video_id: str) -> StageVideo | None:
+        """Locate a video on this stage by its :attr:`StageVideo.video_id`.
+
+        Returns ``None`` when no video on this stage matches. Per-video beep
+        endpoints use this to resolve the URL-bound id back to the stored
+        ``StageVideo`` so they can mutate beep fields and trigger jobs.
+        """
+        for v in self.videos:
+            if v.video_id == video_id:
                 return v
         return None
 
@@ -930,11 +959,23 @@ class MatchProject(BaseModel):
 
         raw_link = self.resolve_video_path(root, video.path)
 
+        # Cache files are keyed on role: primary keeps the legacy
+        # ``stage<N>_primary.wav`` / ``stage<N>_trimmed.mp4`` filenames;
+        # non-primary cameras live under ``stage<N>_cam_<video_id>.*`` so
+        # each angle has its own slot. Either way the removal plan points
+        # at the per-video files so the endpoint sweeps them on disk.
         audio_cache: Path | None = None
         trimmed_cache: Path | None = None
-        if was_primary and stage_number is not None:
-            audio_cache = self.audio_path(root) / f"stage{stage_number}_primary.wav"
-            trimmed_cache = self.trimmed_path(root) / f"stage{stage_number}_trimmed.mp4"
+        if stage_number is not None:
+            if was_primary:
+                audio_cache = self.audio_path(root) / f"stage{stage_number}_primary.wav"
+                trimmed_cache = self.trimmed_path(root) / f"stage{stage_number}_trimmed.mp4"
+            else:
+                vid = video.video_id
+                audio_cache = self.audio_path(root) / f"stage{stage_number}_cam_{vid}.wav"
+                trimmed_cache = (
+                    self.trimmed_path(root) / f"stage{stage_number}_cam_{vid}_trimmed.mp4"
+                )
 
         audit_path: Path | None = None
         audit_reset = False

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -730,9 +730,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             )
         return project, stage, video
 
-    def _run_detect_beep_for_video(
-        handle: JobHandle, stage_number: int, video_id: str
-    ) -> None:
+    def _run_detect_beep_for_video(handle: JobHandle, stage_number: int, video_id: str) -> None:
         """Worker: detect ``video``'s beep, then auto-chain trim.
 
         Generic over role:
@@ -1310,9 +1308,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         """
         if video.beep_time is None or stage.time_seconds <= 0:
             return
-        if state.jobs.find_active(
-            kind="trim", stage_number=stage.stage_number, video_id=video.video_id
-        ) is not None:
+        if (
+            state.jobs.find_active(
+                kind="trim", stage_number=stage.stage_number, video_id=video.video_id
+            )
+            is not None
+        ):
             return
         state.jobs.submit(
             kind="trim",

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -16,8 +16,14 @@ Endpoints (locked v1 surface):
   GET  /api/thumbnails/{key}.jpg    -- serve cached thumbnail
   POST /api/stages/{n}/detect-beep  -- submit a beep-detection job (runs in pool)
   POST /api/stages/{n}/beep         -- manual beep_time override (synchronous)
+  POST /api/stages/{n}/beep/select  -- promote one ranked candidate (synchronous)
   POST /api/stages/{n}/trim         -- submit an audit-mode trim job
   POST /api/stages/{n}/shot-detect  -- submit shot detection on the audit clip
+  POST /api/stages/{n}/videos/{vid}/detect-beep -- per-video beep detection
+  POST /api/stages/{n}/videos/{vid}/beep         -- per-video manual override
+  POST /api/stages/{n}/videos/{vid}/beep/select  -- per-video candidate select
+  POST /api/stages/{n}/videos/{vid}/trim         -- per-video audit-mode trim
+  GET  /api/stages/{n}/videos/{vid}/beep-preview -- per-video ~1s preview MP4
   GET  /api/jobs                    -- list all retained jobs
   GET  /api/jobs/{job_id}           -- poll a single job for progress / status
   GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
@@ -73,6 +79,8 @@ from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
     ScoreboardImportConflictError,
+    StageEntry,
+    StageVideo,
     VideoRole,
 )
 
@@ -699,18 +707,165 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
 
+    def _resolve_stage_video(
+        stage_number: int, video_id: str
+    ) -> tuple[MatchProject, StageEntry, StageVideo]:
+        """Load the project + stage + video for a per-video endpoint.
+
+        Returns the trio so the caller doesn't have to re-read state. Raises
+        404 when stage / video doesn't exist; pre-flight check on the
+        source-on-disk lives at the call site so endpoints that don't need
+        a reachable file (clear, manual override) can skip it.
+        """
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        video = stage.find_video_by_id(video_id)
+        if video is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"stage {stage_number} has no video with id {video_id!r}",
+            )
+        return project, stage, video
+
+    def _run_detect_beep_for_video(
+        handle: JobHandle, stage_number: int, video_id: str
+    ) -> None:
+        """Worker: detect ``video``'s beep, then auto-chain trim.
+
+        Generic over role:
+          - primary: detect -> trim -> shot_detect (existing pipeline).
+          - secondary: detect -> trim (no shot_detect; the audit timeline
+            is anchored to the primary's beep).
+
+        Trim is treated as a soft failure: the beep is valuable on its
+        own and the SPA can re-trim later.
+        """
+        handle.update(progress=0.05, message="Loading project...")
+        proj = state.load()
+        stg = proj.stage(stage_number)
+        video = stg.find_video_by_id(video_id)
+        if video is None:
+            raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
+        source = proj.resolve_video_path(state.project_root, video.path)
+        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
+        handle.update(
+            progress=0.15,
+            message=f"Extracting audio + detecting beep ({role_label})...",
+        )
+        beep = audio_helpers.detect_video_beep(
+            state.project_root,
+            stage_number,
+            video,
+            source,
+            project=proj,
+        )
+        handle.update(progress=0.55, message="Saving beep...")
+        video.beep_time = beep.time
+        video.beep_source = "auto"
+        video.beep_peak_amplitude = beep.peak_amplitude
+        video.beep_duration_ms = beep.duration_ms
+        video.beep_candidates = list(beep.candidates)
+        video.processed["beep"] = True
+
+        trimmed_ok = False
+        if stg.time_seconds > 0:
+            handle.check_cancel()
+            handle.update(progress=0.55, message=f"Trimming audit clip ({role_label})...")
+            try:
+                audio_helpers.ensure_video_audit_trim(
+                    state.project_root,
+                    stage_number,
+                    video,
+                    source,
+                    video.beep_time,
+                    stg.time_seconds,
+                    project=proj,
+                    runner=_cancellable_runner(handle),
+                )
+                video.processed["trim"] = True
+                trimmed_ok = True
+            except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
+                # Soft failure: beep alone is still useful, especially for
+                # secondaries (audit alignment works without a trim cache).
+                logger.warning(
+                    "auto-trim failed for stage %d video %s: %s",
+                    stage_number,
+                    video.video_id,
+                    exc,
+                )
+                handle.update(message=f"beep saved; trim failed: {exc}")
+        handle.update(progress=0.85, message="Saving project...")
+        proj.save(state.project_root)
+        if trimmed_ok and video.role == "primary":
+            # Shot detection is primary-only: secondaries don't carry their
+            # own shot timeline; the audit screen reads shots from the
+            # primary regardless of which camera the user is watching.
+            if state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None:
+                state.jobs.submit(
+                    kind="shot_detect",
+                    stage_number=stage_number,
+                    fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+                )
+        handle.update(progress=1.0, message="Done")
+
+    def _submit_detect_beep(stage_number: int, video: StageVideo) -> JSONResponse:
+        """Validate + dedupe + queue a detect-beep job for ``video``.
+
+        Shared by the per-video endpoint and the primary-only legacy
+        endpoint so both honour the same reachability + manual-override
+        pre-flight checks.
+        """
+        existing = state.jobs.find_active(
+            kind="detect_beep", stage_number=stage_number, video_id=video.video_id
+        )
+        if existing is not None:
+            return JSONResponse(existing.model_dump(mode="json"))
+        job = state.jobs.submit(
+            kind="detect_beep",
+            stage_number=stage_number,
+            video_id=video.video_id,
+            fn=lambda h, n=stage_number, vid=video.video_id: _run_detect_beep_for_video(h, n, vid),
+        )
+        return JSONResponse(job.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/videos/{video_id}/detect-beep")
+    def detect_beep_for_video(
+        stage_number: int, video_id: str, force: bool = False
+    ) -> JSONResponse:
+        """Submit a beep-detection job for ``video_id`` on ``stage_number``.
+
+        Generic over role (primary or secondary): each video gets its own
+        detect job, its own beep timestamp, its own short-GOP trim, and
+        its own dedupe slot in the registry so the user can run primary +
+        Cam 2 + Cam 3 in parallel. Shot detection auto-chains only for
+        primary results; secondaries align to the primary timeline by
+        their own beep so they don't need their own shot timeline.
+        """
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        _ensure_source_reachable(
+            stage_number, project.resolve_video_path(state.project_root, video.path)
+        )
+        if video.beep_source == "manual" and not force:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "video has a manual beep override; pass ?force=true to "
+                    "replace it with auto-detected output"
+                ),
+            )
+        return _submit_detect_beep(stage_number, video)
+
     @app.post("/api/stages/{stage_number}/detect-beep")
     def detect_beep(stage_number: int, force: bool = False) -> JSONResponse:
         """Submit a beep-detection job for the stage's primary.
 
-        Returns a Job snapshot (status=PENDING) immediately; the SPA polls
-        ``/api/jobs/{id}`` for progress and refetches ``/api/project`` on
-        completion. The job pipeline is detect-beep -> auto-trim (when
-        the stage time is known); both happen atomically inside one job.
-
-        Validations are still performed up front and surface as HTTP
-        errors before any job is queued, so the SPA can show e.g. a 409
-        for "manual override exists" without spinning a useless job.
+        Backward-compat shim that resolves the primary's id and forwards to
+        the per-video pipeline. Returns a Job snapshot immediately; the SPA
+        polls ``/api/jobs/{id}`` for progress and refetches ``/api/project``
+        on completion.
         """
         project = state.load()
         try:
@@ -723,10 +878,6 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
-        # Reachability pre-flight: surface the same structured 424 the
-        # export pipeline uses, so the SPA renders a consistent "reconnect
-        # external storage" message regardless of which screen kicked
-        # off the work.
         _ensure_source_reachable(
             stage_number, project.resolve_video_path(state.project_root, primary.path)
         )
@@ -738,76 +889,16 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                     "replace it with auto-detected output"
                 ),
             )
-
-        def run(handle: JobHandle) -> None:
-            handle.update(progress=0.05, message="Loading project...")
-            proj = state.load()
-            stg = proj.stage(stage_number)
-            prim = stg.primary()
-            if prim is None:  # pragma: no cover -- defensive; pre-checked above
-                raise RuntimeError("primary video disappeared mid-flight")
-            source = proj.resolve_video_path(state.project_root, prim.path)
-            handle.update(progress=0.15, message="Extracting audio + detecting beep...")
-            beep = audio_helpers.detect_primary_beep(
-                state.project_root,
-                stage_number,
-                source,
-                project=proj,
-            )
-            handle.update(progress=0.55, message="Saving beep...")
-            prim.beep_time = beep.time
-            prim.beep_source = "auto"
-            prim.beep_peak_amplitude = beep.peak_amplitude
-            prim.beep_duration_ms = beep.duration_ms
-            prim.beep_candidates = list(beep.candidates)
-            prim.processed["beep"] = True
-
-            trimmed_ok = False
-            if stg.time_seconds > 0:
-                handle.check_cancel()
-                handle.update(progress=0.55, message="Trimming audit clip (short GOP)...")
-                try:
-                    audio_helpers.ensure_audit_trim(
-                        state.project_root,
-                        stage_number,
-                        source,
-                        prim.beep_time,
-                        stg.time_seconds,
-                        project=proj,
-                        runner=_cancellable_runner(handle),
-                    )
-                    prim.processed["trim"] = True
-                    trimmed_ok = True
-                except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
-                    # Soft failure: the beep is valuable on its own.
-                    logger.warning("auto-trim failed for stage %d: %s", stage_number, exc)
-                    handle.update(message=f"beep saved; trim failed: {exc}")
-            handle.update(progress=0.85, message="Saving project...")
-            proj.save(state.project_root)
-            # Auto-chain shot detection so the audit screen lands populated.
-            # Dedupe handles the case where the user already kicked one off.
-            if trimmed_ok:
-                if state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None:
-                    state.jobs.submit(
-                        kind="shot_detect",
-                        stage_number=stage_number,
-                        fn=lambda h, n=stage_number: _run_shot_detect(h, n),
-                    )
-            handle.update(progress=1.0, message="Done")
-
-        existing = state.jobs.find_active(kind="detect_beep", stage_number=stage_number)
-        if existing is not None:
-            return JSONResponse(existing.model_dump(mode="json"))
-        job = state.jobs.submit(kind="detect_beep", stage_number=stage_number, fn=run)
-        return JSONResponse(job.model_dump(mode="json"))
+        return _submit_detect_beep(stage_number, primary)
 
     @app.post("/api/stages/{stage_number}/trim")
     def trim_stage(stage_number: int) -> JSONResponse:
         """Submit an audit-mode short-GOP trim job for the stage's primary.
 
-        Returns a Job snapshot. Idempotent on the worker side: when the
-        cached MP4 is newer than the source, the job completes near-
-        instantly without re-encoding.
+        Backward-compat shim: forwards to the per-video pipeline. Returns
+        a Job snapshot. Idempotent on the worker side: when the cached
+        MP4 is newer than the source, the job completes near-instantly
+        without re-encoding.
         """
         project = state.load()
         try:
@@ -820,16 +911,27 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
-        # Same source-reachability pre-flight as detect-beep: a 424 with
-        # ``code: "source_unreachable"`` so the SPA can surface a uniform
-        # "reconnect external storage" message before any job is queued.
+        return _submit_trim(stage_number, stage, primary, project)
+
+    def _submit_trim(
+        stage_number: int,
+        stage: StageEntry,
+        video: StageVideo,
+        project: MatchProject,
+    ) -> JSONResponse:
+        """Validate + dedupe + queue a trim job for ``video``.
+
+        Pre-flight checks (reachability, beep present, stage_time set)
+        apply equally to primary and secondary -- both need a beep_time
+        and a non-zero stage_time to define the trim window.
+        """
         _ensure_source_reachable(
-            stage_number, project.resolve_video_path(state.project_root, primary.path)
+            stage_number, project.resolve_video_path(state.project_root, video.path)
         )
-        if primary.beep_time is None:
+        if video.beep_time is None:
             raise HTTPException(
                 status_code=400,
-                detail=f"stage {stage_number} primary has no beep_time yet",
+                detail=f"stage {stage_number} video has no beep_time yet",
             )
         if stage.time_seconds <= 0:
             raise HTTPException(
@@ -839,49 +941,83 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                     "scoreboard or set the stage time before trimming"
                 ),
             )
-
-        existing = state.jobs.find_active(kind="trim", stage_number=stage_number)
+        existing = state.jobs.find_active(
+            kind="trim", stage_number=stage_number, video_id=video.video_id
+        )
         if existing is not None:
             return JSONResponse(existing.model_dump(mode="json"))
         job = state.jobs.submit(
             kind="trim",
             stage_number=stage_number,
-            fn=lambda h, n=stage_number: _run_trim_for_stage(h, n),
+            video_id=video.video_id,
+            fn=lambda h, n=stage_number, vid=video.video_id: _run_trim_for_video(h, n, vid),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
-    def _run_trim_for_stage(handle: JobHandle, stage_number: int) -> None:
-        """Worker for the audit-mode trim. Auto-chains shot detection on
-        success so a re-trim (e.g. after manual beep override) refreshes
-        the candidate pool the audit screen reads from."""
+    @app.post("/api/stages/{stage_number}/videos/{video_id}/trim")
+    def trim_for_video(stage_number: int, video_id: str) -> JSONResponse:
+        """Submit an audit-mode trim job for ``video_id`` on ``stage_number``."""
+        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        return _submit_trim(stage_number, stage, video, project)
+
+    def _run_trim_for_video(handle: JobHandle, stage_number: int, video_id: str) -> None:
+        """Worker for the audit-mode trim of a specific video.
+
+        Auto-chains shot detection only when the trimmed video is the
+        primary; secondaries align to the primary's audit timeline by
+        their own beep, so they do not need their own shot-detection run.
+        """
         handle.update(progress=0.1, message="Preparing trim...")
         proj = state.load()
         stg = proj.stage(stage_number)
-        prim = stg.primary()
-        if prim is None or prim.beep_time is None:
-            raise RuntimeError("primary or beep disappeared mid-flight")
-        source = proj.resolve_video_path(state.project_root, prim.path)
+        video = stg.find_video_by_id(video_id)
+        if video is None or video.beep_time is None:
+            raise RuntimeError("video or beep disappeared mid-flight")
+        source = proj.resolve_video_path(state.project_root, video.path)
         handle.check_cancel()
-        handle.update(progress=0.3, message="Encoding short-GOP MP4...")
-        audio_helpers.ensure_audit_trim(
+        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
+        handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
+        audio_helpers.ensure_video_audit_trim(
             state.project_root,
             stage_number,
+            video,
             source,
-            prim.beep_time,
+            video.beep_time,
             stg.time_seconds,
             project=proj,
             runner=_cancellable_runner(handle),
         )
         handle.update(progress=0.85, message="Saving project...")
-        prim.processed["trim"] = True
+        video.processed["trim"] = True
         proj.save(state.project_root)
-        if state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None:
+        if (
+            video.role == "primary"
+            and state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None
+        ):
             state.jobs.submit(
                 kind="shot_detect",
                 stage_number=stage_number,
                 fn=lambda h, n=stage_number: _run_shot_detect(h, n),
             )
         handle.update(progress=1.0, message="Done")
+
+    def _run_trim_for_stage(handle: JobHandle, stage_number: int) -> None:
+        """Backward-compat shim for legacy callers (e.g. beep-override
+        endpoints) that submit a trim by stage_number alone.
+
+        Resolves the stage's primary and forwards to the per-video
+        worker. New callers should pass a ``video_id`` and submit via
+        :func:`_run_trim_for_video` directly.
+        """
+        proj = state.load()
+        try:
+            stg = proj.stage(stage_number)
+        except KeyError as exc:
+            raise RuntimeError(f"stage {stage_number} disappeared mid-flight: {exc}") from exc
+        primary = stg.primary()
+        if primary is None:
+            raise RuntimeError(f"stage {stage_number} has no primary mid-flight")
+        _run_trim_for_video(handle, stage_number, primary.video_id)
 
     def _run_shot_detect(handle: JobHandle, stage_number: int, reset: bool = False) -> None:
         """Worker that runs the 4-voter ensemble on the stage's audit clip.
@@ -1123,8 +1259,129 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             raise HTTPException(status_code=404, detail=f"unknown job: {job_id}")
         return job
 
+    def _apply_beep_override(
+        project: MatchProject,
+        stage: StageEntry,
+        video: StageVideo,
+        beep_time: float | None,
+    ) -> None:
+        """Apply a manual beep override to ``video``.
+
+        Generic over role: secondaries also need their cached trim
+        invalidated when the user moves their beep, since the trim window
+        is anchored to that beep. ``beep_time=None`` clears back to "no
+        beep yet"; otherwise sets ``beep_source="manual"`` and drops the
+        candidate list so the UI doesn't keep suggesting a stale auto pick.
+        Shot-detect flag clearing is primary-only -- secondaries don't
+        carry their own shot timeline.
+        """
+        if beep_time is None:
+            video.beep_time = None
+            video.beep_source = None
+            video.beep_peak_amplitude = None
+            video.beep_duration_ms = None
+            video.beep_candidates = []
+            video.processed["beep"] = False
+            video.processed["trim"] = False
+            if video.role == "primary":
+                video.processed["shot_detect"] = False
+        else:
+            video.beep_time = beep_time
+            video.beep_source = "manual"
+            video.beep_peak_amplitude = None
+            video.beep_duration_ms = None
+            video.beep_candidates = []
+            video.processed["beep"] = True
+            video.processed["trim"] = False
+            if video.role == "primary":
+                video.processed["shot_detect"] = False
+
+        audio_helpers.invalidate_video_audit_trim(
+            state.project_root, stage.stage_number, video, project=project
+        )
+
+    def _maybe_chain_trim(stage: StageEntry, video: StageVideo) -> None:
+        """Auto-fire a trim job for ``video`` when conditions allow.
+
+        Used after a beep override / candidate select: if the user just
+        gave us a beep and the stage time is known, the next thing they
+        want is a fresh short-GOP trim. Dedupes through ``find_active``
+        so a still-running job adopts instead of racing.
+        """
+        if video.beep_time is None or stage.time_seconds <= 0:
+            return
+        if state.jobs.find_active(
+            kind="trim", stage_number=stage.stage_number, video_id=video.video_id
+        ) is not None:
+            return
+        state.jobs.submit(
+            kind="trim",
+            stage_number=stage.stage_number,
+            video_id=video.video_id,
+            fn=lambda h, n=stage.stage_number, vid=video.video_id: _run_trim_for_video(h, n, vid),
+        )
+
+    def _select_candidate_on_video(video: StageVideo, time_value: float) -> None:
+        """Promote the candidate at ``time_value`` (within 1 ms) on ``video``.
+
+        Mirrors the v1 primary path: the time still came from the detector
+        so ``beep_source="auto"`` is preserved; only the chosen candidate
+        changes. Raises ``HTTPException`` for caller-facing errors so both
+        the per-video and legacy primary endpoints get the same response
+        shapes.
+        """
+        if not video.beep_candidates:
+            raise HTTPException(
+                status_code=400,
+                detail="video has no candidate list yet; run detect-beep first",
+            )
+        match_eps = 1e-3
+        chosen = None
+        for c in video.beep_candidates:
+            if abs(c.time - time_value) <= match_eps:
+                chosen = c
+                break
+        if chosen is None:
+            available = ", ".join(f"{c.time:.3f}" for c in video.beep_candidates)
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"no candidate within {match_eps * 1000:.0f} ms of "
+                    f"{time_value:.3f}s; available: [{available}]"
+                ),
+            )
+        video.beep_time = chosen.time
+        video.beep_source = "auto"
+        video.beep_peak_amplitude = chosen.peak_amplitude
+        video.beep_duration_ms = chosen.duration_ms
+        video.processed["beep"] = True
+        video.processed["trim"] = False
+        if video.role == "primary":
+            video.processed["shot_detect"] = False
+
+    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep")
+    def override_beep_for_video(
+        stage_number: int, video_id: str, req: BeepOverrideRequest
+    ) -> JSONResponse:
+        """Manually set or clear ``video``'s beep timestamp.
+
+        ``req.beep_time = None`` clears back to "no beep yet"; otherwise
+        the value (in seconds, must be >= 0) is taken as authoritative
+        with ``beep_source="manual"``. Same dedupe + auto-trim chain as
+        the legacy primary endpoint, just keyed per video.
+        """
+        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        if req.beep_time is not None and req.beep_time < 0.0:
+            raise HTTPException(status_code=400, detail="beep_time must be >= 0")
+        _apply_beep_override(project, stage, video, req.beep_time)
+        project.save(state.project_root)
+        if req.beep_time is not None:
+            _maybe_chain_trim(stage, video)
+        return JSONResponse(project.model_dump(mode="json"))
+
     @app.post("/api/stages/{stage_number}/beep")
     def override_beep(stage_number: int, req: BeepOverrideRequest) -> JSONResponse:
+        """Backward-compat shim: manually set / clear the primary's beep."""
         project = state.load()
         try:
             stage = project.stage(stage_number)
@@ -1136,62 +1393,36 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
-        if req.beep_time is None:
-            # Clear: back to "no beep yet"
-            primary.beep_time = None
-            primary.beep_source = None
-            primary.beep_peak_amplitude = None
-            primary.beep_duration_ms = None
-            primary.beep_candidates = []
-            primary.processed["beep"] = False
-            primary.processed["trim"] = False
-            primary.processed["shot_detect"] = False
-        else:
-            if req.beep_time < 0.0:
-                raise HTTPException(status_code=400, detail="beep_time must be >= 0")
-            primary.beep_time = req.beep_time
-            primary.beep_source = "manual"
-            primary.processed["beep"] = True
-            # Diagnostics from a previous auto-detect are no longer authoritative.
-            primary.beep_peak_amplitude = None
-            primary.beep_duration_ms = None
-            # Manual time wins over the ranked-candidate list -- drop it so
-            # the UI doesn't keep offering a different "auto" pick that
-            # contradicts what the user just typed.
-            primary.beep_candidates = []
-            # New beep -> previous trim was cut around the wrong window.
-            # processed.trim flips back so the SPA prompts re-trim.
-            primary.processed["trim"] = False
-            primary.processed["shot_detect"] = False
-
-        # Either branch invalidates the cached trim + audit WAV so the
-        # next audit-screen visit can't serve a stale clip cut around an
-        # outdated beep. Auto-fires a trim job (which auto-chains shot
-        # detection) when we still have enough info to run; otherwise
-        # the user gets the badge on the audit screen.
-        audio_helpers.invalidate_audit_trim(state.project_root, stage_number, project=project)
+        if req.beep_time is not None and req.beep_time < 0.0:
+            raise HTTPException(status_code=400, detail="beep_time must be >= 0")
+        _apply_beep_override(project, stage, primary, req.beep_time)
         project.save(state.project_root)
-        if (
-            req.beep_time is not None
-            and stage.time_seconds > 0
-            and state.jobs.find_active(kind="trim", stage_number=stage_number) is None
-        ):
-            state.jobs.submit(
-                kind="trim",
-                stage_number=stage_number,
-                fn=lambda h, n=stage_number: _run_trim_for_stage(h, n),
-            )
+        if req.beep_time is not None:
+            _maybe_chain_trim(stage, primary)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/select")
+    def select_beep_candidate_for_video(
+        stage_number: int, video_id: str, req: BeepSelectRequest
+    ) -> JSONResponse:
+        """Promote one of ``video``'s ranked candidates as authoritative."""
+        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        _select_candidate_on_video(video, req.time)
+        audio_helpers.invalidate_video_audit_trim(
+            state.project_root, stage_number, video, project=project
+        )
+        project.save(state.project_root)
+        _maybe_chain_trim(stage, video)
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/stages/{stage_number}/beep/select")
     def select_beep_candidate(stage_number: int, req: BeepSelectRequest) -> JSONResponse:
-        """Promote one of the ranked auto-detected candidates as authoritative.
+        """Backward-compat shim: promote a ranked candidate on the primary.
 
         Lets the user fix a wrong auto-pick without typing a timestamp.
-        Re-uses the auto-detect provenance because the time still came from
-        the detector -- we only changed which candidate the project trusts.
-        Triggers a re-trim like the manual override path so the cached
-        audit clip lines up with the new beep.
+        Re-uses the auto-detect provenance because the time still came
+        from the detector -- we only changed which candidate the project
+        trusts. Triggers a re-trim so the cached audit clip lines up.
         """
         project = state.load()
         try:
@@ -1204,51 +1435,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
-        if not primary.beep_candidates:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"stage {stage_number} has no candidate list yet; run " "detect-beep first"
-                ),
-            )
-        # Match by time within 1 ms. Round-tripping floats through JSON +
-        # pydantic preserves the value but a strict equality check is
-        # fragile, so we use the same epsilon the SPA uses to pick the
-        # active row.
-        match_eps = 1e-3
-        chosen = None
-        for c in primary.beep_candidates:
-            if abs(c.time - req.time) <= match_eps:
-                chosen = c
-                break
-        if chosen is None:
-            available = ", ".join(f"{c.time:.3f}" for c in primary.beep_candidates)
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"no candidate within {match_eps * 1000:.0f} ms of "
-                    f"{req.time:.3f}s; available: [{available}]"
-                ),
-            )
-        primary.beep_time = chosen.time
-        primary.beep_source = "auto"
-        primary.beep_peak_amplitude = chosen.peak_amplitude
-        primary.beep_duration_ms = chosen.duration_ms
-        primary.processed["beep"] = True
-        primary.processed["trim"] = False
-        primary.processed["shot_detect"] = False
-
-        audio_helpers.invalidate_audit_trim(state.project_root, stage_number, project=project)
+        _select_candidate_on_video(primary, req.time)
+        audio_helpers.invalidate_video_audit_trim(
+            state.project_root, stage_number, primary, project=project
+        )
         project.save(state.project_root)
-        if (
-            stage.time_seconds > 0
-            and state.jobs.find_active(kind="trim", stage_number=stage_number) is None
-        ):
-            state.jobs.submit(
-                kind="trim",
-                stage_number=stage_number,
-                fn=lambda h, n=stage_number: _run_trim_for_stage(h, n),
-            )
+        _maybe_chain_trim(stage, primary)
         return JSONResponse(project.model_dump(mode="json"))
 
     def _resolve_audit_audio(
@@ -1279,9 +1471,51 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except audio_helpers.AudioExtractionError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+    def _serve_beep_preview(
+        project: MatchProject,
+        stage_number: int,
+        video: StageVideo,
+        t: float | None,
+    ) -> FileResponse:
+        """Build the ~1 s MP4 around ``t`` (or ``video.beep_time``) and serve it.
+
+        Shared by the legacy primary endpoint and the per-video endpoint
+        so both honour the same 404 / 424 / cache semantics.
+        """
+        source = project.resolve_video_path(state.project_root, video.path)
+        _ensure_source_reachable(stage_number, source)
+        center = t if t is not None else video.beep_time
+        if center is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"stage {stage_number} video has no beep_time yet",
+            )
+        if center < 0:
+            raise HTTPException(status_code=400, detail="t must be >= 0")
+        thumbs_dir = project.thumbs_path(state.project_root)
+        try:
+            clip = thumbnail_helpers.ensure_clip(
+                source,
+                cache_dir=thumbs_dir,
+                center_time=float(center),
+                duration_s=1.0,
+                width=480,
+            )
+        except thumbnail_helpers.ThumbnailError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return FileResponse(clip, media_type="video/mp4", filename=clip.name)
+
+    @app.get("/api/stages/{stage_number}/videos/{video_id}/beep-preview")
+    def video_beep_preview(
+        stage_number: int, video_id: str, t: float | None = None
+    ) -> FileResponse:
+        """Serve a ~1 s MP4 around ``video``'s beep (or override ``t``)."""
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        return _serve_beep_preview(project, stage_number, video, t)
+
     @app.get("/api/stages/{stage_number}/beep-preview")
     def stage_beep_preview(stage_number: int, t: float | None = None) -> FileResponse:
-        """Serve a tiny MP4 around a beep timestamp (#27, #22).
+        """Serve a tiny MP4 around the primary's beep timestamp (#27, #22).
 
         Default center is the primary's persisted ``beep_time``. The
         optional ``t`` query param overrides it so the BeepCandidates
@@ -1300,31 +1534,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 status_code=404,
                 detail=f"stage {stage_number} has no primary video",
             )
-        # Reuse the structured 424 path so the SPA gets a uniform
-        # "reconnect external storage" message regardless of which surface
-        # invoked the preview.
-        source = project.resolve_video_path(state.project_root, primary.path)
-        _ensure_source_reachable(stage_number, source)
-        center = t if t is not None else primary.beep_time
-        if center is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"stage {stage_number} has no beep_time yet",
-            )
-        if center < 0:
-            raise HTTPException(status_code=400, detail="t must be >= 0")
-        thumbs_dir = project.thumbs_path(state.project_root)
-        try:
-            clip = thumbnail_helpers.ensure_clip(
-                source,
-                cache_dir=thumbs_dir,
-                center_time=float(center),
-                duration_s=1.0,
-                width=480,
-            )
-        except thumbnail_helpers.ThumbnailError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        return FileResponse(clip, media_type="video/mp4", filename=clip.name)
+        return _serve_beep_preview(project, stage_number, primary, t)
 
     @app.get("/api/stages/{stage_number}/audio")
     def stage_audio(stage_number: int) -> FileResponse:
@@ -1566,9 +1776,13 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         stage, video = located
 
         served_path: Path | None = None
-        if stage is not None and video.role == "primary":
-            trimmed = audio_helpers.trimmed_primary_path(
-                state.project_root, stage.stage_number, project=project
+        if stage is not None:
+            # Prefer the per-video short-GOP trim when one exists. This is
+            # the multi-cam path: each angle gets its own scrub-friendly
+            # cache cut around its own beep, so dragging the audit
+            # playhead doesn't stall on a 4K MOV from a phone.
+            trimmed = audio_helpers.trimmed_video_path(
+                state.project_root, stage.stage_number, video, project=project
             )
             if trimmed.exists():
                 served_path = trimmed.resolve()

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -1,17 +1,24 @@
 /**
- * Per-stage beep detection + correction (issue #22).
+ * Per-video beep detection + correction (issue #22, multi-cam ingest).
  *
- * The beep timestamp anchors the trim window, secondary-video alignment, and
- * shot-detection input window for the audit screen (#15). If detection is
- * wrong, every downstream artefact is wrong. This component exposes:
+ * The beep timestamp anchors the trim window for *every* angle and -- for
+ * the primary -- the shot-detection input window for the audit screen.
+ * Without per-video beep alignment, secondaries can't be slipped into the
+ * audit timeline (a phone shooting at 30 fps and a head-cam at 60 fps need
+ * to land on the same physical instant). This component is rendered once
+ * per video on the stage card so each angle gets the same controls:
  *
  *   - Status: none / auto / manual
  *   - Detect-beep action (or re-detect, with confirmation when overriding manual)
- *   - Manual override: numeric input (seconds, ms precision) + verify-by-ear audio playback
- *   - Clear action: drops the override back to "no beep yet"
+ *   - Manual override: numeric input (seconds, ms precision)
+ *   - Per-video 1 s preview clip around the chosen beep
+ *   - Ranked candidate list (when the detector returned alternatives)
  *
- * Used inside the Ingest screen's <StageCard>; #15 will surface a richer
- * waveform-based correction inline with the audit waveform.
+ * Waveform picker + audio verifier are primary-only because the project
+ * caches a stage-level audit WAV / peaks bundle from the primary's audio.
+ * Secondaries fall back to the numeric input + preview clip; that's
+ * enough for the multi-cam alignment use case (the beep is loud and
+ * visible in the preview).
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -45,26 +52,40 @@ import {
 
 interface Props {
   stageNumber: number;
-  primary: StageVideo;
+  /** The video this section operates on. Beep fields, candidate lists and
+   *  the preview clip are all read from / written to this video; the
+   *  per-video API endpoints carry ``video.video_id`` so jobs and caches
+   *  stay scoped to one camera at a time. */
+  video: StageVideo;
   busy: boolean;
   onProjectUpdate: (next: MatchProject) => void;
   setBusy: (b: boolean) => void;
   setError: (msg: string | null) => void;
 }
 
-export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBusy, setError }: Props) {
+export function BeepSection({
+  stageNumber,
+  video,
+  busy,
+  onProjectUpdate,
+  setBusy,
+  setError,
+}: Props) {
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(primary.beep_time?.toFixed(3) ?? "");
+  const [draft, setDraft] = useState(video.beep_time?.toFixed(3) ?? "");
   const [jobStatus, setJobStatus] = useState<Job | null>(null);
+  const isPrimary = video.role === "primary";
+  const videoId = video.video_id;
 
   useEffect(() => {
-    setDraft(primary.beep_time?.toFixed(3) ?? "");
-  }, [primary.beep_time]);
+    setDraft(video.beep_time?.toFixed(3) ?? "");
+  }, [video.beep_time]);
 
   // After a page reload, an in-flight detect-beep job is still running on
   // the server. Surface it instead of letting the user click "Detect beep"
   // again -- the server now dedupes anyway, but the SPA showing the
-  // progress is the difference between confidence and confusion.
+  // progress is the difference between confidence and confusion. We match
+  // on video_id too so each camera's section picks up its own job.
   useEffect(() => {
     let cancelled = false;
     api
@@ -75,6 +96,7 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
           (j) =>
             j.kind === "detect_beep" &&
             j.stage_number === stageNumber &&
+            j.video_id === videoId &&
             (j.status === "pending" || j.status === "running"),
         );
         if (!active) return;
@@ -98,31 +120,27 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
     return () => {
       cancelled = true;
     };
-  }, [stageNumber, onProjectUpdate, setBusy, setError]);
+  }, [stageNumber, videoId, onProjectUpdate, setBusy, setError]);
 
   const detect = async (force: boolean) => {
     setBusy(true);
     setError(null);
     try {
-      const job = await api.detectBeep(stageNumber, force);
+      const job = await api.detectBeepForVideo(stageNumber, videoId, force);
       setJobStatus(job);
       const final = await api.pollJob(job.id, setJobStatus);
       if (final.status === "failed") {
         setError(final.error ?? "Beep detection failed");
       } else {
-        // Re-fetch the project to pick up beep_time + processed.trim.
         onProjectUpdate(await api.getProject());
       }
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
         const ok = window.confirm(
-          "This stage has a manual beep override. Replace it with the auto-detected value?",
+          "This video has a manual beep override. Replace it with the auto-detected value?",
         );
         if (ok) await detect(true);
       } else {
-        // Source-unreachable (424) gets the same friendly wording the
-        // Export page shows, so the user sees one consistent
-        // "reconnect external storage" message everywhere.
         const unreachable = asSourceUnreachable(e);
         if (unreachable) {
           setError(unreachable.message);
@@ -149,7 +167,7 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
     }
     setBusy(true);
     try {
-      const updated = await api.overrideBeep(stageNumber, value);
+      const updated = await api.overrideBeepForVideo(stageNumber, videoId, value);
       onProjectUpdate(updated);
       setError(null);
       setEditing(false);
@@ -163,7 +181,7 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
   const clear = async () => {
     setBusy(true);
     try {
-      const updated = await api.overrideBeep(stageNumber, null);
+      const updated = await api.overrideBeepForVideo(stageNumber, videoId, null);
       onProjectUpdate(updated);
       setError(null);
       setEditing(false);
@@ -177,7 +195,7 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
   const selectCandidate = async (time: number) => {
     setBusy(true);
     try {
-      const updated = await api.selectBeepCandidate(stageNumber, time);
+      const updated = await api.selectBeepCandidateForVideo(stageNumber, videoId, time);
       onProjectUpdate(updated);
       setError(null);
     } catch (e) {
@@ -215,21 +233,31 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
             Cancel
           </Button>
         </div>
-        <BeepWaveformPicker
-          stageNumber={stageNumber}
-          primaryBeepTime={primary.beep_time}
-          draftSourceTime={draftValid ? draftSourceTime : null}
-          onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
-        />
-        <AudioVerifier
-          stageNumber={stageNumber}
-          suspectedTime={draftValid ? draftSourceTime : primary.beep_time}
-        />
+        {isPrimary ? (
+          <BeepWaveformPicker
+            stageNumber={stageNumber}
+            primaryBeepTime={video.beep_time}
+            draftSourceTime={draftValid ? draftSourceTime : null}
+            onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
+          />
+        ) : null}
+        {isPrimary ? (
+          <AudioVerifier
+            stageNumber={stageNumber}
+            suspectedTime={draftValid ? draftSourceTime : video.beep_time}
+          />
+        ) : (
+          <div className="text-xs text-muted-foreground">
+            Tip: scrub the preview clip below the section header after Apply --
+            secondaries don't have a project-level waveform yet (the audit
+            timeline is anchored to the primary's audio).
+          </div>
+        )}
       </div>
     );
   }
 
-  if (!primary.beep_time) {
+  if (!video.beep_time) {
     return (
       <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
         <Badge variant="statusNotStarted" className="gap-1">
@@ -239,7 +267,9 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
           <JobProgress job={jobStatus} />
         ) : (
           <span className="text-muted-foreground">
-            Audit screen needs this. Run detection or set manually.
+            {isPrimary
+              ? "Audit screen needs this. Run detection or set manually."
+              : "Needed to sync this camera to the primary timeline."}
           </span>
         )}
         <div className="ml-auto flex gap-1">
@@ -256,7 +286,7 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
     );
   }
 
-  const isManual = primary.beep_source === "manual";
+  const isManual = video.beep_source === "manual";
   return (
     <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
       <div className="flex flex-wrap items-center gap-2">
@@ -264,10 +294,10 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
           <Check className="size-3" />
           beep · {isManual ? "user" : "auto"}
         </Badge>
-        <span className="font-mono tabular-nums">{primary.beep_time.toFixed(3)}s</span>
-        {primary.beep_peak_amplitude != null ? (
+        <span className="font-mono tabular-nums">{video.beep_time.toFixed(3)}s</span>
+        {video.beep_peak_amplitude != null ? (
           <span className="text-muted-foreground" title="Peak amplitude on the bandpassed envelope">
-            peak {primary.beep_peak_amplitude.toFixed(2)}
+            peak {video.beep_peak_amplitude.toFixed(2)}
           </span>
         ) : null}
         {jobStatus ? <JobProgress job={jobStatus} /> : null}
@@ -293,20 +323,29 @@ export function BeepSection({ stageNumber, primary, busy, onProjectUpdate, setBu
       </div>
       <BeepCandidates
         stageNumber={stageNumber}
-        candidates={primary.beep_candidates}
-        currentTime={primary.beep_time}
+        videoId={videoId}
+        candidates={video.beep_candidates}
+        currentTime={video.beep_time}
         busy={busy}
         onSelect={selectCandidate}
       />
       <BeepPreview
         stageNumber={stageNumber}
-        beepTime={primary.beep_time}
+        videoId={videoId}
+        beepTime={video.beep_time}
+        isPrimary={isPrimary}
       />
     </div>
   );
 }
 
 /** Click-to-set waveform inside the manual-edit panel.
+ *
+ *  Primary-only: the waveform shows the project's audit clip (or full
+ *  primary WAV when no trim is cached yet). Secondaries don't have a
+ *  project-level waveform endpoint and they don't need one for beep
+ *  alignment -- the beep is a loud sharp pulse the preview clip makes
+ *  obvious.
  *
  *  The /audio + /peaks endpoints serve the **trimmed** audit clip when one
  *  exists (cut around the previously-detected beep) and the **full**
@@ -329,9 +368,6 @@ function BeepWaveformPicker({
   const [peaks, setPeaks] = useState<PeaksResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [unavailable, setUnavailable] = useState(false);
-  // Local clip time in seconds; drives the waveform's playhead while the
-  // user drags. Initialised to the existing primary beep position so the
-  // playhead doesn't snap to 0 on open.
   const [localTime, setLocalTime] = useState<number>(0);
 
   useEffect(() => {
@@ -343,8 +379,6 @@ function BeepWaveformPicker({
       .then((p) => {
         if (cancelled) return;
         setPeaks(p);
-        // Seed the playhead at the served clip's beep marker if we have
-        // one, otherwise at zero.
         setLocalTime(p.beep_time ?? 0);
       })
       .catch(() => {
@@ -359,16 +393,10 @@ function BeepWaveformPicker({
   }, [stageNumber]);
 
   const offset = useMemo(() => {
-    // primary.beep_time and peaks.beep_time are both expressed as the same
-    // physical instant (the beep). Their difference is the trim window's
-    // start time in source coordinates; zero when the audio is the full
-    // source. Falls back to 0 when either side is unset.
     if (primaryBeepTime == null || !peaks || peaks.beep_time == null) return 0;
     return primaryBeepTime - peaks.beep_time;
   }, [primaryBeepTime, peaks]);
 
-  // Keep the visual playhead in sync with the numeric draft when the user
-  // types in the input directly.
   useEffect(() => {
     if (!peaks || draftSourceTime == null) return;
     const local = draftSourceTime - offset;
@@ -386,8 +414,6 @@ function BeepWaveformPicker({
     );
   }
   if (unavailable || !peaks) {
-    // No audio cached yet (the user has never run detect-beep on this
-    // stage). The numeric input + AudioVerifier hint below cover this case.
     return null;
   }
 
@@ -419,27 +445,23 @@ function BeepWaveformPicker({
 
 function BeepCandidates({
   stageNumber,
+  videoId,
   candidates,
   currentTime,
   busy,
   onSelect,
 }: {
   stageNumber: number;
+  videoId: string;
   candidates: BeepCandidate[];
   currentTime: number | null;
   busy: boolean;
   onSelect: (time: number) => void | Promise<void>;
 }) {
-  // Never bother showing a picker when the detector only returned the winner
-  // (no real choice for the user to make). For projects that predate #22 the
-  // list is just empty -- next detect-beep run repopulates it.
   const hasAlternatives = candidates.length > 1;
   const [open, setOpen] = useState(false);
   if (!hasAlternatives) return null;
 
-  // The "currently promoted" candidate is the one whose time matches
-  // primary.beep_time. We compare with a small epsilon because the value
-  // round-trips through JSON. Falls back to index 0 (the auto-winner).
   const activeIndex = (() => {
     if (currentTime == null) return -1;
     let best = -1;
@@ -454,17 +476,11 @@ function BeepCandidates({
     return bestDelta <= 1e-3 ? best : -1;
   })();
 
-  // Single shared preview slot under the candidate list. Holding one
-  // <video> for the whole list keeps the layout predictable and avoids
-  // the SPA stacking 5 different aspect-ratio thumbnails when the user
-  // explores alternatives.
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [previewError, setPreviewError] = useState(false);
   useEffect(() => {
     setPreviewError(false);
-  }, [previewIndex, stageNumber]);
-  // If candidates change underneath us (re-detect, override) drop a stale
-  // preview index.
+  }, [previewIndex, stageNumber, videoId]);
   useEffect(() => {
     if (previewIndex != null && previewIndex >= candidates.length) {
       setPreviewIndex(null);
@@ -478,7 +494,7 @@ function BeepCandidates({
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
         aria-expanded={open}
-        aria-controls={`beep-candidates-${stageNumber}`}
+        aria-controls={`beep-candidates-${stageNumber}-${videoId}`}
         title="Silence-preference ranked; pick a different one if the auto-winner is wrong"
       >
         {open ? (
@@ -494,7 +510,7 @@ function BeepCandidates({
       {open ? (
         <>
           <ul
-            id={`beep-candidates-${stageNumber}`}
+            id={`beep-candidates-${stageNumber}-${videoId}`}
             className="divide-y divide-border/40 border-t border-border/40"
           >
             {candidates.map((c, i) => (
@@ -524,9 +540,10 @@ function BeepCandidates({
                 </div>
               ) : (
                 <video
-                  key={`${stageNumber}:${candidates[previewIndex].time.toFixed(3)}`}
-                  src={api.stageBeepPreviewUrl(
+                  key={`${stageNumber}:${videoId}:${candidates[previewIndex].time.toFixed(3)}`}
+                  src={api.videoBeepPreviewUrl(
                     stageNumber,
+                    videoId,
                     candidates[previewIndex].time,
                   )}
                   className="aspect-video w-full max-w-sm rounded-md border border-border/60 bg-black object-contain"
@@ -563,10 +580,6 @@ function CandidateRow({
   onTogglePreview: () => void;
   onSelect: () => void | Promise<void>;
 }) {
-  // Two-line layout to fit narrow stage cards: top line is the headline
-  // (rank + time + actions); bottom line is muted diagnostics. Buttons
-  // are icon-only with title tooltips so the row never grows wider than
-  // the card.
   return (
     <li
       className={`px-2 py-1.5 text-xs ${isActive ? "bg-muted/40" : ""}`}
@@ -619,18 +632,19 @@ function CandidateRow({
 
 function BeepPreview({
   stageNumber,
+  videoId,
   beepTime,
+  isPrimary,
 }: {
   stageNumber: number;
+  videoId: string;
   beepTime: number;
+  isPrimary: boolean;
 }) {
-  // The clip caches on the source's mtime+size and beep_time, so re-mounting
-  // with a new beepTime forces a fresh fetch. <video> errors when no clip
-  // exists yet (rare race after detect-beep finishes); fall back to a hint.
   const [errored, setErrored] = useState(false);
   useEffect(() => {
     setErrored(false);
-  }, [stageNumber, beepTime]);
+  }, [stageNumber, videoId, beepTime]);
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -641,8 +655,8 @@ function BeepPreview({
         </div>
       ) : (
         <video
-          key={`${stageNumber}:${beepTime.toFixed(3)}`}
-          src={api.stageBeepPreviewUrl(stageNumber, beepTime)}
+          key={`${stageNumber}:${videoId}:${beepTime.toFixed(3)}`}
+          src={api.videoBeepPreviewUrl(stageNumber, videoId, beepTime)}
           className="h-40 w-64 rounded-md border border-border/60 bg-black object-cover"
           playsInline
           controls
@@ -652,14 +666,16 @@ function BeepPreview({
           onError={() => setErrored(true)}
         />
       )}
-      <Link
-        to={`/audit/${stageNumber}`}
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-        title="Open the audit screen to verify or correct this beep on the waveform"
-      >
-        <Sparkles className="size-3" />
-        Looks wrong? Refine in audit
-      </Link>
+      {isPrimary ? (
+        <Link
+          to={`/audit/${stageNumber}`}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          title="Open the audit screen to verify or correct this beep on the waveform"
+        >
+          <Sparkles className="size-3" />
+          Looks wrong? Refine in audit
+        </Link>
+      ) : null}
     </div>
   );
 }
@@ -713,8 +729,6 @@ function AudioVerifier({
   }, [stageNumber]);
 
   useEffect(() => {
-    // Auto-seek the audio element near the suspected beep so the user can
-    // hit play and immediately hear the relevant slice.
     const el = audioRef.current;
     if (el && suspectedTime != null && Number.isFinite(suspectedTime)) {
       const start = Math.max(0, suspectedTime - 0.5);
@@ -730,7 +744,7 @@ function AudioVerifier({
     return (
       <div className="flex items-center gap-1 text-xs text-muted-foreground">
         <Volume2 className="size-3" />
-        Loading audio…
+        Loading audio...
       </div>
     );
   }

--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -45,8 +45,14 @@ function isActive(job: Job): boolean {
 }
 
 function jobLabel(job: Job): string {
-  const stage = job.stage_number != null ? ` (Stage ${job.stage_number})` : "";
-  return `${formatKind(job.kind)}${stage}`;
+  const stage = job.stage_number != null ? ` (Stage ${job.stage_number}` : "";
+  // Per-camera jobs (multi-cam beep / trim) tag the row with the first
+  // 6 chars of the video_id so the user can tell parallel jobs apart.
+  // Stage-level jobs (shot_detect, export) don't carry a video_id, so
+  // the row falls back to "(Stage N)" alone.
+  const cam = job.video_id ? ` -- cam ${job.video_id.slice(0, 6)}` : "";
+  const close = job.stage_number != null ? ")" : "";
+  return `${formatKind(job.kind)}${stage}${cam}${close}`;
 }
 
 interface StatusIconProps {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -22,6 +22,11 @@ export interface BeepCandidate {
 
 export interface StageVideo {
   path: string;
+  /** Stable URL-safe id derived from ``path``. Used by per-video API
+   *  endpoints (/api/stages/{n}/videos/{video_id}/...) so the SPA can
+   *  target a specific camera without re-encoding the path. Computed
+   *  server-side; do not generate it client-side. */
+  video_id: string;
   role: VideoRole;
   added_at: string;
   /** The recording-finished time the match heuristic uses for this video
@@ -301,6 +306,11 @@ export interface Job {
   id: string;
   kind: string;
   stage_number: number | null;
+  /** Targets a specific StageVideo when the operation is per-camera
+   *  (multi-cam beep / trim). Null for stage-level jobs (shot_detect,
+   *  export). The SPA disambiguates concurrent per-camera jobs in
+   *  JobsPanel by this id. */
+  video_id: string | null;
   status: JobStatus;
   progress: number | null;
   message: string | null;
@@ -478,13 +488,28 @@ export const api = {
       json: { skipped },
     }),
 
-  /** Submit a beep-detection job. Returns a Job snapshot; poll the SPA
-   *  via {@link api.pollJob} (or read /api/jobs/{id} directly) until the
-   *  status flips out of "pending"/"running". On success, the SPA should
-   *  re-fetch /api/project to pick up the new beep_time + processed.trim. */
+  /** Submit a beep-detection job for the stage's primary. Returns a Job
+   *  snapshot; poll via {@link api.pollJob} (or read /api/jobs/{id})
+   *  until the status flips out of "pending"/"running". On success the
+   *  SPA should re-fetch /api/project to pick up the new beep_time +
+   *  processed.trim. Backed by the per-video pipeline; identical to
+   *  ``detectBeepForVideo(stage, primary.video_id)``. */
   detectBeep: (stageNumber: number, force = false) =>
     request<Job>(
       `/api/stages/${stageNumber}/detect-beep${force ? "?force=true" : ""}`,
+      { method: "POST" },
+    ),
+
+  /** Submit a beep-detection job for a specific video on a stage.
+   *  Generic over role: each camera gets its own beep_time, its own
+   *  audit-mode trim, and its own dedupe slot in the registry so
+   *  primary + Cam 2 + Cam 3 can run in parallel. Shot detection
+   *  auto-chains for primary results only. */
+  detectBeepForVideo: (stageNumber: number, videoId: string, force = false) =>
+    request<Job>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/detect-beep${
+        force ? "?force=true" : ""
+      }`,
       { method: "POST" },
     ),
 
@@ -493,6 +518,20 @@ export const api = {
       method: "POST",
       json: { beep_time: beepTime },
     }),
+
+  /** Manually set or clear ``video``'s beep timestamp. ``beepTime=null``
+   *  clears back to "no beep yet"; otherwise the value (>= 0) is taken
+   *  as authoritative with ``beep_source="manual"``. Same auto-trim
+   *  chain as the legacy primary endpoint, just keyed per video. */
+  overrideBeepForVideo: (
+    stageNumber: number,
+    videoId: string,
+    beepTime: number | null,
+  ) =>
+    request<MatchProject>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep`,
+      { method: "POST", json: { beep_time: beepTime } },
+    ),
 
   /** Promote one of the ranked auto-detected candidates as authoritative.
    *  ``time`` is matched against ``primary.beep_candidates`` within 1 ms,
@@ -505,11 +544,33 @@ export const api = {
       json: { time },
     }),
 
+  /** Per-video candidate select. Same matching semantics as the primary
+   *  endpoint (1 ms epsilon) but targets the video carrying the candidate
+   *  list, so secondaries can pick from their own ranked alternatives. */
+  selectBeepCandidateForVideo: (
+    stageNumber: number,
+    videoId: string,
+    time: number,
+  ) =>
+    request<MatchProject>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/select`,
+      { method: "POST", json: { time } },
+    ),
+
   /** Submit an audit-mode short-GOP trim job. Returns a Job snapshot;
    *  idempotent on the worker side -- when the cached MP4 is fresh the
    *  job completes near-instantly without re-encoding. */
   trimStage: (stageNumber: number) =>
     request<Job>(`/api/stages/${stageNumber}/trim`, { method: "POST" }),
+
+  /** Per-video audit-mode trim. Mirrors ``trimStage`` for primaries but
+   *  targets one specific camera, so multi-cam ingest can refresh a
+   *  single secondary's scrub clip without retriggering the primary. */
+  trimVideo: (stageNumber: number, videoId: string) =>
+    request<Job>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/trim`,
+      { method: "POST" },
+    ),
 
   /** Submit a shot-detection job for the stage's audit clip. The job
    *  populates _candidates_pending_audit in the audit JSON; the audit
@@ -564,6 +625,11 @@ export const api = {
    *  default flow passes ``primary.beep_time``. */
   stageBeepPreviewUrl: (stageNumber: number, beepTime: number) =>
     `/api/stages/${stageNumber}/beep-preview?t=${beepTime.toFixed(3)}`,
+
+  /** Per-video beep preview URL. Same caching semantics as the primary
+   *  endpoint (cached on source mtime/size + center time + duration). */
+  videoBeepPreviewUrl: (stageNumber: number, videoId: string, beepTime: number) =>
+    `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep-preview?t=${beepTime.toFixed(3)}`,
 
   videoStreamUrl: (videoPath: string) =>
     `/api/videos/stream?path=${encodeURIComponent(videoPath)}`,

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -20,7 +20,6 @@ import {
   Crosshair,
   FileJson,
   FolderInput,
-  Loader2,
   PlayCircle,
   Trash2,
   Video as VideoIcon,
@@ -1199,7 +1198,7 @@ function StageCard({
             />
             <BeepSection
               stageNumber={stage.stage_number}
-              primary={primary}
+              video={primary}
               busy={busy}
               setBusy={setBusy}
               setError={setError}
@@ -1208,24 +1207,33 @@ function StageCard({
           </>
         ) : null}
         {secondaries.map((v) => (
-          <VideoRow
-            key={v.path}
-            video={v}
-            stage={stage}
-            setDragging={setDragging}
-            badge={<Badge variant="secondary">Secondary</Badge>}
-            actions={
-              <RoleActions
-                video={v}
-                stage={stage}
-                allStages={allStages}
-                busy={busy}
-                currentRole="secondary"
-                onMove={onMove}
-                onRemove={onRemove}
-              />
-            }
-          />
+          <div key={v.path} className="space-y-2">
+            <VideoRow
+              video={v}
+              stage={stage}
+              setDragging={setDragging}
+              badge={<Badge variant="secondary">Secondary</Badge>}
+              actions={
+                <RoleActions
+                  video={v}
+                  stage={stage}
+                  allStages={allStages}
+                  busy={busy}
+                  currentRole="secondary"
+                  onMove={onMove}
+                  onRemove={onRemove}
+                />
+              }
+            />
+            <BeepSection
+              stageNumber={stage.stage_number}
+              video={v}
+              busy={busy}
+              setBusy={setBusy}
+              setError={setError}
+              onProjectUpdate={onProjectUpdate}
+            />
+          </div>
         ))}
         {ignored.map((v) => (
           <VideoRow
@@ -1289,12 +1297,7 @@ function VideoRow({
             >
               <CheckCircle2 className="size-3.5" />
             </span>
-          ) : (
-            <Loader2
-              className="size-3.5 text-muted-foreground"
-              aria-label="beep detection pending"
-            />
-          )}
+          ) : null}
         </div>
         <div className="flex gap-1">{actions}</div>
       </div>

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -496,9 +496,12 @@ def _stub_detect(
     *,
     candidates: list | None = None,
 ) -> None:
-    """Replace audio_helpers.detect_primary_beep with a fast stub returning a
+    """Replace the per-video beep detector with a fast stub returning a
     deterministic BeepDetection. The endpoint is otherwise wrapped around
-    ffmpeg + librosa, which we don't want to invoke from a unit test."""
+    ffmpeg + librosa, which we don't want to invoke from a unit test.
+    Both the legacy ``detect_primary_beep`` shim and the new
+    ``detect_video_beep`` are patched so callers on either path get the
+    stubbed result."""
     from splitsmith.config import BeepCandidate, BeepDetection
     from splitsmith.ui import audio as audio_helpers
 
@@ -512,6 +515,7 @@ def _stub_detect(
         )
 
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", fake)
+    monkeypatch.setattr(audio_helpers, "detect_video_beep", fake)
 
 
 def test_detect_beep_persists_auto_result(tmp_path: Path, monkeypatch) -> None:
@@ -1574,6 +1578,7 @@ def test_detect_beep_job_records_failure_when_ffmpeg_blows_up(tmp_path: Path, mo
         raise audio_helpers.AudioExtractionError("ffmpeg fell over")
 
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
+    monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
 
     resp = client.post("/api/stages/1/detect-beep")
     assert resp.status_code == 200
@@ -2297,3 +2302,131 @@ def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     project.save(root)
 
     assert client.get("/api/project").json()["competitor_name"] == "Edited Externally"
+
+
+# Per-video beep endpoints (multi-cam ingest) -------------------------------
+
+
+def _seed_project_with_secondary(tmp_path: Path) -> tuple[TestClient, Path]:
+    """Boot a server with one stage, a primary, and a secondary assigned.
+
+    Returns ``(client, secondary_source_path)`` so the caller can mutate
+    the secondary source if needed.
+    """
+    client, _ = _seed_project_with_primary(tmp_path)
+    src_dir = tmp_path / "videos"
+    cam2 = src_dir / "CAM2.mp4"
+    cam2.write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/CAM2.mp4", "to_stage_number": 1, "role": "secondary"},
+    )
+    return client, cam2
+
+
+def _video_id_for(client: TestClient, stage_number: int, role: str) -> str:
+    """Pull the ``video_id`` for the first video matching ``role`` on a stage."""
+    proj = client.get("/api/project").json()
+    stage = next(s for s in proj["stages"] if s["stage_number"] == stage_number)
+    video = next(v for v in stage["videos"] if v["role"] == role)
+    return video["video_id"]
+
+
+def test_video_id_is_stable_and_exposed(tmp_path: Path) -> None:
+    """The computed ``video_id`` is on the wire and identical across reloads."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    proj1 = client.get("/api/project").json()
+    proj2 = client.get("/api/project").json()
+    vid1 = proj1["stages"][0]["videos"][0]["video_id"]
+    vid2 = proj2["stages"][0]["videos"][0]["video_id"]
+    assert vid1 == vid2
+    assert len(vid1) == 12  # 6-byte blake2s -> 12 hex chars
+
+
+def test_per_video_detect_beep_runs_on_secondary(tmp_path: Path, monkeypatch) -> None:
+    """The /api/stages/{n}/videos/{video_id}/detect-beep endpoint runs the
+    beep pipeline on a secondary and persists the result onto that
+    secondary -- not the primary."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=7.250)
+
+    sec_id = _video_id_for(client, 1, "secondary")
+    resp = client.post(f"/api/stages/1/videos/{sec_id}/detect-beep")
+    assert resp.status_code == 200
+    job = resp.json()
+    assert job["video_id"] == sec_id
+    final = _wait_for_job(client, job["id"])
+    assert final["status"] == "succeeded", final
+
+    proj = client.get("/api/project").json()
+    primary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "primary")
+    secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
+    assert primary["beep_time"] is None  # primary untouched
+    assert secondary["beep_time"] == pytest.approx(7.250)
+    assert secondary["beep_source"] == "auto"
+    assert secondary["processed"]["beep"] is True
+
+
+def test_per_video_detect_beep_dedupes_per_video(tmp_path: Path, monkeypatch) -> None:
+    """Two simultaneous detect-beep posts for the same video adopt one job;
+    a post for a different video on the same stage runs in parallel."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=3.0)
+
+    primary_id = _video_id_for(client, 1, "primary")
+    sec_id = _video_id_for(client, 1, "secondary")
+    j1 = client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()
+    j2 = client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()
+    j3 = client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()
+    assert j1["id"] == j2["id"]  # same video -> same job
+    assert j1["id"] != j3["id"]  # different video -> different job
+    _wait_for_job(client, j1["id"])
+    _wait_for_job(client, j3["id"])
+
+
+def test_per_video_manual_override(tmp_path: Path) -> None:
+    """The /beep override endpoint sets ``beep_source="manual"`` on the
+    targeted video and clears its diagnostic fields."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    sec_id = _video_id_for(client, 1, "secondary")
+
+    resp = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": 4.5})
+    assert resp.status_code == 200
+    proj = resp.json()
+    secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
+    assert secondary["beep_time"] == pytest.approx(4.5)
+    assert secondary["beep_source"] == "manual"
+
+    # Clear flips back to "no beep yet" and resets processed.beep
+    resp = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": None})
+    assert resp.status_code == 200
+    proj = resp.json()
+    secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
+    assert secondary["beep_time"] is None
+    assert secondary["beep_source"] is None
+    assert secondary["processed"]["beep"] is False
+
+
+def test_legacy_primary_endpoints_still_work(tmp_path: Path, monkeypatch) -> None:
+    """The pre-existing /api/stages/{n}/detect-beep endpoint forwards to
+    the per-video pipeline and operates on the stage's primary."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_detect(monkeypatch, beep_time=12.453)
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 200
+    job = resp.json()
+    primary_id = _video_id_for(client, 1, "primary")
+    assert job["video_id"] == primary_id  # forwarded to per-video pipeline
+    final = _wait_for_job(client, job["id"])
+    assert final["status"] == "succeeded", final
+
+
+def test_per_video_endpoint_404_for_unknown_video_id(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.post("/api/stages/1/videos/deadbeef0000/detect-beep")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Adds a video-id-keyed beep + trim pipeline so each camera on a stage gets its own controls and its own job slot. Closes the gap that prevented secondaries from being usable in audit (they had no way to acquire a beep).
- Secondaries auto-trim on beep arrival (short-GOP scrub clip per video). Shot detection stays primary-only -- the audit timeline anchors to the primary; secondaries align via their own beep delta.
- New endpoints under \`/api/stages/{n}/videos/{video_id}/...\` (detect-beep, beep, beep/select, trim, beep-preview). Legacy primary endpoints are thin forwarding shims through shared helpers, so existing clients and tests keep working.
- Ingest screen renders a \`BeepSection\` per video. The perpetual \"loading\" spinner on secondaries is gone -- the per-video controls now carry the status.
- \`Job.video_id\` field for per-camera dedupe so primary + Cam 2 + Cam 3 can run in parallel; JobsPanel rows include a short \`cam <id>\` suffix when targeting a specific video.

## Why

Reported in conversation: a secondary \`.MOV\` showed a perpetual loading spinner with no way to detect a beep. Root cause was server-side -- \`POST /api/stages/{n}/detect-beep\` (and \`BeepSection\`) only operated on the primary. Without per-video beep, multi-cam audit can't align frames across angles.

## Notable design choices

- **Cache filenames**: primary keeps the legacy \`stage<N>_primary.wav\` / \`stage<N>_trimmed.mp4\` so existing caches survive; non-primary cameras land at \`stage<N>_cam_<video_id>.wav\` and \`stage<N>_cam_<video_id>_trimmed.mp4\`.
- **\`StageVideo.video_id\`**: 12-char blake2s of the path, exposed as a Pydantic computed field so the SPA doesn't reimplement the hash.
- **Auto-chain**: beep -> trim for both roles; trim -> shot_detect only for primary.
- **Backward compat**: every primary-only function (detect_primary_beep, ensure_primary_audio, ensure_audit_trim, invalidate_audit_trim) keeps its name and signature; the new per-video variants delegate through them for primaries.
- **Video stream**: \`/api/videos/stream\` now serves the per-video trimmed clip for any video, not just primary, so the audit screen will scrub smoothly on Cam 2.

## Test plan

- [x] \`uv run pytest\` -- 314 tests pass (5 new tests cover stable serialized \`video_id\`, per-video detect-beep on a secondary, per-video dedupe, per-video manual override + clear, legacy primary endpoint forwarding, 404 for unknown video_id).
- [x] \`npm run build\` in \`ui_static\` -- SPA bundle builds clean.
- [x] \`uv run ruff check src/splitsmith/ui\` clean.
- [ ] Manually: assign a secondary \`.MOV\` to a stage, click Detect beep on its row, verify the beep lands on the secondary (not primary) and an audit-mode trim auto-fires.
- [ ] Manually: kick off detect-beep on primary + Cam 2 simultaneously, verify both run in parallel and show distinct rows in JobsPanel.
- [ ] Manually: open the audit screen for a stage with two synced videos and confirm Cam 2 tab activates and scrubs smoothly.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)