### PR TITLE
windows: font fallbacks + cross-platform path assertions in test_report

### DIFF
--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -219,6 +219,11 @@ _FONT_FALLBACKS: tuple[str, ...] = (
     "/Library/Fonts/Andale Mono.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    # Windows: Consolas ships with Vista+, Courier New / Lucida Console are
+    # always present. PIL accepts forward slashes here on Windows too.
+    "C:/Windows/Fonts/consola.ttf",
+    "C:/Windows/Fonts/lucon.ttf",
+    "C:/Windows/Fonts/cour.ttf",
 )
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -376,9 +376,7 @@ def test_retention_protects_unacked_failures_from_succeeded_flood() -> None:
     for i in range(3):
         reg.submit(kind=f"ok-{i}", fn=lambda _h: None)
     assert _wait_until(
-        lambda: not any(
-            j.status in (JobStatus.PENDING, JobStatus.RUNNING) for j in reg.list()
-        )
+        lambda: not any(j.status in (JobStatus.PENDING, JobStatus.RUNNING) for j in reg.list())
     )
 
     surviving = {j.id for j in reg.list()}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -188,7 +188,7 @@ def _make_analysis(*, anomalies: list[str] | None = None) -> StageAnalysis:
     ]
     return StageAnalysis(
         stage=_stage(),
-        video_path=Path("/tmp/stage3.mp4"),
+        video_path=Path("stage3.mp4"),
         beep_time=19.873,
         shots=shots,
         anomalies=anomalies or [],
@@ -208,11 +208,12 @@ def test_render_report_includes_header_and_marker() -> None:
     assert "Detected beep at:     19.873s" in text
     # Last shot time_from_beep = 14.700, official 14.74 -> within 500ms -> [OK]
     assert "[OK]" in text
-    # File footer
+    # File footer. Compare against str(Path) so backslash separators on
+    # Windows match the rendered output.
     assert "Files:" in text
-    assert "analysis/stage3_trimmed.mp4" in text
-    assert "analysis/stage3_splits.csv" in text
-    assert "analysis/stage3.fcpxml" in text
+    assert str(files.video) in text
+    assert str(files.csv) in text
+    assert str(files.fcpxml) in text
 
 
 def test_render_report_marks_draw_and_transition() -> None:
@@ -236,7 +237,7 @@ def test_render_report_color_band_flags() -> None:
     ]
     analysis = StageAnalysis(
         stage=_stage(),
-        video_path=Path("/tmp/x.mp4"),
+        video_path=Path("x.mp4"),
         beep_time=10.0,
         shots=shots,
     )
@@ -275,7 +276,7 @@ def test_write_report_writes_to_path(tmp_path: Path) -> None:
 def test_render_report_no_shots() -> None:
     analysis = StageAnalysis(
         stage=_stage(),
-        video_path=Path("/tmp/x.mp4"),
+        video_path=Path("x.mp4"),
         beep_time=10.0,
         shots=[],
         anomalies=["No shots detected in the stage window."],


### PR DESCRIPTION
First slice of Windows compatibility work. The codebase already gets a
lot right (list-form subprocess, pathlib everywhere, tempfile for scratch
space) but two issues bite immediately on Windows:

overlay_render.py:
- _FONT_FALLBACKS only listed macOS and Linux monospace fonts. PIL's
  default bitmap fallback works but renders the timer overlay as a
  small bitmap font, which looks wrong against 4K footage. Append
  Consolas / Lucida Console / Courier New from C:/Windows/Fonts so
  Windows users get a real TTF without configuring font_path. Forward
  slashes are accepted by PIL on Windows.

tests/test_report.py:
- video_path used POSIX-only literals like Path("/tmp/stage3.mp4").
  These never hit the disk (the field isn't rendered), but switching
  to bare filenames keeps the fixtures platform-neutral.
- test_render_report_includes_header_and_marker asserted the rendered
  text contained literals like "analysis/stage3_trimmed.mp4". On
  Windows, Path stringifies with backslashes, so the assertion would
  fail even though the report is correct. Compare against str(files.X)
  so the assertion tracks whatever separator pathlib emits.

Followup: scripts/build_ensemble_artifacts.py and the Windows mount
discovery in ui/server.py still need attention; documented in the
survey report on the branch.