### PR TITLE
scoreboard: SsiHttpClient + project-local cache (closes #49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "soundfile>=0.12.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
+    "httpx>=0.28.0",
     # Ensemble shot-detection runtime (issue #31). Heavy ML deps live in
     # the runtime path because the production audit UI needs voters
     # B (CLAP), C (GBDT), and D (PANN) to seed shots[] correctly.
@@ -62,6 +63,7 @@ dev = [
     "ruff>=0.4.0",
     "black>=24.0.0",
     "mypy>=1.10.0",
+    "respx>=0.21.1",
 ]
 
 [tool.ruff]
@@ -79,6 +81,11 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "PTH"]
 # verbatim, which is mixed snake_case + camelCase. Translation to splitsmith's
 # snake_case happens in adapters, not in the parsed-response models.
 "src/splitsmith/ui/scoreboard/models.py" = ["N815"]
+# Public scoreboard exceptions use the `*NotFound` / `*RateLimited` naming
+# prescribed by the API contract in issue #49 rather than the N818 `*Error`
+# convention. The names are part of the documented surface; renaming would
+# break callers.
+"src/splitsmith/ui/scoreboard/http.py" = ["N818"]
 
 [tool.black]
 line-length = 100

--- a/src/splitsmith/ui/scoreboard/__init__.py
+++ b/src/splitsmith/ui/scoreboard/__init__.py
@@ -9,8 +9,21 @@ Sub-modules:
   documented at https://github.com/mandakan/ssi-scoreboard ``docs/api-v1.md``
 - ``local``: ``LocalJsonScoreboard`` -- offline implementation that serves
   a single dropped match file (issue #48)
+- ``http``: ``SsiHttpClient`` -- live online implementation (issue #49)
+- ``cache``: ``CachingScoreboardClient`` -- project-local disk cache
+  decorator that wraps any ``ScoreboardClient`` (issue #49)
 """
 
+from splitsmith.ui.scoreboard.cache import CachingScoreboardClient
+from splitsmith.ui.scoreboard.http import (
+    MatchNotFound,
+    ScoreboardAuthError,
+    ScoreboardError,
+    ScoreboardRateLimited,
+    ScoreboardUpstreamError,
+    ShooterNotFound,
+    SsiHttpClient,
+)
 from splitsmith.ui.scoreboard.local import LocalJsonScoreboard
 from splitsmith.ui.scoreboard.models import (
     AchievementProgress,
@@ -31,16 +44,24 @@ from splitsmith.ui.scoreboard.protocol import ScoreboardClient
 __all__ = [
     "AchievementProgress",
     "CacheInfo",
+    "CachingScoreboardClient",
     "CompetitorInfo",
     "LocalJsonScoreboard",
     "MatchData",
+    "MatchNotFound",
     "MatchRef",
+    "ScoreboardAuthError",
     "ScoreboardClient",
+    "ScoreboardError",
+    "ScoreboardRateLimited",
+    "ScoreboardUpstreamError",
     "ShooterAggregateStats",
     "ShooterDashboard",
     "ShooterMatchSummary",
+    "ShooterNotFound",
     "ShooterRef",
     "SquadInfo",
+    "SsiHttpClient",
     "StageInfo",
     "UpcomingMatch",
 ]

--- a/src/splitsmith/ui/scoreboard/cache.py
+++ b/src/splitsmith/ui/scoreboard/cache.py
@@ -1,0 +1,156 @@
+"""Project-local disk cache decorator for any ``ScoreboardClient``.
+
+Sits between the UI and a real client (typically ``SsiHttpClient``) so a
+match opened a second time loads instantly and the cached payload travels
+with the project directory: zip the project folder and the cache goes
+with it (issue #14 acceptance criterion).
+
+Why a decorator instead of caching inside the HTTP client: the cache is
+project-scoped, but the HTTP client is process-scoped; folding caching
+into the HTTP layer would couple cache lifetime to the wrong object and
+prevent zip-and-send portability. Wrap, don't weave.
+
+TTL policy (issue #49):
+
+- Completed matches (``scoring_completed >= 100.0``): cached forever.
+  These payloads don't change after the match wraps.
+- In-progress matches: cached, but flagged ``in_progress=True`` in the
+  envelope. The UI shows a manual refresh button; ``invalidate_match``
+  clears the entry on user request.
+- ``search_matches``, ``find_shooter``, ``get_shooter``: not cached.
+  Lists/dashboards rotate too often for a project-local cache to be
+  useful, and the UI re-runs them only on explicit user input.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from splitsmith.ui.scoreboard.models import (
+    MatchData,
+    MatchRef,
+    ShooterDashboard,
+    ShooterRef,
+)
+from splitsmith.ui.scoreboard.protocol import ScoreboardClient
+
+CACHE_DIRNAME = "cache"
+SCOREBOARD_DIRNAME = "scoreboard"
+CACHE_VERSION = 1
+COMPLETED_THRESHOLD = 100.0
+
+
+class CachingScoreboardClient:
+    """Decorator: serves ``get_match`` from a project-local disk cache."""
+
+    def __init__(self, inner: ScoreboardClient, cache_dir: Path) -> None:
+        self._inner = inner
+        self._cache_dir = cache_dir
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def for_project(cls, inner: ScoreboardClient, project_dir: Path) -> CachingScoreboardClient:
+        """Resolve the conventional ``<project>/scoreboard/cache/`` directory."""
+        return cls(inner, project_dir / SCOREBOARD_DIRNAME / CACHE_DIRNAME)
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._cache_dir
+
+    def search_matches(self, query: str) -> list[MatchRef]:
+        return self._inner.search_matches(query)
+
+    def find_shooter(self, name: str) -> list[ShooterRef]:
+        return self._inner.find_shooter(name)
+
+    def get_shooter(self, shooter_id: int) -> ShooterDashboard:
+        return self._inner.get_shooter(shooter_id)
+
+    def get_match(self, content_type: int, match_id: int) -> MatchData:
+        cache_path = self._match_cache_path(content_type, match_id)
+        cached = _read_envelope(cache_path)
+        if cached is not None and not cached.get("in_progress", False):
+            return MatchData.model_validate(cached["data"])
+
+        match = self._inner.get_match(content_type, match_id)
+        in_progress = match.scoring_completed < COMPLETED_THRESHOLD
+        envelope = {
+            "version": CACHE_VERSION,
+            "endpoint": "match",
+            "params": {"content_type": content_type, "match_id": match_id},
+            "cached_at": _utc_now_iso(),
+            "in_progress": in_progress,
+            "match_status": match.match_status,
+            "scoring_completed": match.scoring_completed,
+            "data": match.model_dump(by_alias=True),
+        }
+        _write_envelope(cache_path, envelope)
+        return match
+
+    def invalidate_match(self, content_type: int, match_id: int) -> bool:
+        """Drop the cached match so the next ``get_match`` refetches.
+
+        Returns True if a cache entry was removed. Used by the UI's manual
+        refresh button for in-progress matches.
+        """
+        path = self._match_cache_path(content_type, match_id)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def is_cached(self, content_type: int, match_id: int) -> bool:
+        return self._match_cache_path(content_type, match_id).exists()
+
+    def _match_cache_path(self, content_type: int, match_id: int) -> Path:
+        params = {"content_type": content_type, "match_id": match_id}
+        return self._cache_dir / f"match_{_param_hash('match', params)}.json"
+
+
+def _param_hash(endpoint: str, params: dict[str, Any]) -> str:
+    """Stable filename hash from (endpoint, sorted_params).
+
+    Uses sorted keys + a JSON canonical form so equivalent param dicts
+    produce the same hash regardless of insertion order. Truncated to 16
+    hex chars -- collision risk over a project's lifetime is negligible.
+    """
+    payload = json.dumps(
+        {"endpoint": endpoint, "params": dict(sorted(params.items()))},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _read_envelope(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != CACHE_VERSION:
+        return None
+    return data
+
+
+def _write_envelope(path: Path, envelope: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic write: tmp file in the same dir, then rename. Avoids a torn
+    # JSON file if the process is killed mid-write.
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, prefix=path.name, suffix=".tmp", delete=False, encoding="utf-8"
+    ) as tmp:
+        json.dump(envelope, tmp, indent=2, sort_keys=True)
+        tmp_path = Path(tmp.name)
+    tmp_path.replace(path)

--- a/src/splitsmith/ui/scoreboard/http.py
+++ b/src/splitsmith/ui/scoreboard/http.py
@@ -1,0 +1,168 @@
+"""Online ``ScoreboardClient`` -- talks to ``scoreboard.urdr.dev/api/v1/``.
+
+Pairs with ``LocalJsonScoreboard`` (issue #48): the same ``MatchData``
+shape comes out either way, so the UI consumes only the
+``ScoreboardClient`` Protocol and never branches on the source.
+
+The HTTP client is intentionally thin: no caching here. Caching lives in
+``CachingScoreboardClient`` so it can be project-local and travel with
+the project directory (issue #14 acceptance criterion). Wrap this client
+in the cache decorator at construction time, not inside the HTTP layer.
+
+Auth: bearer token from ``SPLITSMITH_SSI_TOKEN`` (or the ``token=``
+constructor arg). Missing token raises ``ScoreboardAuthError`` at
+construction so the UI can surface a clear setup message instead of
+hitting a 401 on first request.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from splitsmith.ui.scoreboard.models import (
+    MatchData,
+    MatchRef,
+    ShooterDashboard,
+    ShooterRef,
+)
+
+DEFAULT_BASE_URL = "https://scoreboard.urdr.dev/api/v1"
+TOKEN_ENV_VAR = "SPLITSMITH_SSI_TOKEN"
+API_DOCS_URL = "https://github.com/mandakan/ssi-scoreboard/blob/main/docs/api-v1.md"
+
+
+class ScoreboardError(RuntimeError):
+    """Base class for ``SsiHttpClient`` errors."""
+
+
+class ScoreboardAuthError(ScoreboardError):
+    """Token missing or rejected by the server (401)."""
+
+
+class ScoreboardRateLimited(ScoreboardError):
+    """Server returned 429. ``retry_after`` is seconds if the header was set."""
+
+    def __init__(self, message: str, retry_after: float | None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class ScoreboardUpstreamError(ScoreboardError):
+    """5xx from the upstream API; offline JSON path is the suggested fallback."""
+
+
+class MatchNotFound(ScoreboardError):
+    """``GET /api/v1/match/{ct}/{id}`` returned 404."""
+
+
+class ShooterNotFound(ScoreboardError):
+    """``GET /api/v1/shooter/{shooterId}`` returned 404."""
+
+
+class SsiHttpClient:
+    """``ScoreboardClient`` backed by the live ``/api/v1/`` HTTP API."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        token: str | None = None,
+        timeout: float = 10.0,
+        *,
+        client: httpx.Client | None = None,
+    ) -> None:
+        resolved_token = token if token is not None else os.environ.get(TOKEN_ENV_VAR)
+        if not resolved_token:
+            raise ScoreboardAuthError(
+                f"{TOKEN_ENV_VAR} is not set; obtain a bearer token and export it. "
+                f"See {API_DOCS_URL}"
+            )
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            base_url=base_url.rstrip("/"),
+            headers={"Authorization": f"Bearer {resolved_token}"},
+            timeout=timeout,
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> SsiHttpClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def search_matches(self, query: str) -> list[MatchRef]:
+        data = self._get_json("/events", params={"q": query} if query else None)
+        if not isinstance(data, list):
+            raise ScoreboardUpstreamError(
+                f"unexpected /events response shape: {type(data).__name__}"
+            )
+        return [MatchRef.model_validate(item) for item in data]
+
+    def get_match(self, content_type: int, match_id: int) -> MatchData:
+        try:
+            data = self._get_json(f"/match/{content_type}/{match_id}")
+        except _NotFound as exc:
+            raise MatchNotFound(f"match {content_type}/{match_id} not found on scoreboard") from exc
+        return MatchData.model_validate(data)
+
+    def find_shooter(self, name: str) -> list[ShooterRef]:
+        data = self._get_json("/shooter/search", params={"q": name})
+        if not isinstance(data, list):
+            raise ScoreboardUpstreamError(
+                f"unexpected /shooter/search response shape: {type(data).__name__}"
+            )
+        return [ShooterRef.model_validate(item) for item in data]
+
+    def get_shooter(self, shooter_id: int) -> ShooterDashboard:
+        try:
+            data = self._get_json(f"/shooter/{shooter_id}")
+        except _NotFound as exc:
+            raise ShooterNotFound(f"shooter {shooter_id} not found on scoreboard") from exc
+        return ShooterDashboard.model_validate(data)
+
+    def _get_json(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        try:
+            response = self._client.get(path, params=params)
+        except httpx.HTTPError as exc:
+            raise ScoreboardUpstreamError(
+                f"network error talking to scoreboard ({exc.__class__.__name__}); "
+                "try the offline JSON path"
+            ) from exc
+
+        status = response.status_code
+        if 200 <= status < 300:
+            return response.json()
+        if status == 401:
+            raise ScoreboardAuthError(
+                f"scoreboard rejected the bearer token (401). "
+                f"Set {TOKEN_ENV_VAR}; see {API_DOCS_URL}"
+            )
+        if status == 404:
+            raise _NotFound(path)
+        if status == 429:
+            raw = response.headers.get("Retry-After")
+            retry_after: float | None
+            try:
+                retry_after = float(raw) if raw is not None else None
+            except ValueError:
+                retry_after = None
+            wait_hint = f" (retry after {retry_after:g}s)" if retry_after is not None else ""
+            raise ScoreboardRateLimited(
+                f"scoreboard rate limit hit{wait_hint}",
+                retry_after=retry_after,
+            )
+        if 500 <= status < 600:
+            raise ScoreboardUpstreamError(
+                f"scoreboard upstream returned {status}; try the offline JSON path"
+            )
+        raise ScoreboardError(f"unexpected scoreboard response: {status} {response.text[:200]}")
+
+
+class _NotFound(Exception):
+    """Internal: 404 marker so ``get_match``/``get_shooter`` can map to typed errors."""

--- a/tests/test_scoreboard_cache.py
+++ b/tests/test_scoreboard_cache.py
@@ -1,0 +1,198 @@
+"""Tests for ``CachingScoreboardClient`` (project-local disk cache, issue #49).
+
+Acceptance-criterion mapping:
+
+- "Second open is instant; zero network calls" -- ``respx`` proves no
+  HTTP traffic on the second ``get_match`` call.
+- "Cache survives across instances" -- a fresh ``CachingScoreboardClient``
+  pointed at the same dir reuses the file on disk.
+- "Project portability" -- copy the cache directory to a new path,
+  instantiate fresh, hits still work.
+- "Completed never refetched, in-progress manual-refresh only" -- the
+  TTL test exercises both branches.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from splitsmith.ui.scoreboard.cache import (
+    COMPLETED_THRESHOLD,
+    CachingScoreboardClient,
+)
+from splitsmith.ui.scoreboard.http import DEFAULT_BASE_URL, TOKEN_ENV_VAR, SsiHttpClient
+from splitsmith.ui.scoreboard.models import MatchData
+
+FIXTURES = Path(__file__).parent / "fixtures" / "scoreboard"
+MATCH_FIXTURE = FIXTURES / "match_22_27190.json"
+
+
+@pytest.fixture(autouse=True)
+def _stable_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV_VAR, "test-token-abc123")
+
+
+@pytest.fixture
+def http_client() -> SsiHttpClient:
+    return SsiHttpClient(base_url=DEFAULT_BASE_URL)
+
+
+def _load_match_payload(*, scoring_completed: float) -> dict:
+    payload = json.loads(MATCH_FIXTURE.read_text())
+    payload["scoring_completed"] = scoring_completed
+    return payload
+
+
+@respx.mock
+def test_first_call_hits_network_second_does_not(
+    tmp_path: Path, http_client: SsiHttpClient
+) -> None:
+    cache = CachingScoreboardClient(http_client, tmp_path / "cache")
+    payload = _load_match_payload(scoring_completed=100.0)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    first = cache.get_match(22, 27190)
+    second = cache.get_match(22, 27190)
+
+    assert isinstance(first, MatchData)
+    assert isinstance(second, MatchData)
+    assert first.name == second.name
+    assert route.call_count == 1, "second call must be served from cache"
+
+
+@respx.mock
+def test_in_progress_match_does_not_serve_from_cache(
+    tmp_path: Path, http_client: SsiHttpClient
+) -> None:
+    cache = CachingScoreboardClient(http_client, tmp_path / "cache")
+    payload = _load_match_payload(scoring_completed=42.0)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    cache.get_match(22, 27190)
+    cache.get_match(22, 27190)
+
+    assert route.call_count == 2, "in-progress match must refetch every time"
+    assert cache.is_cached(22, 27190), "in-progress match still gets written to disk"
+
+
+@respx.mock
+def test_completed_threshold_is_inclusive(tmp_path: Path, http_client: SsiHttpClient) -> None:
+    cache = CachingScoreboardClient(http_client, tmp_path / "cache")
+    payload = _load_match_payload(scoring_completed=COMPLETED_THRESHOLD)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    cache.get_match(22, 27190)
+    cache.get_match(22, 27190)
+
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_invalidate_match_forces_refetch(tmp_path: Path, http_client: SsiHttpClient) -> None:
+    cache = CachingScoreboardClient(http_client, tmp_path / "cache")
+    payload = _load_match_payload(scoring_completed=100.0)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    cache.get_match(22, 27190)
+    assert cache.invalidate_match(22, 27190) is True
+    assert cache.invalidate_match(22, 27190) is False
+    cache.get_match(22, 27190)
+
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_cache_survives_across_instances(tmp_path: Path, http_client: SsiHttpClient) -> None:
+    cache_dir = tmp_path / "cache"
+    payload = _load_match_payload(scoring_completed=100.0)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    CachingScoreboardClient(http_client, cache_dir).get_match(22, 27190)
+    CachingScoreboardClient(http_client, cache_dir).get_match(22, 27190)
+
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_project_portability_copy_cache_to_new_path(
+    tmp_path: Path, http_client: SsiHttpClient
+) -> None:
+    project_a = tmp_path / "project_a" / "scoreboard" / "cache"
+    project_b = tmp_path / "project_b" / "scoreboard" / "cache"
+    payload = _load_match_payload(scoring_completed=100.0)
+    route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    cache_a = CachingScoreboardClient(http_client, project_a)
+    cache_a.get_match(22, 27190)
+
+    # Simulate zip + send: copy the whole cache directory across.
+    shutil.copytree(project_a, project_b)
+
+    cache_b = CachingScoreboardClient(http_client, project_b)
+    cache_b.get_match(22, 27190)
+
+    assert route.call_count == 1, "copied cache must serve hits without network"
+
+
+@respx.mock
+def test_for_project_resolves_conventional_path(tmp_path: Path, http_client: SsiHttpClient) -> None:
+    payload = _load_match_payload(scoring_completed=100.0)
+    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    cache = CachingScoreboardClient.for_project(http_client, tmp_path)
+    cache.get_match(22, 27190)
+    assert (tmp_path / "scoreboard" / "cache").is_dir()
+    assert any((tmp_path / "scoreboard" / "cache").iterdir())
+
+
+@respx.mock
+def test_unrelated_endpoints_pass_through_uncached(
+    tmp_path: Path, http_client: SsiHttpClient
+) -> None:
+    cache = CachingScoreboardClient(http_client, tmp_path / "cache")
+    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=[]))
+
+    cache.search_matches("x")
+    cache.search_matches("x")
+
+    assert route.call_count == 2, "search results are not cached by design"
+
+
+def test_corrupt_cache_file_falls_back_to_inner(tmp_path: Path, http_client: SsiHttpClient) -> None:
+    cache_dir = tmp_path / "cache"
+    cache = CachingScoreboardClient(http_client, cache_dir)
+    # Pre-seed a corrupt file at the path the cache would write.
+    corrupt = cache._match_cache_path(22, 27190)  # noqa: SLF001 -- test-only inspection
+    corrupt.parent.mkdir(parents=True, exist_ok=True)
+    corrupt.write_text("not json {")
+
+    payload = _load_match_payload(scoring_completed=100.0)
+    with respx.mock() as mock:
+        mock.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        cache.get_match(22, 27190)
+
+    # After the fetch, the corrupt file should be replaced with a valid envelope.
+    data = json.loads(corrupt.read_text())
+    assert data["version"] == 1

--- a/tests/test_scoreboard_http.py
+++ b/tests/test_scoreboard_http.py
@@ -1,0 +1,192 @@
+"""Tests for ``SsiHttpClient`` (online ``ScoreboardClient``, issue #49).
+
+The same fixtures the local-json tests use back these too: that's the
+acceptance criterion that both sources produce an identical internal
+shape (issue #14). HTTP is mocked with ``respx`` -- no real network ever
+opens.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from splitsmith.ui.scoreboard.http import (
+    DEFAULT_BASE_URL,
+    TOKEN_ENV_VAR,
+    MatchNotFound,
+    ScoreboardAuthError,
+    ScoreboardRateLimited,
+    ScoreboardUpstreamError,
+    ShooterNotFound,
+    SsiHttpClient,
+)
+from splitsmith.ui.scoreboard.models import MatchData, MatchRef, ShooterDashboard, ShooterRef
+from splitsmith.ui.scoreboard.protocol import ScoreboardClient
+
+FIXTURES = Path(__file__).parent / "fixtures" / "scoreboard"
+MATCH_FIXTURE = FIXTURES / "match_22_27190.json"
+EVENTS_FIXTURE = FIXTURES / "events.json"
+SHOOTER_SEARCH_FIXTURE = FIXTURES / "shooter_search.json"
+SHOOTER_DASHBOARD_FIXTURE = FIXTURES / "shooter_dashboard.json"
+
+
+@pytest.fixture(autouse=True)
+def _stable_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV_VAR, "test-token-abc123")
+
+
+@pytest.fixture
+def client() -> SsiHttpClient:
+    return SsiHttpClient(base_url=DEFAULT_BASE_URL)
+
+
+def _load(path: Path):
+    return json.loads(path.read_text())
+
+
+def test_satisfies_protocol(client: SsiHttpClient) -> None:
+    assert isinstance(client, ScoreboardClient)
+
+
+def test_missing_token_raises_at_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    with pytest.raises(ScoreboardAuthError, match=TOKEN_ENV_VAR):
+        SsiHttpClient()
+
+
+def test_explicit_token_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    # Should not raise -- token argument supplies the bearer.
+    SsiHttpClient(token="explicit").close()
+
+
+@respx.mock
+def test_bearer_header_sent(client: SsiHttpClient) -> None:
+    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=[]))
+    client.search_matches("anything")
+    assert route.called
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == "Bearer test-token-abc123"
+
+
+@respx.mock
+def test_get_match_returns_parsed_match_data(client: SsiHttpClient) -> None:
+    payload = _load(MATCH_FIXTURE)
+    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    match = client.get_match(22, 27190)
+    assert isinstance(match, MatchData)
+    assert match.name == payload["name"]
+    assert len(match.stages) == match.stages_count
+
+
+@respx.mock
+def test_get_match_404_maps_to_match_not_found(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/match/22/99999").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    with pytest.raises(MatchNotFound, match="22/99999"):
+        client.get_match(22, 99999)
+
+
+@respx.mock
+def test_search_matches_passes_query(client: SsiHttpClient) -> None:
+    payload = _load(EVENTS_FIXTURE)
+    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    hits = client.search_matches("SPSK")
+    assert all(isinstance(h, MatchRef) for h in hits)
+    assert route.calls.last.request.url.params["q"] == "SPSK"
+
+
+@respx.mock
+def test_search_matches_empty_query_omits_param(client: SsiHttpClient) -> None:
+    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=[]))
+    client.search_matches("")
+    assert "q" not in route.calls.last.request.url.params
+
+
+@respx.mock
+def test_find_shooter(client: SsiHttpClient) -> None:
+    payload = _load(SHOOTER_SEARCH_FIXTURE)
+    respx.get(f"{DEFAULT_BASE_URL}/shooter/search").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    hits = client.find_shooter("Axell")
+    assert hits, "fixture must have at least one shooter"
+    assert all(isinstance(h, ShooterRef) for h in hits)
+
+
+@respx.mock
+def test_get_shooter(client: SsiHttpClient) -> None:
+    payload = _load(SHOOTER_DASHBOARD_FIXTURE)
+    respx.get(f"{DEFAULT_BASE_URL}/shooter/{payload['shooterId']}").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    dash = client.get_shooter(payload["shooterId"])
+    assert isinstance(dash, ShooterDashboard)
+    assert dash.shooterId == payload["shooterId"]
+
+
+@respx.mock
+def test_get_shooter_404_maps_to_shooter_not_found(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/shooter/9999999").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    with pytest.raises(ShooterNotFound, match="9999999"):
+        client.get_shooter(9999999)
+
+
+@respx.mock
+def test_401_unauthorized_message(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(401))
+    with pytest.raises(ScoreboardAuthError, match=TOKEN_ENV_VAR):
+        client.search_matches("x")
+
+
+@respx.mock
+def test_429_surfaces_retry_after(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/events").mock(
+        return_value=httpx.Response(429, headers={"Retry-After": "12"})
+    )
+    with pytest.raises(ScoreboardRateLimited) as excinfo:
+        client.search_matches("x")
+    assert excinfo.value.retry_after == 12.0
+    assert "rate limit" in str(excinfo.value).lower()
+
+
+@respx.mock
+def test_429_without_retry_after_header(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(429))
+    with pytest.raises(ScoreboardRateLimited) as excinfo:
+        client.search_matches("x")
+    assert excinfo.value.retry_after is None
+
+
+@respx.mock
+def test_5xx_maps_to_upstream_error_with_offline_hint(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(503))
+    with pytest.raises(ScoreboardUpstreamError, match="offline JSON"):
+        client.search_matches("x")
+
+
+@respx.mock
+def test_network_error_maps_to_upstream_error(client: SsiHttpClient) -> None:
+    respx.get(f"{DEFAULT_BASE_URL}/events").mock(side_effect=httpx.ConnectError("boom"))
+    with pytest.raises(ScoreboardUpstreamError, match="offline JSON"):
+        client.search_matches("x")
+
+
+@respx.mock
+def test_context_manager_closes_owned_client() -> None:
+    with SsiHttpClient(token="t") as c:
+        respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=[]))
+        c.search_matches("x")
+    assert c._client.is_closed  # noqa: SLF001 -- introspection check

--- a/uv.lock
+++ b/uv.lock
@@ -2204,6 +2204,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2462,6 +2474,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "joblib" },
     { name = "librosa" },
     { name = "numpy" },
@@ -2484,12 +2497,14 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "joblib", specifier = ">=1.4.0" },
     { name = "librosa", specifier = ">=0.10.2" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2512,6 +2527,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "respx", specifier = ">=0.21.1" },
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 


### PR DESCRIPTION
## Summary

- `SsiHttpClient`: online `ScoreboardClient` against `scoreboard.urdr.dev/api/v1/`, bearer auth from `SPLITSMITH_SSI_TOKEN`, typed errors for 401/404/429/5xx (`ScoreboardAuthError`, `MatchNotFound`, `ShooterNotFound`, `ScoreboardRateLimited` with `retry_after`, `ScoreboardUpstreamError`)
- `CachingScoreboardClient`: decorator that caches `get_match` to `<project>/scoreboard/cache/` so the cache travels with the project directory. Completed matches (`scoring_completed >= 100.0`) cached forever; in-progress matches always refetch and expose `invalidate_match()` for the UI's manual refresh
- Adds `httpx` (runtime) and `respx` (dev) deps

## Test plan

- [x] `uv run pytest tests/test_scoreboard_http.py tests/test_scoreboard_cache.py` -- 26 new tests pass
- [x] Full scoreboard subsuite (50 tests) green
- [x] Wider test suite (360 tests excluding heavy ensemble) green
- [x] respx confirms zero network on cache hit
- [x] `shutil.copytree` test confirms cache works after copying the project to a new path
- [ ] Wire into UI in #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)