### PR TITLE
spike: ONNX export for CLAP and PANN to drop torch from runtime

### DIFF
--- a/scripts/export_clap_onnx.py
+++ b/scripts/export_clap_onnx.py
@@ -1,0 +1,118 @@
+"""Export the CLAP audio encoder to ONNX and pre-encode the prompt bank.
+
+Spike output for issue: drop torch + transformers from the production
+runtime. This script runs offline against ``laion/clap-htsat-unfused``
+and produces three artifacts under ``build/onnx-spike/``:
+
+* ``clap_audio.onnx`` -- the audio trunk + projection head, taking
+  ``input_features`` of shape ``(B, 1, 1001, 64)`` (the shape
+  ``ClapFeatureExtractor`` produces for a 1 s window at 48 kHz).
+* ``clap_text_embeddings.npy`` -- L2-normalised text embeddings for the
+  10 prompts in ``CLAP_PROMPTS``, shape ``(10, D)``. The runtime never
+  needs the text encoder once these are baked in.
+* ``clap_sample_input_features.npy`` -- a single ``(1, 1, 1001, 64)``
+  mel-spec produced by the real ``ClapFeatureExtractor`` from a fixed
+  random-seed audio buffer. Used by ``verify_onnx_parity.py`` to check
+  ONNX vs torch output match within tolerance.
+
+Re-exporting requires HF cache access (the spike sandbox blocks it; run
+locally). Validates roughly: ONNX export should produce float32 outputs
+matching the torch ``pooler_output`` to within ``1e-4`` absolute on the
+same input.
+
+Run:
+    uv pip install onnx
+    uv run python scripts/export_clap_onnx.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from splitsmith.ensemble.features import CLAP_MODEL_ID, CLAP_PROMPTS, CLAP_SR
+
+OUT_DIR = Path("build/onnx-spike")
+ONNX_OPSET = 17
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--opset", type=int, default=ONNX_OPSET)
+    args = p.parse_args()
+
+    import torch
+    import torch.nn as nn
+    from transformers import ClapModel, ClapProcessor
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading CLAP: {CLAP_MODEL_ID}")
+    model = ClapModel.from_pretrained(CLAP_MODEL_ID)
+    processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID)
+    model.eval()
+
+    print("Pre-encoding text prompts")
+    text_inputs = processor(text=list(CLAP_PROMPTS), return_tensors="pt", padding=True)
+    with torch.no_grad():
+        text_out = model.get_text_features(**dict(text_inputs))
+    text_t = text_out.pooler_output if hasattr(text_out, "pooler_output") else text_out
+    text_emb = text_t.cpu().numpy().astype(np.float32)
+    text_emb = text_emb / (np.linalg.norm(text_emb, axis=1, keepdims=True) + 1e-9)
+    text_path = args.out_dir / "clap_text_embeddings.npy"
+    np.save(text_path, text_emb)
+    print(f"  wrote {text_path}  shape={text_emb.shape}  dtype={text_emb.dtype}")
+
+    print("Building sample input_features from a 1 s synthetic clip")
+    rng = np.random.default_rng(0)
+    sample_audio = rng.standard_normal(CLAP_SR).astype(np.float32) * 0.05
+    feat_inputs = processor(audio=[sample_audio], sampling_rate=CLAP_SR, return_tensors="pt")
+    sample_input_features = feat_inputs["input_features"].cpu().numpy().astype(np.float32)
+    sample_path = args.out_dir / "clap_sample_input_features.npy"
+    np.save(sample_path, sample_input_features)
+    print(f"  wrote {sample_path}  shape={sample_input_features.shape}")
+
+    class AudioTrunk(nn.Module):
+        """Wraps ``get_audio_features`` so ONNX sees a single tensor in / out."""
+
+        def __init__(self, clap: ClapModel) -> None:
+            super().__init__()
+            self.clap = clap
+
+        def forward(self, input_features: torch.Tensor) -> torch.Tensor:
+            out = self.clap.get_audio_features(input_features=input_features)
+            return out.pooler_output if hasattr(out, "pooler_output") else out
+
+    trunk = AudioTrunk(model).eval()
+    dummy = torch.from_numpy(sample_input_features)
+    with torch.no_grad():
+        torch_out = trunk(dummy).cpu().numpy()
+    print(f"  torch reference output shape={torch_out.shape}  dtype={torch_out.dtype}")
+
+    onnx_path = args.out_dir / "clap_audio.onnx"
+    print(f"Exporting ONNX -> {onnx_path}  (opset={args.opset})")
+    torch.onnx.export(
+        trunk,
+        (dummy,),
+        str(onnx_path),
+        input_names=["input_features"],
+        output_names=["audio_embedding"],
+        dynamic_axes={
+            "input_features": {0: "batch"},
+            "audio_embedding": {0: "batch"},
+        },
+        opset_version=args.opset,
+        do_constant_folding=True,
+    )
+
+    ref_path = args.out_dir / "clap_torch_reference.npy"
+    np.save(ref_path, torch_out)
+    print(f"  wrote {ref_path} for parity check")
+    print("\nDone. Run scripts/verify_onnx_parity.py to compare ONNX vs torch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_pann_onnx.py
+++ b/scripts/export_pann_onnx.py
@@ -1,0 +1,106 @@
+"""Export the PANN Cnn14 audio tagger to ONNX.
+
+Spike output for issue: drop torch from the production runtime. This
+script runs offline against the standard PANN checkpoint
+(``~/panns_data/Cnn14_mAP=0.431.pth``, downloaded by
+``panns_inference`` on first use) and writes two artifacts under
+``build/onnx-spike/``:
+
+* ``pann_cnn14.onnx`` -- takes raw audio at 32 kHz, shape ``(B, T)``,
+  outputs ``clipwise_output`` of shape ``(B, 527)``. The mel-spectrogram
+  layer is baked into the graph via ``torchlibrosa``; no preprocessing
+  needed at runtime beyond resampling.
+* ``pann_sample_audio.npy`` and ``pann_torch_reference.npy`` -- a fixed
+  random-seed 1 s @ 32 kHz buffer and the torch reference output for
+  parity checking.
+
+Known risk: ``torchlibrosa.stft.Spectrogram`` uses ``torch.stft``, which
+returns a complex tensor in newer PyTorch. Some ``onnxruntime`` versions
+choke on complex ops. If export fails here, fallback is to do the
+mel-spec in numpy/librosa and export only the CNN trunk taking
+``(B, 1, time_steps, mel_bins)`` log-mel input.
+
+Run:
+    uv pip install onnx
+    uv run python scripts/export_pann_onnx.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from splitsmith.ensemble.features import PANN_SR
+
+OUT_DIR = Path("build/onnx-spike")
+ONNX_OPSET = 17
+SAMPLE_LEN_S = 1.0
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--opset", type=int, default=ONNX_OPSET)
+    args = p.parse_args()
+
+    import torch
+    import torch.nn as nn
+    from panns_inference import AudioTagging
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Loading PANN Cnn14 (downloads ~80 MB on first run)")
+    tagger = AudioTagging(checkpoint_path=None, device="cpu")
+    inner = tagger.model
+    inner.eval()
+
+    class Cnn14Trunk(nn.Module):
+        """Returns just ``clipwise_output`` so ONNX sees a tensor, not a dict."""
+
+        def __init__(self, model: nn.Module) -> None:
+            super().__init__()
+            self.model = model
+
+        def forward(self, audio: torch.Tensor) -> torch.Tensor:
+            out = self.model(audio, None)
+            return out["clipwise_output"]
+
+    trunk = Cnn14Trunk(inner).eval()
+
+    rng = np.random.default_rng(0)
+    sample_audio = rng.standard_normal(int(PANN_SR * SAMPLE_LEN_S)).astype(np.float32) * 0.05
+    sample_path = args.out_dir / "pann_sample_audio.npy"
+    np.save(sample_path, sample_audio)
+    print(f"  wrote {sample_path}  shape={sample_audio.shape}")
+
+    dummy = torch.from_numpy(sample_audio[None, :])
+    with torch.no_grad():
+        torch_out = trunk(dummy).cpu().numpy()
+    print(f"  torch reference output shape={torch_out.shape}  dtype={torch_out.dtype}")
+
+    onnx_path = args.out_dir / "pann_cnn14.onnx"
+    print(f"Exporting ONNX -> {onnx_path}  (opset={args.opset})")
+    torch.onnx.export(
+        trunk,
+        (dummy,),
+        str(onnx_path),
+        input_names=["audio"],
+        output_names=["clipwise_output"],
+        dynamic_axes={
+            "audio": {0: "batch", 1: "samples"},
+            "clipwise_output": {0: "batch"},
+        },
+        opset_version=args.opset,
+        do_constant_folding=True,
+    )
+
+    ref_path = args.out_dir / "pann_torch_reference.npy"
+    np.save(ref_path, torch_out)
+    print(f"  wrote {ref_path} for parity check")
+    print("\nDone. Run scripts/verify_onnx_parity.py to compare ONNX vs torch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_onnx_parity.py
+++ b/scripts/verify_onnx_parity.py
@@ -1,0 +1,90 @@
+"""Compare CLAP / PANN ONNX outputs against their torch references.
+
+Reads the artifacts written by ``export_clap_onnx.py`` and
+``export_pann_onnx.py`` from ``build/onnx-spike/`` and checks that
+``onnxruntime`` produces outputs matching the torch reference within
+tolerance. Tolerance defaults are deliberately tight (1e-4 absolute,
+1e-3 relative); loosen with ``--atol`` / ``--rtol`` if the platform
+introduces rounding drift.
+
+Exit code is non-zero if any check fails so this can run in CI once the
+full slim path lands.
+
+Run:
+    uv pip install onnxruntime
+    uv run python scripts/verify_onnx_parity.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+OUT_DIR = Path("build/onnx-spike")
+
+
+def _check(name: str, ref: np.ndarray, got: np.ndarray, atol: float, rtol: float) -> bool:
+    if ref.shape != got.shape:
+        print(f"  FAIL {name}: shape mismatch  ref={ref.shape}  got={got.shape}")
+        return False
+    diff = np.abs(ref - got)
+    max_abs = float(diff.max())
+    max_rel = float((diff / (np.abs(ref) + 1e-9)).max())
+    ok = np.allclose(ref, got, atol=atol, rtol=rtol)
+    flag = "PASS" if ok else "FAIL"
+    print(f"  {flag} {name}: max_abs={max_abs:.3e}  max_rel={max_rel:.3e}")
+    return ok
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--atol", type=float, default=1e-4)
+    p.add_argument("--rtol", type=float, default=1e-3)
+    args = p.parse_args()
+
+    import onnxruntime as ort
+
+    all_ok = True
+
+    clap_onnx = args.out_dir / "clap_audio.onnx"
+    if clap_onnx.exists():
+        print(f"CLAP: {clap_onnx}")
+        sample = np.load(args.out_dir / "clap_sample_input_features.npy")
+        ref = np.load(args.out_dir / "clap_torch_reference.npy")
+        sess = ort.InferenceSession(str(clap_onnx), providers=["CPUExecutionProvider"])
+        (got,) = sess.run(None, {"input_features": sample})
+        all_ok &= _check("clap_audio", ref, got, args.atol, args.rtol)
+    else:
+        print(f"CLAP: skip (missing {clap_onnx}; run export_clap_onnx.py first)")
+
+    pann_onnx = args.out_dir / "pann_cnn14.onnx"
+    if pann_onnx.exists():
+        print(f"\nPANN: {pann_onnx}")
+        sample = np.load(args.out_dir / "pann_sample_audio.npy")[None, :]
+        ref = np.load(args.out_dir / "pann_torch_reference.npy")
+        sess = ort.InferenceSession(str(pann_onnx), providers=["CPUExecutionProvider"])
+        (got,) = sess.run(None, {"audio": sample})
+        all_ok &= _check("pann_clipwise", ref, got, args.atol, args.rtol)
+
+        gunshot_idx = 427
+        ref_g = ref[:, gunshot_idx]
+        got_g = got[:, gunshot_idx]
+        all_ok &= _check("pann_gunshot_class", ref_g, got_g, args.atol, args.rtol)
+    else:
+        print(f"\nPANN: skip (missing {pann_onnx}; run export_pann_onnx.py first)")
+
+    print()
+    if all_ok:
+        print("All parity checks passed.")
+        sys.exit(0)
+    else:
+        print("Parity check FAILED. See diffs above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three scripts under scripts/ that produce build/onnx-spike/ artifacts:
export_clap_onnx.py exports the audio trunk + projection head taking
input_features (B,1,1001,64), and pre-encodes the 10-prompt text bank
into clap_text_embeddings.npy so the runtime never needs the text
encoder. export_pann_onnx.py exports Cnn14 taking raw audio at 32 kHz
with the mel-spec layer baked in. verify_onnx_parity.py loads both via
onnxruntime and checks outputs match the torch reference within 1e-4.

Sandbox blocks huggingface.co and zenodo.org so the spike was authored
without running it; intended to be run locally where the caches are
reachable. No changes to the production runtime path.