### PR TITLE
scoreboard: LocalJsonScoreboard offline client (closes #48)

### DIFF
--- a/src/splitsmith/ui/scoreboard/__init__.py
+++ b/src/splitsmith/ui/scoreboard/__init__.py
@@ -7,8 +7,11 @@ Sub-modules:
 - ``protocol``: ``ScoreboardClient`` Protocol the UI consumes
 - ``models``: Pydantic v2 models matching the public ``/api/v1/`` shapes
   documented at https://github.com/mandakan/ssi-scoreboard ``docs/api-v1.md``
+- ``local``: ``LocalJsonScoreboard`` -- offline implementation that serves
+  a single dropped match file (issue #48)
 """
 
+from splitsmith.ui.scoreboard.local import LocalJsonScoreboard
 from splitsmith.ui.scoreboard.models import (
     AchievementProgress,
     CacheInfo,
@@ -29,6 +32,7 @@ __all__ = [
     "AchievementProgress",
     "CacheInfo",
     "CompetitorInfo",
+    "LocalJsonScoreboard",
     "MatchData",
     "MatchRef",
     "ScoreboardClient",

--- a/src/splitsmith/ui/scoreboard/local.py
+++ b/src/splitsmith/ui/scoreboard/local.py
@@ -1,0 +1,137 @@
+"""Offline ``ScoreboardClient`` -- serves a single SSI match from disk.
+
+The user drops the response body of ``GET /api/v1/match/{ct}/{id}`` into
+``<project>/scoreboard/match.json``; this client parses it through the
+same ``MatchData`` model an ``SsiHttpClient`` populates online, so both
+paths produce an identical internal shape (acceptance criterion from
+issue #14).
+
+Cross-match shooter aggregates (``get_shooter``) require many matches and
+are not implementable from a single dropped file -- that operation raises
+``NotImplementedError`` in offline mode.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from splitsmith.ui.scoreboard.models import (
+    MatchData,
+    MatchRef,
+    ShooterDashboard,
+    ShooterRef,
+)
+
+DEFAULT_MATCH_FILENAME = "match.json"
+DEFAULT_SCOREBOARD_DIRNAME = "scoreboard"
+
+# Captures (content_type, match_id) from URLs like
+# ``https://shootnscoreit.com/event/22/27190/``. Used to validate
+# ``get_match(ct, id)`` calls against the loaded file.
+_SSI_URL_RE = re.compile(r"/event/(\d+)/(\d+)/?")
+
+
+class LocalJsonScoreboard:
+    """Read-only ``ScoreboardClient`` backed by one project-local match file."""
+
+    def __init__(self, json_path: Path) -> None:
+        self._path = json_path
+        with json_path.open("r", encoding="utf-8") as f:
+            raw = json.load(f)
+        self._match = MatchData.model_validate(raw)
+        self._content_type, self._match_id = _parse_ssi_url(self._match.ssi_url)
+
+    @classmethod
+    def from_project(cls, project_dir: Path) -> LocalJsonScoreboard:
+        """Resolve the conventional ``<project>/scoreboard/match.json`` path."""
+        return cls(project_dir / DEFAULT_SCOREBOARD_DIRNAME / DEFAULT_MATCH_FILENAME)
+
+    @property
+    def match(self) -> MatchData:
+        """The parsed match -- exposed for callers that don't want a round-trip."""
+        return self._match
+
+    def search_matches(self, query: str) -> list[MatchRef]:
+        needle = query.strip().lower()
+        if not needle:
+            return [self._as_match_ref()]
+        if needle in self._match.name.lower():
+            return [self._as_match_ref()]
+        return []
+
+    def get_match(self, content_type: int, match_id: int) -> MatchData:
+        if (
+            self._content_type is not None
+            and self._match_id is not None
+            and (content_type, match_id) != (self._content_type, self._match_id)
+        ):
+            raise KeyError(
+                f"local scoreboard holds match {self._content_type}/{self._match_id};"
+                f" requested {content_type}/{match_id}"
+            )
+        return self._match
+
+    def find_shooter(self, name: str) -> list[ShooterRef]:
+        needle = name.strip().lower()
+        if not needle:
+            return []
+        last_seen = self._match.date or ""
+        return [
+            ShooterRef(
+                shooterId=c.shooterId,
+                name=c.name,
+                club=c.club,
+                division=c.division,
+                lastSeen=last_seen,
+            )
+            for c in self._match.competitors
+            if needle in c.name.lower()
+        ]
+
+    def get_shooter(self, shooter_id: int) -> ShooterDashboard:
+        # Offline-only by design: a single dropped match.json can't supply
+        # cross-match career aggregates. UI wiring (#50) should hide shooter
+        # search when the active client is a ``LocalJsonScoreboard``.
+        # Future: if the user wants offline shooter dashboards, expand the
+        # file format to also accept ``<project>/scoreboard/shooter/{id}.json``
+        # captured from ``GET /api/v1/shooter/{shooterId}`` -- track in a
+        # follow-up issue rather than reopening #48.
+        raise NotImplementedError(
+            "shooter dashboard requires the live scoreboard; offline JSON only "
+            "carries a single match's competitor list, not cross-match aggregates"
+        )
+
+    def _as_match_ref(self) -> MatchRef:
+        m = self._match
+        return MatchRef(
+            id=self._match_id or 0,
+            content_type=self._content_type or 0,
+            name=m.name,
+            venue=m.venue,
+            date=m.date or "",
+            ends=m.ends,
+            status=m.match_status,
+            region=m.region or "",
+            discipline=m.discipline or "",
+            level=m.level or "",
+            registration_status=m.registration_status,
+            registration_starts=m.registration_starts,
+            registration_closes=m.registration_closes,
+            is_registration_possible=m.is_registration_possible,
+            squadding_starts=m.squadding_starts,
+            squadding_closes=m.squadding_closes,
+            is_squadding_possible=m.is_squadding_possible,
+            max_competitors=m.max_competitors,
+            scoring_completed=m.scoring_completed,
+        )
+
+
+def _parse_ssi_url(url: str | None) -> tuple[int | None, int | None]:
+    if not url:
+        return None, None
+    m = _SSI_URL_RE.search(url)
+    if not m:
+        return None, None
+    return int(m.group(1)), int(m.group(2))

--- a/tests/test_scoreboard_local.py
+++ b/tests/test_scoreboard_local.py
@@ -1,0 +1,148 @@
+"""Tests for ``LocalJsonScoreboard`` (offline ``ScoreboardClient``, issue #48).
+
+The fixture under ``tests/fixtures/scoreboard/match_22_27190.json`` is a
+real ``GET /api/v1/match/22/27190`` response captured for #47 -- the same
+shape the upcoming ``SsiHttpClient`` will return online. Verifying that
+``LocalJsonScoreboard`` round-trips it satisfies the #14 acceptance
+criterion that both code paths produce an identical internal shape.
+
+A ``socket.socket`` patch around the whole module guards the
+"no network calls" criterion: any accidental connect() during tests will
+raise.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+from pathlib import Path
+
+import pytest
+
+from splitsmith.ui.scoreboard.local import LocalJsonScoreboard
+from splitsmith.ui.scoreboard.models import MatchData, MatchRef, ShooterRef
+from splitsmith.ui.scoreboard.protocol import ScoreboardClient
+
+FIXTURE = Path(__file__).parent / "fixtures" / "scoreboard" / "match_22_27190.json"
+
+# Captured from the fixture's ``ssi_url``.
+FIXTURE_CT = 22
+FIXTURE_ID = 27190
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly if any code path opens a socket during these tests."""
+
+    def _refuse(*_args: object, **_kwargs: object) -> socket.socket:
+        raise RuntimeError("network access not allowed in LocalJsonScoreboard tests")
+
+    monkeypatch.setattr(socket, "socket", _refuse)
+
+
+@pytest.fixture
+def client() -> LocalJsonScoreboard:
+    return LocalJsonScoreboard(FIXTURE)
+
+
+def test_satisfies_protocol(client: LocalJsonScoreboard) -> None:
+    assert isinstance(client, ScoreboardClient)
+
+
+def test_get_match_returns_parsed_match_data(client: LocalJsonScoreboard) -> None:
+    match = client.get_match(FIXTURE_CT, FIXTURE_ID)
+    assert isinstance(match, MatchData)
+    assert match.name == "SPSK Open 2026"
+    assert len(match.stages) == match.stages_count
+    assert match.competitors, "fixture must have competitors"
+    assert all(c.shooterId > 0 for c in match.competitors)
+
+
+def test_get_match_round_trips_to_wire_shape(client: LocalJsonScoreboard) -> None:
+    """The same JSON loaded online should equal the loaded-then-dumped local copy."""
+    import json as _json
+
+    raw = _json.loads(FIXTURE.read_text())
+    dumped = client.get_match(FIXTURE_CT, FIXTURE_ID).model_dump(by_alias=True, exclude_none=False)
+    # Strip keys the model defaulted-None for fields the wire didn't carry.
+    present = {k: v for k, v in dumped.items() if not (v is None and k not in raw)}
+    # Top-level scalar parity is enough for the round-trip claim; the deep
+    # equality assertion lives in test_scoreboard_models.test_match_roundtrip.
+    for key in ("name", "level", "discipline", "stages_count", "ssi_url"):
+        assert present[key] == raw[key]
+
+
+def test_get_match_rejects_mismatched_id(client: LocalJsonScoreboard) -> None:
+    with pytest.raises(KeyError, match="local scoreboard holds"):
+        client.get_match(FIXTURE_CT, FIXTURE_ID + 1)
+
+
+def test_search_matches_finds_loaded_match(client: LocalJsonScoreboard) -> None:
+    hits = client.search_matches("SPSK")
+    assert len(hits) == 1
+    ref = hits[0]
+    assert isinstance(ref, MatchRef)
+    assert ref.id == FIXTURE_ID
+    assert ref.content_type == FIXTURE_CT
+    assert ref.name == "SPSK Open 2026"
+
+
+def test_search_matches_is_case_insensitive(client: LocalJsonScoreboard) -> None:
+    assert client.search_matches("spsk")
+    assert client.search_matches("OPEN")
+
+
+def test_search_matches_empty_query_returns_match(client: LocalJsonScoreboard) -> None:
+    """Empty query mirrors the online ``GET /api/v1/events`` "list everything" call."""
+    assert len(client.search_matches("")) == 1
+
+
+def test_search_matches_unknown_query_returns_empty(client: LocalJsonScoreboard) -> None:
+    assert client.search_matches("absolutely-not-a-real-match") == []
+
+
+def test_find_shooter_returns_matching_competitors(client: LocalJsonScoreboard) -> None:
+    match = client.get_match(FIXTURE_CT, FIXTURE_ID)
+    target = match.competitors[0]
+    hits = client.find_shooter(target.name)
+    assert hits, "should find the competitor by exact name"
+    assert any(h.shooterId == target.shooterId for h in hits)
+    assert all(isinstance(h, ShooterRef) for h in hits)
+
+
+def test_find_shooter_substring_match(client: LocalJsonScoreboard) -> None:
+    match = client.get_match(FIXTURE_CT, FIXTURE_ID)
+    # Search for a single letter present in many names; ensures substring
+    # matching, not equality, is what the implementation does.
+    hits = client.find_shooter("a")
+    assert (
+        any(h.name == match.competitors[0].name for h in hits) or hits
+    ), "substring search should return at least one competitor"
+
+
+def test_find_shooter_unknown_name_returns_empty(client: LocalJsonScoreboard) -> None:
+    assert client.find_shooter("zzzzz-not-a-real-shooter") == []
+
+
+def test_find_shooter_empty_query_returns_empty(client: LocalJsonScoreboard) -> None:
+    assert client.find_shooter("") == []
+    assert client.find_shooter("   ") == []
+
+
+def test_get_shooter_raises_in_offline_mode(client: LocalJsonScoreboard) -> None:
+    with pytest.raises(NotImplementedError, match="shooter dashboard"):
+        client.get_shooter(51842)
+
+
+def test_from_project_resolves_conventional_path(tmp_path: Path) -> None:
+    scoreboard_dir = tmp_path / "scoreboard"
+    scoreboard_dir.mkdir()
+    shutil.copy(FIXTURE, scoreboard_dir / "match.json")
+
+    client = LocalJsonScoreboard.from_project(tmp_path)
+    assert client.match.name == "SPSK Open 2026"
+
+
+def test_constructor_fails_on_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        LocalJsonScoreboard(tmp_path / "does-not-exist.json")


### PR DESCRIPTION
## Summary

- New `LocalJsonScoreboard` reads `<project>/scoreboard/match.json` (the `/api/v1/match/{ct}/{id}` shape) into the existing `MatchData` model -- offline drops and live `SsiHttpClient` fetches yield the same internal shape (#14 acceptance criterion).
- `search_matches` and `find_shooter` return refs derived from the loaded match. `get_shooter` raises by design (single match.json can't supply cross-match aggregates); offline shooter dashboards tracked in #60. UI wiring (#50) should hide shooter search when the active client is a `LocalJsonScoreboard`.
- 15 tests with an autouse `socket.socket` patch to enforce the "no network calls" acceptance criterion.

Closes #48.

## Test plan

- [x] `uv run pytest tests/test_scoreboard_local.py tests/test_scoreboard_models.py` -> 24 passed
- [x] `uv run ruff check src/splitsmith/ui/scoreboard/ tests/test_scoreboard_local.py`
- [x] `uv run black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)