### PR TITLE
ingest: snap-to-beep picker + concurrent-save fix + Ctrl-C job summary

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -22,6 +22,7 @@ Endpoints (locked v1 surface):
   POST /api/stages/{n}/videos/{vid}/detect-beep -- per-video beep detection
   POST /api/stages/{n}/videos/{vid}/beep         -- per-video manual override
   POST /api/stages/{n}/videos/{vid}/beep/select  -- per-video candidate select
+  POST /api/stages/{n}/videos/{vid}/beep/snap    -- propose a snapped beep near a user hint
   POST /api/stages/{n}/videos/{vid}/trim         -- per-video audit-mode trim
   GET  /api/stages/{n}/videos/{vid}/beep-preview -- per-video ~1s preview MP4
   GET  /api/jobs                    -- list all retained jobs
@@ -72,7 +73,7 @@ from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
-from ..config import Config
+from ..config import BeepDetectConfig, Config
 from . import audio as audio_helpers
 from . import exports as export_helpers
 from .jobs import Job, JobCancelled, JobHandle, JobRegistry
@@ -597,6 +598,33 @@ class BeepReviewRequest(BaseModel):
     reviewed: bool
 
 
+class BeepSnapRequest(BaseModel):
+    """Body for POST /api/stages/{n}/videos/{vid}/beep/snap.
+
+    ``hint_time`` is the user's ear-aligned guess (seconds into source).
+    ``window_s`` is the half-window the snap is allowed to search inside
+    -- defaults to 1.5 s. Wider than the eyeball precision of a click
+    on a long-range waveform, narrow enough that competing in-stage
+    transients (steel rings, shots) don't enter the candidate pool when
+    the marker is anywhere reasonable.
+    """
+
+    hint_time: float
+    window_s: float = 1.5
+
+
+class BeepSnapResponse(BaseModel):
+    """Result of a snap-to-beep proposal. Stateless -- the SPA decides
+    whether to accept (PUT the snapped time as the manual override) or
+    dismiss (keep the user's hint)."""
+
+    snapped_time: float
+    delta: float
+    peak_amplitude: float
+    score: float
+    duration_ms: float
+
+
 class ExportStageRequest(BaseModel):
     """Body for POST /api/stages/{n}/export.
 
@@ -720,6 +748,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         description="Production UI backend (issue #11/#12).",
         version="0.1.0",
     )
+    # Stash on app.state so the uvicorn server wrapper in :func:`serve`
+    # can read live job state when handling Ctrl-C: the signal handler
+    # needs to enumerate pending / running jobs to tell the user what's
+    # being waited on, and the registry isn't otherwise reachable from
+    # outside the closure.
+    app.state.splitsmith_state = state
 
     # ----------------------------------------------------------------------
     # API
@@ -1419,7 +1453,29 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
                 )
                 handle.update(message=f"beep saved; trim failed: {exc}")
         handle.update(progress=0.85, message="Saving project...")
-        proj.save(state.project_root)
+        # Read-modify-write the project file: extract / detection /
+        # ffmpeg trim can take 30+ s during which the user may have
+        # toggled ``beep_reviewed`` on other stages. Reloading and
+        # copying our targeted fields onto the fresh project preserves
+        # those concurrent edits instead of stomping them with the
+        # snapshot we loaded at job start.
+        fresh = state.load()
+        try:
+            stg_fresh = fresh.stage(stage_number)
+        except KeyError:
+            stg_fresh = None
+        v_fresh = stg_fresh.find_video_by_id(video_id) if stg_fresh is not None else None
+        if v_fresh is not None:
+            v_fresh.beep_time = video.beep_time
+            v_fresh.beep_source = video.beep_source
+            v_fresh.beep_peak_amplitude = video.beep_peak_amplitude
+            v_fresh.beep_duration_ms = video.beep_duration_ms
+            v_fresh.beep_candidates = list(video.beep_candidates)
+            v_fresh.beep_reviewed = video.beep_reviewed
+            v_fresh.processed["beep"] = True
+            if trimmed_ok:
+                v_fresh.processed["trim"] = True
+            fresh.save(state.project_root)
         if trimmed_ok and video.role == "primary" and video.beep_reviewed:
             # Shot detection is primary-only AND gated on the user
             # confirming the beep (#71). Auto-detect always leaves
@@ -1661,8 +1717,14 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             runner=_cancellable_runner(handle),
         )
         handle.update(progress=0.85, message="Saving project...")
-        video.processed["trim"] = True
-        proj.save(state.project_root)
+        # Read-modify-write to avoid stomping concurrent edits made
+        # while ffmpeg was running (e.g. another stage's beep review).
+        fresh = state.load()
+        stg_fresh = fresh.stage(stage_number)
+        v_fresh = stg_fresh.find_video_by_id(video_id)
+        if v_fresh is not None:
+            v_fresh.processed["trim"] = True
+            fresh.save(state.project_root)
         if (
             video.role == "primary"
             and video.beep_reviewed
@@ -1861,8 +1923,18 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             audit_file.replace(backup)
         tmp.replace(audit_file)
 
-        prim.processed["shot_detect"] = True
-        proj.save(state.project_root)
+        # Read-modify-write the project file: a long-running shot_detect
+        # job must not save the snapshot it loaded at start, because the
+        # user may have toggled ``beep_reviewed`` on other stages in the
+        # interim (the review action kicks shot_detect, so concurrent
+        # bursts are the common case). Reloading from disk and mutating
+        # only the targeted field preserves those concurrent edits.
+        fresh = state.load()
+        stg_fresh = fresh.stage(stage_number)
+        prim_fresh = stg_fresh.primary()
+        if prim_fresh is not None:
+            prim_fresh.processed["shot_detect"] = True
+            fresh.save(state.project_root)
         handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
 
     @app.post("/api/stages/{stage_number}/shot-detect")
@@ -2090,6 +2162,98 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         if req.beep_time is not None:
             _maybe_chain_trim(stage, primary)
         return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/snap")
+    def snap_beep_for_video(stage_number: int, video_id: str, req: BeepSnapRequest) -> JSONResponse:
+        """Refine a user-placed beep marker by snapping it to the strongest
+        tone in a tight window around the hint.
+
+        The user has listened to the audio and dropped a marker close to
+        the beep; this endpoint runs the same bandpass + envelope detector
+        on a slice of the WAV and returns the rise-foot leading edge of
+        the strongest run inside ``[hint - window_s, hint + window_s]``.
+        Stateless: caller decides whether to accept the proposal as a
+        manual override (POST .../beep) or dismiss it.
+
+        404 when no run in the window meets the duration / amplitude
+        criteria. The SPA surfaces that as "no beep found nearby; widen
+        the window or move the marker".
+        """
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        source = project.resolve_video_path(state.project_root, video.path)
+        _ensure_source_reachable(stage_number, source)
+        if req.hint_time < 0.0:
+            raise HTTPException(status_code=400, detail="hint_time must be >= 0")
+        if req.window_s <= 0.0:
+            raise HTTPException(status_code=400, detail="window_s must be > 0")
+
+        audio_path = audio_helpers.ensure_video_audio(
+            state.project_root, stage_number, video, source, project=project
+        )
+        audio, sr = beep_detect.load_audio(audio_path)
+        duration_s = audio.size / sr if sr > 0 else 0.0
+        if duration_s <= 0:
+            raise HTTPException(status_code=500, detail="cached audio is empty")
+        if req.hint_time > duration_s:
+            raise HTTPException(
+                status_code=400,
+                detail=f"hint_time {req.hint_time:.3f}s exceeds audio duration {duration_s:.3f}s",
+            )
+
+        slice_start_s = max(0.0, req.hint_time - req.window_s)
+        slice_end_s = min(duration_s, req.hint_time + req.window_s)
+        start_idx = int(round(slice_start_s * sr))
+        end_idx = int(round(slice_end_s * sr))
+        if end_idx <= start_idx:
+            raise HTTPException(
+                status_code=400,
+                detail="snap window is empty after clipping to audio bounds",
+            )
+        sliced = audio[start_idx:end_idx]
+
+        # Relax detection thresholds: the user has already localized the
+        # beep with their marker, so the snap doesn't need the full-clip
+        # detector's belt-and-braces against false positives.
+        # - silence_window_s shrinks to fit the slice (the configured
+        #   1.5 s pre-window would be silently truncated otherwise).
+        # - search_window_s = 0 disables the front-of-audio cap (the
+        #   slice itself is the cap).
+        # - min_duration_ms drops to 40 ms so a clipped / faint beep
+        #   whose envelope only briefly clears the cutoff still
+        #   registers. The full-clip detector keeps 150 ms to suppress
+        #   short clicks; in a 2 s window centred on the marker, those
+        #   competing transients aren't a concern.
+        # - min_abs_peak drops to 0.01 so a quiet recording (Insta360
+        #   GO 3S beep at low gain) still has a candidate run.
+        cfg = BeepDetectConfig(
+            silence_window_s=min(0.3, max(0.05, req.window_s * 0.6)),
+            silence_pre_skip_s=0.05,
+            search_window_s=0.0,
+            top_n_candidates=8,
+            min_duration_ms=40,
+            min_abs_peak=0.01,
+            min_amplitude=0.05,
+        )
+        try:
+            detection = beep_detect.detect_beep(sliced, sr, cfg)
+        except beep_detect.BeepNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        # Times in ``detection`` are slice-local; shift back to source
+        # time. Pick the candidate closest to the user's hint -- in a
+        # tight window the hint is the prior, not silence-preference.
+        hint_in_slice = req.hint_time - slice_start_s
+        chosen = min(detection.candidates, key=lambda c: abs(c.time - hint_in_slice))
+        snapped_time = float(chosen.time + slice_start_s)
+        return JSONResponse(
+            BeepSnapResponse(
+                snapped_time=snapped_time,
+                delta=snapped_time - req.hint_time,
+                peak_amplitude=float(chosen.peak_amplitude),
+                score=float(chosen.score),
+                duration_ms=float(chosen.duration_ms),
+            ).model_dump()
+        )
 
     @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/select")
     def select_beep_candidate_for_video(
@@ -3413,7 +3577,15 @@ def serve(
     port: int = 5174,
     reload: bool = False,
 ) -> None:
-    """Boot uvicorn synchronously. Used by the ``splitsmith ui`` CLI command."""
+    """Boot uvicorn synchronously. Used by the ``splitsmith ui`` CLI command.
+
+    Wraps ``uvicorn.Server`` so the first Ctrl-C prints a summary of the
+    background jobs that are still running (detect_beep, trim,
+    shot_detect) -- otherwise uvicorn's graceful-shutdown wait looks
+    like the process hanging. Uvicorn already promotes a second Ctrl-C
+    to a force-exit; we just decorate the first press with the job
+    inventory + a hint about pressing again.
+    """
     import uvicorn
 
     _ensure_ui_built()
@@ -3426,4 +3598,77 @@ def serve(
         logger.warning("reload=True is not supported yet; running without reload")
 
     app = create_app(project_root=project_root, project_name=project_name)
-    uvicorn.run(app, host=host, port=port, log_level="info")
+    config = uvicorn.Config(app, host=host, port=port, log_level="info")
+    server = _JobAwareServer(config, app)
+    server.run()
+
+
+class _JobAwareServer:
+    """Lazy wrapper that builds a ``uvicorn.Server`` subclass on demand.
+
+    The subclass override has to live next to the import to avoid
+    pulling uvicorn into module import; we lift it via a closure inside
+    :meth:`run` so unit tests don't pay the import cost.
+    """
+
+    def __init__(self, config: Any, app: FastAPI) -> None:
+        self._config = config
+        self._app = app
+
+    def run(self) -> None:
+        import uvicorn
+
+        app = self._app
+
+        class _Inner(uvicorn.Server):
+            def handle_exit(self, sig: int, frame: Any) -> None:  # type: ignore[override]
+                # First press: announce active jobs so the wait is
+                # visible; let uvicorn flip should_exit and shut down
+                # gracefully. Second press (uvicorn already detects
+                # repeat SIGINT) escalates to force_exit, which kills
+                # in-flight requests + the job thread pool.
+                if not self.should_exit:
+                    _print_active_jobs(app)
+                uvicorn.Server.handle_exit(self, sig, frame)
+
+        server = _Inner(self._config)
+        server.run()
+
+
+def _print_active_jobs(app: FastAPI) -> None:
+    """Dump pending / running jobs to stderr on first Ctrl-C."""
+    state = getattr(app.state, "splitsmith_state", None)
+    if state is None:
+        return
+    try:
+        jobs = state.jobs.list()
+    except Exception:  # pragma: no cover -- defensive: never block shutdown
+        logger.warning("could not enumerate jobs on shutdown", exc_info=True)
+        return
+    from .jobs import JobStatus
+
+    active = [j for j in jobs if j.status in (JobStatus.PENDING, JobStatus.RUNNING)]
+    print("", file=sys.stderr, flush=True)
+    if not active:
+        print("Shutting down (no background jobs running).", file=sys.stderr, flush=True)
+        return
+    print(
+        f"Shutting down -- waiting for {len(active)} background job"
+        f"{'' if len(active) == 1 else 's'}:",
+        file=sys.stderr,
+        flush=True,
+    )
+    for j in active:
+        bits = [j.kind]
+        if j.stage_number is not None:
+            bits.append(f"stage {j.stage_number}")
+        msg = j.message or j.status.value
+        bits.append(msg)
+        if j.progress is not None:
+            bits.append(f"{round(j.progress * 100)}%")
+        print(f"  - {' / '.join(bits)}", file=sys.stderr, flush=True)
+    print(
+        "Press Ctrl-C again to force quit (in-flight ffmpeg / detection " "will be killed).",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -21,19 +21,23 @@
  * visible in the preview).
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Check,
   ChevronDown,
   ChevronRight,
+  Crosshair,
   Loader2,
+  Pause,
   Pencil,
   Play,
   RefreshCw,
   Sparkles,
   Trash2,
   Volume2,
+  ZoomIn,
+  ZoomOut,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -44,6 +48,7 @@ import {
   api,
   asSourceUnreachable,
   type BeepCandidate,
+  type BeepSnapResult,
   type Job,
   type MatchProject,
   type PeaksResult,
@@ -236,15 +241,11 @@ export function BeepSection({
         {isPrimary ? (
           <BeepWaveformPicker
             stageNumber={stageNumber}
+            videoId={videoId}
             primaryBeepTime={video.beep_time}
             draftSourceTime={draftValid ? draftSourceTime : null}
             onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
-          />
-        ) : null}
-        {isPrimary ? (
-          <AudioVerifier
-            stageNumber={stageNumber}
-            suspectedTime={draftValid ? draftSourceTime : video.beep_time}
+            setError={setError}
           />
         ) : (
           <div className="text-xs text-muted-foreground">
@@ -403,36 +404,56 @@ export function BeepSection({
   );
 }
 
-/** Click-to-set waveform inside the manual-edit panel.
+/** Combined waveform + audio player + snap-to-beep, primary-only.
  *
- *  Primary-only: the waveform shows the project's audit clip (or full
- *  primary WAV when no trim is cached yet). Secondaries don't have a
- *  project-level waveform endpoint and they don't need one for beep
- *  alignment -- the beep is a loud sharp pulse the preview clip makes
- *  obvious.
+ *  Workflow:
+ *    1. User plays the audio (controls below the waveform). The playhead
+ *       on the canvas tracks the <audio> element's currentTime via rAF.
+ *    2. User clicks / drags the waveform to seek. Seeking moves the
+ *       playhead but does NOT touch the draft -- this is for listening,
+ *       not for committing a beep time.
+ *    3. "Set marker here" copies the playhead time (in source coords)
+ *       into the draft. A blue dashed marker appears at that position.
+ *    4. "Snap to beep" calls /beep/snap with the marker time + a tight
+ *       window. The server returns the rise-foot leading edge of the
+ *       strongest tone in that neighbourhood. The picker offers the
+ *       proposal as Accept (replace draft) / Dismiss (keep marker).
+ *    5. Zoom controls (in / out) feed pixelsPerSecond to the Waveform so
+ *       the user can see sub-frame detail near the beep.
  *
- *  The /audio + /peaks endpoints serve the **trimmed** audit clip when one
- *  exists (cut around the previously-detected beep) and the **full**
- *  primary WAV otherwise. Time on the waveform is therefore "local clip
- *  time", not source time. We translate using the offset
- *  ``primary.beep_time - peaks.beep_time``: in the trimmed case this is
- *  exactly the trim window's start; in the untrimmed case both sides are
- *  the same number so the offset is zero. */
+ *  Time conversion: /audio + /peaks serve clip-local time (the trimmed
+ *  audit clip when cached, the full primary WAV otherwise). The picker's
+ *  draft is in source time. ``offset = primary.beep_time - peaks.beep_time``
+ *  bridges the two -- zero when the WAV is full source, equal to the trim
+ *  start when it's a trimmed audit clip.
+ *
+ *  Secondary cameras don't have a project-level waveform endpoint and
+ *  fall back to the numeric input + preview clip in BeepSection. */
 function BeepWaveformPicker({
   stageNumber,
+  videoId,
   primaryBeepTime,
   draftSourceTime,
   onPick,
+  setError,
 }: {
   stageNumber: number;
+  videoId: string;
   primaryBeepTime: number | null;
   draftSourceTime: number | null;
   onPick: (sourceTime: number) => void;
+  setError: (msg: string | null) => void;
 }) {
   const [peaks, setPeaks] = useState<PeaksResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [unavailable, setUnavailable] = useState(false);
   const [localTime, setLocalTime] = useState<number>(0);
+  const [playing, setPlaying] = useState(false);
+  const [pxPerSec, setPxPerSec] = useState<number | null>(null);
+  const [snapping, setSnapping] = useState(false);
+  const [proposal, setProposal] = useState<BeepSnapResult | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -456,18 +477,122 @@ function BeepWaveformPicker({
     };
   }, [stageNumber]);
 
+  // Source-time <-> clip-time bridge. Zero when the WAV is the full
+  // primary; equal to the trim window's start when the audit clip is
+  // cached.
   const offset = useMemo(() => {
     if (primaryBeepTime == null || !peaks || peaks.beep_time == null) return 0;
     return primaryBeepTime - peaks.beep_time;
   }, [primaryBeepTime, peaks]);
 
-  useEffect(() => {
-    if (!peaks || draftSourceTime == null) return;
-    const local = draftSourceTime - offset;
-    if (local >= 0 && local <= peaks.duration) {
-      setLocalTime(local);
+  // The draft (in source coords) becomes a dashed marker on the
+  // waveform. Falls back to the auto-detected beep when no draft yet.
+  const markerLocal = useMemo(() => {
+    if (!peaks) return null;
+    if (draftSourceTime != null) {
+      const local = draftSourceTime - offset;
+      if (local >= 0 && local <= peaks.duration) return local;
+      return null;
     }
-  }, [draftSourceTime, peaks, offset]);
+    return peaks.beep_time;
+  }, [peaks, draftSourceTime, offset]);
+
+  // Drive the playhead from the <audio> element while playing. The
+  // browser fires `timeupdate` only ~4 Hz; rAF gives us ~60 Hz so the
+  // playhead doesn't visibly stutter against the static waveform.
+  useEffect(() => {
+    if (!playing) return;
+    const tick = () => {
+      const el = audioRef.current;
+      if (el) setLocalTime(el.currentTime);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [playing]);
+
+  const togglePlay = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (el.paused) {
+      el.play().catch(() => {
+        /* ignore autoplay restrictions; user can hit play in the controls */
+      });
+    } else {
+      el.pause();
+    }
+  }, []);
+
+  // Click / drag = seek audio AND set the marker. Marker and the
+  // numeric input both read from the draft state in the parent, so they
+  // stay in lock-step: dragging the waveform updates the input,
+  // typing into the input moves the dashed marker.
+  const handleScrub = useCallback(
+    (t: number) => {
+      setLocalTime(t);
+      const el = audioRef.current;
+      if (el) {
+        try {
+          el.currentTime = t;
+        } catch {
+          /* metadata not loaded yet */
+        }
+      }
+    },
+    [],
+  );
+
+  const handleScrubEnd = useCallback(() => {
+    if (!peaks) return;
+    const sourceTime = Math.max(0, localTime + offset);
+    setProposal(null);
+    onPick(sourceTime);
+  }, [peaks, localTime, offset, onPick]);
+
+  const requestSnap = useCallback(async () => {
+    if (draftSourceTime == null) return;
+    setSnapping(true);
+    setError(null);
+    try {
+      const result = await api.snapBeepForVideo(stageNumber, videoId, draftSourceTime, 1.5);
+      setProposal(result);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) {
+        setError(
+          "No beep candidate found within ±1.5s of the marker. Move the marker closer or set the time manually.",
+        );
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setSnapping(false);
+    }
+  }, [draftSourceTime, stageNumber, videoId, setError]);
+
+  const acceptProposal = useCallback(() => {
+    if (proposal == null) return;
+    onPick(proposal.snapped_time);
+    setProposal(null);
+  }, [proposal, onPick]);
+
+  const dismissProposal = useCallback(() => setProposal(null), []);
+
+  const zoomIn = useCallback(() => {
+    setPxPerSec((cur) => {
+      if (cur == null) return 240;
+      return Math.min(2000, cur * 2);
+    });
+  }, []);
+  const zoomOut = useCallback(() => {
+    setPxPerSec((cur) => {
+      if (cur == null) return null;
+      const next = cur / 2;
+      return next < 60 ? null : next;
+    });
+  }, []);
 
   if (loading) {
     return (
@@ -478,20 +603,44 @@ function BeepWaveformPicker({
     );
   }
   if (unavailable || !peaks) {
-    return null;
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Volume2 className="size-3" />
+        Run "Detect beep" first to extract audio for the picker.
+      </div>
+    );
   }
-
-  const handleScrub = (t: number) => {
-    setLocalTime(t);
-  };
-  const handleScrubEnd = () => {
-    onPick(localTime + offset);
-  };
 
   return (
     <div className="space-y-1">
-      <div className="text-xs text-muted-foreground">
-        Drag the waveform to set the beep time (releases snap to source seconds)
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground">
+          Click / drag the waveform to set the marker (input below
+          updates), then "Snap to beep"
+        </span>
+        <div className="flex items-center gap-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={zoomOut}
+            disabled={pxPerSec == null}
+            aria-label="Zoom out"
+            title="Zoom out"
+            className="size-7"
+          >
+            <ZoomOut className="size-3.5" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={zoomIn}
+            aria-label="Zoom in"
+            title="Zoom in"
+            className="size-7"
+          >
+            <ZoomIn className="size-3.5" />
+          </Button>
+        </div>
       </div>
       <Waveform
         peaks={peaks.peaks}
@@ -499,10 +648,90 @@ function BeepWaveformPicker({
         currentTime={localTime}
         onScrub={handleScrub}
         onScrubEnd={handleScrubEnd}
-        beepTime={peaks.beep_time}
+        beepTime={markerLocal}
+        pixelsPerSecond={pxPerSec}
         height={80}
         ariaLabel={`Beep editor waveform for stage ${stageNumber}`}
       />
+      <audio
+        ref={audioRef}
+        src={api.stageAudioUrl(stageNumber)}
+        preload="metadata"
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        controls
+        className="w-full"
+      />
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={togglePlay}
+          title="Play / pause the audio"
+        >
+          {playing ? <Pause /> : <Play />}
+          {playing ? "Pause" : "Play"}
+        </Button>
+        <Button
+          size="sm"
+          variant="default"
+          onClick={() => void requestSnap()}
+          disabled={draftSourceTime == null || snapping}
+          title="Snap the marker to the rise-foot of the nearest beep tone (±1.5s)"
+        >
+          {snapping ? <Loader2 className="animate-spin" /> : <Crosshair />}
+          Snap to beep
+        </Button>
+      </div>
+      {proposal != null ? (
+        <SnapProposal
+          proposal={proposal}
+          onAccept={acceptProposal}
+          onDismiss={dismissProposal}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function SnapProposal({
+  proposal,
+  onAccept,
+  onDismiss,
+}: {
+  proposal: BeepSnapResult;
+  onAccept: () => void;
+  onDismiss: () => void;
+}) {
+  const deltaMs = Math.round(proposal.delta * 1000);
+  const sign = deltaMs >= 0 ? "+" : "";
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-2 py-1.5 text-xs">
+      <Sparkles className="size-3" />
+      <span className="font-mono tabular-nums">
+        Suggested: {proposal.snapped_time.toFixed(3)}s
+      </span>
+      <span className="text-muted-foreground">
+        ({sign}
+        {deltaMs} ms)
+      </span>
+      <span
+        className="text-muted-foreground"
+        title={`Silence-preference score: ${proposal.score.toFixed(1)}. Run peak amplitude: ${proposal.peak_amplitude.toFixed(2)}. Run duration: ${Math.round(proposal.duration_ms)} ms.`}
+      >
+        peak {proposal.peak_amplitude.toFixed(2)} &middot;{" "}
+        {Math.round(proposal.duration_ms)} ms
+      </span>
+      <div className="ml-auto flex gap-1">
+        <Button size="sm" variant="default" onClick={onAccept}>
+          <Check />
+          Accept
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
     </div>
   );
 }
@@ -768,77 +997,3 @@ function JobProgress({ job }: { job: Job }) {
   );
 }
 
-function AudioVerifier({
-  stageNumber,
-  suspectedTime,
-}: {
-  stageNumber: number;
-  suspectedTime: number | null;
-}) {
-  const audioRef = useRef<HTMLAudioElement>(null);
-  const [available, setAvailable] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch(api.stageAudioUrl(stageNumber), { method: "HEAD" })
-      .then((r) => {
-        if (!cancelled) setAvailable(r.ok);
-      })
-      .catch(() => {
-        if (!cancelled) setAvailable(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [stageNumber]);
-
-  useEffect(() => {
-    const el = audioRef.current;
-    if (el && suspectedTime != null && Number.isFinite(suspectedTime)) {
-      const start = Math.max(0, suspectedTime - 0.5);
-      try {
-        el.currentTime = start;
-      } catch {
-        /* the metadata may not be loaded yet; the seek runs on load below */
-      }
-    }
-  }, [suspectedTime]);
-
-  if (available === null) {
-    return (
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
-        <Volume2 className="size-3" />
-        Loading audio...
-      </div>
-    );
-  }
-  if (!available) {
-    return (
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
-        <Volume2 className="size-3" />
-        Run "Detect beep" first to extract audio for verification.
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
-        <Play className="size-3" />
-        Verify by ear (jumps to ~0.5s before the beep)
-      </div>
-      <audio
-        ref={audioRef}
-        src={api.stageAudioUrl(stageNumber)}
-        controls
-        preload="metadata"
-        onLoadedMetadata={() => {
-          const el = audioRef.current;
-          if (el && suspectedTime != null && Number.isFinite(suspectedTime)) {
-            el.currentTime = Math.max(0, suspectedTime - 0.5);
-          }
-        }}
-        className="w-full"
-      />
-    </div>
-  );
-}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -20,6 +20,18 @@ export interface BeepCandidate {
   duration_ms: number;
 }
 
+/** Response from POST /api/stages/{n}/videos/{vid}/beep/snap. The user
+ *  placed a marker by ear; the server returns the rise-foot leading edge
+ *  of the strongest run inside a tight window so the SPA can offer the
+ *  refinement as Accept / Dismiss. */
+export interface BeepSnapResult {
+  snapped_time: number;
+  delta: number;
+  peak_amplitude: number;
+  score: number;
+  duration_ms: number;
+}
+
 export interface StageVideo {
   path: string;
   /** Stable URL-safe id derived from ``path``. Used by per-video API
@@ -772,6 +784,22 @@ export const api = {
     request<MatchProject>(
       `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/select`,
       { method: "POST", json: { time } },
+    ),
+
+  /** Snap a user-placed beep marker to the strongest tone in a tight
+   *  window around the hint. Stateless -- the caller decides whether to
+   *  accept the proposal as a manual override. 404 means "no run met
+   *  duration / amplitude in that window"; widen ``windowS`` or move
+   *  the marker. */
+  snapBeepForVideo: (
+    stageNumber: number,
+    videoId: string,
+    hintTime: number,
+    windowS: number = 0.5,
+  ) =>
+    request<BeepSnapResult>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/snap`,
+      { method: "POST", json: { hint_time: hintTime, window_s: windowS } },
     ),
 
   /** Flip ``beep_reviewed`` on a single video (issue #71). Pure UI-state

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1149,6 +1149,85 @@ def test_select_beep_candidate_400_when_time_no_match(tmp_path: Path, monkeypatc
     assert "8.100" in detail
 
 
+_BEEP_FIXTURE_WAV = Path(__file__).parent / "fixtures" / "beep-test.wav"
+_BEEP_FIXTURE_TRUTH = 4.877  # seconds (rise-foot, see beep-test.json)
+
+
+def _stub_video_audio_with_fixture(monkeypatch) -> None:
+    """Point the snap endpoint's audio loader at the real beep fixture WAV.
+
+    The seeded primary's source is a zero-byte ``.mp4`` so we can't run
+    ffmpeg against it; the fixture WAV gives the snap detector a real
+    signal to refine against.
+    """
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake_ensure(root, n, video, source, **kwargs):  # type: ignore[no-untyped-def]
+        return _BEEP_FIXTURE_WAV
+
+    monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure)
+
+
+def test_snap_beep_refines_user_hint_to_truth(tmp_path: Path, monkeypatch) -> None:
+    """User dropped a marker ~70 ms after the real beep; the snap endpoint
+    pulls it back to the rise-foot leading edge within tolerance."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_video_audio_with_fixture(monkeypatch)
+
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    video_id = primary["video_id"]
+
+    hint = _BEEP_FIXTURE_TRUTH + 0.072
+    resp = client.post(
+        f"/api/stages/1/videos/{video_id}/beep/snap",
+        json={"hint_time": hint, "window_s": 0.5},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # 20 ms tolerance matches the fixture's ground-truth tolerance.
+    assert abs(body["snapped_time"] - _BEEP_FIXTURE_TRUTH) <= 0.020
+    assert body["delta"] == pytest.approx(body["snapped_time"] - hint, abs=1e-9)
+    assert body["peak_amplitude"] > 0.0
+    assert body["duration_ms"] > 0.0
+
+
+def test_snap_beep_400_on_negative_hint(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_video_audio_with_fixture(monkeypatch)
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    resp = client.post(
+        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        json={"hint_time": -0.1, "window_s": 0.5},
+    )
+    assert resp.status_code == 400
+
+
+def test_snap_beep_400_on_zero_window(tmp_path: Path, monkeypatch) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_video_audio_with_fixture(monkeypatch)
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    resp = client.post(
+        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        json={"hint_time": 4.0, "window_s": 0.0},
+    )
+    assert resp.status_code == 400
+
+
+def test_snap_beep_404_when_window_excludes_beep(tmp_path: Path, monkeypatch) -> None:
+    """A hint nowhere near the actual beep with a tight window returns 404
+    so the SPA can prompt the user to widen the window or move the marker."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    _stub_video_audio_with_fixture(monkeypatch)
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    # Place the hint into the post-beep silence; 50 ms half-window has
+    # nothing crossing the run-duration threshold.
+    resp = client.post(
+        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        json={"hint_time": 0.30, "window_s": 0.05},
+    )
+    assert resp.status_code == 404
+
+
 def test_manual_override_clears_candidate_list(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())


### PR DESCRIPTION
## Summary

- **Snap-to-beep manual picker**: replace the static manual-beep waveform with a combined audio + waveform widget. Click/drag to set the marker (numeric input stays in lock-step), play/pause, zoom, and a new "Snap to beep" button that calls a new `/beep/snap` endpoint -- the user gets the marker close by ear, the server refines it to the rise-foot leading edge of the strongest tone in a +/-1.5s window and surfaces an Accept / Dismiss proposal with the millisecond delta.
- **Concurrent-save bug**: `_run_detect_beep_for_video`, `_run_trim_for_video`, and `_run_shot_detect` each loaded the project at job start and saved the whole snapshot at the end. A long shot-detect job kicked off by a "Mark reviewed" click would stomp the `beep_reviewed` flags set on other stages while it was still running. Now each job reloads from disk just before save and applies only its targeted fields onto the fresh copy.
- **Ctrl-C job visibility**: `splitsmith ui` wraps `uvicorn.Server` so the first SIGINT prints the live PENDING/RUNNING job list to stderr + a "Press Ctrl-C again to force quit" hint. Uvicorn's existing repeat-SIGINT -> force_exit behaviour handles the kill path.

## Test plan

- [x] `uv run ruff check src tests` clean
- [x] `uv run black --check src tests` clean
- [x] `uv run pytest -q` -- 437 tests pass, including 4 new snap-beep tests that exercise the fixture WAV
- [x] UI typecheck (`tsc -b --noEmit`) + production build clean
- [ ] Manual: open the manual beep editor on a primary, click/drag marker, hit "Snap to beep", verify Accept moves the marker and Dismiss keeps the user's pick
- [ ] Manual: kick shot-detect on stage 1 by marking reviewed, immediately mark stages 2/3/4 reviewed, wait for shot-detect to finish, restart server, verify all 4 reviewed flags survive
- [ ] Manual: start a detect-beep job, Ctrl-C the terminal, verify the job summary prints; second Ctrl-C force-quits
- [ ] Manual: confirm the snap window is wide enough on quiet head-cam recordings (the original report was beeps not being found even on a marker placed at the start of the tone)

Filed alongside: #75 (global user settings dir, separate from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)