### PR TITLE
ui: global user config dir + recent projects + saved SSI identity (closes #75)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -38,6 +38,10 @@ Endpoints (locked v1 surface):
   GET  /api/fixture/peaks?path=...  -- waveform peaks for a fixture's sibling WAV
   GET  /api/fixture/audio?path=...  -- serve the fixture's sibling WAV (Range)
   GET  /api/fixture/video?path=...  -- serve a fixture-bound video file (Range)
+  GET  /api/user/recent-projects    -- recently-opened MatchProject roots (#75)
+  POST /api/user/recent-projects/forget -- drop one entry from the list
+  GET  /api/user/scoreboard-identity -- saved SSI identity (404 if none)
+  PUT  /api/user/scoreboard-identity -- write the SSI identity
 
 Design notes:
 - Localhost only. No auth, no CORS configuration beyond what Vite needs in dev.
@@ -68,7 +72,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from .. import beep_detect, report, video_probe
+from .. import beep_detect, report, user_config, video_probe
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
@@ -268,26 +272,30 @@ def _now_iso() -> str:
 
 
 def _load_env_files(project_root: Path) -> list[Path]:
-    """Pick up ``.env.local`` then ``.env`` from the project root *and* the
-    cwd the user launched the server from.
+    """Pick up ``.env.local`` then ``.env`` from the project root, the cwd
+    the user launched the server from, and the global user-config dir.
 
     ``SPLITSMITH_SSI_TOKEN`` (and any other ``SPLITSMITH_*`` env var) lives
     in one of these files for typical setups; without this hook the token
     only works if the user remembered to ``export`` it before launching
     ``splitsmith ui``.
 
-    Search order (later files override earlier ones, but never an explicit
-    ``export`` -- the process env always wins via ``override=False``):
+    Search order (process env always wins via ``override=False``; the
+    first file to define a key keeps it):
 
     1. ``<project_root>/.env`` -- shared per-project defaults
     2. ``<project_root>/.env.local`` -- per-machine secret, gitignored
     3. ``<cwd>/.env``           -- repo / launch-dir shared default
     4. ``<cwd>/.env.local``     -- repo / launch-dir per-machine secret
+    5. ``<user_config_dir>/.env`` -- global per-user default
+    6. ``<user_config_dir>/.env.local`` -- global per-user secret (#75)
 
-    The cwd entries cover the common case where the user keeps the token
-    next to the splitsmith repo they ``uv run splitsmith ui`` from, while
-    the project-root entries cover per-match configuration. Duplicate paths
-    (when the user runs from inside the project directory) are loaded once.
+    The user-config layer is the natural home for the SSI API token,
+    which is per-user rather than per-project; per-project settings still
+    win because they're loaded earlier.
+    Duplicate paths (when the user runs from inside the project directory,
+    or sets ``SPLITSMITH_HOME`` to one of the other locations) are loaded
+    once.
     """
     try:
         from dotenv import load_dotenv
@@ -296,10 +304,15 @@ def _load_env_files(project_root: Path) -> list[Path]:
 
     candidates: list[Path] = []
     seen: set[Path] = set()
-    cwd = Path.cwd().resolve()
-    for base in (project_root.resolve(), cwd):
+    bases: list[Path] = [project_root.resolve(), Path.cwd().resolve()]
+    if not user_config.is_disabled():
+        bases.append(user_config.user_config_dir())
+    for base in bases:
         for name in (".env", ".env.local"):
-            candidate = (base / name).resolve()
+            try:
+                candidate = (base / name).resolve()
+            except OSError:
+                continue
             if candidate in seen:
                 continue
             seen.add(candidate)
@@ -476,6 +489,27 @@ class HealthResponse(BaseModel):
 class ScoreboardImportRequest(BaseModel):
     data: dict[str, Any]
     overwrite: bool = False
+
+
+class ForgetRecentProjectRequest(BaseModel):
+    """Body for POST /api/user/recent-projects/forget (#75)."""
+
+    path: str
+
+
+class ScoreboardIdentityRequest(BaseModel):
+    """Body for PUT /api/user/scoreboard-identity (#75).
+
+    Mirrors :class:`splitsmith.user_config.ScoreboardIdentity`. ``shooter_id``
+    is required; everything else is optional so the SPA can save a partial
+    identity without forcing the user to fill division / club.
+    """
+
+    shooter_id: int
+    display_name: str | None = None
+    division: str | None = None
+    club: str | None = None
+    base_url: str | None = None
 
 
 class ScoreboardUploadRequest(BaseModel):
@@ -742,6 +776,17 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     loaded_env = _load_env_files(resolved_root)
     if loaded_env:
         logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
+
+    # Record this open in the global recent-projects list (issue #75). The
+    # disk name on the project may differ from ``project_name`` -- prefer
+    # whatever ``MatchProject.init`` settled on so re-opens don't flip the
+    # display name based on which CLI invocation got there first.
+    try:
+        loaded_project = MatchProject.load(resolved_root)
+        recorded_name = loaded_project.name or project_name
+    except Exception:  # pragma: no cover -- defensive: never block boot
+        recorded_name = project_name
+    user_config.record_project_open(resolved_root, recorded_name)
 
     app = FastAPI(
         title="splitsmith UI",
@@ -3244,6 +3289,56 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         stage.skipped = req.skipped
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
+
+    # ----------------------------------------------------------------------
+    # Global user config (#75)
+    # ----------------------------------------------------------------------
+    #
+    # Cross-project state lives in ``~/.splitsmith/`` (override via
+    # ``SPLITSMITH_HOME``; opt out with ``SPLITSMITH_DISABLE_USER_CONFIG=1``).
+    # The endpoints below let the SPA read the recent-projects list for its
+    # project picker and read/write the saved SSI Scoreboard identity so the
+    # scoreboard import flow can prefill 'me' instead of asking each project.
+
+    @app.get("/api/user/recent-projects")
+    def list_recent_projects() -> JSONResponse:
+        projects = user_config.get_recent_projects()
+        return JSONResponse({"projects": [p.model_dump(mode="json") for p in projects]})
+
+    @app.post("/api/user/recent-projects/forget")
+    def forget_recent_project(req: ForgetRecentProjectRequest) -> JSONResponse:
+        removed = user_config.remove_recent_project(Path(req.path))
+        projects = user_config.get_recent_projects()
+        return JSONResponse(
+            {
+                "removed": removed,
+                "projects": [p.model_dump(mode="json") for p in projects],
+            }
+        )
+
+    @app.get("/api/user/scoreboard-identity")
+    def get_scoreboard_identity() -> JSONResponse:
+        identity = user_config.load_scoreboard_identity()
+        if identity is None:
+            raise HTTPException(status_code=404, detail="no scoreboard identity saved")
+        return JSONResponse(identity.model_dump(mode="json"))
+
+    @app.put("/api/user/scoreboard-identity")
+    def put_scoreboard_identity(req: ScoreboardIdentityRequest) -> JSONResponse:
+        identity = user_config.ScoreboardIdentity(
+            shooter_id=req.shooter_id,
+            display_name=req.display_name,
+            division=req.division,
+            club=req.club,
+            base_url=req.base_url,
+        )
+        user_config.save_scoreboard_identity(identity)
+        return JSONResponse(identity.model_dump(mode="json"))
+
+    @app.delete("/api/user/scoreboard-identity")
+    def delete_scoreboard_identity() -> JSONResponse:
+        user_config.clear_scoreboard_identity()
+        return JSONResponse({"ok": True})
 
     # ----------------------------------------------------------------------
     # Static asset serving (SPA)

--- a/src/splitsmith/user_config.py
+++ b/src/splitsmith/user_config.py
@@ -1,0 +1,355 @@
+"""Global user-config directory (issue #75).
+
+Splitsmith is fundamentally per-project: each match folder is its own
+``MatchProject`` with its own scoreboard cache and settings. Anything
+cross-project (recent projects, the user's SSI Scoreboard identity, default
+preferences) lives here.
+
+On-disk layout::
+
+    <home>/
+      config.yaml          # global preferences (theme, default trim mode, ...)
+      projects.json        # ordered list of recently-opened MatchProject roots
+      scoreboard.json      # SSI Scoreboard identity (shooter_id, display name, base URL)
+      cache/               # cross-project caches (reserved; not used yet)
+
+Resolution order for ``<home>``:
+
+1. ``SPLITSMITH_HOME`` env var (any platform): full override.
+2. Linux + ``XDG_CONFIG_HOME`` set: ``$XDG_CONFIG_HOME/splitsmith``.
+3. Linux fallback: ``~/.config/splitsmith``.
+4. macOS / Windows / other: ``~/.splitsmith``.
+
+Set ``SPLITSMITH_DISABLE_USER_CONFIG=1`` to opt out: every read returns an
+empty default and every write is a no-op. Same behaviour falls out
+naturally when the directory can't be created (permission denied, etc.) --
+the module logs a warning once and continues without persisting.
+
+The directory is created lazily on first write. Read paths never create
+files. All writes are atomic (tmp file + ``os.replace``) so a crashed
+write can't corrupt state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Bumped when an on-disk schema in this directory changes incompatibly. The
+# loader records this on every write so a future migration has a hook.
+SCHEMA_VERSION = 1
+
+ENV_HOME = "SPLITSMITH_HOME"
+ENV_DISABLE = "SPLITSMITH_DISABLE_USER_CONFIG"
+ENV_XDG = "XDG_CONFIG_HOME"
+
+PROJECTS_FILENAME = "projects.json"
+SCOREBOARD_FILENAME = "scoreboard.json"
+CONFIG_FILENAME = "config.yaml"
+CACHE_DIRNAME = "cache"
+
+# Cap recent-projects history. The SPA shows ~5-10; 50 is a comfortable
+# ceiling that doesn't grow unbounded for users who churn through projects.
+RECENT_PROJECTS_LIMIT = 50
+
+
+class RecentProject(BaseModel):
+    """One entry in ``projects.json``."""
+
+    path: str
+    name: str
+    last_opened_at: datetime
+
+
+class ProjectsIndex(BaseModel):
+    schema_version: int = SCHEMA_VERSION
+    projects: list[RecentProject] = Field(default_factory=list)
+
+
+class ScoreboardIdentity(BaseModel):
+    """The user's SSI Scoreboard identity, shared across projects.
+
+    All fields are optional except ``shooter_id`` so the SPA can save a
+    partial identity (e.g. user pinned themselves but never set a custom
+    base URL). The scoreboard import flow uses this as the default 'me'
+    competitor; per-project overrides remain possible (matches where the
+    user shoots a different division / club).
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    shooter_id: int
+    display_name: str | None = None
+    division: str | None = None
+    club: str | None = None
+    base_url: str | None = None
+
+
+class GlobalPrefs(BaseModel):
+    """Global preferences read from ``config.yaml``.
+
+    Tiny on purpose -- only fields that genuinely don't belong on a
+    per-project model live here. Add sparingly; per-project state is the
+    default and project.json should keep winning ties.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    theme: str | None = None
+    default_trim_mode: str | None = None
+    last_scoreboard_url: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Directory resolution
+# ---------------------------------------------------------------------------
+
+
+def is_disabled() -> bool:
+    return os.environ.get(ENV_DISABLE, "").strip() not in ("", "0", "false", "False")
+
+
+def user_config_dir() -> Path:
+    """Resolve the user-config directory path. Does not create it."""
+    override = os.environ.get(ENV_HOME)
+    if override:
+        return Path(override).expanduser()
+    if sys.platform.startswith("linux"):
+        xdg = os.environ.get(ENV_XDG)
+        if xdg:
+            return Path(xdg).expanduser() / "splitsmith"
+        return Path.home() / ".config" / "splitsmith"
+    return Path.home() / ".splitsmith"
+
+
+def _ensure_dir() -> Path | None:
+    """Return the directory, creating it if needed. ``None`` if disabled
+    or creation failed (permission denied, read-only FS).
+    """
+    if is_disabled():
+        return None
+    target = user_config_dir()
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("Could not create user config dir %s: %s", target, exc)
+        return None
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON / YAML helpers
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via a temp file + ``os.replace``.
+
+    Mirrors the pattern used by ``MatchProject.save`` so a crashed write
+    can never leave a half-written config behind.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        tmp.replace(path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: Path) -> Any | None:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Ignoring unreadable user-config file %s: %s", path, exc)
+        return None
+
+
+def _read_yaml(path: Path) -> Any | None:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Ignoring unreadable user-config file %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Recent projects
+# ---------------------------------------------------------------------------
+
+
+def _projects_path() -> Path:
+    return user_config_dir() / PROJECTS_FILENAME
+
+
+def _load_projects_index() -> ProjectsIndex:
+    if is_disabled():
+        return ProjectsIndex()
+    raw = _read_json(_projects_path())
+    if not isinstance(raw, dict):
+        return ProjectsIndex()
+    try:
+        return ProjectsIndex.model_validate(raw)
+    except Exception as exc:
+        logger.warning("Discarding malformed %s: %s", PROJECTS_FILENAME, exc)
+        return ProjectsIndex()
+
+
+def _save_projects_index(index: ProjectsIndex) -> None:
+    target = _ensure_dir()
+    if target is None:
+        return
+    payload = json.dumps(index.model_dump(mode="json"), indent=2, sort_keys=True)
+    try:
+        _atomic_write_text(target / PROJECTS_FILENAME, payload)
+    except OSError as exc:
+        logger.warning("Could not write %s: %s", PROJECTS_FILENAME, exc)
+
+
+def record_project_open(path: Path, name: str) -> None:
+    """Append or refresh a project entry in ``projects.json``.
+
+    Resolves ``path`` so two opens of the same project via different
+    relative paths collapse to one entry. Moves the entry to the front
+    of the list and trims to ``RECENT_PROJECTS_LIMIT``. No-op if the
+    user-config directory is disabled or unwritable.
+    """
+    if is_disabled():
+        return
+    resolved = str(Path(path).expanduser().resolve())
+    now = datetime.now(UTC)
+    index = _load_projects_index()
+    remaining = [p for p in index.projects if p.path != resolved]
+    updated = [RecentProject(path=resolved, name=name, last_opened_at=now), *remaining]
+    if len(updated) > RECENT_PROJECTS_LIMIT:
+        updated = updated[:RECENT_PROJECTS_LIMIT]
+    index.projects = updated
+    index.schema_version = SCHEMA_VERSION
+    _save_projects_index(index)
+
+
+def get_recent_projects() -> list[RecentProject]:
+    """Return the recent-projects list, most-recent first.
+
+    Entries whose ``path`` no longer exists on disk are kept (the issue
+    asks us not to auto-prune; the SPA can flag stale entries).
+    """
+    return list(_load_projects_index().projects)
+
+
+def remove_recent_project(path: Path) -> bool:
+    """Drop one entry from the recent-projects list. Returns ``True`` if
+    something was removed. Used by the SPA's "forget this project"
+    affordance so users can prune entries the daemon won't auto-delete.
+    """
+    if is_disabled():
+        return False
+    resolved = str(Path(path).expanduser().resolve())
+    index = _load_projects_index()
+    before = len(index.projects)
+    index.projects = [p for p in index.projects if p.path != resolved]
+    if len(index.projects) == before:
+        return False
+    _save_projects_index(index)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Scoreboard identity
+# ---------------------------------------------------------------------------
+
+
+def _scoreboard_path() -> Path:
+    return user_config_dir() / SCOREBOARD_FILENAME
+
+
+def load_scoreboard_identity() -> ScoreboardIdentity | None:
+    if is_disabled():
+        return None
+    raw = _read_json(_scoreboard_path())
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return ScoreboardIdentity.model_validate(raw)
+    except Exception as exc:
+        logger.warning("Discarding malformed %s: %s", SCOREBOARD_FILENAME, exc)
+        return None
+
+
+def save_scoreboard_identity(identity: ScoreboardIdentity) -> None:
+    target = _ensure_dir()
+    if target is None:
+        return
+    identity = identity.model_copy(update={"schema_version": SCHEMA_VERSION})
+    payload = json.dumps(identity.model_dump(mode="json"), indent=2, sort_keys=True)
+    try:
+        _atomic_write_text(target / SCOREBOARD_FILENAME, payload)
+    except OSError as exc:
+        logger.warning("Could not write %s: %s", SCOREBOARD_FILENAME, exc)
+
+
+def clear_scoreboard_identity() -> None:
+    if is_disabled():
+        return
+    path = _scoreboard_path()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("Could not delete %s: %s", SCOREBOARD_FILENAME, exc)
+
+
+# ---------------------------------------------------------------------------
+# Global preferences (config.yaml)
+# ---------------------------------------------------------------------------
+
+
+def _config_path() -> Path:
+    return user_config_dir() / CONFIG_FILENAME
+
+
+def load_global_prefs() -> GlobalPrefs:
+    if is_disabled():
+        return GlobalPrefs()
+    raw = _read_yaml(_config_path())
+    if not isinstance(raw, dict):
+        return GlobalPrefs()
+    try:
+        return GlobalPrefs.model_validate(raw)
+    except Exception as exc:
+        logger.warning("Discarding malformed %s: %s", CONFIG_FILENAME, exc)
+        return GlobalPrefs()
+
+
+def save_global_prefs(prefs: GlobalPrefs) -> None:
+    target = _ensure_dir()
+    if target is None:
+        return
+    prefs = prefs.model_copy(update={"schema_version": SCHEMA_VERSION})
+    payload = yaml.safe_dump(prefs.model_dump(mode="json"), sort_keys=True)
+    try:
+        _atomic_write_text(target / CONFIG_FILENAME, payload)
+    except OSError as exc:
+        logger.warning("Could not write %s: %s", CONFIG_FILENAME, exc)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3522,3 +3522,135 @@ def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> 
     assert resp.status_code == 200
     jobs_after = client.get("/api/jobs").json()
     assert any(j["kind"] == "shot_detect" for j in jobs_after)
+
+
+# ---------------------------------------------------------------------------
+# Global user-config endpoints (#75)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _user_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``~/.splitsmith/`` to a per-test directory so the user's
+    real recent-projects list isn't touched by these tests.
+    """
+    from splitsmith import user_config
+
+    home = tmp_path / "user-config"
+    monkeypatch.setenv(user_config.ENV_HOME, str(home))
+    monkeypatch.delenv(user_config.ENV_DISABLE, raising=False)
+    return home
+
+
+def test_create_app_records_recent_project(tmp_path: Path, _user_config_home: Path) -> None:
+    from splitsmith import user_config
+
+    create_app(project_root=tmp_path / "match", project_name="Recent Match")
+    recent = user_config.get_recent_projects()
+    assert len(recent) == 1
+    assert recent[0].name == "Recent Match"
+    assert Path(recent[0].path) == (tmp_path / "match").resolve()
+
+
+def test_recent_projects_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
+    create_app(project_root=tmp_path / "alpha", project_name="Alpha")
+    app = create_app(project_root=tmp_path / "beta", project_name="Beta")
+    client = TestClient(app)
+
+    resp = client.get("/api/user/recent-projects")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = [p["name"] for p in body["projects"]]
+    assert names[0] == "Beta"  # most-recent first
+    assert "Alpha" in names
+
+
+def test_forget_recent_project_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
+    create_app(project_root=tmp_path / "alpha", project_name="Alpha")
+    app = create_app(project_root=tmp_path / "beta", project_name="Beta")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/user/recent-projects/forget",
+        json={"path": str((tmp_path / "alpha").resolve())},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["removed"] is True
+    assert [p["name"] for p in body["projects"]] == ["Beta"]
+
+
+def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    # Empty: 404 (SPA renders the prompt rather than autopin).
+    assert client.get("/api/user/scoreboard-identity").status_code == 404
+
+    payload = {
+        "shooter_id": 12345,
+        "display_name": "Mathias Axell",
+        "division": "Production Optics",
+        "club": "Bromma PK",
+        "base_url": "https://shootnscoreit.com",
+    }
+    resp = client.put("/api/user/scoreboard-identity", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["shooter_id"] == 12345
+
+    # Now readable.
+    got = client.get("/api/user/scoreboard-identity")
+    assert got.status_code == 200
+    assert got.json()["display_name"] == "Mathias Axell"
+
+    # Delete clears it.
+    client.delete("/api/user/scoreboard-identity")
+    assert client.get("/api/user/scoreboard-identity").status_code == 404
+
+
+def test_user_config_disable_flag_makes_endpoints_safe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from splitsmith import user_config
+
+    monkeypatch.setenv(user_config.ENV_DISABLE, "1")
+    app = create_app(project_root=tmp_path / "match", project_name="Disabled")
+    client = TestClient(app)
+
+    # Recording was a no-op.
+    body = client.get("/api/user/recent-projects").json()
+    assert body == {"projects": []}
+
+    # PUT silently drops; GET still returns 404.
+    client.put("/api/user/scoreboard-identity", json={"shooter_id": 1})
+    assert client.get("/api/user/scoreboard-identity").status_code == 404
+
+
+def test_load_env_files_picks_up_user_config_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SSI token (and any other ``SPLITSMITH_*`` var) can live in
+    ``~/.splitsmith/.env`` -- it's per-user, not per-project. Project /
+    cwd files still win because they're loaded earlier with
+    ``override=False``.
+    """
+    pytest.importorskip("dotenv")
+    from splitsmith import user_config
+    from splitsmith.ui import server as server_mod
+
+    home = tmp_path / "user-home"
+    home.mkdir()
+    (home / ".env").write_text("SPLITSMITH_TEST_TOKEN=from-user-config\n")
+    monkeypatch.setenv(user_config.ENV_HOME, str(home))
+    monkeypatch.delenv(user_config.ENV_DISABLE, raising=False)
+    monkeypatch.delenv("SPLITSMITH_TEST_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    project_root = tmp_path / "no-env-project"
+    project_root.mkdir()
+    loaded = server_mod._load_env_files(project_root)
+    assert any(p.parent.resolve() == home.resolve() for p in loaded)
+
+    import os
+
+    assert os.environ.get("SPLITSMITH_TEST_TOKEN") == "from-user-config"

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,0 +1,249 @@
+"""Tests for splitsmith.user_config (issue #75)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from splitsmith import user_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_user_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every test at a per-test ``SPLITSMITH_HOME`` so the user's
+    real ``~/.splitsmith/`` is never touched. The fixture also clears the
+    disable flag so each test opts in / out explicitly.
+    """
+    home = tmp_path / "splitsmith-home"
+    monkeypatch.setenv(user_config.ENV_HOME, str(home))
+    monkeypatch.delenv(user_config.ENV_DISABLE, raising=False)
+    return home
+
+
+def test_user_config_dir_uses_env_override(_isolated_user_config: Path) -> None:
+    assert user_config.user_config_dir() == _isolated_user_config
+
+
+def test_user_config_dir_unset_falls_back_to_platform_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(user_config.ENV_HOME, raising=False)
+    monkeypatch.delenv(user_config.ENV_XDG, raising=False)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    resolved = user_config.user_config_dir()
+    if sys.platform.startswith("linux"):
+        assert resolved == fake_home / ".config" / "splitsmith"
+    else:
+        assert resolved == fake_home / ".splitsmith"
+
+
+def test_xdg_config_home_honoured_on_linux(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    if not sys.platform.startswith("linux"):
+        pytest.skip("XDG layout only applies on Linux")
+    monkeypatch.delenv(user_config.ENV_HOME, raising=False)
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv(user_config.ENV_XDG, str(xdg))
+    assert user_config.user_config_dir() == xdg / "splitsmith"
+
+
+def test_directory_created_lazily_on_first_write(
+    _isolated_user_config: Path, tmp_path: Path
+) -> None:
+    project = tmp_path / "match"
+    project.mkdir()
+    assert not _isolated_user_config.exists()
+
+    # Pure reads must NOT create the directory (acceptance: no error if it
+    # doesn't exist).
+    assert user_config.get_recent_projects() == []
+    assert user_config.load_scoreboard_identity() is None
+    assert user_config.load_global_prefs() == user_config.GlobalPrefs()
+    assert not _isolated_user_config.exists()
+
+    # Writing creates the directory + the file.
+    user_config.record_project_open(project, "Test Match")
+    assert _isolated_user_config.is_dir()
+    assert (_isolated_user_config / user_config.PROJECTS_FILENAME).is_file()
+
+
+def test_record_project_open_appends_and_dedupes(
+    _isolated_user_config: Path, tmp_path: Path
+) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+
+    user_config.record_project_open(a, "A")
+    user_config.record_project_open(b, "B")
+    recent = user_config.get_recent_projects()
+    assert [p.name for p in recent] == ["B", "A"]
+    assert [Path(p.path) for p in recent] == [b.resolve(), a.resolve()]
+
+    # Re-opening A bumps it back to the front and refreshes the timestamp.
+    earlier = recent[1].last_opened_at
+    user_config.record_project_open(a, "A renamed")
+    refreshed = user_config.get_recent_projects()
+    assert [p.name for p in refreshed] == ["A renamed", "B"]
+    assert refreshed[0].last_opened_at >= earlier
+
+
+def test_record_project_open_resolves_paths(_isolated_user_config: Path, tmp_path: Path) -> None:
+    project = tmp_path / "m"
+    project.mkdir()
+    user_config.record_project_open(project, "M")
+    user_config.record_project_open(project / "..", "M alt")
+    user_config.record_project_open(project / "." / "..", "M alt 2")
+    # Different relative paths to the SAME project must collapse to one
+    # entry; otherwise users see one row per ``cd`` they tried.
+    assert len(user_config.get_recent_projects()) <= 2  # parent + project both valid
+    # The exact project itself is one entry, not duplicated.
+    project_entries = [
+        p for p in user_config.get_recent_projects() if Path(p.path) == project.resolve()
+    ]
+    assert len(project_entries) == 1
+
+
+def test_recent_projects_capped(
+    _isolated_user_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(user_config, "RECENT_PROJECTS_LIMIT", 3)
+    for i in range(5):
+        d = tmp_path / f"p{i}"
+        d.mkdir()
+        user_config.record_project_open(d, f"P{i}")
+    recent = user_config.get_recent_projects()
+    assert len(recent) == 3
+    assert [p.name for p in recent] == ["P4", "P3", "P2"]
+
+
+def test_remove_recent_project(_isolated_user_config: Path, tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    user_config.record_project_open(a, "A")
+    user_config.record_project_open(b, "B")
+
+    assert user_config.remove_recent_project(a) is True
+    remaining = user_config.get_recent_projects()
+    assert [p.name for p in remaining] == ["B"]
+
+    # Removing again is a no-op (returns False, no crash).
+    assert user_config.remove_recent_project(a) is False
+
+
+def test_save_and_load_scoreboard_identity(_isolated_user_config: Path) -> None:
+    identity = user_config.ScoreboardIdentity(
+        shooter_id=12345,
+        display_name="Mathias Axell",
+        division="Production Optics",
+        club="Bromma PK",
+        base_url="https://shootnscoreit.com",
+    )
+    user_config.save_scoreboard_identity(identity)
+
+    loaded = user_config.load_scoreboard_identity()
+    assert loaded is not None
+    assert loaded.shooter_id == 12345
+    assert loaded.display_name == "Mathias Axell"
+    assert loaded.base_url == "https://shootnscoreit.com"
+
+    # Schema version is stamped on write.
+    on_disk = json.loads((_isolated_user_config / user_config.SCOREBOARD_FILENAME).read_text())
+    assert on_disk["schema_version"] == user_config.SCHEMA_VERSION
+
+
+def test_clear_scoreboard_identity(_isolated_user_config: Path) -> None:
+    user_config.save_scoreboard_identity(user_config.ScoreboardIdentity(shooter_id=1))
+    assert user_config.load_scoreboard_identity() is not None
+    user_config.clear_scoreboard_identity()
+    assert user_config.load_scoreboard_identity() is None
+    # Idempotent.
+    user_config.clear_scoreboard_identity()
+
+
+def test_malformed_files_are_ignored(_isolated_user_config: Path) -> None:
+    _isolated_user_config.mkdir(parents=True, exist_ok=True)
+    (_isolated_user_config / user_config.PROJECTS_FILENAME).write_text("not json{{{")
+    (_isolated_user_config / user_config.SCOREBOARD_FILENAME).write_text("also bad")
+    (_isolated_user_config / user_config.CONFIG_FILENAME).write_text(": : :\n: : :")
+
+    assert user_config.get_recent_projects() == []
+    assert user_config.load_scoreboard_identity() is None
+    assert user_config.load_global_prefs() == user_config.GlobalPrefs()
+
+
+def test_disable_flag_blocks_reads_and_writes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _isolated_user_config: Path
+) -> None:
+    monkeypatch.setenv(user_config.ENV_DISABLE, "1")
+    project = tmp_path / "m"
+    project.mkdir()
+    user_config.record_project_open(project, "M")
+    user_config.save_scoreboard_identity(user_config.ScoreboardIdentity(shooter_id=99))
+    user_config.save_global_prefs(user_config.GlobalPrefs(theme="dark"))
+    assert not _isolated_user_config.exists()
+    assert user_config.get_recent_projects() == []
+    assert user_config.load_scoreboard_identity() is None
+    assert user_config.load_global_prefs() == user_config.GlobalPrefs()
+
+
+def test_global_prefs_round_trip(_isolated_user_config: Path) -> None:
+    prefs = user_config.GlobalPrefs(
+        theme="dark",
+        default_trim_mode="audit",
+        last_scoreboard_url="https://scoreboard.urdr.dev/competitions/1/2",
+    )
+    user_config.save_global_prefs(prefs)
+
+    loaded = user_config.load_global_prefs()
+    assert loaded.theme == "dark"
+    assert loaded.default_trim_mode == "audit"
+    assert loaded.last_scoreboard_url is not None
+
+    # Stored as YAML for human-editability.
+    on_disk = yaml.safe_load((_isolated_user_config / user_config.CONFIG_FILENAME).read_text())
+    assert on_disk["theme"] == "dark"
+
+
+def test_record_project_open_swallows_write_errors(
+    _isolated_user_config: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the global config dir is unwritable, ``record_project_open``
+    must not crash the caller -- the acceptance criterion says global
+    state is opt-out friendly. We simulate the disk-full / permission-
+    denied case by making ``_atomic_write_text`` raise.
+    """
+    project = tmp_path / "m"
+    project.mkdir()
+    user_config.record_project_open(project, "Original")
+    target = _isolated_user_config / user_config.PROJECTS_FILENAME
+    original = target.read_text()
+
+    def boom(*_a: object, **_kw: object) -> None:
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(user_config, "_atomic_write_text", boom)
+    # The write swallows the OSError and logs; the file stays intact.
+    user_config.record_project_open(project, "Updated")
+
+    assert target.read_text() == original
+
+
+def test_recent_project_last_opened_at_is_iso(_isolated_user_config: Path, tmp_path: Path) -> None:
+    project = tmp_path / "m"
+    project.mkdir()
+    user_config.record_project_open(project, "M")
+    raw = json.loads((_isolated_user_config / user_config.PROJECTS_FILENAME).read_text())
+    ts = raw["projects"][0]["last_opened_at"]
+    # Round-trips through datetime so the SPA can parse it as ISO 8601.
+    assert datetime.fromisoformat(ts.replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary
- New ``splitsmith/user_config.py``: ``~/.splitsmith/`` (override via ``SPLITSMITH_HOME``; XDG-aware on Linux; opt out with ``SPLITSMITH_DISABLE_USER_CONFIG=1``) for cross-project state. Lazy directory creation, atomic writes, schema-version stamped on every write, swallows write failures so a read-only ``$HOME`` never breaks the server.
- ``create_app`` records each open in ``projects.json``. New endpoints: ``GET /api/user/recent-projects``, ``POST /api/user/recent-projects/forget``, ``GET/PUT/DELETE /api/user/scoreboard-identity``.
- ``_load_env_files`` now also picks up ``~/.splitsmith/.env[.local]`` -- the SSI API token is per-user, not per-project. Per-project / cwd files still win because they're loaded earlier with ``override=False``.

## Test plan
- [x] ``uv run pytest tests/test_user_config.py tests/test_ui_server.py`` (154 pass, 1 skip)
- [x] ``uv run pytest`` full suite (461 pass)
- [x] ``uv run ruff check`` + ``uv run black --check`` clean on all touched files

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)