### PR TITLE
overlay: pre-rendered alpha MOV for FCP composite (closes #45)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"18a6de77-d077-4dc2-8ec6-8633e6625b64","pid":73266,"procStart":"Sat May  2 04:40:37 2026","acquiredAt":1777722733004}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"18a6de77-d077-4dc2-8ec6-8633e6625b64","pid":73266,"procStart":"Sat May  2 04:40:37 2026","acquiredAt":1777722733004}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tests/fixtures/.cache/
 *.peaks-*.json
 # And audit-mode trim params sidecars from splitsmith.ui.audio.
 *_trimmed.params.json
+.claude/

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -194,12 +194,8 @@ def generate_fcpxml(
     overlay_duration_str: str | None = None
     if use_overlay:
         assert overlay_path is not None  # narrowed by use_overlay
-        overlay_duration_frames = int(
-            round(overlay_meta.duration_seconds / float(frame_duration))
-        )
-        overlay_duration_str = _frame_aligned_str(
-            overlay_duration_frames, fd_num, fd_den
-        )
+        overlay_duration_frames = int(round(overlay_meta.duration_seconds / float(frame_duration)))
+        overlay_duration_str = _frame_aligned_str(overlay_duration_frames, fd_num, fd_den)
         overlay_asset = ET.SubElement(
             resources,
             "asset",

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -110,6 +110,8 @@ def generate_fcpxml(
     output_path: Path,
     project_name: str,
     config: OutputConfig,
+    overlay_path: Path | None = None,
+    overlay_video: VideoMetadata | None = None,
 ) -> None:
     """Write a minimal FCPXML 1.10 timeline for the trimmed video.
 
@@ -120,6 +122,13 @@ def generate_fcpxml(
     Each entry in ``shots`` must have ``time_from_beep`` set; shot times are
     converted to clip-local time via ``beep_offset + time_from_beep`` and
     rationalized against the source frame duration.
+
+    ``overlay_path``: optional pre-rendered alpha MOV (issue #45) to place
+    on V2 as a connected clip. When the file exists the timeline gets a
+    second asset + a lane=1 asset-clip nested in the V1 clip; when it's
+    None the FCPXML is unchanged. ``overlay_video`` is the probed metadata
+    for the overlay -- when omitted, the trimmed video's metadata is used
+    (the renderer mirrors the source frame-for-frame so this is correct).
     """
     if not video_path.exists():
         raise FileNotFoundError(f"video not found: {video_path}")
@@ -133,6 +142,8 @@ def generate_fcpxml(
 
     asset_id = "r2"
     format_id = "r1"
+    overlay_asset_id = "r3"
+    use_overlay = overlay_path is not None and overlay_path.exists()
 
     fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
 
@@ -179,6 +190,36 @@ def generate_fcpxml(
         {"kind": "original-media", "src": video_path.resolve().as_uri()},
     )
 
+    overlay_meta = overlay_video if overlay_video is not None else video
+    overlay_duration_str: str | None = None
+    if use_overlay:
+        assert overlay_path is not None  # narrowed by use_overlay
+        overlay_duration_frames = int(
+            round(overlay_meta.duration_seconds / float(frame_duration))
+        )
+        overlay_duration_str = _frame_aligned_str(
+            overlay_duration_frames, fd_num, fd_den
+        )
+        overlay_asset = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": overlay_asset_id,
+                "name": overlay_path.stem,
+                "start": "0s",
+                "duration": overlay_duration_str,
+                "hasVideo": "1",
+                "hasAudio": "0",
+                "format": format_id,
+                "videoSources": "1",
+            },
+        )
+        ET.SubElement(
+            overlay_asset,
+            "media-rep",
+            {"kind": "original-media", "src": overlay_path.resolve().as_uri()},
+        )
+
     library = ET.SubElement(fcpxml, "library")
     event = ET.SubElement(library, "event", {"name": "splitsmith"})
     project = ET.SubElement(event, "project", {"name": project_name})
@@ -211,6 +252,26 @@ def generate_fcpxml(
             "format": format_id,
         },
     )
+
+    if use_overlay and overlay_duration_str is not None:
+        # Connected clip on V2 (lane=1). FCPXML stacks lanes above 0 over
+        # the primary, so this puts the overlay on top of the trim with
+        # its own alpha. ``offset="0s"`` aligns its head to the primary's
+        # head; the renderer matches the trim duration so we don't need a
+        # nested clip for trims.
+        ET.SubElement(
+            asset_clip,
+            "asset-clip",
+            {
+                "ref": overlay_asset_id,
+                "lane": "1",
+                "offset": "0s",
+                "name": "Splitsmith overlay",
+                "start": "0s",
+                "duration": overlay_duration_str,
+                "format": format_id,
+            },
+        )
 
     fd_seconds = float(frame_duration)
     for shot in shots:

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -180,9 +180,7 @@ class DefaultTemplate(Template):
 
         if state.last_split is not None and state.last_shot_time_in_clip is not None:
             since_shot = state.time_seconds - state.last_shot_time_in_clip
-            alpha = _split_alpha(
-                since_shot, self.split_hold_seconds, self.split_fade_seconds
-            )
+            alpha = _split_alpha(since_shot, self.split_hold_seconds, self.split_fade_seconds)
             if alpha > 0:
                 split_text = f"{state.last_split:.2f}s"
                 bbox = d.textbbox((0, 0), split_text, font=self.font_big)
@@ -190,9 +188,7 @@ class DefaultTemplate(Template):
                 th = bbox[3] - bbox[1]
                 x = (self.width - tw) // 2
                 y = self.height - th - self.pad * 2
-                _draw_text_with_shadow(
-                    d, (x, y), split_text, self.font_big, (255, 220, 80, alpha)
-                )
+                _draw_text_with_shadow(d, (x, y), split_text, self.font_big, (255, 220, 80, alpha))
 
 
 def _split_alpha(since_shot: float, hold: float, fade: float) -> int:
@@ -252,9 +248,7 @@ def _draw_text_with_shadow(
     draw.text(xy, text, font=font, fill=fill)
 
 
-def _shot_times_from_audit(
-    audit_data: dict, *, beep_offset_seconds: float
-) -> list[float]:
+def _shot_times_from_audit(audit_data: dict, *, beep_offset_seconds: float) -> list[float]:
     """Convert audit JSON shots to clip-local seconds. Skips shots without
     ``ms_after_beep`` -- those aren't placed on the timer's timeline yet."""
     raw_shots = audit_data.get("shots") if isinstance(audit_data, dict) else None
@@ -303,23 +297,16 @@ def render_overlay(
     Returns the written ``output_path``.
     """
     if not audit_path.exists():
-        raise OverlayRenderError(
-            f"no audit JSON at {audit_path}; finish auditing this stage first"
-        )
+        raise OverlayRenderError(f"no audit JSON at {audit_path}; finish auditing this stage first")
     try:
         audit_data = json.loads(audit_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise OverlayRenderError(
-            f"failed to read audit JSON {audit_path}: {exc}"
-        ) from exc
+        raise OverlayRenderError(f"failed to read audit JSON {audit_path}: {exc}") from exc
 
-    shot_times = _shot_times_from_audit(
-        audit_data, beep_offset_seconds=beep_offset_seconds
-    )
+    shot_times = _shot_times_from_audit(audit_data, beep_offset_seconds=beep_offset_seconds)
     if not shot_times:
         raise OverlayRenderError(
-            f"audit JSON {audit_path} has no shots with ms_after_beep set; "
-            "nothing to render"
+            f"audit JSON {audit_path} has no shots with ms_after_beep set; " "nothing to render"
         )
 
     if probe is None:
@@ -386,17 +373,11 @@ def render_overlay(
     except (BrokenPipeError, OSError) as exc:
         proc.kill()
         proc.wait()
-        stderr = (
-            proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
-        )
-        raise OverlayRenderError(
-            f"ffmpeg failed during render: {stderr or exc}"
-        ) from exc
+        stderr = proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
+        raise OverlayRenderError(f"ffmpeg failed during render: {stderr or exc}") from exc
 
     rc = proc.wait()
     if rc != 0:
-        stderr = (
-            proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
-        )
+        stderr = proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
         raise OverlayRenderError(f"ffmpeg exited with {rc}: {stderr}")
     return output_path

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -1,0 +1,402 @@
+"""Pre-rendered overlay MOV (alpha) for FCP composite (issue #45).
+
+Generates a transparent video per stage that drops onto the trimmed clip in
+FCP as a connected clip on V2. The overlay matches the trim frame-for-frame:
+same fps, resolution and duration; ProRes 4444 with an alpha channel.
+
+Pipeline:
+1. Probe the trimmed clip with ffprobe -- never trust user config; the
+   overlay must mirror the source or it will drift off the timeline.
+2. Build per-frame state from the audit JSON (which shots have fired by
+   time t, the most recent split, the running total since the beep).
+3. PIL renders each RGBA frame.
+4. Pipe raw RGBA bytes to ``ffmpeg -f rawvideo ... -c:v prores_ks
+   -profile:v 4444 -pix_fmt yuva444p10le`` writing the final MOV.
+
+A :class:`Template` ABC keeps the v1 layout pluggable: a future second
+template is a subclass with its own ``draw_frame``, not a rewrite of the
+renderer. v1 ships exactly one template -- :class:`DefaultTemplate`.
+
+The renderer is pure of detection: the audit JSON is the source of truth.
+Stages without a completed audit cannot render an overlay -- callers MUST
+gate on that before invoking :func:`render_overlay`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from .config import VideoMetadata
+from .fcpxml_gen import probe_video
+
+
+@dataclass(frozen=True)
+class FrameState:
+    """Per-frame overlay state derived from the audit JSON.
+
+    All times are seconds in the trimmed clip's local timeline (i.e., from
+    the clip's t=0). ``beep_time_in_clip`` is where the start beep lives in
+    the same timeline -- typically equal to the trim's pre-buffer.
+    """
+
+    time_seconds: float
+    beep_time_in_clip: float
+    shot_count: int  # M -- total kept shots in the stage
+    shots_fired: int  # N -- how many shots have been fired by ``time_seconds``
+    last_split: float | None  # split of the most-recently-fired shot
+    last_shot_time_in_clip: float | None  # for fade timing on the last-split label
+    running_total: float  # max(0, time_seconds - beep_time_in_clip)
+
+
+class OverlayRenderError(RuntimeError):
+    """Raised when the audit JSON is missing / malformed, when ffmpeg
+    blows up, or when the trimmed clip can't be probed."""
+
+
+class Template(ABC):
+    """Pluggable overlay layout.
+
+    Subclasses mutate the supplied RGBA canvas in place to draw the overlay
+    for one frame's :class:`FrameState`. v1 ships :class:`DefaultTemplate`;
+    a second template lands as a subclass without touching the renderer.
+    """
+
+    @abstractmethod
+    def draw_frame(self, canvas: Image.Image, state: FrameState) -> None:
+        """Render one frame onto ``canvas`` (mode ``RGBA``)."""
+
+
+def build_frame_states(
+    *,
+    shot_times_in_clip: list[float],
+    beep_time_in_clip: float,
+    fps: float,
+    duration_seconds: float,
+) -> list[FrameState]:
+    """Pre-compute every frame's state. Pure -- no I/O.
+
+    The result has exactly ``round(duration_seconds * fps)`` entries; entry
+    ``i`` describes the frame at ``i / fps``. ``shot_times_in_clip`` is
+    sorted before scanning so out-of-order audit JSONs don't bleed shots
+    into the wrong frames.
+    """
+    n_frames = max(0, int(round(duration_seconds * fps)))
+    shots_sorted = sorted(shot_times_in_clip)
+    shot_count = len(shots_sorted)
+    states: list[FrameState] = []
+    cursor = 0  # index of the first shot whose time > current frame time
+    for i in range(n_frames):
+        t = i / fps
+        while cursor < shot_count and shots_sorted[cursor] <= t:
+            cursor += 1
+        fired = cursor
+        if fired == 0:
+            last_shot = None
+            last_split: float | None = None
+        else:
+            last_shot = shots_sorted[fired - 1]
+            if fired == 1:
+                # Shot 1's "split" is the draw -- its time from the beep.
+                last_split = shots_sorted[0] - beep_time_in_clip
+            else:
+                last_split = shots_sorted[fired - 1] - shots_sorted[fired - 2]
+        running_total = max(0.0, t - beep_time_in_clip)
+        states.append(
+            FrameState(
+                time_seconds=t,
+                beep_time_in_clip=beep_time_in_clip,
+                shot_count=shot_count,
+                shots_fired=fired,
+                last_split=last_split,
+                last_shot_time_in_clip=last_shot,
+                running_total=running_total,
+            )
+        )
+    return states
+
+
+class DefaultTemplate(Template):
+    """v1 layout. Three pieces:
+
+    - Top-left: ``N/M`` (current of total kept shots).
+    - Top-right: running total elapsed since the beep. Holds at ``00.00``
+      pre-beep; ticks up after.
+    - Bottom-center: most recent split, held at full alpha for
+      ``split_hold_seconds`` after each shot, then fades over
+      ``split_fade_seconds``.
+
+    Sizes scale to the source resolution so 1080p / 2K / 4K all look
+    reasonable without re-tuning. Numerals use a monospaced TTF when one
+    can be located; otherwise PIL's default bitmap font, which is ugly
+    but always available (CI / minimal Linux).
+    """
+
+    def __init__(
+        self,
+        *,
+        width: int,
+        height: int,
+        font_path: Path | None = None,
+        split_hold_seconds: float = 1.0,
+        split_fade_seconds: float = 0.3,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.split_hold_seconds = split_hold_seconds
+        self.split_fade_seconds = split_fade_seconds
+        big = max(48, height // 14)
+        try:
+            self.font_big = _load_font(font_path, big)
+        except OSError as exc:
+            raise OverlayRenderError(f"failed to load font: {exc}") from exc
+        self.pad = max(24, height // 36)
+
+    def draw_frame(self, canvas: Image.Image, state: FrameState) -> None:
+        d = ImageDraw.Draw(canvas)
+
+        if state.shot_count > 0:
+            shot_text = f"{state.shots_fired}/{state.shot_count}"
+            _draw_text_with_shadow(
+                d, (self.pad, self.pad), shot_text, self.font_big, (255, 255, 255, 255)
+            )
+
+        total_text = _format_running_total(state.running_total)
+        bbox = d.textbbox((0, 0), total_text, font=self.font_big)
+        tw = bbox[2] - bbox[0]
+        _draw_text_with_shadow(
+            d,
+            (self.width - tw - self.pad, self.pad),
+            total_text,
+            self.font_big,
+            (255, 255, 255, 255),
+        )
+
+        if state.last_split is not None and state.last_shot_time_in_clip is not None:
+            since_shot = state.time_seconds - state.last_shot_time_in_clip
+            alpha = _split_alpha(
+                since_shot, self.split_hold_seconds, self.split_fade_seconds
+            )
+            if alpha > 0:
+                split_text = f"{state.last_split:.2f}s"
+                bbox = d.textbbox((0, 0), split_text, font=self.font_big)
+                tw = bbox[2] - bbox[0]
+                th = bbox[3] - bbox[1]
+                x = (self.width - tw) // 2
+                y = self.height - th - self.pad * 2
+                _draw_text_with_shadow(
+                    d, (x, y), split_text, self.font_big, (255, 220, 80, alpha)
+                )
+
+
+def _split_alpha(since_shot: float, hold: float, fade: float) -> int:
+    """0..255 alpha for the "last split" label given seconds-since-shot."""
+    if since_shot < 0:
+        return 0
+    if since_shot <= hold:
+        return 255
+    if fade <= 0 or since_shot >= hold + fade:
+        return 0
+    t = (since_shot - hold) / fade
+    return int(round(255 * (1.0 - t)))
+
+
+def _format_running_total(seconds: float) -> str:
+    """``SS.SS`` under a minute; ``M:SS.SS`` past it. Width-stable so the
+    overlay doesn't jitter from frame to frame."""
+    if seconds < 60:
+        return f"{seconds:5.2f}"
+    m = int(seconds // 60)
+    s = seconds - m * 60
+    return f"{m:d}:{s:05.2f}"
+
+
+_FONT_FALLBACKS: tuple[str, ...] = (
+    "/System/Library/Fonts/Menlo.ttc",
+    "/System/Library/Fonts/Monaco.ttf",
+    "/Library/Fonts/Andale Mono.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+)
+
+
+def _load_font(font_path: Path | None, size: int) -> ImageFont.ImageFont:
+    if font_path is not None:
+        return ImageFont.truetype(str(font_path), size=size)
+    for candidate in _FONT_FALLBACKS:
+        p = Path(candidate)
+        if p.exists():
+            return ImageFont.truetype(str(p), size=size)
+    return ImageFont.load_default()
+
+
+def _draw_text_with_shadow(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int],
+    text: str,
+    font: ImageFont.ImageFont,
+    fill: tuple[int, int, int, int],
+) -> None:
+    """1-px black shadow under coloured text so the overlay stays legible
+    over bright backgrounds. The shadow's alpha tracks the foreground so
+    fades stay clean."""
+    x, y = xy
+    shadow_alpha = max(0, fill[3] - 64)
+    draw.text((x + 2, y + 2), text, font=font, fill=(0, 0, 0, shadow_alpha))
+    draw.text(xy, text, font=font, fill=fill)
+
+
+def _shot_times_from_audit(
+    audit_data: dict, *, beep_offset_seconds: float
+) -> list[float]:
+    """Convert audit JSON shots to clip-local seconds. Skips shots without
+    ``ms_after_beep`` -- those aren't placed on the timer's timeline yet."""
+    raw_shots = audit_data.get("shots") if isinstance(audit_data, dict) else None
+    out: list[float] = []
+    if not isinstance(raw_shots, list):
+        return out
+    for raw in raw_shots:
+        if not isinstance(raw, dict):
+            continue
+        ms = raw.get("ms_after_beep")
+        if ms is None:
+            continue
+        try:
+            out.append(beep_offset_seconds + float(ms) / 1000.0)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def render_overlay(
+    *,
+    audit_path: Path,
+    trimmed_video_path: Path,
+    output_path: Path,
+    beep_offset_seconds: float,
+    template: Template | None = None,
+    ffmpeg_binary: str = "ffmpeg",
+    probe: VideoMetadata | None = None,
+) -> Path:
+    """Render an alpha overlay MOV alongside a trimmed clip.
+
+    ``audit_path``: ``stage<N>.json`` with the user's audited ``shots[]``.
+        This is the source of truth -- raw detector output is not allowed
+        to render anywhere.
+    ``trimmed_video_path``: the lossless trim that the FCP timeline
+        references. Probed for fps / width / height / duration so the
+        overlay matches frame-for-frame.
+    ``beep_offset_seconds``: where the beep lives in the trimmed clip.
+        Audit ``ms_after_beep`` is converted to clip-local time as
+        ``beep_offset + ms_after_beep / 1000``.
+    ``template``: defaults to :class:`DefaultTemplate` sized to the probe.
+    ``probe``: optional pre-computed metadata. When given, ``ffprobe`` is
+        skipped -- useful from tests and to share one probe across the
+        export's other steps.
+
+    Returns the written ``output_path``.
+    """
+    if not audit_path.exists():
+        raise OverlayRenderError(
+            f"no audit JSON at {audit_path}; finish auditing this stage first"
+        )
+    try:
+        audit_data = json.loads(audit_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OverlayRenderError(
+            f"failed to read audit JSON {audit_path}: {exc}"
+        ) from exc
+
+    shot_times = _shot_times_from_audit(
+        audit_data, beep_offset_seconds=beep_offset_seconds
+    )
+    if not shot_times:
+        raise OverlayRenderError(
+            f"audit JSON {audit_path} has no shots with ms_after_beep set; "
+            "nothing to render"
+        )
+
+    if probe is None:
+        probe = probe_video(trimmed_video_path)
+    width = probe.width
+    height = probe.height
+    fps = probe.frame_rate_num / probe.frame_rate_den
+    duration_seconds = probe.duration_seconds
+
+    if template is None:
+        template = DefaultTemplate(width=width, height=height)
+
+    states = build_frame_states(
+        shot_times_in_clip=shot_times,
+        beep_time_in_clip=beep_offset_seconds,
+        fps=fps,
+        duration_seconds=duration_seconds,
+    )
+
+    if shutil.which(ffmpeg_binary) is None:
+        raise OverlayRenderError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rate = f"{probe.frame_rate_num}/{probe.frame_rate_den}"
+    cmd = [
+        ffmpeg_binary,
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgba",
+        "-s",
+        f"{width}x{height}",
+        "-r",
+        rate,
+        "-i",
+        "-",
+        "-c:v",
+        "prores_ks",
+        "-profile:v",
+        "4444",
+        "-pix_fmt",
+        "yuva444p10le",
+        "-r",
+        rate,
+        str(output_path),
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stdin is not None
+    try:
+        for state in states:
+            canvas = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+            template.draw_frame(canvas, state)
+            proc.stdin.write(canvas.tobytes())
+        proc.stdin.close()
+    except (BrokenPipeError, OSError) as exc:
+        proc.kill()
+        proc.wait()
+        stderr = (
+            proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
+        )
+        raise OverlayRenderError(
+            f"ffmpeg failed during render: {stderr or exc}"
+        ) from exc
+
+    rc = proc.wait()
+    if rc != 0:
+        stderr = (
+            proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
+        )
+        raise OverlayRenderError(f"ffmpeg exited with {rc}: {stderr}")
+    return output_path

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .. import csv_gen, fcpxml_gen, report, trim
+from .. import csv_gen, fcpxml_gen, overlay_render, report, trim
 from ..config import Config, ReportFiles, Shot, StageAnalysis, StageData
 
 
@@ -40,6 +40,7 @@ class StageExportRequest:
     write_csv: bool = True
     write_fcpxml: bool = True
     write_report: bool = True
+    write_overlay: bool = False
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,7 @@ class StageExportResult:
     csv_path: Path | None
     fcpxml_path: Path | None
     report_path: Path | None
+    overlay_path: Path | None
     shots_written: int
     anomalies: list[str]
 
@@ -252,6 +254,54 @@ def export_stage(
         csv_path = exports_dir / f"{base}_splits.csv"
         csv_gen.write_splits_csv(shots, csv_path)
 
+    # Overlay render (issue #45). Gated on having a trimmed clip to mirror;
+    # the overlay must match the trim frame-for-frame or it will drift on
+    # the FCP timeline. ``write_overlay`` defaults False so existing flows
+    # (and CSV-only re-runs without a source) don't pay the cost.
+    overlay_path: Path | None = None
+    fcp_overlay_path: Path | None = None
+    overlay_target = exports_dir / f"{base}_overlay.mov"
+    if request.write_overlay:
+        # Resolve the trim we'll mirror: prefer the one we just wrote, then
+        # a stale lossless trim from a prior run. If none exists -- e.g.
+        # source unreachable AND no prior trim -- skip with a clear reason.
+        mirror_target: Path | None = None
+        if trimmed_path is not None and trimmed_path.exists():
+            mirror_target = trimmed_path
+        elif (exports_dir / f"{base}_trimmed.mp4").exists():
+            mirror_target = exports_dir / f"{base}_trimmed.mp4"
+
+        if mirror_target is None:
+            if missing_msg:
+                skip_reasons.append(f"overlay not written: {missing_msg}")
+            else:
+                skip_reasons.append(
+                    "overlay not written: no lossless trim in exports/. "
+                    "Re-run Generate with the Trim toggle enabled."
+                )
+        else:
+            try:
+                overlay_render.render_overlay(
+                    audit_path=audit_path,
+                    trimmed_video_path=mirror_target,
+                    output_path=overlay_target,
+                    beep_offset_seconds=pre_buffer_seconds,
+                )
+                overlay_path = overlay_target
+            except (overlay_render.OverlayRenderError, OSError) as exc:
+                skip_reasons.append(f"overlay not written: {exc}")
+                overlay_path = None
+                if overlay_target.exists():
+                    # Stale render from a prior run; still surface so the
+                    # FCPXML can reference it.
+                    overlay_path = overlay_target
+
+    # Whether or not the overlay was just rendered, an existing
+    # ``<base>_overlay.mov`` should be referenced from the FCPXML so the
+    # same XML works regardless of which render produced it.
+    if overlay_target.exists():
+        fcp_overlay_path = overlay_target
+
     fcpxml_path: Path | None = None
     if request.write_fcpxml:
         # FCPXML needs a video to reference. Prefer the lossless trim we
@@ -291,6 +341,7 @@ def export_stage(
                     output_path=fcpxml_path,
                     project_name=base,
                     config=config.output,
+                    overlay_path=fcp_overlay_path,
                 )
             except (fcpxml_gen.FFprobeError, OSError) as exc:
                 skip_reasons.append(f"fcpxml not written: {exc}")
@@ -330,6 +381,7 @@ def export_stage(
         csv_path=csv_path,
         fcpxml_path=fcpxml_path,
         report_path=report_path,
+        overlay_path=overlay_path if overlay_path is not None and overlay_path.exists() else None,
         shots_written=len(shots),
         anomalies=anomalies,
     )

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -201,6 +201,11 @@ class StageExportStatus(BaseModel):
     csv_path: Path | None
     fcpxml_path: Path | None
     report_path: Path | None
+    # Pre-rendered alpha overlay MOV (issue #45). ``None`` until the user
+    # ticks the Overlay toggle on Generate at least once for this stage.
+    # The FCPXML references this file as a connected clip on V2 when it
+    # exists; absent, the FCPXML is unchanged.
+    overlay_path: Path | None = None
     has_exports: bool
     last_export_at: datetime | None
     ready_to_export: bool
@@ -433,6 +438,7 @@ class MatchProject(BaseModel):
             csv_p = exports_dir / f"{base}_splits.csv"
             fcpxml_p = exports_dir / f"{base}.fcpxml"
             report_p = exports_dir / f"{base}_report.txt"
+            overlay_p = exports_dir / f"{base}_overlay.mov"
             # The "trimmed video" surfaced to the Export screen is the
             # lossless trim in exports/ (the FCP-bound deliverable), not
             # the audit-mode short-GOP scrub copy in <project>/trimmed/.
@@ -450,12 +456,15 @@ class MatchProject(BaseModel):
             fcpxml_exists = fcpxml_p.exists()
             report_exists = report_p.exists()
             trim_exists = lossless_trim_p.exists()
-            has_exports = csv_exists or fcpxml_exists or report_exists or trim_exists
+            overlay_exists = overlay_p.exists()
+            has_exports = (
+                csv_exists or fcpxml_exists or report_exists or trim_exists or overlay_exists
+            )
             last_export_at: datetime | None = None
             if has_exports:
                 mtimes = [
                     p.stat().st_mtime
-                    for p in (csv_p, fcpxml_p, report_p, lossless_trim_p)
+                    for p in (csv_p, fcpxml_p, report_p, lossless_trim_p, overlay_p)
                     if p.exists()
                 ]
                 if mtimes:
@@ -495,6 +504,7 @@ class MatchProject(BaseModel):
                     csv_path=csv_p if csv_exists else None,
                     fcpxml_path=fcpxml_p if fcpxml_exists else None,
                     report_path=report_p if report_exists else None,
+                    overlay_path=overlay_p if overlay_exists else None,
                     lossless_trim_present=trim_exists,
                     has_exports=has_exports,
                     last_export_at=last_export_at,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -381,6 +381,11 @@ class ExportStageRequest(BaseModel):
     write_csv: bool = True
     write_fcpxml: bool = True
     write_report: bool = True
+    # Pre-rendered alpha overlay MOV (issue #45). Defaults False because
+    # the render is per-frame PIL + ffmpeg ProRes 4444 -- non-trivially
+    # slower than the other writers. The Analysis & Export checkbox
+    # opts-in per stage.
+    write_overlay: bool = False
 
 
 class RevealRequest(BaseModel):
@@ -2175,6 +2180,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                     write_csv=req.write_csv,
                     write_fcpxml=req.write_fcpxml,
                     write_report=req.write_report,
+                    write_overlay=req.write_overlay,
                 ),
                 audit_path=audit_file,
                 exports_dir=exports_dir,
@@ -2207,6 +2213,8 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             bits.append("fcpxml")
         if result.report_path is not None:
             bits.append("report")
+        if result.overlay_path is not None:
+            bits.append("overlay")
         summary = ", ".join(bits) if bits else "nothing written"
         if result.anomalies:
             n = len(result.anomalies)

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -189,6 +189,10 @@ export interface StageExportStatus {
   csv_path: string | null;
   fcpxml_path: string | null;
   report_path: string | null;
+  /** Pre-rendered alpha overlay MOV (issue #45). ``null`` until the user
+   *  opts in via the Overlay toggle on Generate. When present, the FCPXML
+   *  references it as a connected clip on V2. */
+  overlay_path: string | null;
   has_exports: boolean;
   last_export_at: string | null;
   ready_to_export: boolean;
@@ -204,6 +208,9 @@ export interface ExportStageRequestPayload {
   write_csv?: boolean;
   write_fcpxml?: boolean;
   write_report?: boolean;
+  /** Render the per-frame PIL + ffmpeg overlay MOV (issue #45). Defaults
+   *  off because it's the slowest writer; opt in per stage. */
+  write_overlay?: boolean;
 }
 
 export interface ExportStageResult {
@@ -212,6 +219,7 @@ export interface ExportStageResult {
   csv_path: string | null;
   fcpxml_path: string | null;
   report_path: string | null;
+  overlay_path: string | null;
   shots_written: number;
   anomalies: string[];
 }
@@ -672,6 +680,7 @@ export const api = {
         write_csv: opts.write_csv ?? true,
         write_fcpxml: opts.write_fcpxml ?? true,
         write_report: opts.write_report ?? true,
+        write_overlay: opts.write_overlay ?? false,
       },
     }),
 

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -252,6 +252,9 @@ function StageActions({
   const [csv, setCsv] = useState(true);
   const [fcpxml, setFcpxml] = useState(true);
   const [reportFlag, setReportFlag] = useState(true);
+  // Overlay (issue #45) defaults off: render is slower than the other
+  // writers and most users only want it once per stage.
+  const [overlay, setOverlay] = useState(false);
   const [job, setJob] = useState<Job | null>(null);
 
   const sourceUnreachable = row.has_primary && row.source_reachable === false;
@@ -299,6 +302,7 @@ function StageActions({
         write_csv: csv,
         write_fcpxml: fcpxml,
         write_report: reportFlag,
+        write_overlay: overlay,
       });
       setJob(submitted);
       const final = await api.pollJob(submitted.id, setJob);
@@ -398,13 +402,31 @@ function StageActions({
           />
           Report
         </label>
+        <label
+          className="flex items-center gap-1.5"
+          title={
+            row.audit_shot_count > 0
+              ? "Pre-render an alpha overlay MOV (N/M, last split, " +
+                "running total) and reference it from the FCPXML on V2"
+              : "Finish the audit first -- overlay needs at least one shot"
+          }
+        >
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={overlay}
+            disabled={busy || row.audit_shot_count === 0}
+            onChange={(e) => setOverlay(e.target.checked)}
+          />
+          Overlay (alpha MOV)
+        </label>
         <Button
           size="sm"
           onClick={generate}
           disabled={
             busy ||
             !row.ready_to_export ||
-            (!trim && !csv && !fcpxml && !reportFlag)
+            (!trim && !csv && !fcpxml && !reportFlag && !overlay)
           }
           title={
             row.ready_to_export
@@ -464,6 +486,7 @@ function FileLinks({
     { label: "Splits CSV", path: row.csv_path },
     { label: "FCPXML", path: row.fcpxml_path },
     { label: "Report", path: row.report_path },
+    { label: "Overlay (alpha MOV)", path: row.overlay_path },
   ];
   return (
     <div className="space-y-1 text-xs">

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -279,6 +279,86 @@ def test_tag_source_application_tolerates_missing_xattr_binary(
     assert out.exists()
 
 
+def test_generate_fcpxml_omits_overlay_clip_when_path_is_none(tmp_path: Path) -> None:
+    """No ``overlay_path`` -> the FCPXML must be byte-identical to the
+    no-overlay v1 output: one asset, no lane-1 connected clip."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    assert len(assets) == 1
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert nested == []
+
+
+def test_generate_fcpxml_omits_overlay_clip_when_file_missing(tmp_path: Path) -> None:
+    """Pointed at a non-existent overlay path -> still no V2 connected clip.
+    Exercise: the FCPXML can be re-generated unconditionally and only sprouts
+    the overlay when the .mov is actually on disk."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        overlay_path=tmp_path / "missing_overlay.mov",
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    assert len(assets) == 1
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert nested == []
+
+
+def test_generate_fcpxml_inserts_overlay_as_lane_1_connected_clip(tmp_path: Path) -> None:
+    """Overlay file present -> a second asset is registered and a lane=1
+    connected ``asset-clip`` lives inside the V1 spine clip on V2."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    overlay = tmp_path / "v_overlay.mov"
+    overlay.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        overlay_path=overlay,
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    assert len(assets) == 2
+    overlay_asset = assets[1]
+    assert overlay_asset.attrib["hasAudio"] == "0"
+    media = overlay_asset.find("media-rep")
+    assert media is not None and media.attrib["src"].endswith("v_overlay.mov")
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert len(nested) == 1
+    overlay_clip = nested[0]
+    assert overlay_clip.attrib["lane"] == "1"
+    assert overlay_clip.attrib["offset"] == "0s"
+    # Same duration as the primary so FCP doesn't truncate the overlay.
+    assert overlay_clip.attrib["duration"] == "600/30s"  # 20s @ 30fps
+
+
 def test_generate_fcpxml_raises_on_missing_video(tmp_path: Path) -> None:
     out = tmp_path / "v.fcpxml"
     with pytest.raises(FileNotFoundError):

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -1,0 +1,359 @@
+"""Tests for overlay_render (issue #45).
+
+Pure unit tests on frame-state derivation and template rendering. The
+ffmpeg pipe path is exercised via a mocked Popen so CI doesn't need
+prores_ks support; an integration test skipped without ffmpeg covers the
+real binary in development.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from splitsmith import overlay_render
+from splitsmith.config import VideoMetadata
+
+
+def _meta_30fps(duration: float = 2.0) -> VideoMetadata:
+    return VideoMetadata(
+        width=320,
+        height=180,
+        duration_seconds=duration,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+# --- build_frame_states -----------------------------------------------------
+
+
+def test_build_frame_states_count_matches_duration_times_fps() -> None:
+    states = overlay_render.build_frame_states(
+        shot_times_in_clip=[],
+        beep_time_in_clip=0.5,
+        fps=30.0,
+        duration_seconds=2.0,
+    )
+    assert len(states) == 60
+    assert states[0].time_seconds == pytest.approx(0.0)
+    assert states[-1].time_seconds == pytest.approx(59 / 30.0)
+
+
+def test_build_frame_states_running_total_clamps_pre_beep() -> None:
+    states = overlay_render.build_frame_states(
+        shot_times_in_clip=[],
+        beep_time_in_clip=1.0,
+        fps=30.0,
+        duration_seconds=2.0,
+    )
+    # Frames before t=1.0 must hold at 0.
+    assert states[0].running_total == pytest.approx(0.0)
+    assert states[15].running_total == pytest.approx(0.0)
+    # Frame at t=1.0 starts ticking.
+    assert states[30].running_total == pytest.approx(0.0)
+    # Frame at t > 1.0 is positive.
+    assert states[45].running_total == pytest.approx(45 / 30.0 - 1.0)
+
+
+def test_build_frame_states_advances_shots_fired() -> None:
+    # Two shots at clip-local 1.0 and 1.5 (with beep at 0.5).
+    states = overlay_render.build_frame_states(
+        shot_times_in_clip=[1.0, 1.5],
+        beep_time_in_clip=0.5,
+        fps=30.0,
+        duration_seconds=2.0,
+    )
+    # Pre-shot frame (t=0.5): no shots fired.
+    assert states[15].shots_fired == 0
+    assert states[15].last_split is None
+    # Frame at t=1.0: 1 shot fired; split is the draw == 1.0 - 0.5 = 0.5.
+    assert states[30].shots_fired == 1
+    assert states[30].last_split == pytest.approx(0.5)
+    # Frame at t=1.5: 2 shots fired; split is 0.5.
+    assert states[45].shots_fired == 2
+    assert states[45].last_split == pytest.approx(0.5)
+
+
+def test_build_frame_states_sorts_unsorted_input() -> None:
+    states = overlay_render.build_frame_states(
+        shot_times_in_clip=[1.5, 1.0],
+        beep_time_in_clip=0.5,
+        fps=30.0,
+        duration_seconds=2.0,
+    )
+    # Same as the sorted case above -- the renderer mustn't bleed shots
+    # into the wrong frames just because the JSON wrote them out of order.
+    assert states[30].shots_fired == 1
+    assert states[30].last_split == pytest.approx(0.5)
+
+
+# --- _split_alpha -----------------------------------------------------------
+
+
+def test_split_alpha_holds_then_fades_then_zero() -> None:
+    # 1.0s hold, 0.5s fade.
+    assert overlay_render._split_alpha(0.0, 1.0, 0.5) == 255
+    assert overlay_render._split_alpha(0.5, 1.0, 0.5) == 255
+    assert overlay_render._split_alpha(1.0, 1.0, 0.5) == 255
+    # Mid-fade.
+    mid = overlay_render._split_alpha(1.25, 1.0, 0.5)
+    assert 100 < mid < 200
+    # End of fade.
+    assert overlay_render._split_alpha(1.5, 1.0, 0.5) == 0
+    assert overlay_render._split_alpha(2.0, 1.0, 0.5) == 0
+    # Pre-shot (negative since_shot can happen at frame boundary).
+    assert overlay_render._split_alpha(-0.1, 1.0, 0.5) == 0
+
+
+# --- DefaultTemplate --------------------------------------------------------
+
+
+def test_default_template_draws_n_over_m_and_running_total() -> None:
+    tmpl = overlay_render.DefaultTemplate(width=320, height=180)
+    canvas = Image.new("RGBA", (320, 180), (0, 0, 0, 0))
+    state = overlay_render.FrameState(
+        time_seconds=2.0,
+        beep_time_in_clip=0.5,
+        shot_count=5,
+        shots_fired=2,
+        last_split=0.21,
+        last_shot_time_in_clip=1.5,
+        running_total=1.5,
+    )
+    tmpl.draw_frame(canvas, state)
+    # The template wrote SOMETHING -- at least one pixel is non-transparent.
+    assert canvas.getextrema()[3][1] > 0  # alpha channel max > 0
+
+
+def test_default_template_skips_split_after_fade() -> None:
+    """Long after the last shot, the split label fades to zero. The N/M
+    and total are still drawn, but the split region is empty."""
+    tmpl = overlay_render.DefaultTemplate(width=320, height=180)
+    canvas_after = Image.new("RGBA", (320, 180), (0, 0, 0, 0))
+    state_after = overlay_render.FrameState(
+        time_seconds=10.0,
+        beep_time_in_clip=0.5,
+        shot_count=2,
+        shots_fired=2,
+        last_split=0.21,
+        last_shot_time_in_clip=1.5,  # 8.5s ago -> well past fade
+        running_total=9.5,
+    )
+    tmpl.draw_frame(canvas_after, state_after)
+    # Bottom strip (where the split label lives) must be fully transparent.
+    bottom = canvas_after.crop((0, 140, 320, 180))
+    assert bottom.getextrema()[3][1] == 0
+
+
+# --- format helpers ---------------------------------------------------------
+
+
+def test_format_running_total_under_minute() -> None:
+    assert overlay_render._format_running_total(0.0).strip() == "0.00"
+    assert overlay_render._format_running_total(7.42).strip() == "7.42"
+
+
+def test_format_running_total_over_minute() -> None:
+    assert overlay_render._format_running_total(75.5) == "1:15.50"
+
+
+# --- render_overlay error paths ---------------------------------------------
+
+
+def test_render_overlay_raises_when_audit_missing(tmp_path: Path) -> None:
+    with pytest.raises(overlay_render.OverlayRenderError):
+        overlay_render.render_overlay(
+            audit_path=tmp_path / "missing.json",
+            trimmed_video_path=tmp_path / "trim.mp4",
+            output_path=tmp_path / "overlay.mov",
+            beep_offset_seconds=5.0,
+        )
+
+
+def test_render_overlay_raises_when_no_shots(tmp_path: Path) -> None:
+    audit = tmp_path / "stage1.json"
+    audit.write_text(json.dumps({"shots": []}), encoding="utf-8")
+    with pytest.raises(overlay_render.OverlayRenderError):
+        overlay_render.render_overlay(
+            audit_path=audit,
+            trimmed_video_path=tmp_path / "trim.mp4",
+            output_path=tmp_path / "overlay.mov",
+            beep_offset_seconds=5.0,
+        )
+
+
+def test_render_overlay_pipes_rgba_frames_and_writes_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke: with a stub Popen we capture how many bytes get piped and
+    confirm the output path comes back. Frame count = round(fps * dur)."""
+    audit = tmp_path / "stage1.json"
+    audit.write_text(
+        json.dumps(
+            {
+                "shots": [
+                    {"shot_number": 1, "ms_after_beep": 200},
+                    {"shot_number": 2, "ms_after_beep": 500},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "overlay.mov"
+
+    captured: dict[str, Any] = {"bytes": 0, "cmd": None}
+
+    class StubStdin:
+        def write(self, data: bytes) -> int:
+            captured["bytes"] += len(data)
+            return len(data)
+
+        def close(self) -> None:
+            return None
+
+    class StubStderr:
+        def read(self) -> bytes:
+            return b""
+
+    class StubProc:
+        def __init__(self, *, stdin: Any, stderr: Any) -> None:
+            self.stdin = stdin
+            self.stderr = stderr
+
+        def wait(self) -> int:
+            output.write_bytes(b"")
+            return 0
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd: list[str], **_: Any) -> StubProc:
+        captured["cmd"] = cmd
+        return StubProc(stdin=StubStdin(), stderr=StubStderr())
+
+    monkeypatch.setattr(overlay_render.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(overlay_render.shutil, "which", lambda _b: "/bin/ffmpeg")
+
+    result = overlay_render.render_overlay(
+        audit_path=audit,
+        trimmed_video_path=tmp_path / "trim.mp4",
+        output_path=output,
+        beep_offset_seconds=0.0,
+        probe=_meta_30fps(duration=1.0),  # 30 frames
+    )
+
+    assert result == output
+    # 30 frames * 320 * 180 * 4 bytes = 6_912_000.
+    assert captured["bytes"] == 30 * 320 * 180 * 4
+    cmd = captured["cmd"]
+    assert "rawvideo" in cmd
+    assert "rgba" in cmd
+    assert "prores_ks" in cmd
+    assert "yuva444p10le" in cmd
+    # Frame rate is mirrored as a rational so 29.97 doesn't drift.
+    assert "30/1" in cmd
+
+
+def test_render_overlay_raises_when_ffmpeg_returns_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audit = tmp_path / "stage1.json"
+    audit.write_text(
+        json.dumps({"shots": [{"shot_number": 1, "ms_after_beep": 100}]}),
+        encoding="utf-8",
+    )
+
+    class StubStdin:
+        def write(self, data: bytes) -> int:
+            return len(data)
+
+        def close(self) -> None:
+            return None
+
+    class StubStderr:
+        def read(self) -> bytes:
+            return b"prores_ks: encoder not found"
+
+    class StubProc:
+        def __init__(self, **_: Any) -> None:
+            self.stdin = StubStdin()
+            self.stderr = StubStderr()
+
+        def wait(self) -> int:
+            return 1
+
+        def kill(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        overlay_render.subprocess, "Popen", lambda cmd, **_: StubProc()
+    )
+    monkeypatch.setattr(overlay_render.shutil, "which", lambda _b: "/bin/ffmpeg")
+
+    with pytest.raises(overlay_render.OverlayRenderError, match="prores_ks"):
+        overlay_render.render_overlay(
+            audit_path=audit,
+            trimmed_video_path=tmp_path / "trim.mp4",
+            output_path=tmp_path / "overlay.mov",
+            beep_offset_seconds=0.0,
+            probe=_meta_30fps(duration=0.1),
+        )
+
+
+@pytest.mark.integration
+def test_render_overlay_writes_real_prores_4444_alpha(tmp_path: Path) -> None:
+    """End-to-end: real ffmpeg writes a parseable ProRes 4444 alpha MOV.
+    Skipped when ffmpeg / ffprobe aren't on PATH (e.g. CI without them)."""
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        pytest.skip("ffmpeg/ffprobe not available")
+    audit = tmp_path / "stage1.json"
+    audit.write_text(
+        json.dumps(
+            {
+                "shots": [
+                    {"shot_number": 1, "ms_after_beep": 100},
+                    {"shot_number": 2, "ms_after_beep": 350},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "overlay.mov"
+
+    overlay_render.render_overlay(
+        audit_path=audit,
+        trimmed_video_path=tmp_path / "ignored.mp4",
+        output_path=output,
+        beep_offset_seconds=0.0,
+        probe=_meta_30fps(duration=0.5),  # 15 frames
+    )
+
+    assert output.exists() and output.stat().st_size > 0
+    proc = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name,pix_fmt,width,height",
+            "-of",
+            "json",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    info = json.loads(proc.stdout)["streams"][0]
+    assert info["codec_name"] == "prores"
+    assert "yuva" in info["pix_fmt"]  # alpha channel present
+    assert info["width"] == 320 and info["height"] == 180

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -292,9 +292,7 @@ def test_render_overlay_raises_when_ffmpeg_returns_nonzero(
         def kill(self) -> None:
             return None
 
-    monkeypatch.setattr(
-        overlay_render.subprocess, "Popen", lambda cmd, **_: StubProc()
-    )
+    monkeypatch.setattr(overlay_render.subprocess, "Popen", lambda cmd, **_: StubProc())
     monkeypatch.setattr(overlay_render.shutil, "which", lambda _b: "/bin/ffmpeg")
 
     with pytest.raises(overlay_render.OverlayRenderError, match="prores_ks"):


### PR DESCRIPTION
## Summary

- New ``src/splitsmith/overlay_render.py`` -- pure renderer with a ``Template`` ABC + ``DefaultTemplate`` (N/M, last split with 1s hold + 0.3s fade, running total). PIL frames piped to ``ffmpeg`` as raw RGBA -> ``prores_ks`` 4444 + ``yuva444p10le``. Probes the trim with ``ffprobe`` so fps / resolution / duration mirror the source frame-for-frame.
- ``fcpxml_gen``: optional ``overlay_path``. When the file exists the FCPXML registers a second asset (``hasAudio=0``) and nests a ``lane=1`` connected ``asset-clip`` inside V1; absent -> FCPXML is byte-identical to before. Same FCPXML works whether or not the overlay was rendered.
- Export pipeline: ``write_overlay`` flag (default False) threaded end-to-end; ``export_stage`` renders to ``<base>_overlay.mov`` after the trim, then references it from FCPXML. Skip messages match the existing source-unreachable wording.
- SPA: Overlay checkbox on the Generate row (disabled until ``audit_shot_count > 0``); file row in the existing list.

## Test plan

- [x] ``pytest tests/test_overlay_render.py tests/test_fcpxml_gen.py tests/test_ui_exports.py`` -- 40 pass.
- [x] Full UI test suite -- 175 pass.
- [x] ``ruff check`` clean on touched files.
- [x] ``tsc --noEmit`` clean in ``ui_static``.
- [x] Integration test against real ffmpeg writes a parseable ProRes 4444 alpha MOV.
- [ ] Drop the produced MOV next to the trim on a real stage and confirm FCP imports it as a connected V2 clip with a working alpha channel (manual; user has confirmed this works).

Follow-up #54 tracks expanding the export flow to cover secondary cams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)