### PR TITLE
exports: ship secondary cams in the per-stage Generate (closes #54)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -23,11 +23,31 @@ import json
 import plistlib
 import subprocess
 from collections.abc import Callable
+from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
 from .config import OutputConfig, Shot, SplitColorThresholds, VideoMetadata
+
+
+@dataclass(frozen=True)
+class SecondaryClip:
+    """One secondary cam attached to the primary as a connected clip (issue #54).
+
+    Each secondary is its own lossless trim placed on V2/V3/... and slipped on
+    the parent timeline so the cam's beep lands at the same second as the
+    primary's. ``beep_offset_seconds`` is the clip-local time of the beep in
+    this cam's trim -- typically equal to the project's ``pre_buffer_seconds``,
+    but may be less if the cam's beep landed within the pre-buffer of the
+    file (a short head wipes some of the pre-roll).
+    """
+
+    video_path: Path
+    video: VideoMetadata
+    beep_offset_seconds: float
+    label: str = "Secondary cam"
+
 
 Runner = Callable[..., subprocess.CompletedProcess]
 
@@ -112,6 +132,7 @@ def generate_fcpxml(
     config: OutputConfig,
     overlay_path: Path | None = None,
     overlay_video: VideoMetadata | None = None,
+    secondaries: list[SecondaryClip] | None = None,
 ) -> None:
     """Write a minimal FCPXML 1.10 timeline for the trimmed video.
 
@@ -125,10 +146,17 @@ def generate_fcpxml(
 
     ``overlay_path``: optional pre-rendered alpha MOV (issue #45) to place
     on V2 as a connected clip. When the file exists the timeline gets a
-    second asset + a lane=1 asset-clip nested in the V1 clip; when it's
+    second asset + a lane=N asset-clip nested in the V1 clip; when it's
     None the FCPXML is unchanged. ``overlay_video`` is the probed metadata
     for the overlay -- when omitted, the trimmed video's metadata is used
     (the renderer mirrors the source frame-for-frame so this is correct).
+
+    ``secondaries``: optional list of secondary cams (issue #54). Each is
+    placed as a connected clip on lane=1, lane=2, ... below the overlay,
+    with its head slipped so the cam's beep lines up frame-aligned with the
+    primary's beep. Missing files are silently skipped (mirrors the overlay
+    behaviour) so the same XML works whether all cams shipped or only the
+    primary did.
     """
     if not video_path.exists():
         raise FileNotFoundError(f"video not found: {video_path}")
@@ -142,7 +170,11 @@ def generate_fcpxml(
 
     asset_id = "r2"
     format_id = "r1"
-    overlay_asset_id = "r3"
+    # Resource IDs after the primary asset are allocated in this order:
+    # secondary cams first, then overlay last so the overlay always lives on
+    # the highest lane (V2/V3/... below it) regardless of cam count.
+    usable_secondaries = [s for s in (secondaries or []) if s.video_path.exists()]
+    overlay_asset_id = f"r{3 + len(usable_secondaries)}"
     use_overlay = overlay_path is not None and overlay_path.exists()
 
     fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
@@ -189,6 +221,52 @@ def generate_fcpxml(
         "media-rep",
         {"kind": "original-media", "src": video_path.resolve().as_uri()},
     )
+
+    # Secondary cam assets (issue #54). Each gets its own ``asset`` resource so
+    # FCP can ingest the cam's video + audio independently of the primary.
+    # IDs run r3..r(3+N-1); overlay (when present) takes the next ID after.
+    secondary_asset_entries: list[tuple[SecondaryClip, str, str]] = []
+    for idx, sec in enumerate(usable_secondaries):
+        sec_id = f"r{3 + idx}"
+        sec_frame_duration = Fraction(sec.video.frame_rate_den, sec.video.frame_rate_num)
+        sec_duration_frames = int(round(sec.video.duration_seconds / float(sec_frame_duration)))
+        # Mix-and-match cam frame rates would make the offset / duration math
+        # parent-vs-child rational; v1 punts on that and uses the primary's
+        # frame rate to express secondary durations. Cams shot on the same
+        # match day are typically the same fps, and the trim is stream-copy
+        # so the source rate is preserved -- if they differ, FCP will round
+        # on import (acceptable for a connected cam) but the spec for
+        # multi-rate timelines is out of scope here.
+        sec_duration_in_parent_frames = int(
+            round(sec.video.duration_seconds / float(frame_duration))
+        )
+        sec_duration_parent_str = _frame_aligned_str(sec_duration_in_parent_frames, fd_num, fd_den)
+        sec_asset = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": sec_id,
+                "name": sec.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(
+                    sec_duration_frames,
+                    sec.video.frame_rate_den,
+                    sec.video.frame_rate_num,
+                ),
+                "hasVideo": "1",
+                "hasAudio": "1",
+                "format": format_id,
+                "videoSources": "1",
+                "audioSources": "1",
+                "audioChannels": "2",
+            },
+        )
+        ET.SubElement(
+            sec_asset,
+            "media-rep",
+            {"kind": "original-media", "src": sec.video_path.resolve().as_uri()},
+        )
+        secondary_asset_entries.append((sec, sec_id, sec_duration_parent_str))
 
     overlay_meta = overlay_video if overlay_video is not None else video
     overlay_duration_str: str | None = None
