### PR TITLE
windows: classify mapped network drives + read volume labels

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3618,12 +3618,100 @@ def _linux_network_mounts(network_fstypes: set[str]) -> set[str]:
     return out
 
 
+# GetDriveTypeW return values (winbase.h). REMOVABLE/FIXED/CDROM/RAMDISK
+# all collapse to ``"removable"`` for picker purposes; only REMOTE gets
+# its own bucket and only UNKNOWN / NO_ROOT_DIR are filtered out.
+_DRIVE_UNKNOWN = 0
+_DRIVE_NO_ROOT_DIR = 1
+_DRIVE_REMOTE = 4
+
+
 def _discover_windows_drives() -> list[tuple[Path, str, str]]:
+    """Enumerate Windows drives via Win32 + classify type & label.
+
+    Replaces the old D-Z directory-existence scan with kernel32 calls so
+    we can: (a) skip drives that aren't actually present, (b) classify
+    mapped network drives (``DRIVE_REMOTE``) as ``"network"`` instead of
+    lumping everything under ``"removable"``, and (c) read the volume
+    label so the picker shows ``"INSTA360 (D:)"`` rather than just
+    ``"D:"``.
+
+    UNC shares without a drive letter (``\\\\nas\\share``) aren't
+    enumerated -- the typical Windows workflow maps network drives to a
+    letter via "Map Network Drive", which this picks up.
+    """
+    drives = _query_windows_drives()
     out: list[tuple[Path, str, str]] = []
-    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":  # skip C: (system)
-        path = Path(f"{letter}:\\")
-        if _is_dir_with_timeout(path):
-            out.append((path, f"{letter}:", "removable"))
+    for letter, (drive_type, label) in sorted(drives.items()):
+        if letter == "C":  # skip system drive, matching prior behaviour
+            continue
+        if drive_type in (_DRIVE_UNKNOWN, _DRIVE_NO_ROOT_DIR):
+            continue
+        kind = "network" if drive_type == _DRIVE_REMOTE else "removable"
+        display = f"{label} ({letter}:)" if label else f"{letter}:"
+        out.append((Path(f"{letter}:\\"), display, kind))
+    return out
+
+
+def _query_windows_drives() -> dict[str, tuple[int, str | None]]:
+    """Return ``{letter: (drive_type, volume_label)}`` for present drives.
+
+    Empty on non-Windows or any kernel32 failure -- the caller falls back
+    to "no removable drives discovered". Volume label is skipped for
+    ``DRIVE_REMOTE`` because ``GetVolumeInformationW`` can hang on a
+    stale share; the drive letter is still reported so the user can
+    still navigate to it manually.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except ImportError:
+        return {}
+
+    try:
+        # ``ctypes.windll`` is only defined on Windows; on Linux/macOS the
+        # AttributeError below short-circuits to {}.
+        kernel32: Any = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        return {}
+
+    try:
+        bitmask = int(kernel32.GetLogicalDrives())
+    except OSError:
+        return {}
+    if not bitmask:
+        return {}
+
+    out: dict[str, tuple[int, str | None]] = {}
+    for i in range(26):
+        if not (bitmask >> i) & 1:
+            continue
+        letter = chr(ord("A") + i)
+        root = f"{letter}:\\"
+        try:
+            drive_type = int(kernel32.GetDriveTypeW(ctypes.c_wchar_p(root)))
+        except OSError:
+            continue
+        label: str | None = None
+        if drive_type != _DRIVE_REMOTE:
+            label_buf = ctypes.create_unicode_buffer(261)  # MAX_PATH + 1
+            fs_buf = ctypes.create_unicode_buffer(261)
+            try:
+                ok = kernel32.GetVolumeInformationW(
+                    ctypes.c_wchar_p(root),
+                    label_buf,
+                    wintypes.DWORD(len(label_buf)),
+                    None,
+                    None,
+                    None,
+                    fs_buf,
+                    wintypes.DWORD(len(fs_buf)),
+                )
+            except OSError:
+                ok = 0
+            if ok:
+                label = label_buf.value or None
+        out[letter] = (drive_type, label)
     return out
 
 

--- a/tests/test_ui_mount_discovery.py
+++ b/tests/test_ui_mount_discovery.py
@@ -1,0 +1,100 @@
+"""Tests for the picker's external-mount discovery.
+
+Focus is the Windows path -- macOS / Linux already exercise their
+discoverers via integration runs on those platforms. The Windows
+helpers split into a Win32 query (``_query_windows_drives``) and a
+pure orchestration step (``_discover_windows_drives``). The
+orchestration is unit-tested with a fake query dict; the actual
+``ctypes.windll`` call is verified to short-circuit to ``{}`` on
+non-Windows so Linux CI can run the test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from splitsmith.ui import server
+
+
+def _drive(letter: str, drive_type: int, label: str | None) -> tuple[str, tuple[int, str | None]]:
+    return letter, (drive_type, label)
+
+
+def test_discover_windows_drives_classifies_remote_as_network() -> None:
+    fake = dict([_drive("Z", server._DRIVE_REMOTE, None)])
+    with patch.object(server, "_query_windows_drives", return_value=fake):
+        out = server._discover_windows_drives()
+    assert out == [(Path("Z:\\"), "Z:", "network")]
+
+
+def test_discover_windows_drives_classifies_removable_and_fixed_as_removable() -> None:
+    # Drive type 2 (removable) and 3 (fixed) both bucket into "removable"
+    # -- the picker treats a USB stick and a second internal SSD the same.
+    fake = dict(
+        [
+            _drive("D", 2, "INSTA360"),
+            _drive("E", 3, "DATA"),
+        ]
+    )
+    with patch.object(server, "_query_windows_drives", return_value=fake):
+        out = server._discover_windows_drives()
+    assert out == [
+        (Path("D:\\"), "INSTA360 (D:)", "removable"),
+        (Path("E:\\"), "DATA (E:)", "removable"),
+    ]
+
+
+def test_discover_windows_drives_skips_c_drive() -> None:
+    fake = dict(
+        [
+            _drive("C", 3, "Windows"),
+            _drive("D", 2, "USB"),
+        ]
+    )
+    with patch.object(server, "_query_windows_drives", return_value=fake):
+        out = server._discover_windows_drives()
+    # C: must be filtered out even when reported by GetLogicalDrives;
+    # the system drive isn't a "removable" the picker should surface.
+    assert out == [(Path("D:\\"), "USB (D:)", "removable")]
+
+
+def test_discover_windows_drives_skips_unknown_and_no_root_dir() -> None:
+    fake = dict(
+        [
+            _drive("D", server._DRIVE_UNKNOWN, None),
+            _drive("E", server._DRIVE_NO_ROOT_DIR, None),
+            _drive("F", 2, "OK"),
+        ]
+    )
+    with patch.object(server, "_query_windows_drives", return_value=fake):
+        out = server._discover_windows_drives()
+    assert out == [(Path("F:\\"), "OK (F:)", "removable")]
+
+
+def test_discover_windows_drives_no_label_falls_back_to_letter() -> None:
+    fake = dict([_drive("D", 2, None)])
+    with patch.object(server, "_query_windows_drives", return_value=fake):
+        out = server._discover_windows_drives()
+    assert out == [(Path("D:\\"), "D:", "removable")]
+
+
+def test_discover_windows_drives_empty_query_returns_empty() -> None:
+    # Non-Windows / kernel32 failure: query returns {}, list returns [].
+    with patch.object(server, "_query_windows_drives", return_value={}):
+        assert server._discover_windows_drives() == []
+
+
+def test_query_windows_drives_returns_empty_on_non_windows() -> None:
+    # On Linux/macOS there's no ``ctypes.windll`` -- the helper must
+    # short-circuit to {} rather than raise. (On Windows CI this would
+    # actually exercise the kernel32 path; that's fine, the assertion
+    # still holds because GetLogicalDrives() returns >=1 bit including
+    # C: which the orchestration filters.)
+    import sys
+
+    if sys.platform.startswith("win"):
+        # On Windows we can't assert {} -- skip rather than make the
+        # test platform-specific the other way.
+        return
+    assert server._query_windows_drives() == {}


