### PR TITLE
ui: failed-jobs dismiss + surface + auto-rolloff (closes #73)

### DIFF
--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -116,6 +116,12 @@ class Job(BaseModel):
     # status=CANCELLED. The flag stays True on the terminal snapshot so
     # the UI can label the row "Cancelled by user" instead of "Aborted".
     cancel_requested: bool = False
+    # True after the SPA POSTed /api/jobs/{id}/acknowledge (issue #73).
+    # The flag is meaningful only on FAILED jobs: the JobsPanel's badge
+    # counts only failures with acknowledged=False, and retention prefers
+    # evicting acknowledged failures so the user's dismissed errors roll
+    # off faster than the ones they haven't seen yet.
+    acknowledged: bool = False
     created_at: datetime
     updated_at: datetime
     started_at: datetime | None = None
@@ -292,6 +298,45 @@ class JobRegistry:
                 logger.warning("cancel: terminate() failed for job %s", job_id, exc_info=True)
         return snapshot
 
+    def acknowledge(self, job_id: str) -> Job | None:
+        """Mark a failed job as seen by the user (issue #73).
+
+        No-op for non-FAILED jobs and for failures already acknowledged.
+        Returns the post-ack snapshot, or ``None`` if ``job_id`` is
+        unknown. Acknowledgment lowers the job's eviction priority, so
+        a dismissed failure rolls off the retained list before the
+        unacknowledged ones the user still hasn't seen.
+        """
+        with self._lock:
+            j = self._jobs.get(job_id)
+            if j is None:
+                return None
+            if j.status == JobStatus.FAILED and not j.acknowledged:
+                j.acknowledged = True
+                j.updated_at = datetime.now(UTC)
+            return j.model_copy(deep=True)
+
+    def acknowledge_all_failures(self) -> list[Job]:
+        """Mark every currently-unacknowledged FAILED job as seen.
+
+        Returns the snapshots that actually changed (already-acknowledged
+        failures and non-failed jobs are skipped). The SPA uses the
+        return value to decide whether to flash a "Dismissed N failures"
+        toast.
+        """
+        now = datetime.now(UTC)
+        affected: list[Job] = []
+        with self._lock:
+            for jid in self._order:
+                j = self._jobs.get(jid)
+                if j is None:
+                    continue
+                if j.status == JobStatus.FAILED and not j.acknowledged:
+                    j.acknowledged = True
+                    j.updated_at = now
+                    affected.append(j.model_copy(deep=True))
+        return affected
+
     def find_active(
         self,
         *,
@@ -427,10 +472,16 @@ class JobRegistry:
             self._subprocs.pop(job_id, None)
 
     def _trim_retained_locked(self) -> None:
-        """Evict oldest finished jobs once the retention limit is hit.
+        """Evict finished jobs once the retention limit is hit.
 
         Active jobs (PENDING / RUNNING) are never evicted. Called under
         ``self._lock``; do not acquire it again.
+
+        Eviction priority (issue #73): succeeded jobs go first, then
+        acknowledged failures, then unacknowledged failures last. Within
+        each tier we evict oldest first. This keeps an unseen failure
+        visible in the registry even when a flurry of trim/beep
+        successes would otherwise have pushed it off the tail.
         """
         finished = [
             jid
@@ -439,7 +490,19 @@ class JobRegistry:
             and self._jobs[jid].status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
         ]
         excess = len(finished) - self._retain
-        if excess > 0:
-            for jid in finished[:excess]:
-                self._jobs.pop(jid, None)
-                self._order.remove(jid)
+        if excess <= 0:
+            return
+
+        def _eviction_priority(jid: str) -> int:
+            j = self._jobs[jid]
+            if j.status == JobStatus.SUCCEEDED:
+                return 0
+            if j.status == JobStatus.FAILED and j.acknowledged:
+                return 1
+            return 2  # unacknowledged failure -- protect
+
+        order_index = {jid: i for i, jid in enumerate(self._order)}
+        ranked = sorted(finished, key=lambda jid: (_eviction_priority(jid), order_index[jid]))
+        for jid in ranked[:excess]:
+            self._jobs.pop(jid, None)
+            self._order.remove(jid)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -27,6 +27,9 @@ Endpoints (locked v1 surface):
   GET  /api/stages/{n}/videos/{vid}/beep-preview -- per-video ~1s preview MP4
   GET  /api/jobs                    -- list all retained jobs
   GET  /api/jobs/{job_id}           -- poll a single job for progress / status
+  POST /api/jobs/{job_id}/cancel    -- cooperative cancel of a running job
+  POST /api/jobs/{job_id}/acknowledge      -- dismiss a failed job (issue #73)
+  POST /api/jobs/acknowledge-failures      -- dismiss every unacknowledged failure
   GET  /api/stages/{n}/audio        -- serve cached primary WAV (Range supported)
   GET  /api/stages/{n}/peaks?bins=N -- waveform peak data for the audit screen
   GET  /api/stages/{n}/beep-preview -- ~1s MP4 around the detected beep (#27)
@@ -2037,6 +2040,29 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     def get_job(job_id: str) -> Job:
         """Poll a single job. SPA polls ~1 Hz while a job is active."""
         job = state.jobs.get(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail=f"unknown job: {job_id}")
+        return job
+
+    @app.post("/api/jobs/acknowledge-failures", response_model=list[Job])
+    def acknowledge_all_failures() -> list[Job]:
+        """Mark every currently-unacknowledged FAILED job as seen (issue #73).
+
+        Used by the JobsPanel "Dismiss all failures" header action. Returns
+        the snapshots that actually flipped to acknowledged so the SPA can
+        diff against its in-memory list without an extra refetch.
+        """
+        return state.jobs.acknowledge_all_failures()
+
+    @app.post("/api/jobs/{job_id}/acknowledge", response_model=Job)
+    def acknowledge_job(job_id: str) -> Job:
+        """Mark a single failed job as seen (issue #73).
+
+        No-op for jobs that aren't failed or are already acknowledged --
+        the snapshot is returned unchanged so the SPA can still pin its
+        local state to the server response.
+        """
+        job = state.jobs.acknowledge(job_id)
         if job is None:
             raise HTTPException(status_code=404, detail=f"unknown job: {job_id}")
         return job

--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -1,10 +1,16 @@
 /**
- * Floating jobs FAB (issues #26, #51).
+ * Floating jobs FAB (issues #26, #51, #73).
  *
  * Renders a fixed bottom-right action button that summarises the job
- * registry and opens a popover with the same per-job rows the old
- * in-header panel used. The FAB lives outside page scroll so multi-cam
- * beep / trim runs stay visible on long screens (audit, export).
+ * registry and opens a popover with the per-job rows. The FAB lives
+ * outside page scroll so multi-cam beep / trim runs stay visible on
+ * long screens (audit, export).
+ *
+ * Failures (#73) are first-class: the badge counts only failures the
+ * user hasn't dismissed, the popover splits failures into a red strip
+ * at the top with explicit "Dismiss" buttons, and a "Dismiss all"
+ * action clears the badge in one click. Acknowledgment is server-side
+ * (POST /api/jobs/{id}/acknowledge) so it survives a page reload.
  *
  * Polling cadence is 1 Hz while any job is active and 5 s otherwise so
  * an idle screen barely talks to the backend.
@@ -28,8 +34,11 @@ import { cn } from "@/lib/utils";
 
 const ACTIVE_POLL_MS = 1000;
 const IDLE_POLL_MS = 5000;
-// Show at most this many jobs in the popover to keep it scannable.
-const VISIBLE_LIMIT = 8;
+// Cap each section so a runaway registry can't stretch the popover off
+// screen. Failures get their own quota so a flood of successes can't
+// push the unread errors out of view.
+const FAILED_VISIBLE_LIMIT = 6;
+const SECTION_VISIBLE_LIMIT = 8;
 const POPOVER_ID = "jobs-panel-popover";
 
 const KIND_LABEL: Record<string, string> = {
@@ -44,6 +53,10 @@ function formatKind(kind: string): string {
 
 function isActive(job: Job): boolean {
   return job.status === "pending" || job.status === "running";
+}
+
+function isUnackedFailure(job: Job): boolean {
+  return job.status === "failed" && !job.acknowledged;
 }
 
 function jobLabel(job: Job): string {
@@ -98,13 +111,14 @@ export function JobsPanel() {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [open, setOpen] = useState(false);
   const [cancelInFlight, setCancelInFlight] = useState<Set<string>>(() => new Set());
-  // Failed-job ids the user has already seen. A failure stays "sticky"
-  // (destructive FAB state) until either the popover opens or the
-  // failed job ages out of the registry. Acked-but-still-failed jobs
-  // continue to render in the list, just without driving FAB state.
-  const [acked, setAcked] = useState<Set<string>>(() => new Set());
+  // Per-row "Dismiss" click optimism: while the POST is in flight the
+  // row's button shows a spinner. The server is the source of truth
+  // for ``acknowledged`` -- we never set it client-only.
+  const [ackInFlight, setAckInFlight] = useState<Set<string>>(() => new Set());
+  const [bulkAckInFlight, setBulkAckInFlight] = useState(false);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const failedSectionRef = useRef<HTMLElement | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -141,51 +155,51 @@ export function JobsPanel() {
     };
   }, [refresh]);
 
-  const sorted = useMemo(() => {
-    // Active first (newest first within active), then most recent finished.
-    const active = jobs.filter(isActive);
-    const finished = jobs.filter((j) => !isActive(j));
-    active.sort(
+  const failed = useMemo(
+    () => jobs.filter(isUnackedFailure),
+    [jobs],
+  );
+  const active = useMemo(() => jobs.filter(isActive), [jobs]);
+  const finished = useMemo(
+    () => jobs.filter((j) => !isActive(j) && !isUnackedFailure(j)),
+    [jobs],
+  );
+
+  // Sort each section by recency. Failures lead with most-recent first
+  // because the user just got paged to look at them.
+  const sortedFailed = useMemo(() => {
+    const list = [...failed];
+    list.sort(
+      (a, b) =>
+        new Date(b.finished_at ?? b.updated_at).getTime() -
+        new Date(a.finished_at ?? a.updated_at).getTime(),
+    );
+    return list.slice(0, FAILED_VISIBLE_LIMIT);
+  }, [failed]);
+  const sortedActive = useMemo(() => {
+    const list = [...active];
+    list.sort(
       (a, b) =>
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     );
-    finished.sort((a, b) => {
+    return list.slice(0, SECTION_VISIBLE_LIMIT);
+  }, [active]);
+  const sortedFinished = useMemo(() => {
+    const list = [...finished];
+    list.sort((a, b) => {
       const at = a.finished_at ?? a.updated_at;
       const bt = b.finished_at ?? b.updated_at;
       return new Date(bt).getTime() - new Date(at).getTime();
     });
-    return [...active, ...finished].slice(0, VISIBLE_LIMIT);
-  }, [jobs]);
+    return list.slice(0, SECTION_VISIBLE_LIMIT);
+  }, [finished]);
 
-  const activeCount = jobs.filter(isActive).length;
-  const unackedFailedIds = useMemo(
-    () =>
-      jobs
-        .filter((j) => j.status === "failed" && !acked.has(j.id))
-        .map((j) => j.id),
-    [jobs, acked],
-  );
-  const unackedFailedCount = unackedFailedIds.length;
+  const activeCount = active.length;
+  const unackedFailedCount = failed.length;
 
-  // Drop ack entries for jobs that have aged out of the registry so
-  // the set doesn't grow unbounded across long sessions.
-  useEffect(() => {
-    setAcked((prev) => {
-      if (prev.size === 0) return prev;
-      const live = new Set(jobs.map((j) => j.id));
-      let changed = false;
-      const next = new Set<string>();
-      prev.forEach((id) => {
-        if (live.has(id)) next.add(id);
-        else changed = true;
-      });
-      return changed ? next : prev;
-    });
-  }, [jobs]);
-
-  // Auto-open on a new failure. Re-fires when the unacked count grows,
-  // not when an existing failure remains unacked, so the popover doesn't
-  // keep popping back if the user closes it without clicking through.
+  // Auto-open on a new failure. Re-fires when the unacked count grows
+  // so a fresh failure always surfaces; doesn't re-open if the user
+  // closes the panel without dismissing -- they took an action.
   const prevUnackCountRef = useRef(0);
   useEffect(() => {
     if (unackedFailedCount > prevUnackCountRef.current && !open) {
@@ -193,18 +207,6 @@ export function JobsPanel() {
     }
     prevUnackCountRef.current = unackedFailedCount;
   }, [unackedFailedCount, open]);
-
-  // Acknowledge unacked failures whenever the popover is open. Runs on
-  // open transitions and also while open if a new failure lands, so the
-  // failed badge clears immediately once the user has the panel up.
-  useEffect(() => {
-    if (!open || unackedFailedCount === 0) return;
-    setAcked((prev) => {
-      const next = new Set(prev);
-      unackedFailedIds.forEach((id) => next.add(id));
-      return next;
-    });
-  }, [open, unackedFailedCount, unackedFailedIds]);
 
   // Close popover on outside click / Escape.
   useEffect(() => {
@@ -297,6 +299,15 @@ export function JobsPanel() {
     };
   }, [open]);
 
+  // When the panel opens with unread failures, scroll the failures
+  // section into view inside the popover. Without this, a panel taller
+  // than the viewport could open with the failures off-screen.
+  useEffect(() => {
+    if (!open) return;
+    if (unackedFailedCount === 0) return;
+    failedSectionRef.current?.scrollIntoView({ block: "start", behavior: "auto" });
+  }, [open, unackedFailedCount]);
+
   const cancel = async (jobId: string) => {
     setCancelInFlight((prev) => {
       const next = new Set(prev);
@@ -314,6 +325,40 @@ export function JobsPanel() {
         next.delete(jobId);
         return next;
       });
+    }
+  };
+
+  const dismiss = async (jobId: string) => {
+    setAckInFlight((prev) => {
+      const next = new Set(prev);
+      next.add(jobId);
+      return next;
+    });
+    try {
+      const updated = await api.acknowledgeJob(jobId);
+      setJobs((prev) => prev.map((j) => (j.id === jobId ? updated : j)));
+    } catch {
+      /* ignore -- next poll will resync */
+    } finally {
+      setAckInFlight((prev) => {
+        const next = new Set(prev);
+        next.delete(jobId);
+        return next;
+      });
+    }
+  };
+
+  const dismissAll = async () => {
+    setBulkAckInFlight(true);
+    try {
+      const updated = await api.acknowledgeAllFailures();
+      if (updated.length === 0) return;
+      const byId = new Map(updated.map((j) => [j.id, j] as const));
+      setJobs((prev) => prev.map((j) => byId.get(j.id) ?? j));
+    } catch {
+      /* ignore -- next poll will resync */
+    } finally {
+      setBulkAckInFlight(false);
     }
   };
 
@@ -391,30 +436,94 @@ export function JobsPanel() {
           role="dialog"
           aria-label="Background jobs"
           tabIndex={-1}
-          className="absolute bottom-full right-0 z-50 mb-2 w-96 max-w-[calc(100vw-2rem)] rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-lg focus:outline-none"
+          className="absolute bottom-full right-0 z-50 mb-2 flex max-h-[70vh] w-96 max-w-[calc(100vw-2rem)] flex-col rounded-md border border-border bg-popover text-popover-foreground shadow-lg focus:outline-none"
         >
-          <div className="mb-2 flex items-center justify-between">
+          <div className="flex items-center justify-between border-b border-border px-3 py-2">
             <h2 className="text-sm font-semibold tracking-tight">Background jobs</h2>
             <span className="text-xs text-muted-foreground">
               {activeCount > 0 ? `${activeCount} active` : "Idle"}
             </span>
           </div>
-          {sorted.length === 0 ? (
-            <p className="py-6 text-center text-xs text-muted-foreground">
-              No recent jobs.
-            </p>
-          ) : (
-            <ul className="flex flex-col gap-1">
-              {sorted.map((job) => (
-                <JobRow
-                  key={job.id}
-                  job={job}
-                  busy={cancelInFlight.has(job.id)}
-                  onCancel={() => cancel(job.id)}
-                />
-              ))}
-            </ul>
-          )}
+          <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3">
+            {unackedFailedCount > 0 ? (
+              <section
+                ref={failedSectionRef}
+                aria-label="Failed jobs"
+                className="overflow-hidden rounded-md border border-destructive/40 bg-destructive/5"
+              >
+                <div className="flex items-center justify-between border-b border-destructive/30 bg-destructive/10 px-2 py-1.5">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-destructive">
+                    <AlertTriangle className="size-3.5" aria-hidden />
+                    {unackedFailedCount} failed
+                  </div>
+                  {unackedFailedCount > 1 ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-[11px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      onClick={() => void dismissAll()}
+                      disabled={bulkAckInFlight}
+                    >
+                      {bulkAckInFlight ? (
+                        <Loader2 className="size-3 motion-safe:animate-spin" aria-hidden />
+                      ) : null}
+                      Dismiss all
+                    </Button>
+                  ) : null}
+                </div>
+                <ul className="flex flex-col gap-1 p-1.5">
+                  {sortedFailed.map((job) => (
+                    <JobRow
+                      key={job.id}
+                      job={job}
+                      cancelBusy={cancelInFlight.has(job.id)}
+                      ackBusy={ackInFlight.has(job.id)}
+                      onCancel={() => cancel(job.id)}
+                      onDismiss={() => dismiss(job.id)}
+                      tone="failed"
+                    />
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+            {sortedActive.length > 0 ? (
+              <section aria-label="Active jobs" className="flex flex-col gap-1">
+                {sortedActive.map((job) => (
+                  <JobRow
+                    key={job.id}
+                    job={job}
+                    cancelBusy={cancelInFlight.has(job.id)}
+                    ackBusy={false}
+                    onCancel={() => cancel(job.id)}
+                    onDismiss={() => undefined}
+                    tone="default"
+                  />
+                ))}
+              </section>
+            ) : null}
+            {sortedFinished.length > 0 ? (
+              <section aria-label="Finished jobs" className="flex flex-col gap-1">
+                {sortedFinished.map((job) => (
+                  <JobRow
+                    key={job.id}
+                    job={job}
+                    cancelBusy={false}
+                    ackBusy={false}
+                    onCancel={() => undefined}
+                    onDismiss={() => undefined}
+                    tone="default"
+                  />
+                ))}
+              </section>
+            ) : null}
+            {sortedFailed.length === 0 &&
+            sortedActive.length === 0 &&
+            sortedFinished.length === 0 ? (
+              <p className="py-6 text-center text-xs text-muted-foreground">
+                No recent jobs.
+              </p>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>
@@ -423,21 +532,38 @@ export function JobsPanel() {
 
 interface JobRowProps {
   job: Job;
-  busy: boolean;
+  cancelBusy: boolean;
+  ackBusy: boolean;
   onCancel: () => void;
+  onDismiss: () => void;
+  tone: "default" | "failed";
 }
 
-function JobRow({ job, busy, onCancel }: JobRowProps) {
+function JobRow({ job, cancelBusy, ackBusy, onCancel, onDismiss, tone }: JobRowProps) {
   const active = isActive(job);
+  const showDismiss = job.status === "failed" && !job.acknowledged;
+  const dismissedTag =
+    job.status === "failed" && job.acknowledged ? " (dismissed)" : "";
   const progressPct =
     job.progress != null ? Math.round(Math.min(1, Math.max(0, job.progress)) * 100) : null;
   const statusLine = job.cancel_requested
     ? "Cancelled by user"
     : job.status === "failed"
-      ? job.error ?? "Failed"
+      ? `${job.error ?? "Failed"}${dismissedTag}`
       : (job.message ?? job.status);
   return (
-    <li className="rounded-md border border-border/60 bg-card/50 p-2">
+    <li
+      className={cn(
+        "rounded-md border p-2",
+        tone === "failed"
+          ? "border-destructive/30 bg-card"
+          : "border-border/60 bg-card/50",
+        // Acknowledged failures live in the regular finished section but
+        // visually fade so the user can tell at a glance which entries
+        // are stale.
+        job.status === "failed" && job.acknowledged && "opacity-60",
+      )}
+    >
       <div className="flex items-start gap-2">
         <StatusIcon job={job} className="mt-0.5" />
         <div className="min-w-0 flex-1">
@@ -470,16 +596,30 @@ function JobRow({ job, busy, onCancel }: JobRowProps) {
             variant="ghost"
             size="icon"
             className="size-7 shrink-0"
-            disabled={busy || job.cancel_requested}
+            disabled={cancelBusy || job.cancel_requested}
             onClick={onCancel}
             aria-label={`Cancel ${jobLabel(job)}`}
             title="Cancel"
           >
-            {busy ? (
+            {cancelBusy ? (
               <Loader2 className="size-3.5 motion-safe:animate-spin" aria-hidden />
             ) : (
               <X className="size-3.5" aria-hidden />
             )}
+          </Button>
+        ) : showDismiss ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 px-2 text-[11px]"
+            disabled={ackBusy}
+            onClick={onDismiss}
+            aria-label={`Dismiss failure: ${jobLabel(job)}`}
+          >
+            {ackBusy ? (
+              <Loader2 className="size-3 motion-safe:animate-spin" aria-hidden />
+            ) : null}
+            Dismiss
           </Button>
         ) : null}
       </div>

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -479,6 +479,12 @@ export interface Job {
    *  stays True on the terminal snapshot so the row can be labelled
    *  "Cancelled by user" instead of "Aborted". */
   cancel_requested: boolean;
+  /** True once the user has dismissed this failure via
+   *  /api/jobs/{id}/acknowledge (issue #73). Meaningful only on FAILED
+   *  jobs; the JobsPanel badge counts failures with acknowledged=false
+   *  and the registry rolls acknowledged failures off faster than
+   *  unacknowledged ones. */
+  acknowledged: boolean;
   created_at: string;
   updated_at: string;
   started_at: string | null;
@@ -846,6 +852,17 @@ export const api = {
    *  ffmpeg subprocess so the cancel takes effect immediately. */
   cancelJob: (jobId: string) =>
     request<Job>(`/api/jobs/${encodeURIComponent(jobId)}/cancel`, { method: "POST" }),
+
+  /** Mark a single failed job as seen (issue #73). The badge stops
+   *  counting it and the registry rolls it off ahead of unacknowledged
+   *  failures. No-op for non-failed / already-acknowledged jobs. */
+  acknowledgeJob: (jobId: string) =>
+    request<Job>(`/api/jobs/${encodeURIComponent(jobId)}/acknowledge`, { method: "POST" }),
+
+  /** Bulk-dismiss every currently-unacknowledged failure. Returns the
+   *  jobs that actually flipped to acknowledged. */
+  acknowledgeAllFailures: () =>
+    request<Job[]>(`/api/jobs/acknowledge-failures`, { method: "POST" }),
 
   /** Poll a job until it leaves the running state. ``onUpdate`` fires on
    *  every snapshot (including the final one). Returns the terminal Job. */

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -299,3 +299,110 @@ def test_attach_after_cancel_terminates_immediately() -> None:
     assert _wait_until(lambda: reg.get(job.id).status == JobStatus.CANCELLED)
     assert fake.terminated, "post-cancel attach must still terminate the proc"
     assert cancel_observed.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Failure acknowledgment (issue #73)
+# ---------------------------------------------------------------------------
+
+
+def test_acknowledge_flips_failed_job_to_seen() -> None:
+    reg = JobRegistry(max_concurrent=1)
+
+    def boom(_h):
+        raise ValueError("kaboom")
+
+    job = reg.submit(kind="test", fn=boom)
+    assert _wait_until(lambda: reg.get(job.id).status == JobStatus.FAILED)
+    assert reg.get(job.id).acknowledged is False
+    snap = reg.acknowledge(job.id)
+    assert snap is not None
+    assert snap.acknowledged is True
+    # Idempotent: a second ack returns the same snapshot.
+    again = reg.acknowledge(job.id)
+    assert again is not None and again.acknowledged is True
+
+
+def test_acknowledge_noop_for_non_failed_job() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    job = reg.submit(kind="test", fn=lambda _h: None)
+    assert _wait_until(lambda: reg.get(job.id).status == JobStatus.SUCCEEDED)
+    snap = reg.acknowledge(job.id)
+    assert snap is not None
+    assert snap.acknowledged is False, "acknowledge() must not mark non-failed jobs"
+
+
+def test_acknowledge_unknown_job_returns_none() -> None:
+    reg = JobRegistry()
+    assert reg.acknowledge("does-not-exist") is None
+
+
+def test_acknowledge_all_failures_marks_only_unacked_failures() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    fail_a = reg.submit(kind="a", fn=lambda _h: (_ for _ in ()).throw(RuntimeError("a")))
+    fail_b = reg.submit(kind="b", fn=lambda _h: (_ for _ in ()).throw(RuntimeError("b")))
+    ok = reg.submit(kind="ok", fn=lambda _h: None)
+
+    def _all_done() -> bool:
+        return all(
+            reg.get(j.id) is not None
+            and reg.get(j.id).status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
+            for j in (fail_a, fail_b, ok)
+        )
+
+    assert _wait_until(_all_done)
+
+    # Pre-ack one failure so we can confirm the bulk endpoint skips it.
+    reg.acknowledge(fail_a.id)
+
+    affected = reg.acknowledge_all_failures()
+    affected_ids = {j.id for j in affected}
+    assert affected_ids == {fail_b.id}
+    assert reg.get(fail_b.id).acknowledged is True
+    assert reg.get(ok.id).acknowledged is False, "non-failed jobs must stay untouched"
+
+
+def test_retention_protects_unacked_failures_from_succeeded_flood() -> None:
+    """An unacknowledged failure must survive a flurry of successes
+    that would otherwise push it past the retention cap."""
+    reg = JobRegistry(max_concurrent=1, retain_recent=2)
+
+    def boom(_h):
+        raise RuntimeError("boom")
+
+    fail = reg.submit(kind="fail", fn=boom)
+    assert _wait_until(lambda: reg.get(fail.id).status == JobStatus.FAILED)
+
+    for i in range(3):
+        reg.submit(kind=f"ok-{i}", fn=lambda _h: None)
+    assert _wait_until(
+        lambda: not any(
+            j.status in (JobStatus.PENDING, JobStatus.RUNNING) for j in reg.list()
+        )
+    )
+
+    surviving = {j.id for j in reg.list()}
+    assert fail.id in surviving, "unacknowledged failure must not be evicted"
+
+
+def test_retention_evicts_acked_failure_before_unacked() -> None:
+    """When the registry is forced to drop a failure, the dismissed one
+    goes first so the user keeps seeing the failures they haven't
+    acknowledged yet."""
+    reg = JobRegistry(max_concurrent=1, retain_recent=1)
+
+    def boom(_h):
+        raise RuntimeError("boom")
+
+    older = reg.submit(kind="older", fn=boom)
+    assert _wait_until(lambda: reg.get(older.id).status == JobStatus.FAILED)
+    reg.acknowledge(older.id)
+
+    newer = reg.submit(kind="newer", fn=boom)
+    assert _wait_until(lambda: reg.get(newer.id).status == JobStatus.FAILED)
+
+    # retention=1 with two failures (one acked, one not) must evict the
+    # acknowledged one and keep the unacknowledged one visible.
+    surviving = {j.id for j in reg.list()}
+    assert newer.id in surviving
+    assert older.id not in surviving

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2125,6 +2125,109 @@ def test_detect_beep_job_records_failure_when_ffmpeg_blows_up(tmp_path: Path, mo
     assert "ffmpeg fell over" in final["error"]
 
 
+def test_acknowledge_endpoint_marks_failed_job_as_seen(tmp_path: Path, monkeypatch) -> None:
+    """POST /api/jobs/{id}/acknowledge flips ``acknowledged`` on a failed
+    job (issue #73). The SPA drives the per-row "Dismiss" button against
+    this; subsequent /api/jobs snapshots return acknowledged=True so the
+    badge stops counting it."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    from splitsmith.ui import audio as audio_helpers
+
+    def boom(*a, **kw):  # type: ignore[no-untyped-def]
+        raise audio_helpers.AudioExtractionError("kaboom")
+
+    monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
+    monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
+
+    submit = client.post("/api/stages/1/detect-beep")
+    assert submit.status_code == 200
+    job_id = submit.json()["id"]
+    final = _wait_for_job(client, job_id)
+    assert final["status"] == "failed"
+    assert final["acknowledged"] is False
+
+    ack = client.post(f"/api/jobs/{job_id}/acknowledge")
+    assert ack.status_code == 200
+    assert ack.json()["acknowledged"] is True
+
+    listing = client.get("/api/jobs").json()
+    assert next(j for j in listing if j["id"] == job_id)["acknowledged"] is True
+
+
+def test_acknowledge_endpoint_404_for_unknown_job(tmp_path: Path) -> None:
+    client, _ = _seed_project_with_primary(tmp_path)
+    resp = client.post("/api/jobs/does-not-exist/acknowledge")
+    assert resp.status_code == 404
+
+
+def test_acknowledge_endpoint_noop_for_succeeded_job(tmp_path: Path, monkeypatch) -> None:
+    """Acknowledging a non-failed job is a quiet no-op so the SPA's
+    optimistic flow doesn't have to special-case statuses."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    project.stages[0].time_seconds = 5.0
+    project.save(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"S")
+
+    from splitsmith import beep_detect
+    from splitsmith.ui import audio as audio_helpers
+
+    class FakeBeep:
+        time = 1.0
+        peak_amplitude = 0.5
+        duration_ms = 80.0
+        candidates: list = []
+
+    monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "z.wav")
+    (tmp_path / "z.wav").write_bytes(b"\x00")
+    monkeypatch.setattr(beep_detect, "load_audio", lambda p: ([0.0] * 100, 48_000))
+    monkeypatch.setattr(beep_detect, "detect_beep", lambda *a, **kw: FakeBeep())
+
+    submit = client.post("/api/stages/1/detect-beep")
+    job_id = submit.json()["id"]
+    assert _wait_for_job(client, job_id)["status"] == "succeeded"
+    resp = client.post(f"/api/jobs/{job_id}/acknowledge")
+    assert resp.status_code == 200
+    assert resp.json()["acknowledged"] is False
+
+
+def test_acknowledge_failures_bulk_endpoint(tmp_path: Path, monkeypatch) -> None:
+    """POST /api/jobs/acknowledge-failures dismisses every unacked failure
+    in one call and returns the snapshots that flipped, so the SPA can
+    apply the diff without an extra GET."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    from splitsmith.ui import audio as audio_helpers
+
+    def boom(*a, **kw):  # type: ignore[no-untyped-def]
+        raise audio_helpers.AudioExtractionError("kaboom")
+
+    monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
+    monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
+
+    ids: list[str] = []
+    for _ in range(2):
+        submit = client.post("/api/stages/1/detect-beep")
+        jid = submit.json()["id"]
+        assert _wait_for_job(client, jid)["status"] == "failed"
+        ids.append(jid)
+
+    # Pre-ack one so the bulk endpoint reports only the other.
+    client.post(f"/api/jobs/{ids[0]}/acknowledge")
+
+    bulk = client.post("/api/jobs/acknowledge-failures")
+    assert bulk.status_code == 200
+    affected = bulk.json()
+    assert {j["id"] for j in affected} == {ids[1]}
+
+    listing = client.get("/api/jobs").json()
+    by_id = {j["id"]: j for j in listing}
+    assert by_id[ids[0]]["acknowledged"] is True
+    assert by_id[ids[1]]["acknowledged"] is True
+
+
 def test_post_trim_400_when_no_beep(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     project_root = tmp_path / "match"


### PR DESCRIPTION
## Summary
- Server: \`Job.acknowledged\` flag, \`POST /api/jobs/{id}/acknowledge\`, \`POST /api/jobs/acknowledge-failures\`, retention prefers evicting acknowledged failures so unread ones survive a flood of successes.
- SPA: badge counts unacknowledged failures only; failures render in a top-of-panel red strip with per-row Dismiss + Dismiss-all; acknowledged failures stay briefly in the finished list with a muted \"(dismissed)\" label until they roll off.
- Drops the client-side \`acked\` Set added in #51 -- the server is now the source of truth, so dismissals survive a page reload (acceptance criterion).
- Pre-existing FAB behaviours from #51 (focus trap, Alt+J, motion-safe spinners, mobile-safe insets) carry through.

## Test plan
- [x] \`uv run pytest tests/test_jobs.py tests/test_ui_server.py\` (164 passing, 4 new ack tests)
- [x] \`npm run typecheck\` and \`npm run build\` in \`src/splitsmith/ui_static\`
- [ ] Trigger a failed detect-beep -> badge red \`1\`, FAB destructive
- [ ] Click Dismiss on the failed row -> badge clears, row shifts to finished list with \"(dismissed)\"
- [ ] Trigger 2+ failures, click \"Dismiss all\" -> badge clears
- [ ] Refresh the page -> dismissed failures stay dismissed (no badge)
- [ ] Open panel while a failure is in view -> failures section auto-scrolls to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)