### PR TITLE
ingest: scoreboard card polish + USB/network mount sidebar

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1167,6 +1167,16 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             project.last_scanned_dir = str(last_dir)
 
         project.save(state.project_root)
+
+        # Queue auto-beep for every freshly-primaried video (#67). Done
+        # after save so the persisted state reflects the assignment when
+        # the worker re-loads the project.
+        for stage_num, video_path in auto_assigned.items():
+            stage = project.stage(stage_num)
+            video = next((v for v in stage.videos if str(v.path) == video_path), None)
+            if video is not None:
+                _auto_queue_beep_if_needed(project, stage_num, video)
+
         return ScanResponse(
             registered=registered,
             auto_assigned=auto_assigned,
@@ -1400,6 +1410,53 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             fn=lambda h, n=stage_number, vid=video.video_id: _run_detect_beep_for_video(h, n, vid),
         )
         return JSONResponse(job.model_dump(mode="json"))
+
+    def _auto_queue_beep_if_needed(
+        project: MatchProject, stage_number: int, video: StageVideo
+    ) -> bool:
+        """Best-effort auto-queue of detect_beep on a freshly-assigned video.
+
+        Hooked into scan auto-assign, ``/assignments/move``, and
+        ``/assignments/swap-primary`` so the user doesn't have to click
+        "detect beep" on every camera before the audit screen is useful
+        (#67). Auto-firing is conservative -- we silently skip whenever
+        manual user action is the right call:
+
+        - already detected (``processed.beep``) or manually overridden
+          (``beep_source == "manual"``) -- never replace user input
+        - role ``ignored`` -- video is intentionally outside the pipeline
+        - source not reachable -- USB / SD card likely unplugged; the
+          user will retry by hand once it's back
+        - duplicate active job -- ``_submit_detect_beep`` already dedupes
+          by (kind, stage, video_id), but checking up front avoids the
+          unnecessary JSONResponse round-trip
+        - ``SPLITSMITH_AUTO_BEEP_DISABLED=1`` is set -- escape hatch for
+          tests that need to assert pre-detection state without racing
+          against an auto-fired worker
+
+        Returns True when a job was queued (or already running), False
+        when skipped. Callers don't need to react; the SPA picks up the
+        new job via its existing JobsPanel polling.
+        """
+        if os.environ.get("SPLITSMITH_AUTO_BEEP_DISABLED") == "1":
+            return False
+        if video.role == "ignored":
+            return False
+        if video.processed.get("beep") or video.beep_time is not None:
+            return False
+        if video.beep_source == "manual":
+            return False
+        source = project.resolve_video_path(state.project_root, video.path)
+        if not source.exists():
+            logger.info(
+                "auto-beep skipped for stage %d video %s: source not reachable (%s)",
+                stage_number,
+                video.video_id,
+                source,
+            )
+            return False
+        _submit_detect_beep(stage_number, video)
+        return True
 
     @app.post("/api/stages/{stage_number}/videos/{video_id}/detect-beep")
     def detect_beep_for_video(
@@ -2624,6 +2681,16 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         project.save(state.project_root)
+
+        # Auto-queue beep on assignment to a real stage (#67). Skip when
+        # unassigning (to_stage_number=None) or marking ignored -- those
+        # don't put the video into the pipeline.
+        if req.to_stage_number is not None and req.role != "ignored":
+            stage = project.stage(req.to_stage_number)
+            video = next((v for v in stage.videos if str(v.path) == req.video_path), None)
+            if video is not None:
+                _auto_queue_beep_if_needed(project, req.to_stage_number, video)
+
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/assignments/swap-primary")
@@ -2668,6 +2735,15 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         project.save(state.project_root)
+
+        # Auto-queue beep for the new primary (#67). swap_primary may
+        # clear ``processed.beep`` to force re-detection on the new
+        # video's audio; the helper picks up the cleared flag and queues
+        # accordingly. No-op when the video already had a current beep.
+        new_primary = project.stage(req.stage_number).primary()
+        if new_primary is not None:
+            _auto_queue_beep_if_needed(project, req.stage_number, new_primary)
+
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.get("/api/exports/overview")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -667,11 +667,27 @@ class FsEntry(BaseModel):
     thumbnail_url: str | None = None
 
 
+class SuggestedStart(BaseModel):
+    """One sidebar bookmark in the FolderPicker.
+
+    Distinct from a flat string list so the SPA can group entries by
+    ``kind`` (recent / home / removable / network) and render the right
+    icon. ``label`` is what to show in the sidebar; ``path`` is the
+    absolute path to navigate to. Only ``kind="removable"`` and
+    ``"network"`` carry the platform-specific mount discovery output --
+    everything else is the user-stable bookmarks.
+    """
+
+    path: str
+    label: str
+    kind: Literal["recent", "home", "removable", "network"]
+
+
 class FsListing(BaseModel):
     path: str
     parent: str | None
     entries: list[FsEntry]
-    suggested_starts: list[str]  # bookmarks: home, ~/Movies, last_scanned_dir, etc.
+    suggested_starts: list[SuggestedStart]
 
 
 def create_app(*, project_root: Path, project_name: str) -> FastAPI:
@@ -845,15 +861,18 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             if results is not None:
                 merged = project.merge_stage_times(results)
                 project.selected_competitor_id = default_cid
-                # The legacy file format only carries shooterId on
-                # competitors when the auto-built CompetitorInfo also
-                # had it; pull from the resolved match if available.
-                shooter = next(
-                    (c.shooterId for c in scoreboard.match.competitors if c.id == default_cid),
+                # Resolve the picked competitor inside the parsed match.
+                # We persist shooter_id (for the global "this is me"
+                # identity) and competitor_name (so the SPA can show
+                # who's pinned without re-fetching MatchData on every
+                # render).
+                picked = next(
+                    (c for c in scoreboard.match.competitors if c.id == default_cid),
                     None,
                 )
-                if shooter is not None:
-                    project.selected_shooter_id = shooter
+                if picked is not None:
+                    project.selected_shooter_id = picked.shooterId
+                    project.competitor_name = picked.name
         project.save(state.project_root)
         return JSONResponse({**project.model_dump(mode="json"), "stage_times_merged": merged})
 
@@ -1005,7 +1024,11 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 match_data = client.get_match(ct, mid)
             except ScoreboardError as exc:
                 _raise_scoreboard_http(exc)
-        if not any(c.id == req.competitor_id for c in match_data.competitors):
+        picked = next(
+            (c for c in match_data.competitors if c.id == req.competitor_id),
+            None,
+        )
+        if picked is None:
             raise HTTPException(
                 status_code=404,
                 detail={
@@ -1019,6 +1042,10 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
 
         project.selected_shooter_id = req.shooter_id
         project.selected_competitor_id = req.competitor_id
+        # Persist the human-readable name so the SPA's collapsed
+        # scoreboard summary doesn't have to re-fetch MatchData just to
+        # render "pinned: Mathias Rinaldo" instead of an integer id.
+        project.competitor_name = picked.name
         project.save(state.project_root)
 
         merged = _fetch_and_merge_stage_times(project, ct, mid, req.competitor_id)
@@ -3034,26 +3061,212 @@ def _default_start(last_scanned_dir: str | None) -> Path:
     return home
 
 
-def _suggested_starts(last_scanned_dir: str | None) -> list[str]:
-    """Bookmarks the folder picker shows in a sidebar."""
-    home = Path.home()
-    candidates = []
+def _suggested_starts(last_scanned_dir: str | None) -> list[dict[str, str]]:
+    """Bookmarks the folder picker shows in a sidebar.
+
+    Three groups, in display order:
+
+    1. **Recent** -- the last folder the user scanned (if any). Surfaced
+       on top so the cam-over-USB flow ("plug in, scan, repeat") doesn't
+       require re-typing the path.
+    2. **Home** -- the user's home plus the conventional video folders
+       (~/Movies, ~/Videos, ~/Downloads, ~/Desktop). Cross-platform
+       sensible defaults.
+    3. **Removable & network** -- platform-specific mount discovery,
+       best-effort. Each entry is wrapped in a per-path 200ms timeout
+       so a stale network mount can't hang the picker open.
+    """
+    seen: set[str] = set()
+    out: list[dict[str, str]] = []
+
+    def add(path: Path | str, label: str, kind: str) -> None:
+        p = str(Path(path))
+        if p in seen:
+            return
+        seen.add(p)
+        out.append({"path": p, "label": label, "kind": kind})
+
     if last_scanned_dir:
         p = Path(last_scanned_dir).expanduser()
-        if p.is_dir():
-            candidates.append(str(p))
-    for c in (home, home / "Movies", home / "Videos", home / "Downloads", home / "Desktop"):
-        if c.is_dir():
-            candidates.append(str(c))
-    # De-duplicate while preserving order.
-    seen: set[str] = set()
-    result = []
-    for c in candidates:
-        if c in seen:
+        if _is_dir_with_timeout(p):
+            add(p, p.name or str(p), "recent")
+
+    home = Path.home()
+    home_candidates = [
+        (home, "Home"),
+        (home / "Movies", "Movies"),
+        (home / "Videos", "Videos"),
+        (home / "Downloads", "Downloads"),
+        (home / "Desktop", "Desktop"),
+    ]
+    for path, label in home_candidates:
+        if _is_dir_with_timeout(path):
+            add(path, label, "home")
+
+    for path, label, kind in _discover_mounts():
+        add(path, label, kind)
+
+    return out
+
+
+def _is_dir_with_timeout(path: Path, *, timeout: float = 0.2) -> bool:
+    """``path.is_dir()`` with a wall-clock cap.
+
+    Stale network mounts can hang ``stat()`` indefinitely. Running the
+    check on a worker thread and bailing on timeout keeps the picker
+    responsive at the cost of a false negative on slow-but-alive shares
+    (the user can still type the path manually).
+    """
+    import concurrent.futures
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(path.is_dir)
+            return future.result(timeout=timeout)
+    except (concurrent.futures.TimeoutError, OSError):
+        return False
+
+
+def _discover_mounts() -> list[tuple[Path, str, str]]:
+    """Cross-platform best-effort discovery of mounted volumes.
+
+    Returns a list of ``(path, label, kind)`` tuples. Kind is
+    ``"network"`` for paths reported by the platform's mount table as a
+    network filesystem (cifs/nfs/smbfs/afpfs/fuse.sshfs); everything
+    else under a removable-mount root is ``"removable"``.
+
+    No external dependency: psutil would give cleaner fstype info but
+    pulling it in for this one feature isn't worth the deploy weight.
+    Stdlib reads of ``/proc/mounts`` (Linux) and the ``/Volumes``
+    directory (macOS) cover the cases users actually hit.
+    """
+    out: list[tuple[Path, str, str]] = []
+    if sys.platform == "darwin":
+        out.extend(_discover_macos_volumes())
+    elif sys.platform.startswith("linux"):
+        out.extend(_discover_linux_mounts())
+    elif sys.platform.startswith("win"):
+        out.extend(_discover_windows_drives())
+    return out
+
+
+def _discover_macos_volumes() -> list[tuple[Path, str, str]]:
+    volumes_root = Path("/Volumes")
+    if not _is_dir_with_timeout(volumes_root):
+        return []
+    try:
+        boot_inode = Path("/").stat().st_ino
+    except OSError:
+        boot_inode = None
+    network_fstypes = _macos_network_volumes()
+    out: list[tuple[Path, str, str]] = []
+    try:
+        for entry in sorted(volumes_root.iterdir()):
+            # Hidden mounts (e.g. ``/Volumes/.timemachine``) are
+            # platform internals the user never wants to scan; skip.
+            if entry.name.startswith("."):
+                continue
+            try:
+                # Skip the boot volume; ``/`` and ``/Volumes/Macintosh HD``
+                # share an inode, so we filter the duplicate.
+                if boot_inode is not None and entry.stat().st_ino == boot_inode:
+                    continue
+            except OSError:
+                continue
+            if not _is_dir_with_timeout(entry):
+                continue
+            kind = "network" if str(entry) in network_fstypes else "removable"
+            out.append((entry, entry.name, kind))
+    except OSError:
+        return out
+    return out
+
+
+def _macos_network_volumes() -> set[str]:
+    """Parse ``mount`` output to flag network-backed volumes under /Volumes.
+
+    macOS prints lines like ``//user@host/share on /Volumes/Share (smbfs, ...)``.
+    Best-effort: on parse failure return empty so everything in
+    ``/Volumes`` falls through to ``"removable"``.
+    """
+    try:
+        result = subprocess.run(["/sbin/mount"], capture_output=True, text=True, timeout=1.0)
+    except (OSError, subprocess.TimeoutExpired):
+        return set()
+    if result.returncode != 0:
+        return set()
+    network_kinds = {"smbfs", "afpfs", "nfs", "webdav", "ftp", "fuse"}
+    out: set[str] = set()
+    for line in result.stdout.splitlines():
+        # ``<src> on <mountpoint> (<fstype>, ...)``
+        try:
+            on_split = line.split(" on ", 1)
+            if len(on_split) != 2:
+                continue
+            rest = on_split[1]
+            paren = rest.find(" (")
+            if paren < 0:
+                continue
+            mountpoint = rest[:paren]
+            attrs = rest[paren + 2 :].rstrip(")")
+            fstype = attrs.split(",", 1)[0].strip().lower()
+            if fstype in network_kinds:
+                out.add(mountpoint)
+        except (ValueError, IndexError):
             continue
-        seen.add(c)
-        result.append(c)
-    return result
+    return out
+
+
+def _discover_linux_mounts() -> list[tuple[Path, str, str]]:
+    user = os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+    roots: list[Path] = []
+    if user:
+        roots.append(Path(f"/media/{user}"))
+        roots.append(Path(f"/run/media/{user}"))
+    roots.extend([Path("/media"), Path("/mnt")])
+
+    network_fstypes = {"cifs", "nfs", "nfs4", "smbfs", "fuse.sshfs", "fuse.gvfsd-fuse"}
+    network_paths = _linux_network_mounts(network_fstypes)
+
+    out: list[tuple[Path, str, str]] = []
+    for root in roots:
+        if not _is_dir_with_timeout(root):
+            continue
+        try:
+            for entry in sorted(root.iterdir()):
+                if not _is_dir_with_timeout(entry):
+                    continue
+                kind = "network" if str(entry) in network_paths else "removable"
+                out.append((entry, entry.name, kind))
+        except OSError:
+            continue
+    return out
+
+
+def _linux_network_mounts(network_fstypes: set[str]) -> set[str]:
+    try:
+        with Path("/proc/mounts").open(encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return set()
+    out: set[str] = set()
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        mountpoint, fstype = parts[1], parts[2]
+        if fstype in network_fstypes:
+            out.add(mountpoint)
+    return out
+
+
+def _discover_windows_drives() -> list[tuple[Path, str, str]]:
+    out: list[tuple[Path, str, str]] = []
+    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":  # skip C: (system)
+        path = Path(f"{letter}:\\")
+        if _is_dir_with_timeout(path):
+            out.append((path, f"{letter}:", "removable"))
+    return out
 
 
 def _video_metadata_for(

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -51,6 +51,14 @@ interface FolderPickerProps {
   onCancel?: () => void;
   /** Render mode: inline (e.g. inside a card) vs. compact. */
   mode?: "inline" | "compact";
+  /** Optional match window (epoch seconds, inclusive). Files whose
+   *  ``mtime`` falls inside this window are highlighted as likely
+   *  candidates so the user can spot them in a folder full of mixed
+   *  clips. Computed by the caller from the project's stage analysis;
+   *  null when no scoreboard times are loaded yet. The window already
+   *  includes whatever margin the caller wants (typically a couple of
+   *  hours on each side to cover warm-up + drive home with the cam). */
+  matchWindow?: { startEpoch: number; endEpoch: number } | null;
 }
 
 export function FolderPicker({
@@ -59,6 +67,7 @@ export function FolderPicker({
   onSelectFiles,
   onCancel,
   mode = "inline",
+  matchWindow = null,
 }: FolderPickerProps) {
   const [listing, setListing] = useState<FsListing | null>(null);
   const [path, setPath] = useState<string | null>(initialPath ?? null);
@@ -124,6 +133,20 @@ export function FolderPicker({
   const selectAll = () => {
     setSelectedFiles(new Set(videoEntries.map((e) => e.name)));
   };
+
+  const selectInMatchWindow = () => {
+    setSelectedFiles(
+      new Set(
+        videoEntries
+          .filter((e) => isInMatchWindow(e.mtime, matchWindow))
+          .map((e) => e.name),
+      ),
+    );
+  };
+
+  const inWindowVideoCount = matchWindow
+    ? videoEntries.filter((e) => isInMatchWindow(e.mtime, matchWindow)).length
+    : 0;
 
   const confirmFiles = () => {
     if (!path || selectedCount === 0) return;
@@ -195,13 +218,19 @@ export function FolderPicker({
               <ul className="max-h-80 divide-y divide-border overflow-y-auto">
               {dirEntries.map((entry) => {
                 const childPath = path ? joinPath(path, entry.name) : entry.name;
+                const inWindow = isInMatchWindow(entry.mtime, matchWindow);
                 return (
                   <li key={`d-${entry.name}`}>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground",
+                        inWindow &&
+                          "border-l-2 border-l-status-info bg-status-info/5",
+                      )}
                       onClick={() => void load(childPath)}
                       disabled={busy}
+                      title={inWindow ? "Modified during the match window" : undefined}
                     >
                       <span className="flex min-w-0 items-center gap-2">
                         <Folder className="size-4 shrink-0 text-muted-foreground" />
@@ -228,6 +257,7 @@ export function FolderPicker({
                         fullPath={fullPath}
                         checked={checked}
                         busy={busy}
+                        inMatchWindow={isInMatchWindow(entry.mtime, matchWindow)}
                         onToggle={() => toggleSelect(entry.name)}
                         onProbed={(duration, thumbnail_url) => {
                           // Patch the listing in-place so the row remembers
@@ -274,6 +304,17 @@ export function FolderPicker({
               disabled={busy}
             >
               {selectedCount === videosHere ? "Clear selection" : "Select all"}
+            </button>
+          ) : null}
+          {multiFileMode && inWindowVideoCount > 0 ? (
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-status-info underline-offset-2 hover:underline"
+              onClick={selectInMatchWindow}
+              disabled={busy}
+              title="Select videos whose modified time falls inside the match window"
+            >
+              Select {inWindowVideoCount} in match window
             </button>
           ) : null}
         </div>
@@ -375,6 +416,7 @@ function VideoRowMulti({
   fullPath,
   checked,
   busy,
+  inMatchWindow,
   onToggle,
   onProbed,
 }: {
@@ -382,6 +424,7 @@ function VideoRowMulti({
   fullPath: string;
   checked: boolean;
   busy: boolean;
+  inMatchWindow: boolean;
   onToggle: () => void;
   onProbed: (duration: number | null, thumbnail_url: string | null) => void;
 }) {
@@ -414,9 +457,12 @@ function VideoRowMulti({
     >
       <label
         className={cn(
-          "flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm hover:bg-accent/40",
+          "flex cursor-pointer items-center justify-between gap-2 border-l-2 border-l-transparent px-3 py-2 text-sm hover:bg-accent/40",
           checked && "bg-accent/30",
+          inMatchWindow && !checked && "border-l-status-info bg-status-info/5",
+          inMatchWindow && checked && "border-l-status-info",
         )}
+        title={inMatchWindow ? "Modified during the match window" : undefined}
       >
         <span className="flex min-w-0 items-center gap-2">
           <input
@@ -533,6 +579,14 @@ function SortHeader({
       </button>
     </div>
   );
+}
+
+function isInMatchWindow(
+  mtime: number | null | undefined,
+  win: { startEpoch: number; endEpoch: number } | null,
+): boolean {
+  if (!win || mtime == null) return false;
+  return mtime >= win.startEpoch && mtime <= win.endEpoch;
 }
 
 function formatMtime(epochSeconds: number): string {

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -18,15 +18,23 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronRight,
   Clock,
+  Cloud,
   Film,
   Folder,
   FolderOpen,
+  HardDrive,
   Home,
   Loader2,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { ApiError, api, type FsEntry, type FsListing } from "@/lib/api";
+import {
+  ApiError,
+  api,
+  type FsEntry,
+  type FsListing,
+  type SuggestedStart,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface FolderPickerProps {
@@ -134,30 +142,32 @@ export function FolderPicker({
         ))}
       </div>
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-[180px_1fr]">
-        <aside className="flex flex-col gap-1 text-sm">
-          {(listing?.suggested_starts ?? []).slice(0, 6).map((s, i) => (
-            <button
-              key={s}
-              type="button"
-              className={cn(
-                "flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
-                path === s && "bg-accent text-accent-foreground",
-              )}
-              onClick={() => void load(s)}
-              disabled={busy}
-              title={s}
-            >
-              {i === 0 ? <Clock className="size-3.5" /> : <Home className="size-3.5" />}
-              <span className="truncate text-xs">{s.split("/").filter(Boolean).pop() || "/"}</span>
-            </button>
-          ))}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[200px_1fr]">
+        <aside className="flex flex-col gap-3 text-sm">
+          <SuggestedStartsSidebar
+            starts={listing?.suggested_starts ?? []}
+            currentPath={path}
+            disabled={busy}
+            onPick={(p) => void load(p)}
+          />
         </aside>
 
-        <div className="min-h-[12rem] rounded-md border border-border bg-background">
+        <div className="relative min-h-[12rem] rounded-md border border-border bg-background">
+          {/* When ``busy && listing`` (we're navigating into a slow
+              folder while an old listing is still on screen), overlay a
+              translucent spinner instead of swapping the whole panel.
+              Keeps the user oriented and signals that the next listing
+              is coming. The first-load spinner case below renders
+              directly when there's no listing yet. */}
+          {busy && listing ? (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-background/70 backdrop-blur-[1px]">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : null}
           {busy && !listing ? (
-            <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+            <div className="flex h-full items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" />
+              <span>Reading folder...</span>
             </div>
           ) : error ? (
             <div className="p-4 text-sm text-destructive">{error}</div>
@@ -278,6 +288,67 @@ export function FolderPicker({
       </div>
     </div>
   );
+}
+
+/** Sidebar bookmarks, grouped by ``kind`` so the user can scan
+ *  recent / home / removable+network sections separately. The wire
+ *  shape carries one entry per bookmark; we group client-side to keep
+ *  the contract simple. */
+function SuggestedStartsSidebar({
+  starts,
+  currentPath,
+  disabled,
+  onPick,
+}: {
+  starts: SuggestedStart[];
+  currentPath: string | null;
+  disabled: boolean;
+  onPick: (path: string) => void;
+}) {
+  const groups: { title: string; kinds: SuggestedStart["kind"][]; }[] = [
+    { title: "Recent", kinds: ["recent"] },
+    { title: "Home", kinds: ["home"] },
+    { title: "Removable & network", kinds: ["removable", "network"] },
+  ];
+  return (
+    <>
+      {groups.map((g) => {
+        const items = starts.filter((s) => g.kinds.includes(s.kind));
+        if (items.length === 0) return null;
+        return (
+          <div key={g.title} className="space-y-1">
+            <div className="px-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+              {g.title}
+            </div>
+            {items.map((s) => (
+              <button
+                key={s.path}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                  currentPath === s.path && "bg-accent text-accent-foreground",
+                )}
+                onClick={() => onPick(s.path)}
+                disabled={disabled}
+                title={s.path}
+              >
+                <SidebarIcon kind={s.kind} />
+                <span className="truncate text-xs">{s.label}</span>
+              </button>
+            ))}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function SidebarIcon({ kind }: { kind: SuggestedStart["kind"] }) {
+  const className = "size-3.5 shrink-0";
+  if (kind === "recent") return <Clock className={className} />;
+  if (kind === "removable") return <HardDrive className={className} />;
+  if (kind === "network") return <Cloud className={className} />;
+  return <Home className={className} />;
 }
 
 function VideoRowMulti({

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -16,6 +16,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ArrowDownAZ,
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
   ChevronRight,
   Clock,
   Cloud,
@@ -62,6 +65,12 @@ export function FolderPicker({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
+  // ``name`` keeps directories above videos in alphabetical order (the
+  // historical default). ``date-desc`` puts the most recent video at
+  // the top, which is what the cam-over-USB workflow wants -- you
+  // typically just shot the match, plug in, and want today's clips
+  // first. Toggling cycles name -> date-desc -> date-asc -> name.
+  const [sortMode, setSortMode] = useState<SortMode>("name");
 
   const wantMetadata = onSelectFiles !== undefined;
 
@@ -90,8 +99,15 @@ export function FolderPicker({
   }, []);
 
   const breadcrumb = useMemo(() => buildBreadcrumb(path), [path]);
-  const dirEntries = listing?.entries.filter((e) => e.kind === "dir") ?? [];
-  const videoEntries = listing?.entries.filter((e) => e.kind === "video") ?? [];
+  const dirEntries = useMemo(
+    () => sortEntries(listing?.entries.filter((e) => e.kind === "dir") ?? [], sortMode),
+    [listing, sortMode],
+  );
+  const videoEntries = useMemo(
+    () =>
+      sortEntries(listing?.entries.filter((e) => e.kind === "video") ?? [], sortMode),
+    [listing, sortMode],
+  );
   const videosHere = videoEntries.length;
   const multiFileMode = onSelectFiles !== undefined;
   const selectedCount = selectedFiles.size;
@@ -174,7 +190,9 @@ export function FolderPicker({
           ) : !listing ? null : dirEntries.length === 0 && videoEntries.length === 0 ? (
             <div className="p-4 text-sm text-muted-foreground">Empty folder.</div>
           ) : (
-            <ul className="max-h-80 divide-y divide-border overflow-y-auto">
+            <>
+              <SortHeader mode={sortMode} onChange={setSortMode} />
+              <ul className="max-h-80 divide-y divide-border overflow-y-auto">
               {dirEntries.map((entry) => {
                 const childPath = path ? joinPath(path, entry.name) : entry.name;
                 return (
@@ -233,6 +251,7 @@ export function FolderPicker({
                   })
                 : null}
             </ul>
+            </>
           )}
         </div>
       </div>
@@ -448,18 +467,87 @@ function ThumbnailFloat({ anchor, src, alt }: { anchor: DOMRect; src: string; al
   );
 }
 
+type SortMode = "name" | "date-desc" | "date-asc";
+
+/** Sort directory + video entries together. Directories without an
+ *  ``mtime`` fall back to name order so they don't bunch at the
+ *  bottom of a date sort. */
+function sortEntries<T extends { name: string; mtime: number | null }>(
+  entries: T[],
+  mode: SortMode,
+): T[] {
+  if (mode === "name") {
+    return [...entries].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" }),
+    );
+  }
+  const factor = mode === "date-desc" ? -1 : 1;
+  return [...entries].sort((a, b) => {
+    const am = a.mtime;
+    const bm = b.mtime;
+    if (am == null && bm == null) {
+      return a.name.localeCompare(b.name, undefined, { numeric: true });
+    }
+    if (am == null) return 1; // entries without mtime sink to the end
+    if (bm == null) return -1;
+    return (am - bm) * factor;
+  });
+}
+
+function SortHeader({
+  mode,
+  onChange,
+}: {
+  mode: SortMode;
+  onChange: (next: SortMode) => void;
+}) {
+  // Click cycles name -> date-desc -> date-asc -> name. Two icons so
+  // the user can see at a glance which axis is active without a
+  // dropdown.
+  const cycle: Record<SortMode, SortMode> = {
+    name: "date-desc",
+    "date-desc": "date-asc",
+    "date-asc": "name",
+  };
+  const labels: Record<SortMode, string> = {
+    name: "Name",
+    "date-desc": "Date (newest)",
+    "date-asc": "Date (oldest)",
+  };
+  const icons: Record<SortMode, React.ReactNode> = {
+    name: <ArrowDownAZ className="size-3.5" />,
+    "date-desc": <ArrowDownNarrowWide className="size-3.5" />,
+    "date-asc": <ArrowUpNarrowWide className="size-3.5" />,
+  };
+  return (
+    <div className="flex items-center justify-end gap-2 border-b border-border px-2 py-1 text-[11px] text-muted-foreground">
+      <span>Sort:</span>
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-accent-foreground"
+        onClick={() => onChange(cycle[mode])}
+        title="Click to cycle: Name -> Date (newest) -> Date (oldest)"
+      >
+        {icons[mode]}
+        <span>{labels[mode]}</span>
+      </button>
+    </div>
+  );
+}
+
 function formatMtime(epochSeconds: number): string {
+  // Render in local-time ISO-8601 (``YYYY-MM-DD HH:MM``) so dates sort
+  // correctly as strings and don't read as gibberish for users with
+  // non-US locales (the previous ``toLocaleDateString`` flipped to
+  // ``DD/MM/YY`` or ``YY-MM-DD`` depending on system locale, which made
+  // the column harder to scan).
   const d = new Date(epochSeconds * 1000);
-  const date = d.toLocaleDateString(undefined, {
-    year: "2-digit",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  const time = d.toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-  return `${date} ${time}`;
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
 }
 
 function formatDuration(seconds: number): string {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -365,11 +365,20 @@ export interface RemoveVideoResponse {
   plan: RemovalPlan;
 }
 
+/** One sidebar bookmark in the FolderPicker. ``kind`` lets the SPA
+ *  group entries (Recent / Home / Removable & network) and pick the
+ *  right icon. Mirrors ``splitsmith.ui.server.SuggestedStart``. */
+export interface SuggestedStart {
+  path: string;
+  label: string;
+  kind: "recent" | "home" | "removable" | "network";
+}
+
 export interface FsListing {
   path: string;
   parent: string | null;
   entries: FsEntry[];
-  suggested_starts: string[];
+  suggested_starts: SuggestedStart[];
 }
 
 export interface PeaksResult {

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -559,16 +559,29 @@ function ScoreboardSection({
     setLastComplete(ingestComplete);
   }, [ingestComplete, lastComplete]);
 
-  const description = realCount
-    ? `${realCount} stages loaded for ${project!.competitor_name ?? "the primary competitor"}.`
+  const stageSummary = realCount
+    ? `${realCount} stages loaded`
     : placeholderCount
-      ? `${placeholderCount} placeholder stages -- upload a real scoreboard to fill in names, competitor metadata, and timestamps.`
+      ? `${placeholderCount} placeholder stages -- upload a real scoreboard or pin yourself online to fill in stage times`
       : "No stages yet. Drop in an SSI Scoreboard JSON, or search the live scoreboard.";
   const dropLabel = realCount
     ? "Replace scoreboard JSON (warns first)"
     : placeholderCount
       ? "Upload scoreboard to overlay placeholders"
       : "Drop or pick an SSI Scoreboard JSON";
+
+  // Collapsed-state summary: lead with the human-readable identity
+  // (match name + competitor name) so the user can see who's pinned
+  // without expanding. Numeric ids stay tucked into a tooltip.
+  const matchTitle = project?.name && project.name !== "Untitled match" ? project.name : null;
+  const competitorLabel = project?.competitor_name ?? null;
+  const idsTooltip = project?.scoreboard_match_id
+    ? `match ${project.scoreboard_match_id}${
+        project.scoreboard_content_type != null
+          ? ` (ct ${project.scoreboard_content_type})`
+          : ""
+      }${project.selected_competitor_id != null ? ` · cid ${project.selected_competitor_id}` : ""}`
+    : undefined;
 
   return (
     <Card>
@@ -585,30 +598,31 @@ function ScoreboardSection({
             {expanded ? "Hide" : "Change"}
           </span>
         </CardTitle>
-        <CardDescription className="flex flex-wrap items-center gap-x-2">
-          <span>{description}</span>
-          {project?.scoreboard_match_id ? (
-            <span className="text-xs text-muted-foreground">
-              · match <code>{project.scoreboard_match_id}</code>
-              {project.scoreboard_content_type !== null &&
-              project.scoreboard_content_type !== undefined
-                ? ` (ct ${project.scoreboard_content_type})`
-                : null}
+        <CardDescription
+          className="flex flex-wrap items-center gap-x-2"
+          title={idsTooltip}
+        >
+          {matchTitle ? (
+            <span className="font-medium text-foreground">{matchTitle}</span>
+          ) : null}
+          {competitorLabel ? (
+            <span className="text-foreground">
+              · {competitorLabel}
             </span>
           ) : null}
+          <span className="text-muted-foreground">
+            {matchTitle || competitorLabel ? "· " : ""}
+            {stageSummary}
+          </span>
         </CardDescription>
       </CardHeader>
       {expanded ? (
+        // Order is intentional: source badge (status), then the primary
+        // happy-path inputs (live search, then shooter pinner once a
+        // match is loaded), then the offline drop-zone fallback last
+        // and compact since most users will go online.
         <CardContent className="space-y-4">
           {source ? <ScoreboardSourceBadge source={source} /> : null}
-
-          <FileDropZone
-            accept=".json,application/json"
-            label={dropLabel}
-            icon={<FileJson className="size-5" />}
-            disabled={busy}
-            onFile={onScoreboard}
-          />
 
           {!isLocal && onlineReady ? (
             <OnlineMatchSearch
@@ -627,6 +641,13 @@ function ScoreboardSection({
               onError={setScoreboardError}
             />
           ) : null}
+
+          <CompactFileDropZone
+            accept=".json,application/json"
+            label={dropLabel}
+            disabled={busy}
+            onFile={onScoreboard}
+          />
         </CardContent>
       ) : null}
     </Card>
@@ -2549,16 +2570,21 @@ function StatusGlyph({ stage }: { stage: StageEntry }) {
   );
 }
 
-function FileDropZone({
+/** Compact, single-row drop zone used in the Scoreboard card.
+ *
+ *  The offline JSON path is the secondary option (most users will go
+ *  online), so it sits last in the card and reads as a one-line
+ *  affordance instead of the full-bleed marketing-style box. Same drag
+ *  + click semantics as ``FileDropZone``, just less screen real estate.
+ */
+function CompactFileDropZone({
   accept,
   label,
-  icon,
   disabled,
   onFile,
 }: {
   accept: string;
   label: string;
-  icon: React.ReactNode;
   disabled?: boolean;
   onFile: (f: File) => void;
 }) {
@@ -2566,8 +2592,8 @@ function FileDropZone({
   return (
     <label
       className={cn(
-        "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-muted/20 px-4 py-6 text-sm transition-colors",
-        over && "border-ring bg-muted/40",
+        "group flex cursor-pointer items-center justify-between gap-3 rounded-md border border-dashed border-border bg-muted/10 px-3 py-2 text-xs transition-colors hover:bg-muted/20",
+        over && "border-ring bg-muted/30",
         disabled && "pointer-events-none opacity-50",
       )}
       onDragOver={(e) => {
@@ -2582,9 +2608,11 @@ function FileDropZone({
         if (file) onFile(file);
       }}
     >
-      {icon}
-      <span className="text-foreground">{label}</span>
-      <span className="text-xs text-muted-foreground">drag & drop, or click to browse</span>
+      <span className="flex items-center gap-2 text-muted-foreground">
+        <FileJson className="size-3.5 shrink-0" />
+        <span>{label}</span>
+      </span>
+      <span className="text-muted-foreground/70">drag &amp; drop or click</span>
       <input
         type="file"
         accept={accept}
@@ -2599,3 +2627,4 @@ function FileDropZone({
     </label>
   );
 }
+

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -12,7 +12,7 @@
  * bay-cam dropped in days later) without losing audit work.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   CalendarDays,
@@ -83,6 +83,13 @@ export function Ingest() {
     video: StageVideo;
     stage: StageEntry | null;
   } | null>(null);
+
+  // Match window for the FolderPicker highlight + "Select N in match
+  // window" affordance: union of every stage's analysis window, padded
+  // by ~2h on each side to cover warm-up and the drive home with the
+  // cam still rolling. ``null`` until a scoreboard with at least one
+  // scorecard time is loaded.
+  const matchWindow = useMemo(() => computeMatchWindow(analysis), [analysis]);
 
   const refreshAnalysis = useCallback(async () => {
     // Cheap GET that re-runs the heuristic over current project state. Fire
@@ -435,6 +442,7 @@ export function Ingest() {
           <StartFromVideosSection
             project={project}
             busy={busy}
+            matchWindow={matchWindow}
             onSubmit={handleStartFromVideos}
           />
         </div>
@@ -454,6 +462,7 @@ export function Ingest() {
       <ScanSection
         disabled={busy || !project || project.stages.length === 0}
         initialPath={project?.last_scanned_dir ?? null}
+        matchWindow={matchWindow}
         onScan={handleScan}
         onScanFiles={handleScanFiles}
       />
@@ -1098,10 +1107,12 @@ function isSsiV1MatchData(data: unknown): boolean {
 function StartFromVideosSection({
   project,
   busy,
+  matchWindow,
   onSubmit,
 }: {
   project: MatchProject;
   busy: boolean;
+  matchWindow: { startEpoch: number; endEpoch: number } | null;
   onSubmit: (
     files: { path: string; mtime: number | null }[],
     stageCount: number,
@@ -1165,6 +1176,7 @@ function StartFromVideosSection({
         {picking ? (
           <FolderPicker
             initialPath={project.last_scanned_dir ?? null}
+            matchWindow={matchWindow}
             onSelect={() => {
               /* not used: this card always wants files, not a folder. */
             }}
@@ -1242,11 +1254,13 @@ function StartFromVideosSection({
 function ScanSection({
   disabled,
   initialPath,
+  matchWindow,
   onScan,
   onScanFiles,
 }: {
   disabled: boolean;
   initialPath: string | null;
+  matchWindow: { startEpoch: number; endEpoch: number } | null;
   onScan: (sourceDir: string) => void;
   onScanFiles: (sourcePaths: string[]) => void;
 }) {
@@ -1291,6 +1305,7 @@ function ScanSection({
         ) : (
           <FolderPicker
             initialPath={initialPath}
+            matchWindow={matchWindow}
             onSelect={(p) => {
               setOpen(false);
               onScan(p);
@@ -2628,3 +2643,35 @@ function CompactFileDropZone({
   );
 }
 
+
+/** Compute the union match window from per-stage analysis (epoch
+ *  seconds) for the FolderPicker highlight (#NN). Returns null when
+ *  no stage has a scorecard time yet -- the picker degrades to no
+ *  highlight, which is the right behaviour for placeholder-only
+ *  projects. The 2h padding on each side covers warm-up videos shot
+ *  before the first stage and clips recorded after the last scorecard
+ *  was typed (cool-down chatter, drive home with the cam rolling). */
+const MATCH_WINDOW_PADDING_SECONDS = 2 * 60 * 60;
+
+function computeMatchWindow(
+  analysis: MatchAnalysis | null,
+): { startEpoch: number; endEpoch: number } | null {
+  if (!analysis) return null;
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const s of analysis.stages) {
+    if (s.lower) {
+      const t = new Date(s.lower).getTime() / 1000;
+      if (Number.isFinite(t) && t < lo) lo = t;
+    }
+    if (s.upper) {
+      const t = new Date(s.upper).getTime() / 1000;
+      if (Number.isFinite(t) && t > hi) hi = t;
+    }
+  }
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) return null;
+  return {
+    startEpoch: lo - MATCH_WINDOW_PADDING_SECONDS,
+    endEpoch: hi + MATCH_WINDOW_PADDING_SECONDS,
+  };
+}

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -869,8 +869,10 @@ def test_fs_list_default_path_uses_last_scanned_dir(tmp_path: Path) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["path"] == str(seeded.resolve())
-    # The seeded dir is suggested first in bookmarks.
-    assert body["suggested_starts"][0] == str(seeded.resolve())
+    # The seeded dir is suggested first in bookmarks (the "Recent" group).
+    first = body["suggested_starts"][0]
+    assert first["path"] == str(seeded.resolve())
+    assert first["kind"] == "recent"
 
 
 def test_fs_list_404_on_missing_path(tmp_path: Path) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -15,6 +15,24 @@ from splitsmith.ui.server import create_app
 from splitsmith.video_probe import ProbeError, ProbeResult
 
 
+@pytest.fixture(autouse=True)
+def _disable_auto_beep_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Most tests in this module exercise specific beep flows (manual
+    overrides, force re-detect, candidate selection) and would race
+    against the on-assignment auto-fire from #67. Default to disabled
+    here; the new auto-fire tests explicitly re-enable via
+    :func:`_enable_auto_beep` so the assertions stay deterministic.
+    """
+    monkeypatch.setenv("SPLITSMITH_AUTO_BEEP_DISABLED", "1")
+
+
+def _enable_auto_beep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opt back into the on-assignment auto-fire for the calling test.
+    Pairs with the autouse disable fixture above.
+    """
+    monkeypatch.delenv("SPLITSMITH_AUTO_BEEP_DISABLED", raising=False)
+
+
 def _wait_for_job(client: TestClient, job_id: str, *, timeout: float = 5.0) -> dict:
     """Poll /api/jobs/{id} until the job is no longer running.
 
@@ -2926,3 +2944,340 @@ def test_per_video_endpoint_404_for_unknown_video_id(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     resp = client.post("/api/stages/1/videos/deadbeef0000/detect-beep")
     assert resp.status_code == 404
+
+
+# -----------------------------------------------------------------------------
+# Auto-fire beep on assignment (#67). Re-enables the env-var feature flag
+# the autouse fixture turns off for the rest of this module.
+# -----------------------------------------------------------------------------
+
+
+def _wait_for_jobs_to_drain(client: TestClient, *, timeout: float = 5.0) -> list[dict]:
+    """Poll /api/jobs until every job has left running/pending, then return
+    the final snapshot. Used by the auto-fire tests since the SPA-equivalent
+    flow doesn't return a job id from the assignment endpoint."""
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        jobs = client.get("/api/jobs").json()
+        active = [j for j in jobs if j["status"] in ("pending", "running")]
+        if not active:
+            return jobs
+        time.sleep(0.02)
+    raise AssertionError(f"jobs did not drain within {timeout}s: {jobs}")
+
+
+def test_auto_beep_queued_on_move_to_stage(tmp_path: Path, monkeypatch) -> None:
+    """Dragging a video onto a stage queues detect_beep automatically --
+    the user shouldn't have to click 'detect beep' on every camera."""
+    _enable_auto_beep(monkeypatch)
+    _stub_detect(monkeypatch, beep_time=8.42)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "VID.mp4").write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+
+    # Move triggers auto-fire.
+    resp = client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    assert resp.status_code == 200
+    jobs = _wait_for_jobs_to_drain(client)
+    auto_beep_jobs = [j for j in jobs if j["kind"] == "detect_beep"]
+    assert len(auto_beep_jobs) == 1
+    assert auto_beep_jobs[0]["status"] == "succeeded"
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary["beep_time"] == 8.42
+    assert primary["beep_source"] == "auto"
+    assert primary["processed"]["beep"] is True
+
+
+def test_auto_beep_fires_for_secondaries_too(tmp_path: Path, monkeypatch) -> None:
+    """The hook isn't primary-only -- secondaries assigned to a stage also
+    get beeped, since they need their own beep timestamp to align with
+    the primary's audit timeline."""
+    _enable_auto_beep(monkeypatch)
+    _stub_detect(monkeypatch, beep_time=8.42)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "PRIMARY.mp4").write_bytes(b"")
+    (src_dir / "SECONDARY.mp4").write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+
+    # Sequence the moves so each worker's project save doesn't race the
+    # other -- the per-job runner loads project state on entry and
+    # writes it back on exit; concurrent saves would clobber each
+    # other's ``processed.beep`` flag.
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/PRIMARY.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    _wait_for_jobs_to_drain(client)
+    client.post(
+        "/api/assignments/move",
+        json={
+            "video_path": "raw/SECONDARY.mp4",
+            "to_stage_number": 1,
+            "role": "secondary",
+        },
+    )
+    _wait_for_jobs_to_drain(client)
+    stage = client.get("/api/project").json()["stages"][0]
+    assert all(v["processed"]["beep"] for v in stage["videos"])
+
+
+def test_auto_beep_skipped_for_unassigned_destination(tmp_path: Path, monkeypatch) -> None:
+    """Moving a video back to the unassigned tray (to_stage_number=None)
+    must not queue a beep job -- there's no stage context for the
+    audio-cache layout or the trim chain to use."""
+    _enable_auto_beep(monkeypatch)
+    _stub_detect(monkeypatch, beep_time=8.42)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "VID.mp4").write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+
+    # Move to stage -> auto-beep
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    _wait_for_jobs_to_drain(client)
+    job_count_after_assign = len(client.get("/api/jobs").json())
+
+    # Move back to tray -> no new job (idempotent on already-beeped is
+    # also covered: the helper would skip even if we re-assigned).
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": None, "role": "secondary"},
+    )
+    assert len(client.get("/api/jobs").json()) == job_count_after_assign
+
+
+def test_auto_beep_skipped_when_already_processed(tmp_path: Path, monkeypatch) -> None:
+    """A video that already has ``processed.beep == True`` (because the
+    user clicked detect-beep manually, or we already auto-fired) doesn't
+    re-fire on a subsequent move between stages."""
+    _enable_auto_beep(monkeypatch)
+    _stub_detect(monkeypatch, beep_time=8.42)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S1",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                    {
+                        "stage_number": 2,
+                        "stage_name": "S2",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "VID.mp4").write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+
+    # First move to stage 1 -> auto-fires.
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    _wait_for_jobs_to_drain(client)
+    jobs_before = len(client.get("/api/jobs").json())
+
+    # Move to stage 2 -> processed.beep is already True, no new job.
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 2, "role": "primary"},
+    )
+    assert len(client.get("/api/jobs").json()) == jobs_before
+
+
+def test_auto_beep_disabled_via_env_var(tmp_path: Path, monkeypatch) -> None:
+    """The autouse fixture disables auto-beep for the rest of this module
+    via the env var; this test makes the contract explicit."""
+    monkeypatch.setenv("SPLITSMITH_AUTO_BEEP_DISABLED", "1")
+    _stub_detect(monkeypatch, beep_time=8.42)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    (src_dir / "VID.mp4").write_bytes(b"")
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+    client.post(
+        "/api/assignments/move",
+        json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
+    )
+    # No auto job; primary still un-beeped until the user clicks detect.
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary["processed"]["beep"] is False
+
+
+def test_auto_beep_queued_on_scan_auto_assign(tmp_path: Path, monkeypatch) -> None:
+    """Scanning a folder with ``auto_assign_primary=true`` and matching
+    timestamps lands a primary on the stage; the auto-fire hook queues
+    its beep without the user clicking anything."""
+    _enable_auto_beep(monkeypatch)
+    _stub_detect(monkeypatch, beep_time=4.5)
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+    sb = {
+        "match": {"id": "1", "name": "x"},
+        "competitors": [
+            {
+                "competitor_id": 1,
+                "name": "T",
+                "stages": [
+                    {
+                        "stage_number": 1,
+                        "stage_name": "S",
+                        "time_seconds": 10.0,
+                        "scorecard_updated_at": "2026-01-01T12:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+    client.post("/api/scoreboard/import", json={"data": sb})
+
+    # Drop a video whose mtime matches the stage's scorecard window so
+    # auto_match picks it up.
+    src_dir = tmp_path / "videos"
+    src_dir.mkdir()
+    src = src_dir / "VID.mp4"
+    src.write_bytes(b"")
+    import os as _os
+
+    target_mtime = 1767268500  # within +/- tolerance of 2026-01-01T12:00:00Z
+    _os.utime(src, (target_mtime, target_mtime))
+
+    client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": True},
+    )
+    _wait_for_jobs_to_drain(client)
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary["role"] == "primary"
+    assert primary["processed"]["beep"] is True
+    assert primary["beep_time"] == 4.5


### PR DESCRIPTION
Stacked on #66 -> #68 -> this branch.

## Summary

Four UX fixes from dogfooding the live #64 flow:

**1. Reordered Scoreboard card.** Live search + shooter pinner moved up; drop zone is now compact and sits last (the offline path is the secondary option for most users).

**2. Collapsed card shows human names, not ids.** The header now reads "SPSK Open 2026 · Mathias Rinaldo · 10 stages loaded" instead of "match 27190 (ct 22)". Numeric ids stay in a hover tooltip. Server persists ``competitor_name`` on ``/select-shooter`` and the auto-pin upload path so the SPA doesn't have to re-fetch MatchData to render it.

**3. FolderPicker spinner during navigation.** The picker had a spinner on the initial load only; subsequent navigations into slow folders had no in-flight signal. Added a translucent overlay so the user sees something is happening.

**4. USB & network mounts in the sidebar.** Plug in a USB stick (or mount a network share) and it shows up as a sidebar bookmark instead of forcing the user to type the path:

| OS | Removable root | Network detection |
|---|---|---|
| macOS | ``/Volumes/*`` (minus boot, dotfile mounts) | parse ``mount`` for ``smbfs``/``afpfs``/``nfs``/``webdav`` |
| Linux | ``/media/$USER``, ``/run/media/$USER``, ``/mnt`` | ``/proc/mounts`` for ``cifs``/``nfs``/``fuse.sshfs`` etc. |
| Windows | drive letters D..Z | (skipped -- net-use parsing is a follow-up if needed) |

Stale network mounts can't hang the picker: every ``is_dir`` probe runs on a worker thread with a 200ms cap, falling back to "skip the candidate."

## Wire shape change

``FsListing.suggested_starts`` was ``list[str]``; now it's ``list[{path, label, kind}]`` where kind is ``recent`` / ``home`` / ``removable`` / ``network``. Sidebar groups by kind. Single existing test updated for the new shape.

## What's NOT in this PR

- ``psutil`` for accurate fstype classification on macOS (currently best-effort via ``mount`` parsing). Add later if a user hits a misclassified network share.
- Auto-refresh of mount discovery while the picker is open. The user can Cancel and re-open after plugging in.
- Time Machine backup volumes still show as ``removable`` -- they technically are, but they're not what the user wants to scan. Heuristic filtering is a follow-up.

## Test plan

- [ ] Open the picker -> sidebar shows three sections (Recent / Home / Removable & network)
- [ ] Plug in a USB stick -> next picker open lists it under Removable
- [ ] Navigate into a folder with hundreds of files -> spinner overlay visible
- [ ] Pin a shooter -> collapse the card -> header shows match + competitor names
- [ ] ``uv run pytest`` -- 425 passed, ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)