### PR TITLE
ingest: expand VIDEO_EXTENSIONS for common camera formats (closes #70)

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -38,7 +38,19 @@ from .. import video_match
 from ..config import BeepCandidate, StageData, VideoMatchConfig
 from ..video_match import match_videos_to_stages
 
-VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
+VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".mov",
+    ".m4v",
+    ".mts",
+    ".m2ts",
+    ".mkv",
+    ".avi",
+    ".mxf",
+    ".lrv",
+    ".360",
+    ".webm",
+}
 
 PROJECT_FILE = "project.json"
 SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard", "probes", "thumbs")

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -21,11 +21,29 @@ from splitsmith.ui.project import (
     PROJECT_FILE,
     SCHEMA_VERSION,
     SUBDIRS,
+    VIDEO_EXTENSIONS,
     MatchProject,
     StageEntry,
     StageVideo,
     atomic_write_json,
 )
+
+
+def test_video_extensions_includes_common_camera_formats() -> None:
+    expected = {
+        ".mp4",
+        ".mov",
+        ".m4v",
+        ".mts",
+        ".m2ts",
+        ".mkv",
+        ".avi",
+        ".mxf",
+        ".lrv",
+        ".360",
+        ".webm",
+    }
+    assert expected.issubset(VIDEO_EXTENSIONS)
 
 
 def test_init_creates_layout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Expands `VIDEO_EXTENSIONS` in `src/splitsmith/ui/project.py` from `{.mp4, .mov, .m4v}` to also include `.mts`, `.m2ts`, `.mkv`, `.avi`, `.mxf`, `.lrv`, `.360`, `.webm` so the FolderPicker stops hiding clips from cameras beyond GoPro/iPhone.
- `server.py` imports the same set, so all server-side filtering call sites pick up the change without duplication.
- Adds `test_video_extensions_includes_common_camera_formats` asserting the new entries.

Picks option (A) from #70. ffmpeg will fail loudly downstream if an unsupported codec slips through; (B)/(C) deferred until there's a real complaint.

## Test plan
- [x] `uv run pytest tests/test_ui_project.py -k video_extensions`
- [ ] Manual: drop a `.mts` / `.mkv` clip in a folder and confirm it shows up in the FolderPicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)