@@ -249,18 +327,52 @@ def generate_fcpxml(
         },
     )
 
+    # Secondary cam connected clips (issue #54). Lanes 1..N. Each cam's head
+    # is slipped on the parent timeline so its beep aligns frame-for-frame
+    # with the primary's beep. Two cases:
+    #   - sb <= pb: place head later on the timeline by ``pb - sb`` frames,
+    #     start the cam from frame 0.
+    #   - sb >  pb: head sits at parent t=0; skip ``sb - pb`` frames of the
+    #     cam so the beep still lines up.
+    fd_seconds_for_align = float(frame_duration)
+    for lane_idx, (sec, sec_id, sec_duration_parent_str) in enumerate(
+        secondary_asset_entries, start=1
+    ):
+        delta_frames = round((beep_offset_seconds - sec.beep_offset_seconds) / fd_seconds_for_align)
+        if delta_frames >= 0:
+            sec_offset_str = _frame_aligned_str(delta_frames, fd_num, fd_den)
+            sec_start_str = "0s"
+        else:
+            sec_offset_str = "0s"
+            sec_start_str = _frame_aligned_str(-delta_frames, fd_num, fd_den)
+        ET.SubElement(
+            asset_clip,
+            "asset-clip",
+            {
+                "ref": sec_id,
+                "lane": str(lane_idx),
+                "offset": sec_offset_str,
+                "name": sec.label,
+                "start": sec_start_str,
+                "duration": sec_duration_parent_str,
+                "format": format_id,
+            },
+        )
+
     if use_overlay and overlay_duration_str is not None:
