### PR TITLE
audit: live anomaly panel with click-to-jump (closes #42)

### DIFF
--- a/src/splitsmith/report.py
+++ b/src/splitsmith/report.py
@@ -8,11 +8,23 @@ Anomaly rules (from SPEC.md):
 
 ASCII-only output (per CLAUDE.md): tags use ``[OK]``, ``[!]``, etc. instead of
 Unicode glyphs so the report renders the same in any terminal / pager.
+
+Two flavours of the anomaly check live here:
+
+- :func:`detect_anomalies_structured` returns :class:`Anomaly` records
+  carrying ``kind`` + ``shot_number`` + ``time`` so the audit screen can
+  render clickable entries that jump to the offending marker (issue #42).
+- :func:`detect_anomalies` is the legacy string-list shape used by the
+  CLI / report.txt; it stringifies the structured output so the rendered
+  report bytes are unchanged.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
 
 from .config import ReportFiles, Shot, SplitColorThresholds, StageAnalysis
 
@@ -24,47 +36,127 @@ _SLOW_DRAW_S = 1.500  # shot 1 split greater than this gets a slow-draw note
 _TYPICAL_ROUND_RANGE = (8, 32)  # informational shot-count band
 
 
-def detect_anomalies(
+AnomalyKind = Literal[
+    "no_shots",
+    "stage_time_mismatch",
+    "double_detection",
+    "long_pause",
+    "shot_count_low",
+    "shot_count_high",
+]
+AnomalySeverity = Literal["info", "warn"]
+
+
+class Anomaly(BaseModel):
+    """Structured anomaly emitted by :func:`detect_anomalies_structured`.
+
+    ``kind`` tags the rule so the SPA can group / filter without parsing
+    ``message``. ``shot_number`` (1-based, matches :class:`Shot.shot_number`)
+    and ``time`` (seconds from beep) are populated for shot-bound anomalies
+    so the audit screen can scroll to the offending marker on click.
+    Stage-level anomalies (count band, no shots) leave both null.
+    """
+
+    kind: AnomalyKind
+    severity: AnomalySeverity
+    message: str
+    shot_number: int | None = None
+    time: float | None = None
+
+
+def detect_anomalies_structured(
     shots: list[Shot],
     beep_time: float,  # noqa: ARG001 -- kept for symmetry with caller; absolute beep time
     stage_time: float,
-) -> list[str]:
-    """Return human-readable anomaly strings; empty list means "all clean"."""
-    anomalies: list[str] = []
+) -> list[Anomaly]:
+    """Return structured :class:`Anomaly` records; empty list means "all clean"."""
+    anomalies: list[Anomaly] = []
 
     if not shots:
-        anomalies.append("No shots detected in the stage window.")
+        anomalies.append(
+            Anomaly(
+                kind="no_shots",
+                severity="warn",
+                message="No shots detected in the stage window.",
+            )
+        )
         return anomalies
 
     last_after_beep = shots[-1].time_from_beep
     delta = last_after_beep - stage_time
     if abs(delta) > _OFFICIAL_TIME_TOLERANCE_S:
         anomalies.append(
-            f"Last detected shot is {abs(delta) * 1000:.0f} ms "
-            f"{'after' if delta > 0 else 'before'} official stage time "
-            f"({last_after_beep:.3f} s vs {stage_time:.3f} s)."
+            Anomaly(
+                kind="stage_time_mismatch",
+                severity="warn",
+                message=(
+                    f"Last detected shot is {abs(delta) * 1000:.0f} ms "
+                    f"{'after' if delta > 0 else 'before'} official stage time "
+                    f"({last_after_beep:.3f} s vs {stage_time:.3f} s)."
+                ),
+                shot_number=shots[-1].shot_number,
+                time=last_after_beep,
+            )
         )
 
     for s in shots[1:]:  # shot 1's "split" is the draw, not a real split
         if s.split < _DOUBLE_DETECTION_MAX_S:
             anomalies.append(
-                f"Shot {s.shot_number} split is {s.split * 1000:.0f} ms "
-                f"(< {_DOUBLE_DETECTION_MAX_S * 1000:.0f} ms): possible double-detection."
+                Anomaly(
+                    kind="double_detection",
+                    severity="warn",
+                    message=(
+                        f"Shot {s.shot_number} split is {s.split * 1000:.0f} ms "
+                        f"(< {_DOUBLE_DETECTION_MAX_S * 1000:.0f} ms): "
+                        f"possible double-detection."
+                    ),
+                    shot_number=s.shot_number,
+                    time=s.time_from_beep,
+                )
             )
         elif s.split > _LONG_PAUSE_MAX_S:
             anomalies.append(
-                f"Shot {s.shot_number} split is {s.split:.3f} s "
-                f"(> {_LONG_PAUSE_MAX_S:.1f} s): missed shot or long transition?"
+                Anomaly(
+                    kind="long_pause",
+                    severity="warn",
+                    message=(
+                        f"Shot {s.shot_number} split is {s.split:.3f} s "
+                        f"(> {_LONG_PAUSE_MAX_S:.1f} s): missed shot or long transition?"
+                    ),
+                    shot_number=s.shot_number,
+                    time=s.time_from_beep,
+                )
             )
 
     lo, hi = _TYPICAL_ROUND_RANGE
     if not (lo <= len(shots) <= hi):
+        is_low = len(shots) < lo
         anomalies.append(
-            f"Detected {len(shots)} shots; typical IPSC stages have {lo}-{hi}. Review for "
-            f"{'missed shots' if len(shots) < lo else 'false positives (echoes / other bays)'}."
+            Anomaly(
+                kind="shot_count_low" if is_low else "shot_count_high",
+                severity="info",
+                message=(
+                    f"Detected {len(shots)} shots; typical IPSC stages have {lo}-{hi}. "
+                    f"Review for "
+                    f"{'missed shots' if is_low else 'false positives (echoes / other bays)'}."
+                ),
+            )
         )
 
     return anomalies
+
+
+def detect_anomalies(
+    shots: list[Shot],
+    beep_time: float,
+    stage_time: float,
+) -> list[str]:
+    """Return human-readable anomaly strings; empty list means "all clean".
+
+    Thin wrapper over :func:`detect_anomalies_structured` so the report.txt
+    bullet rendering stays byte-identical to its pre-#42 output.
+    """
+    return [a.message for a in detect_anomalies_structured(shots, beep_time, stage_time)]
 
 
 def render_report(

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -66,7 +66,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from .. import beep_detect, video_probe
+from .. import beep_detect, report, video_probe
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
@@ -1645,6 +1645,43 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 tmp.unlink()
             raise HTTPException(status_code=500, detail=f"audit write failed: {exc}") from exc
         return JSONResponse(payload)
+
+    @app.get("/api/stages/{stage_number}/anomalies")
+    def get_stage_anomalies(stage_number: int) -> JSONResponse:
+        """Return structured anomalies for the saved audit JSON (issue #42).
+
+        Single source of truth for ``report.detect_anomalies_structured``:
+        the audit screen also runs the same rules client-side for live
+        feedback while the user keeps / rejects markers, but consumers
+        that only need a snapshot (external tooling, integration tests,
+        the report.txt writer) can hit this endpoint instead of reading
+        the JSON and re-deriving.
+
+        Returns ``{anomalies: []}`` when the stage has no audit JSON, no
+        beep yet, or an empty ``shots[]`` -- the SPA renders these as
+        "no anomalies" / "no shots audited yet" depending on context.
+        """
+        project = state.load()
+        try:
+            stg = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        audit_file = project.audit_path(state.project_root) / f"stage{stage_number}.json"
+        if not audit_file.exists():
+            return JSONResponse({"anomalies": []})
+        try:
+            audit_payload = json.loads(audit_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
+
+        prim = stg.primary()
+        beep_time = prim.beep_time if prim is not None and prim.beep_time is not None else 0.0
+        shots = export_helpers.audit_shots_to_engine_shots(
+            audit_payload, beep_time_in_source=beep_time
+        )
+        anomalies = report.detect_anomalies_structured(shots, beep_time, stg.time_seconds)
+        return JSONResponse({"anomalies": [a.model_dump() for a in anomalies]})
 
     # ----------------------------------------------------------------------
     # Fixture-review endpoints (closes #19 -- the old splitsmith.review_server

--- a/src/splitsmith/ui_static/src/components/AnomalyPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/AnomalyPanel.tsx
@@ -1,0 +1,149 @@
+/**
+ * Live anomaly panel for the audit screen (issue #42).
+ *
+ * Mirrors what ``report.txt`` will say once the user clicks Generate, but
+ * shown live while they keep / reject markers so the audit step is the
+ * one place where audit work is actually decided. Anomaly rows that
+ * reference a shot number are clickable -- one click puts the playhead
+ * on the offending marker with the previous one in view, which is what
+ * makes the panel actually useful for hand-auditing.
+ *
+ * Severity follows the report's ``[!]`` (warn) / ``[~]`` (info) split:
+ * ``warn`` rules (double-detection, long pause, stage-time mismatch, no
+ * shots) get the warning palette; ``info`` rules (shot-count band) stay
+ * neutral so they don't drown out real issues.
+ *
+ * Anomalies are derived state -- they live in memory and recompute on
+ * every marker mutation. They are NOT persisted into the audit JSON;
+ * a future "snooze" feature would change that, but per #42's AC the
+ * panel is purely a view over the in-memory truth.
+ */
+
+import { AlertTriangle, CheckCircle2, Info } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Anomaly } from "@/lib/anomalies";
+import { cn } from "@/lib/utils";
+
+export interface AnomalyPanelProps {
+  anomalies: Anomaly[];
+  /** Called when the user clicks an anomaly that references a shot.
+   *  The page-level handler resolves ``shotNumber`` to the matching kept
+   *  marker and scrolls + focuses it. Stage-level anomalies (count band,
+   *  no shots) ignore the click. */
+  onJumpToShot: (shotNumber: number) => void;
+}
+
+export function AnomalyPanel({ anomalies, onJumpToShot }: AnomalyPanelProps) {
+  if (anomalies.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CheckCircle2
+              aria-hidden
+              className="size-4 text-status-complete"
+            />
+            Anomalies
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          No anomalies. Stage looks clean.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const warnCount = anomalies.filter((a) => a.severity === "warn").length;
+  const infoCount = anomalies.length - warnCount;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <AlertTriangle
+            aria-hidden
+            className={cn(
+              "size-4",
+              warnCount > 0 ? "text-status-warning" : "text-muted-foreground",
+            )}
+          />
+          Anomalies
+          <span className="ml-1 text-xs font-normal text-muted-foreground">
+            {warnCount > 0 ? `${warnCount} to review` : null}
+            {warnCount > 0 && infoCount > 0 ? " - " : null}
+            {infoCount > 0 ? `${infoCount} info` : null}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1.5 pt-0 text-sm">
+        {anomalies.map((a, i) => (
+          <AnomalyRow
+            key={`${a.kind}-${a.shot_number ?? "stage"}-${i}`}
+            anomaly={a}
+            onJumpToShot={onJumpToShot}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AnomalyRow({
+  anomaly,
+  onJumpToShot,
+}: {
+  anomaly: Anomaly;
+  onJumpToShot: (shotNumber: number) => void;
+}) {
+  const clickable = anomaly.shot_number != null;
+  const Icon = anomaly.severity === "warn" ? AlertTriangle : Info;
+
+  // Tone classes are colour-blind-safe (Okabe-Ito derived; same palette
+  // as marker colours) -- ``status-warning`` is the orange used elsewhere
+  // for "needs attention", ``status-in-progress`` blue for purely
+  // informational rows.
+  const toneClasses =
+    anomaly.severity === "warn"
+      ? "border-status-warning/40 bg-status-warning/5"
+      : "border-border bg-muted/30";
+  const iconClasses =
+    anomaly.severity === "warn"
+      ? "text-status-warning"
+      : "text-status-in-progress";
+
+  const content = (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-md border px-2.5 py-1.5",
+        toneClasses,
+        clickable &&
+          "cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground",
+      )}
+    >
+      <Icon
+        aria-hidden
+        className={cn("mt-0.5 size-4 shrink-0", iconClasses)}
+      />
+      <span className="leading-snug">{anomaly.message}</span>
+    </div>
+  );
+
+  if (!clickable) {
+    return content;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (anomaly.shot_number != null) onJumpToShot(anomaly.shot_number);
+      }}
+      className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md"
+      aria-label={`Jump to shot ${anomaly.shot_number}: ${anomaly.message}`}
+      title={`Jump to shot ${anomaly.shot_number}`}
+    >
+      {content}
+    </button>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/anomalies.ts
+++ b/src/splitsmith/ui_static/src/lib/anomalies.ts
@@ -1,0 +1,173 @@
+/**
+ * Live anomaly detection for the audit screen (issue #42).
+ *
+ * Mirrors ``splitsmith.report.detect_anomalies_structured`` so the panel
+ * the user sees while keeping / rejecting markers shows the same flags
+ * that ``report.txt`` will. Living in TypeScript instead of round-tripping
+ * to the server keeps recompute zero-latency on every mutation.
+ *
+ * Tuning constants are duplicated from ``report.py``; SPEC.md is the
+ * canonical source. If thresholds change, update both files (the backend
+ * tests + this module's tests would catch the drift).
+ */
+import type { AuditMarker } from "@/components/MarkerLayer";
+
+/** Beep -> last shot vs official stage time tolerance (seconds). */
+const OFFICIAL_TIME_TOLERANCE_S = 0.5;
+/** Splits below this look like a single shot detected twice. */
+const DOUBLE_DETECTION_MAX_S = 0.08;
+/** Splits above this look like a missed shot or a long transition. */
+const LONG_PAUSE_MAX_S = 3.0;
+/** Informational shot-count band (typical IPSC stage). */
+const TYPICAL_ROUND_RANGE: [number, number] = [8, 32];
+
+export type AnomalyKind =
+  | "no_shots"
+  | "stage_time_mismatch"
+  | "double_detection"
+  | "long_pause"
+  | "shot_count_low"
+  | "shot_count_high";
+
+export type AnomalySeverity = "info" | "warn";
+
+export interface Anomaly {
+  kind: AnomalyKind;
+  severity: AnomalySeverity;
+  message: string;
+  /** 1-based shot index for click-to-jump. Null for stage-level
+   *  anomalies (count band, no shots). */
+  shot_number: number | null;
+  /** Time on the audit timeline (clip-local seconds) for the offending
+   *  shot. Null when ``shot_number`` is null. */
+  time: number | null;
+}
+
+interface KeptShot {
+  /** 1-based, in the same order as ``shots[].shot_number`` after a save. */
+  shot_number: number;
+  /** Time on the audit timeline (clip-local seconds). */
+  time: number;
+  /** ``time - beep_time``; used by the report rule wording. */
+  time_from_beep: number;
+  /** Difference from the previous shot's ``time_from_beep`` (seconds).
+   *  Shot 1's split is the draw (= ``time_from_beep``). */
+  split: number;
+}
+
+/** Build the kept-shot list the audit screen treats as the source of truth.
+ *
+ * ``markers`` are the in-memory state from the audit page; we filter to
+ * detected + manual (the user's "keep" set), sort by time, and compute
+ * ``time_from_beep`` + ``split`` so the rules match :class:`Shot` exactly.
+ *
+ * ``beepTime`` is the audit-clip-local beep position (``peaks.beep_time``);
+ * when null we fall back to 0 so anomalies still fire on shot count etc.
+ */
+export function keptShotsFromMarkers(
+  markers: AuditMarker[],
+  beepTime: number | null,
+): KeptShot[] {
+  const beep = beepTime ?? 0;
+  const kept = markers
+    .filter((m) => m.kind === "detected" || m.kind === "manual")
+    .slice()
+    .sort((a, b) => a.time - b.time || a.id.localeCompare(b.id));
+  const out: KeptShot[] = [];
+  let prev: number | null = null;
+  kept.forEach((m, i) => {
+    const time_from_beep = m.time - beep;
+    const split = prev == null ? time_from_beep : time_from_beep - prev;
+    prev = time_from_beep;
+    out.push({
+      shot_number: i + 1,
+      time: m.time,
+      time_from_beep,
+      split,
+    });
+  });
+  return out;
+}
+
+/** Compute the structured anomaly list for the current audit state.
+ *
+ * Mirrors :func:`splitsmith.report.detect_anomalies_structured` so the
+ * audit screen and the report.txt file flag the exact same things.
+ */
+export function detectAnomalies(
+  shots: KeptShot[],
+  stageTime: number,
+): Anomaly[] {
+  const out: Anomaly[] = [];
+
+  if (shots.length === 0) {
+    out.push({
+      kind: "no_shots",
+      severity: "warn",
+      message: "No shots detected in the stage window.",
+      shot_number: null,
+      time: null,
+    });
+    return out;
+  }
+
+  const last = shots[shots.length - 1];
+  const delta = last.time_from_beep - stageTime;
+  if (Math.abs(delta) > OFFICIAL_TIME_TOLERANCE_S) {
+    const direction = delta > 0 ? "after" : "before";
+    out.push({
+      kind: "stage_time_mismatch",
+      severity: "warn",
+      message:
+        `Last detected shot is ${Math.round(Math.abs(delta) * 1000)} ms ` +
+        `${direction} official stage time ` +
+        `(${last.time_from_beep.toFixed(3)} s vs ${stageTime.toFixed(3)} s).`,
+      shot_number: last.shot_number,
+      time: last.time,
+    });
+  }
+
+  for (let i = 1; i < shots.length; i++) {
+    const s = shots[i];
+    if (s.split < DOUBLE_DETECTION_MAX_S) {
+      out.push({
+        kind: "double_detection",
+        severity: "warn",
+        message:
+          `Shot ${s.shot_number} split is ${Math.round(s.split * 1000)} ms ` +
+          `(< ${Math.round(DOUBLE_DETECTION_MAX_S * 1000)} ms): ` +
+          `possible double-detection.`,
+        shot_number: s.shot_number,
+        time: s.time,
+      });
+    } else if (s.split > LONG_PAUSE_MAX_S) {
+      out.push({
+        kind: "long_pause",
+        severity: "warn",
+        message:
+          `Shot ${s.shot_number} split is ${s.split.toFixed(3)} s ` +
+          `(> ${LONG_PAUSE_MAX_S.toFixed(1)} s): missed shot or long transition?`,
+        shot_number: s.shot_number,
+        time: s.time,
+      });
+    }
+  }
+
+  const [lo, hi] = TYPICAL_ROUND_RANGE;
+  if (shots.length < lo || shots.length > hi) {
+    const isLow = shots.length < lo;
+    out.push({
+      kind: isLow ? "shot_count_low" : "shot_count_high",
+      severity: "info",
+      message:
+        `Detected ${shots.length} shots; typical IPSC stages have ${lo}-${hi}. ` +
+        `Review for ${
+          isLow ? "missed shots" : "false positives (echoes / other bays)"
+        }.`,
+      shot_number: null,
+      time: null,
+    });
+  }
+
+  return out;
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -663,6 +663,17 @@ export const api = {
       json: payload,
     }),
 
+  /** Structured anomalies for the *saved* audit JSON (issue #42).
+   *
+   *  The audit screen does its own live recompute (see ``lib/anomalies``)
+   *  so the panel updates without a network round-trip on every keep /
+   *  reject. This endpoint exists for external consumers + integration
+   *  tests that want the same flags ``report.txt`` will produce. */
+  getStageAnomalies: (stageNumber: number) =>
+    request<{ anomalies: import("./anomalies").Anomaly[] }>(
+      `/api/stages/${stageNumber}/anomalies`,
+    ),
+
   /** Match-overview payload for the Analysis & Export screen. */
   getExportOverview: () => request<ExportOverview>("/api/exports/overview"),
 

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -43,6 +43,7 @@ import {
   Undo2,
 } from "lucide-react";
 
+import { AnomalyPanel } from "@/components/AnomalyPanel";
 import {
   DEFAULT_FILTERS,
   FilterBar,
@@ -77,6 +78,10 @@ import {
   type StageAudit,
   type StageVideo,
 } from "@/lib/api";
+import {
+  detectAnomalies,
+  keptShotsFromMarkers,
+} from "@/lib/anomalies";
 import { isTypingTextTarget, useBlurOnPointerClick } from "@/lib/audit-input";
 import { cn } from "@/lib/utils";
 
@@ -687,6 +692,32 @@ export function Audit() {
     [handleScrub, keptShots],
   );
 
+  // ---- Live anomalies (issue #42) ----------------------------------------
+  // Recomputed on every marker mutation -- pure function, zero detection
+  // cost. Mirrors ``report.detect_anomalies_structured`` so the panel
+  // shows what report.txt will once Generate runs.
+  const anomalies = useMemo(() => {
+    if (!stage) return [];
+    const shots = keptShotsFromMarkers(markers, auditBeep);
+    return detectAnomalies(shots, stage.time_seconds);
+  }, [markers, auditBeep, stage]);
+
+  // Anomaly rows that mention a shot number jump to that kept shot's
+  // marker on click -- the killer feature: "Shot 48 is too close" -> one
+  // click puts the playhead on shot 48 with shot 47 in view.
+  const handleAnomalyJump = useCallback(
+    (shotNumber: number) => {
+      // ``shot_number`` in the anomaly is a 1-based index into the
+      // kept-shots list (detected + manual, sorted by time) -- the same
+      // ordering ``keptShotsFromMarkers`` produces. Map back to the
+      // matching marker via that ordering.
+      const target = keptShots[shotNumber - 1];
+      if (!target) return;
+      jumpToMarker(target);
+    },
+    [keptShots, jumpToMarker],
+  );
+
   const pixelsPerSecond = useMemo(
     () => zoomToPixelsPerSecond(zoom, waveformViewport, peaks?.duration ?? 0),
     [zoom, waveformViewport, peaks],
@@ -1238,6 +1269,10 @@ export function Audit() {
                   currentIndex={currentShotIndex}
                   onStep={stepShot}
                   onNoteChange={handleNoteChange}
+                />
+                <AnomalyPanel
+                  anomalies={anomalies}
+                  onJumpToShot={handleAnomalyJump}
                 />
               </>
             ) : null}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,7 +12,12 @@ from splitsmith.config import (
     StageAnalysis,
     StageData,
 )
-from splitsmith.report import detect_anomalies, render_report, write_report
+from splitsmith.report import (
+    detect_anomalies,
+    detect_anomalies_structured,
+    render_report,
+    write_report,
+)
 
 
 def _stage(
@@ -94,6 +99,80 @@ def test_anomalies_shot_count_high() -> None:
         shots.append(_shot(i, shots[-1].time_from_beep + 0.30, 0.30))
     anomalies = detect_anomalies(shots, beep_time=10.0, stage_time=shots[-1].time_from_beep)
     assert any("false positives" in a for a in anomalies)
+
+
+# --- detect_anomalies_structured -----------------------------------------
+
+
+def test_anomalies_structured_no_shots_emits_warn() -> None:
+    """``no_shots`` is the discriminator for "stage hasn't been audited yet"."""
+    out = detect_anomalies_structured([], beep_time=10.0, stage_time=14.74)
+    assert len(out) == 1
+    assert out[0].kind == "no_shots"
+    assert out[0].severity == "warn"
+    assert out[0].shot_number is None
+    assert out[0].time is None
+
+
+def test_anomalies_structured_double_detection_carries_shot_number() -> None:
+    """Click-to-jump works because each shot anomaly carries the offending
+    shot's 1-based number + audit-timeline time."""
+    shots = [_shot(1, 1.0, 1.0), _shot(2, 1.05, 0.05)]  # 50ms split
+    out = detect_anomalies_structured(shots, beep_time=10.0, stage_time=1.05)
+    doubles = [a for a in out if a.kind == "double_detection"]
+    assert len(doubles) == 1
+    assert doubles[0].shot_number == 2
+    assert doubles[0].time == shots[1].time_from_beep
+    assert doubles[0].severity == "warn"
+
+
+def test_anomalies_structured_long_pause() -> None:
+    shots = [_shot(1, 1.0, 1.0), _shot(2, 4.5, 3.5)]  # 3.5s split
+    out = detect_anomalies_structured(shots, beep_time=10.0, stage_time=4.5)
+    longs = [a for a in out if a.kind == "long_pause"]
+    assert len(longs) == 1
+    assert longs[0].shot_number == 2
+
+
+def test_anomalies_structured_stage_time_mismatch_points_at_last_shot() -> None:
+    """The mismatch anomaly anchors on the last shot so click-to-jump puts
+    the user on the marker that decides the calculation."""
+    shots = [_shot(1, 1.0, 1.0), _shot(2, 1.5, 0.5)]
+    out = detect_anomalies_structured(shots, beep_time=10.0, stage_time=0.5)
+    mismatch = [a for a in out if a.kind == "stage_time_mismatch"]
+    assert len(mismatch) == 1
+    assert mismatch[0].shot_number == 2
+    assert mismatch[0].time == 1.5
+
+
+def test_anomalies_structured_count_band_is_info_severity() -> None:
+    """Shot-count anomalies are informational, not warnings -- the report
+    explicitly calls them out as "informational, not a hard error"."""
+    shots = [_shot(1, 1.0, 1.0), _shot(2, 1.5, 0.5)]
+    out = detect_anomalies_structured(shots, beep_time=10.0, stage_time=1.5)
+    count = [a for a in out if a.kind == "shot_count_low"]
+    assert len(count) == 1
+    assert count[0].severity == "info"
+    assert count[0].shot_number is None
+    assert count[0].time is None
+
+
+def test_anomalies_structured_high_count_uses_distinct_kind() -> None:
+    shots = [_shot(1, 1.0, 1.0)]
+    for i in range(2, 50):
+        shots.append(_shot(i, shots[-1].time_from_beep + 0.30, 0.30))
+    out = detect_anomalies_structured(shots, beep_time=10.0, stage_time=shots[-1].time_from_beep)
+    assert any(a.kind == "shot_count_high" for a in out)
+    assert not any(a.kind == "shot_count_low" for a in out)
+
+
+def test_detect_anomalies_string_messages_match_structured() -> None:
+    """The legacy string list is a stringification of the structured form;
+    report.txt rendering depends on this byte-for-byte equivalence."""
+    shots = [_shot(1, 1.0, 1.0), _shot(2, 1.05, 0.05)]
+    structured = detect_anomalies_structured(shots, beep_time=10.0, stage_time=0.5)
+    legacy = detect_anomalies(shots, beep_time=10.0, stage_time=0.5)
+    assert legacy == [a.message for a in structured]
 
 
 # --- render_report --------------------------------------------------------

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1688,6 +1688,57 @@ def test_put_stage_audit_404_when_stage_unknown(tmp_path: Path) -> None:
     assert resp.status_code == 404
 
 
+def test_get_stage_anomalies_empty_when_no_audit_file(tmp_path: Path) -> None:
+    """No audit JSON yet -> empty anomalies list (issue #42).
+
+    The audit screen calls this on mount; pre-detection there's nothing
+    useful to flag, so the panel renders the "looks clean" empty state.
+    """
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.get("/api/stages/1/anomalies")
+    assert resp.status_code == 200
+    assert resp.json() == {"anomalies": []}
+
+
+def test_get_stage_anomalies_flags_double_detection_with_shot_number(
+    tmp_path: Path,
+) -> None:
+    """The endpoint returns structured anomalies that carry the offending
+    shot's 1-based number so the SPA can scroll to that marker on click."""
+    import json as _json
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    audit_dir = project_root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    # Two shots 50 ms apart -> double-detection rule fires on shot 2.
+    payload = {
+        "stage_number": 1,
+        "stage_name": "Stage One",
+        "shots": [
+            {"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 1000},
+            {"shot_number": 2, "candidate_number": 2, "time": 1.05, "ms_after_beep": 1050},
+        ],
+    }
+    (audit_dir / "stage1.json").write_text(_json.dumps(payload), encoding="utf-8")
+
+    resp = client.get("/api/stages/1/anomalies")
+    assert resp.status_code == 200
+    anomalies = resp.json()["anomalies"]
+    kinds = {a["kind"] for a in anomalies}
+    assert "double_detection" in kinds
+    double = next(a for a in anomalies if a["kind"] == "double_detection")
+    assert double["shot_number"] == 2
+    assert double["severity"] == "warn"
+    assert double["time"] == 1.05
+
+
+def test_get_stage_anomalies_404_when_stage_unknown(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.get("/api/stages/99/anomalies")
+    assert resp.status_code == 404
+
+
 def test_fixture_audit_round_trip(tmp_path: Path) -> None:
     """The fixture endpoints read + write a JSON file in place. Closes #19's
     standalone review SPA -- localhost-only, no project context."""


### PR DESCRIPTION
The audit screen now surfaces the same anomalies report.txt would once
Generate runs -- shown live while the user keeps / rejects markers, so
the audit step is the one place where audit decisions actually happen.
Anomaly rows that reference a shot number are clickable and jump the
playhead to the offending marker.

- ``report.detect_anomalies_structured`` returns ``Anomaly`` records
  carrying ``kind``, ``severity``, ``shot_number``, and ``time``.
  ``detect_anomalies`` is now a thin stringification wrapper so the
  report.txt bytes are unchanged.
- ``GET /api/stages/{n}/anomalies`` returns the structured shape for
  the saved audit JSON (issue #42 Option B). The audit screen runs the
  same rules client-side via ``lib/anomalies`` so recompute is
  zero-latency on every mutation; the endpoint is for external
  consumers + integration tests.
- ``AnomalyPanel`` lives below the shot stepper; uses the existing
  status-warning / status-in-progress palette so severity is
  colour-blind safe.