### PR DESCRIPTION
## Summary

Third slice of the Windows-compat work (#81, #82). Rewrites the picker's Windows drive enumeration so mapped network drives get their own bucket and the picker shows real volume labels.

The previous `_discover_windows_drives()` scanned letters D-Z with `Path.is_dir()` and labelled every present drive `"removable"`. Two visible holes:
1. A mapped network drive (e.g. `Z:` → NAS) showed up under the same "removable" header as a USB stick.
2. Drives showed as bare `"D:"` / `"E:"` with no volume name.

### kernel32 calls

- **`GetLogicalDrives()`** — authoritative bitmask of present letters, cheaper than 25 `Path.is_dir()` probes.
- **`GetDriveTypeW(root)`** — classify each. `DRIVE_REMOTE` → `"network"`; everything else (`REMOVABLE` / `FIXED` / `CDROM` / `RAMDISK`) collapses to `"removable"` (matches Linux/macOS picker behaviour — a USB stick and a second internal SSD are treated the same). `UNKNOWN` / `NO_ROOT_DIR` are filtered out.
- **`GetVolumeInformationW(root)`** — volume label, formatted as `"INSTA360 (D:)"` instead of just `"D:"`. Skipped on `DRIVE_REMOTE` because that call can hang indefinitely on a stale share; the drive letter is still listed so the user can navigate manually.

### Not in scope

UNC shares without a drive letter (`\\nas\share`) aren't enumerated. Adding `WNetEnumResourceW` traversal would be a lot of structure marshalling for a small gain — the typical Windows workflow maps network drives to a letter via "Map Network Drive", which this already picks up.

### Testing

Function split into `_query_windows_drives` (the kernel32 dance) and `_discover_windows_drives` (orchestration / filtering) so the classification is testable on Linux without faking ctypes. New `tests/test_ui_mount_discovery.py` has 7 tests covering:
- `DRIVE_REMOTE` → `"network"` classification
- `DRIVE_REMOVABLE` / `DRIVE_FIXED` → `"removable"`
- C: drive filter
- `DRIVE_UNKNOWN` / `DRIVE_NO_ROOT_DIR` filter
- volume-label-present and volume-label-absent display formats
- non-Windows short-circuit (`_query_windows_drives()` returns `{}` on Linux)

## Test plan

- [x] `uv run pytest -q` — 470 passed, 6 skipped
- [x] `uv run ruff check src tests` — clean
- [x] `uv run black --check src tests` — clean
- [x] `uv run mypy src/splitsmith/ui/server.py` — error count unchanged from baseline
- [ ] CI green
- [ ] Manual smoke test on a real Windows machine: plug in a USB stick + map a NAS share, run `splitsmith ui`, confirm picker groups them under "Removable" and "Network" with correct labels

## Followups still open from the survey

- CI matrix with `windows-latest` (held per request)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGD8ayu6JayXxpqAAF56EQ)_