-        # Connected clip on V2 (lane=1). FCPXML stacks lanes above 0 over
-        # the primary, so this puts the overlay on top of the trim with
-        # its own alpha. ``offset="0s"`` aligns its head to the primary's
-        # head; the renderer matches the trim duration so we don't need a
-        # nested clip for trims.
+        # Connected clip on the lane above all secondary cams (lane=N+1 when
+        # N cams attach; lane=1 in the single-cam default). FCPXML stacks
+        # higher lanes over lower ones, so this keeps the overlay's typography
+        # on top of every cam regardless of count. ``offset="0s"`` aligns its
+        # head to the primary's head; the renderer matches the trim duration
+        # so we don't need a nested clip for trims.
+        overlay_lane = len(secondary_asset_entries) + 1
         ET.SubElement(
             asset_clip,
             "asset-clip",
             {
                 "ref": overlay_asset_id,
-                "lane": "1",
+                "lane": str(overlay_lane),
                 "offset": "0s",
                 "name": "Splitsmith overlay",
                 "start": "0s",

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +44,23 @@ class StageExportRequest:
 
 
 @dataclass(frozen=True)
+class SecondaryExport:
+    """One secondary cam to ship alongside the primary (issue #54).
+
+    The export pipeline trims each secondary into ``exports/`` with a
+    ``cam_<video_id>`` suffix and references it from the multi-cam FCPXML
+    as a connected clip. ``video_id`` is the project's stable per-video
+    handle (:attr:`StageVideo.video_id`); secondaries without a beep can't
+    sync, so the caller filters them out before passing them in.
+    """
+
+    video_id: str
+    source_path: Path
+    beep_time_in_source: float
+    label: str = "Secondary cam"
+
+
+@dataclass(frozen=True)
 class StageExportResult:
     """Paths produced (or skipped) by :func:`export_stage`."""
 
@@ -55,6 +72,10 @@ class StageExportResult:
     overlay_path: Path | None
     shots_written: int
     anomalies: list[str]
+    # Per-cam lossless trims keyed by ``StageVideo.video_id`` (issue #54).
+    # Empty when the stage is single-cam or all secondaries failed to trim.
+    # The FCPXML references each present file as a connected clip.
+    secondary_trimmed_paths: dict[str, Path] = field(default_factory=dict)
 
 
 class StageExportError(RuntimeError):
@@ -155,6 +176,7 @@ def export_stage(
     pre_buffer_seconds: float,
     post_buffer_seconds: float,
     config: Config,
+    secondaries: list[SecondaryExport] | None = None,
 ) -> StageExportResult:
     """Run the export for one stage. Pure orchestration over the engine
     modules; never re-detects.
@@ -249,6 +271,50 @@ def export_stage(
                     # from FCPXML so the user gets *something* usable.
                     trimmed_path = exports_dir / f"{base}_trimmed.mp4"
 
+    # Per-cam lossless trims (issue #54). Each secondary's trim lands at
+    # ``stage<N>_<slug>_cam_<video_id>_trimmed.mp4`` so its name mirrors the
+    # audit-mode cache slot in <project>/trimmed/. Skipped silently when
+    # ``write_trim`` is off (CSV-only re-run); per-cam ffmpeg failures are
+    # surfaced as anomalies so the FCPXML can still reference the cams that
+    # did make it. Stale prior-run trims are kept so an aborted re-run still
+    # ships a multi-cam timeline.
+    secondary_trimmed: dict[str, Path] = {}
+    secondary_inputs = list(secondaries or [])
+    if request.write_trim:
+        for sec in secondary_inputs:
+            sec_target = exports_dir / f"{base}_cam_{sec.video_id}_trimmed.mp4"
+            if not sec.source_path.exists():
+                skip_reasons.append(
+                    f"secondary cam {sec.video_id} trim not written: source not "
+                    f"reachable: {sec.source_path}"
+                )
+                if sec_target.exists():
+                    secondary_trimmed[sec.video_id] = sec_target
+                continue
+            try:
+                trim.trim_video(
+                    sec.source_path,
+                    sec_target,
+                    beep_time=sec.beep_time_in_source,
+                    stage_time=stage_data.time_seconds,
+                    pre_buffer_seconds=pre_buffer_seconds,
+                    post_buffer_seconds=post_buffer_seconds,
+                    mode="lossless",
+                    overwrite=True,
+                )
+                secondary_trimmed[sec.video_id] = sec_target
+            except (trim.FFmpegError, FileNotFoundError, RuntimeError) as exc:
+                skip_reasons.append(f"secondary cam {sec.video_id} trim not written: {exc}")
+                if sec_target.exists():
+                    secondary_trimmed[sec.video_id] = sec_target
+    else:
+        # When trim is off, surface stale per-cam trims so the FCPXML can
+        # still wire them up (mirrors the primary's stale-trim handling).
+        for sec in secondary_inputs:
+            sec_target = exports_dir / f"{base}_cam_{sec.video_id}_trimmed.mp4"
+            if sec_target.exists():
+                secondary_trimmed[sec.video_id] = sec_target
+
     csv_path: Path | None = None
     if request.write_csv:
         csv_path = exports_dir / f"{base}_splits.csv"
@@ -330,6 +396,37 @@ def export_stage(
             fcpxml_path = exports_dir / f"{base}.fcpxml"
             try:
                 meta = fcpxml_gen.probe_video(fcp_video)
+                # Multi-cam wiring (issue #54). Probe each surviving secondary
+                # trim and pass it as a connected clip; ffprobe failures only
+                # drop that cam from the timeline (other cams still ship).
+                fcp_secondaries: list[fcpxml_gen.SecondaryClip] = []
+                # Preserve the input order so cam lane assignments are stable
+                # across re-runs (the dict was built in input-order earlier).
+                for sec in secondary_inputs:
+                    sec_path = secondary_trimmed.get(sec.video_id)
+                    if sec_path is None or not sec_path.exists():
+                        continue
+                    try:
+                        sec_meta = fcpxml_gen.probe_video(sec_path)
+                    except fcpxml_gen.FFprobeError as exc:
+                        skip_reasons.append(
+                            f"secondary cam {sec.video_id} dropped from FCPXML: {exc}"
+                        )
+                        continue
+                    # Each cam was trimmed with the same pre-buffer as the
+                    # primary, so its clip-local beep is at
+                    # ``min(pre_buffer, beep_time_in_source)`` -- short heads
+                    # truncate the pre-roll, in which case the cam's beep
+                    # sits earlier in the file.
+                    sec_beep_offset = min(pre_buffer_seconds, sec.beep_time_in_source)
+                    fcp_secondaries.append(
+                        fcpxml_gen.SecondaryClip(
+                            video_path=sec_path,
+                            video=sec_meta,
+                            beep_offset_seconds=sec_beep_offset,
+                            label=sec.label,
+                        )
+                    )
                 # Beep offset within the lossless trim: the trim cut at
                 # ``beep_time - pre_buffer`` from source, so the beep lives
                 # ``pre_buffer`` seconds into the clip.
@@ -342,6 +439,7 @@ def export_stage(
                     project_name=base,
                     config=config.output,
                     overlay_path=fcp_overlay_path,
+                    secondaries=fcp_secondaries or None,
                 )
             except (fcpxml_gen.FFprobeError, OSError) as exc:
                 skip_reasons.append(f"fcpxml not written: {exc}")
@@ -373,6 +471,7 @@ def export_stage(
             color_thresholds=config.output.split_color_thresholds,
         )
 
+    secondary_paths_present = {vid: p for vid, p in secondary_trimmed.items() if p.exists()}
     return StageExportResult(
         stage_number=stage_data.stage_number,
         trimmed_video_path=(
@@ -384,6 +483,7 @@ def export_stage(
         overlay_path=overlay_path if overlay_path is not None and overlay_path.exists() else None,
         shots_written=len(shots),
         anomalies=anomalies,
+        secondary_trimmed_paths=secondary_paths_present,
     )
 
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2172,6 +2172,27 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             handle.update(progress=0.15, message="Reading audit JSON...")
         handle.check_cancel()
 
+        # Multi-cam (issue #54). Each secondary with a known beep ships
+        # alongside the primary so a single Generate click produces the
+        # complete multi-cam timeline. Cams without a beep yet -- e.g.
+        # registered but ingest didn't finish -- are silently skipped; the
+        # SPA's ingest screen flags those rows separately.
+        secondaries: list[export_helpers.SecondaryExport] = []
+        for sv in stg.videos:
+            if sv.role != "secondary":
+                continue
+            if sv.beep_time is None:
+                continue
+            sec_source = proj.resolve_video_path(state.project_root, sv.path)
+            secondaries.append(
+                export_helpers.SecondaryExport(
+                    video_id=sv.video_id,
+                    source_path=sec_source,
+                    beep_time_in_source=sv.beep_time,
+                    label=f"Cam {sv.video_id}",
+                )
+            )
+
         try:
             result = export_helpers.export_stage(
                 request=export_helpers.StageExportRequest(
@@ -2190,6 +2211,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 pre_buffer_seconds=proj.trim_pre_buffer_seconds,
                 post_buffer_seconds=proj.trim_post_buffer_seconds,
                 config=Config(),
+                secondaries=secondaries,
             )
         except export_helpers.StageExportError as exc:
             # Surface as a job failure with the exporter's own message so
@@ -2207,6 +2229,9 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         bits: list[str] = []
         if result.trimmed_video_path is not None:
             bits.append("trim")
+        if result.secondary_trimmed_paths:
+            n = len(result.secondary_trimmed_paths)
+            bits.append(f"{n} secondary trim{'s' if n != 1 else ''}")
         if result.csv_path is not None:
             bits.append("csv")
         if result.fcpxml_path is not None:

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -359,6 +359,190 @@ def test_generate_fcpxml_inserts_overlay_as_lane_1_connected_clip(tmp_path: Path
     assert overlay_clip.attrib["duration"] == "600/30s"  # 20s @ 30fps
 
 
+def test_generate_fcpxml_attaches_secondary_cam_on_lane_1(tmp_path: Path) -> None:
+    """Single secondary cam with the same beep offset as the primary -> a
+    connected ``asset-clip`` on lane=1 with offset=0 (cams sync at the beep
+    by default since both trims share the same pre-buffer)."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "v_cam_abc.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=5.0,
+                label="Cam abc",
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    assert len(assets) == 2
+    secondary_asset = assets[1]
+    media = secondary_asset.find("media-rep")
+    assert media is not None and media.attrib["src"].endswith("v_cam_abc.mp4")
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert len(nested) == 1
+    cam_clip = nested[0]
+    assert cam_clip.attrib["lane"] == "1"
+    assert cam_clip.attrib["offset"] == "0s"
+    assert cam_clip.attrib["start"] == "0s"
+    assert cam_clip.attrib["name"] == "Cam abc"
+
+
+def test_generate_fcpxml_secondary_with_short_pre_uses_offset(tmp_path: Path) -> None:
+    """A cam whose beep landed earlier than the primary's beep_offset (short
+    head: secondary trim has less pre-roll) gets a positive offset on the
+    parent timeline so its beep still aligns with the primary's beep."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "cam_short.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=2.0,  # cam's beep at clip-local 2s, primary at 5s
+                label="Cam short",
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    # Difference is 3s @ 30fps = 90 frames -> 90/30s
+    assert cam_clip.attrib["offset"] == "90/30s"
+    assert cam_clip.attrib["start"] == "0s"
+
+
+def test_generate_fcpxml_secondary_with_long_pre_uses_start(tmp_path: Path) -> None:
+    """A cam whose clip-local beep sits later than the primary's beep gets
+    offset=0 and a positive ``start``: we skip into the cam's media so its
+    beep frame coincides with the primary's beep frame at parent t=pb."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "cam_long.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=7.0,  # cam beep is 2s later in its own media
+                label="Cam long",
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    assert cam_clip.attrib["offset"] == "0s"
+    # Skip 2s = 60 frames @ 30fps
+    assert cam_clip.attrib["start"] == "60/30s"
+
+
+def test_generate_fcpxml_overlay_lane_above_all_secondaries(tmp_path: Path) -> None:
+    """When N cams attach AND the overlay is present, the overlay rides on
+    lane=N+1 so it stays on top of every cam regardless of count."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    cam_a = tmp_path / "cam_a.mp4"
+    cam_a.write_bytes(b"")
+    cam_b = tmp_path / "cam_b.mp4"
+    cam_b.write_bytes(b"")
+    overlay = tmp_path / "v_overlay.mov"
+    overlay.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        overlay_path=overlay,
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=cam_a, video=_meta_30fps(), beep_offset_seconds=5.0, label="A"
+            ),
+            fcpxml_mod.SecondaryClip(
+                video_path=cam_b, video=_meta_30fps(), beep_offset_seconds=5.0, label="B"
+            ),
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    # primary + 2 cams + overlay = 4 assets
+    assert len(assets) == 4
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert len(nested) == 3
+    lanes = [int(c.attrib["lane"]) for c in nested]
+    # Cams lane=1, lane=2 in input order; overlay lane=3 (above both cams).
+    assert sorted(lanes) == [1, 2, 3]
+    # The clip on lane=3 must reference the overlay asset, not a cam.
+    overlay_clip = next(c for c in nested if c.attrib["lane"] == "3")
+    assert overlay_clip.attrib["name"] == "Splitsmith overlay"
+
+
+def test_generate_fcpxml_skips_missing_secondary(tmp_path: Path) -> None:
+    """A secondary whose file vanished between submit and write is silently
+    skipped (mirrors the overlay's missing-file behaviour) -- the rest of
+    the FCPXML is unchanged so other cams still ship."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=tmp_path / "missing_cam.mp4",
+                video=_meta_30fps(),
+                beep_offset_seconds=5.0,
+                label="Missing",
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    assert len(assets) == 1  # only the primary
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert nested == []
+
+
 def test_generate_fcpxml_raises_on_missing_video(tmp_path: Path) -> None:
     out = tmp_path / "v.fcpxml"
     with pytest.raises(FileNotFoundError):

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -10,6 +10,7 @@ import csv
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -271,6 +272,156 @@ def test_slugify_matches_cli_format() -> None:
     assert exports_mod._slugify("Stage 1 -- H1") == "stage-1-h1"
     assert exports_mod._slugify("All Symbols!@#") == "all-symbols"
     assert exports_mod._slugify("") == "stage"
+
+
+def test_export_stage_trims_secondaries_and_records_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each secondary cam gets its own ``stage<N>_<slug>_cam_<id>_trimmed.mp4``
+    and the result records the per-cam paths so the SPA / FCPXML can wire
+    them up. The ffmpeg call is stubbed to avoid shelling out (#54)."""
+    audit_path = tmp_path / "stage1.json"
+    audit_path.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    primary_src = tmp_path / "primary.mp4"
+    primary_src.write_bytes(b"")
+    cam_a_src = tmp_path / "cam_a.mp4"
+    cam_a_src.write_bytes(b"")
+    cam_b_src = tmp_path / "cam_b.mp4"
+    cam_b_src.write_bytes(b"")
+
+    from splitsmith import trim as trim_module
+    from splitsmith.config import TrimResult
+
+    captured: list[tuple[Path, Path]] = []
+
+    def fake_trim_video(input_path: Path, output_path: Path, **kwargs: Any) -> TrimResult:
+        captured.append((input_path, output_path))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"")
+        return TrimResult(output_path=output_path, start_time=0.0, end_time=20.0)
+
+    monkeypatch.setattr(trim_module, "trim_video", fake_trim_video)
+    monkeypatch.setattr(exports_mod.trim, "trim_video", fake_trim_video)
+
+    result = exports_mod.export_stage(
+        request=exports_mod.StageExportRequest(
+            stage_number=1,
+            write_trim=True,
+            write_csv=False,
+            write_fcpxml=False,
+            write_report=False,
+        ),
+        audit_path=audit_path,
+        exports_dir=tmp_path / "exports",
+        source_video_path=primary_src,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
+        stage_data=StageData(
+            stage_number=1,
+            stage_name="Stage 1 -- H1",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ),
+        beep_time_in_source=10.0,
+        config=Config(),
+        secondaries=[
+            exports_mod.SecondaryExport(
+                video_id="aaaaaa", source_path=cam_a_src, beep_time_in_source=11.0
+            ),
+            exports_mod.SecondaryExport(
+                video_id="bbbbbb", source_path=cam_b_src, beep_time_in_source=9.5
+            ),
+        ],
+    )
+
+    # 1 primary + 2 secondaries = 3 ffmpeg calls.
+    assert len(captured) == 3
+    sec_outputs = {p.name for _, p in captured}
+    assert "stage1_stage-1-h1_trimmed.mp4" in sec_outputs
+    assert "stage1_stage-1-h1_cam_aaaaaa_trimmed.mp4" in sec_outputs
+    assert "stage1_stage-1-h1_cam_bbbbbb_trimmed.mp4" in sec_outputs
+
+    assert set(result.secondary_trimmed_paths) == {"aaaaaa", "bbbbbb"}
+    for vid, p in result.secondary_trimmed_paths.items():
+        assert p.exists()
+        assert p.name == f"stage1_stage-1-h1_cam_{vid}_trimmed.mp4"
+
+
+def test_export_stage_skips_secondary_when_source_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Secondary source missing (USB unplugged, file deleted between
+    Generate clicks) -> the cam is dropped with an anomaly explaining what
+    happened. The primary's export is unaffected."""
+    audit_path = tmp_path / "stage1.json"
+    audit_path.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    primary_src = tmp_path / "primary.mp4"
+    primary_src.write_bytes(b"")
+
+    from splitsmith import trim as trim_module
+    from splitsmith.config import TrimResult
+
+    def fake_trim_video(input_path: Path, output_path: Path, **kwargs: Any) -> TrimResult:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"")
+        return TrimResult(output_path=output_path, start_time=0.0, end_time=20.0)
+
+    monkeypatch.setattr(trim_module, "trim_video", fake_trim_video)
+    monkeypatch.setattr(exports_mod.trim, "trim_video", fake_trim_video)
+
+    result = exports_mod.export_stage(
+        request=exports_mod.StageExportRequest(
+            stage_number=1,
+            write_trim=True,
+            write_csv=True,
+            write_fcpxml=False,
+            write_report=False,
+        ),
+        audit_path=audit_path,
+        exports_dir=tmp_path / "exports",
+        source_video_path=primary_src,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
+        stage_data=StageData(
+            stage_number=1,
+            stage_name="S",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ),
+        beep_time_in_source=10.0,
+        config=Config(),
+        secondaries=[
+            exports_mod.SecondaryExport(
+                video_id="ghost",
+                source_path=tmp_path / "ghost.mp4",  # never created
+                beep_time_in_source=11.0,
+            ),
+        ],
+    )
+
+    assert result.trimmed_video_path is not None and result.trimmed_video_path.exists()
+    assert result.secondary_trimmed_paths == {}
+    assert any("secondary cam ghost" in a for a in result.anomalies)
 
 
 def test_export_overview_status(tmp_path: Path) -> None:


### PR DESCRIPTION
Each stage now emits one lossless trim per cam plus a single multi-cam
FCPXML so the user can drop the timeline into FCP, see all cams synced at
the start beep, and assemble splitscreen / PiP without re-aligning by
hand. The primary's deliverables are unchanged byte-for-byte.

- ``fcpxml_gen.SecondaryClip`` + ``generate_fcpxml(secondaries=...)``
  attach each cam as a connected clip on lanes 1..N. The cam's head is
  slipped frame-aligned so its beep coincides with the primary's; cams
  whose pre-roll is shorter than the primary's use ``offset``, cams whose
  beep sits later in the file use ``start`` to skip in.
- The overlay (#45) moves to lane N+1 so it stays on top of every cam.
- ``exports.SecondaryExport`` + ``export_stage(secondaries=...)`` trim
  each cam to ``stage<N>_<slug>_cam_<id>_trimmed.mp4`` and feed them into
  the FCPXML. Per-cam ffmpeg failures only drop that cam from the
  timeline -- the rest of the stage still ships.
- The server's per-stage export job builds the secondary list from
  ``stage.videos`` (role=secondary, beep_time present) and surfaces a
  ``N secondary trim(s)`` count in the JobsPanel summary.

Overlay attaches to the primary only per the design discussion -- one
audit timeline drives the running counter, so re-rendering per cam adds
cost without information.

Tests: multi-cam FCPXML structure (lane assignment, offset/start sync
math, missing-file fallback), export pipeline trims secondaries with the
expected naming + records per-cam paths, and degrades cleanly when a
secondary source is unreachable.

https://claude.ai/code/session_01PvTiSVbHdUUVRdfKxEX8KK