### PR TITLE
lab: fixture catalog, ensemble eval, and live tuning UI

### DIFF
--- a/LAB.md
+++ b/LAB.md
@@ -214,8 +214,18 @@ review UI), and either:
 ### After adding a fixture
 
 The ensemble's calibration artifacts (`src/splitsmith/data/`) were
-built against the original calibration set. New fixtures **don't** alter
-calibration until you rebuild:
+built against the original calibration set. New fixtures **don't**
+alter calibration until you rebuild.
+
+**From the UI**: click **Rebuild calibration** in the Lab header. The
+popover lets you pick `target_recall` and `tolerance_ms` and requires
+an explicit confirmation checkbox before submitting -- the operation
+overwrites `src/splitsmith/data/ensemble_calibration.json` and
+`voter_c_gbdt.joblib`. Progress streams into the popover as the script
+logs; the cached `EnsembleRuntime` is invalidated on success so the
+next Run eval picks up the new thresholds.
+
+**From the CLI**:
 
 ```bash
 uv run python scripts/build_ensemble_artifacts.py
@@ -224,13 +234,19 @@ uv run python scripts/build_ensemble_artifacts.py
 The Lab's eval step re-computes per-candidate features on every call,
 so it can score against any fixture immediately. But the *thresholds*
 voter A/B/C/D use are still the shipped ones until you rebuild. If you
-want the new fixture to influence those thresholds, run the build
-script (this regenerates `src/splitsmith/data/ensemble_calibration.json`
-and `voter_c_gbdt.joblib`).
+want the new fixture to influence those thresholds, hit Rebuild
+calibration (or run the build script) -- this regenerates the JSON +
+joblib artifacts.
 
 For pure regression-tracking ("is the current pipeline still good on
 this new stage?"), no rebuild is needed -- just add the fixture and
 hit Run eval.
+
+> **Heads up**: rebuild calibration requires the CLAP / PANN feature
+> caches under `tests/fixtures/.cache/`. If you've added a new fixture,
+> build its caches first via `scripts/extract_clap_features.py` and
+> `scripts/extract_audio_embeddings.py`. The build script will refuse
+> to proceed without them.
 
 ---
 
@@ -409,7 +425,14 @@ fixtures regressed" works well.
 ## Reproducing and committing a tuning result
 
 When you find a config you like, capture it as YAML so it lives in git
-and can be replayed:
+and can be replayed.
+
+**From the UI**: click **Save as YAML** (next to Run eval). Pick a name,
+optionally write a note, and confirm. The popover shows the path on
+success. The button is disabled until at least one eval / rescore has
+populated the cache.
+
+**From the CLI**:
 
 ```bash
 uv run splitsmith lab save-config \
@@ -530,6 +553,8 @@ Top-level keys: `config`, `summary`, `universe`, `config_hash`, `built_at`.
 | POST | `/api/lab/eval` | `{slugs?, config?, persist?}` | Slow path. Caches universe server-side and (by default) writes `build/lab/runs/<...>.json`. |
 | POST | `/api/lab/rescore` | `{config}` | Uses last cached universe. 409 if no eval has run. |
 | POST | `/api/lab/promote` | `{stage_number, slug, overwrite?}` | Copies stage audit JSON + WAV into `tests/fixtures/`. |
+| POST | `/api/lab/save-config` | `{name, note?, overwrite?}` | Persists the active run's config + summary as `configs/ensemble.<name>.yaml`. 409 when no eval has run. |
+| POST | `/api/lab/rebuild-calibration` | `{target_recall?, tolerance_ms?, fixtures?}` | Submits a `rebuild_calibration` job that re-runs the calibration build script. Poll `/api/jobs/{id}` for progress. |
 
 ### CLI
 

--- a/LAB.md
+++ b/LAB.md
@@ -1,0 +1,545 @@
+# Lab guide
+
+The Lab is splitsmith's algorithm-development surface. It lives at `/lab`
+in the production UI and is mirrored as a `splitsmith lab` CLI. End-user
+paths (Ingest, Audit, Export) are untouched -- the Lab is opt-in and
+loads its heavy ML models lazily on the first eval call.
+
+This guide walks through:
+
+1. [What the Lab actually does](#what-the-lab-actually-does)
+2. [Running the Lab end-to-end](#running-the-lab-end-to-end)
+3. [Adding new videos as fixtures](#adding-new-videos-as-fixtures)
+4. [Tuning parameters interactively](#tuning-parameters-interactively)
+5. [Working with Claude Code in parallel](#working-with-claude-code-in-parallel)
+6. [Reproducing and committing a tuning result](#reproducing-and-committing-a-tuning-result)
+7. [Reference: file layout and JSON shapes](#reference)
+
+---
+
+## What the Lab actually does
+
+The shot-detection pipeline is a 4-voter ensemble (see `CLAUDE.md` for
+the architecture). Every Lab call runs against the audited fixtures
+under `tests/fixtures/` -- short hand-labeled audio clips with ground
+truth in adjacent JSON.
+
+There are three operations the Lab supports:
+
+| Operation | Endpoint | CLI | Cost | When to use |
+| --- | --- | --- | --- | --- |
+| **List** fixtures | `GET /api/lab/fixtures` | `splitsmith lab fixtures` | instant | always (catalog) |
+| **Eval** the ensemble | `POST /api/lab/eval` | `splitsmith lab eval` | seconds (loads CLAP+PANN; runs detector+models against every fixture) | first run, or after fixtures / models change |
+| **Rescore** a cached universe | `POST /api/lab/rescore` | `splitsmith lab rescore` | <100 ms | tweaking thresholds / consensus / boost |
+
+Eval emits an `EvalRun` JSON containing:
+
+- `summary`: aggregate precision / recall / F1 / TP-FP-FN across all fixtures.
+- `universe.fixtures[]`: one entry per fixture with the full per-candidate
+  feature universe (CLAP / PANN / GBDT signals), the per-candidate vote
+  vector, ground-truth labels, and per-fixture metrics.
+- `config_hash`: 12-char SHA prefix of the active `EvalConfig` -- two
+  runs with identical config produce identical hashes, so it doubles as
+  a "did anything change?" check.
+
+Rescore takes that universe + a new `EvalConfig` and recomputes only
+votes / consensus / metrics. No model calls. That's what makes the UI
+sliders feel live.
+
+---
+
+## Running the Lab end-to-end
+
+### 1. Start the production UI
+
+The Lab is part of the production server, so the same command that runs
+the audit/ingest UI also serves the Lab:
+
+```bash
+cd /path/to/splitsmith
+uv run splitsmith ui --project /path/to/your/match
+```
+
+Open the URL it prints (usually `http://127.0.0.1:5174/`). The sidebar
+has a new **Lab** entry; click it.
+
+> **First-time only**: the first `Run eval` click downloads / loads the
+> CLAP and PANN model weights into `~/.cache/`. Expect 30-90 seconds.
+> Subsequent eval calls reuse the cached `EnsembleRuntime` on the
+> server, so they only pay the per-fixture forward pass (a few seconds
+> for the full set of 12 fixtures).
+
+### 2. Run the first eval
+
+Click **Run eval**. The Summary card fills in once the run completes:
+
+- **Precision / Recall / F1 / TP-FP-FN** across the whole fixture set.
+- The fixture table at the bottom now shows per-fixture P/R/F1, plus
+  FP/FN counts highlighted (orange / red) when non-zero.
+- The `cfg <hash>` badge in the header is the run identity.
+
+The run is also persisted to disk:
+
+```
+build/lab/runs/<timestamp>-<config_hash>.json
+build/lab/runs/latest.json   # always points at the most recent run
+```
+
+These files are deterministic JSON (sorted keys, ASCII), so they diff
+cleanly across runs.
+
+### 3. Drill into a fixture
+
+Click any row in the fixture table. A detail card appears below with:
+
+- **Waveform** of the fixture's WAV. Pins overlay every kept candidate
+  (green = TP, orange = FP, top-edge red = FN ground truth that no
+  kept candidate matched within the configured tolerance).
+- **Per-voter recall** on this fixture (which voter actually carried the
+  ground-truth shots).
+- **Diff list**: timestamps of FPs and FNs.
+- **Candidate table** (collapsed by default): every candidate the
+  detector emitted, with its per-voter votes, ensemble score, kept flag,
+  and truth label, color-coded by outcome.
+
+Use this view to ask "*why* did fixture X regress?". The candidate
+table makes it obvious whether voter A produced the candidate, which
+voters voted for it, and what the ensemble score landed at.
+
+### 4. Run the same thing from the terminal
+
+Every UI action has a CLI counterpart. The CLI emits JSON to stdout, so
+it composes with `jq` and Claude Code's tool calls:
+
+```bash
+# List fixtures (mirrors the catalog table).
+uv run splitsmith lab fixtures --no-pretty | jq '.[] | {slug, n_shots, expected_rounds}'
+
+# Run an eval at the default config; print summary only.
+uv run splitsmith lab eval --summary-only
+
+# Run on a subset (matches what selecting rows would do in the UI).
+uv run splitsmith lab eval -s stage-shots-blacksmith-2026-stage1 -s stage-shots-tallmilan-2026-stage5 --summary-only
+
+# Tweak knobs from the CLI; --save persists under build/lab/runs/.
+uv run splitsmith lab eval --consensus 2 --apriori-boost 1.5 --summary-only
+```
+
+The CLI calls into the same `splitsmith.lab` Python module the FastAPI
+server uses, so the JSON shapes are byte-identical between channels.
+
+---
+
+## Adding new videos as fixtures
+
+A fixture is a hand-labeled audio clip of a single stage. There are two
+paths to create one: from inside the production UI (the typical flow)
+or from the CLI (for batch / scripted runs).
+
+### Path A -- promote from the production UI (recommended)
+
+This is the one-button flow once a stage has been audited end-to-end.
+
+1. **Open the project that contains the stage you want to capture.**
+
+   ```bash
+   uv run splitsmith ui --project /path/to/match
+   ```
+
+2. **Run the full pipeline for that stage.** Ingest the video, detect
+   the beep, audit-trim, run shot-detect, and walk the audit screen
+   accepting / nudging / rejecting candidates as usual. The fixture
+   inherits whatever ground truth you finalize here.
+
+3. **Click the flask icon** (next to Save) on the audit screen. The
+   "Promote to fixture" popover appears with:
+
+   - **Slug**: pre-filled with `stage-shots-<match-slug>-stage<N>`.
+     Edit if you want a different stem.
+   - **Overwrite if exists**: leave unchecked unless you mean to.
+
+   Click **Promote**. The popover shows the destination path on success.
+
+   What this does, atomically:
+
+   - Copies `<project>/audit/stage<N>.json` to
+     `tests/fixtures/<slug>.json`, adding `promoted_at`,
+     `promoted_from`, and a `provenance` block (project root, stage
+     number, stage name).
+   - Copies the stage's audit-mode WAV (the same clip the audit screen
+     was scrubbing) to `tests/fixtures/<slug>.wav`.
+
+4. **Re-run eval in the Lab.** The new fixture shows up in the catalog
+   table immediately. The Run eval button picks it up on the next click.
+
+### Path B -- promote from the CLI
+
+Useful when you're scripting from Claude Code, working on a remote
+machine, or batching a backlog of audited stages:
+
+```bash
+uv run splitsmith lab promote \
+  --audit-json /path/to/match/audit/stage4.json \
+  --audit-wav /path/to/match/audio/stage4_audit.wav \
+  --slug stage-shots-myclub-2026-stage4
+```
+
+The command refuses to overwrite an existing fixture without
+`--overwrite`. On success it prints the same `FixtureRecord` JSON the
+UI catalog uses.
+
+### Path C -- audit-prep from a fresh video
+
+When you don't have a project yet and just want to curate a fixture
+directly from a raw video, the existing `audit-prep` / `audit-apply`
+flow still works:
+
+```bash
+uv run splitsmith audit-prep \
+  --video /path/to/clip.mp4 \
+  --time 42.76 \
+  --stage-number 1 \
+  --stage-name "K-vallen" \
+  --stem stage-shots-myclub-2026-stage1 \
+  --output-dir tests/fixtures
+```
+
+Then audit it (`splitsmith review tests/fixtures/<stem>.json` opens the
+review UI), and either:
+
+- run `splitsmith audit-apply` to finalize, or
+- promote-then-audit by opening it in the production UI's `/review`
+  route and editing in place.
+
+### After adding a fixture
+
+The ensemble's calibration artifacts (`src/splitsmith/data/`) were
+built against the original calibration set. New fixtures **don't** alter
+calibration until you rebuild:
+
+```bash
+uv run python scripts/build_ensemble_artifacts.py
+```
+
+The Lab's eval step re-computes per-candidate features on every call,
+so it can score against any fixture immediately. But the *thresholds*
+voter A/B/C/D use are still the shipped ones until you rebuild. If you
+want the new fixture to influence those thresholds, run the build
+script (this regenerates `src/splitsmith/data/ensemble_calibration.json`
+and `voter_c_gbdt.joblib`).
+
+For pure regression-tracking ("is the current pipeline still good on
+this new stage?"), no rebuild is needed -- just add the fixture and
+hit Run eval.
+
+---
+
+## Tuning parameters interactively
+
+### The cached-universe trick
+
+Tuning is the loop:
+
+1. **Run eval once.** This is the slow path: detector + CLAP + PANN +
+   GBDT for every fixture. The result is cached server-side as the
+   "current universe".
+2. **Move sliders.** The SPA debounces (~120ms) and posts the new
+   `EvalConfig` to `/api/lab/rescore`. The server reuses the cached
+   universe -- no model calls -- and recomputes votes + consensus +
+   metrics. Result: sub-100ms updates across all 12 fixtures.
+3. **Run eval again** only if you've changed something the cache
+   doesn't cover (added a fixture, edited audit JSON / WAV, swapped
+   models).
+
+In other words: the universe is the model output. The config is the
+post-processing. Sliders only re-run post-processing.
+
+### Knobs in the Tuning panel
+
+- **Consensus K** (1-4 of 4): how many voters must agree to keep a
+  candidate. Default 3. Lower it to recover recall on hard fixtures;
+  raise it to cull FP-noisy stages.
+- **Apriori boost** (0-2, step 0.05): when the audit JSON has
+  `stage_rounds.expected`, the top-K candidates by detector confidence
+  get this boost added to their consensus score. 0 disables; the
+  default 1.0 is "equivalent to one extra vote".
+- **Use expected_rounds** (checkbox): when off, the ensemble ignores
+  `stage_rounds.expected` -- voter C reverts to its global threshold,
+  apriori boost goes to 0. Useful for comparing "with vs without prior".
+- **Per-voter threshold overrides** (advanced details panel):
+  - **Voter A floor** (0 - 0.5): detector confidence floor.
+  - **Voter B threshold** (-0.05 - 0.2): CLAP shot-vs-not-shot
+    differential.
+  - **Voter C threshold** (0 - 1): GBDT probability cutoff (only used
+    when expected_rounds is unavailable / disabled).
+  - **Voter D threshold** (0 - 0.5): PANN gunshot-class probability.
+
+  Each row shows the calibrated value next to the live override; click
+  **clear** to revert the override and re-use the calibrated default.
+
+### A typical tuning session
+
+1. Run eval at the default config; note the headline P/R/F1.
+2. Find the worst fixture(s) in the catalog table -- click into them.
+3. Look at the candidate table. Are the FPs being kept by 3-of-4 or
+   barely scraping in at consensus 3 with the boost? That tells you
+   which knob has leverage.
+4. Slide consensus to 4. Watch the table: did FPs drop more than TPs?
+   If recall holds, you've improved precision for free.
+5. Open the per-voter override details. If voter D thinks every
+   movement clip is a gunshot, raise its threshold by a hair until
+   the worst FP loses its D vote.
+6. Switch fixtures to verify the change generalizes -- this is what
+   the live rescore is for; you don't have to re-run eval.
+7. When you're happy: click `cfg <hash>` mentally vs the original.
+   Save the config (next section) so the result is reproducible.
+
+### Tuning from the CLI
+
+Same operations as the UI, but you point at a saved run JSON and
+override knobs by flag:
+
+```bash
+# Latest UI eval lives here.
+LATEST=build/lab/runs/latest.json
+
+# Try consensus 2 with no apriori boost.
+uv run splitsmith lab rescore --universe $LATEST --consensus 2 --apriori-boost 0 --summary-only
+
+# Per-voter threshold sweep, scripted.
+for d in 0.20 0.25 0.30 0.35 0.40; do
+  uv run splitsmith lab rescore --universe $LATEST --voter-d-threshold $d --summary-only \
+    | jq --arg d "$d" '{d: $d, summary}'
+done
+```
+
+`rescore --save` writes a new entry under `build/lab/runs/`, which is
+what you want for "I ran a sweep, here are the results, let me diff
+them".
+
+---
+
+## Working with Claude Code in parallel
+
+The whole point of the Lab's CLI symmetry is to let you have a browser
+window open *and* a Claude Code session running, both touching the same
+artifacts.
+
+### Recommended workflow
+
+1. **You drive exploration in the UI.**
+
+   Click around. Eyeball the waveform diffs. Find the regression. Move
+   sliders until you have a hypothesis ("voter D is too eager for
+   movement noise on Tallmilan stages").
+
+2. **Hand the hypothesis to Claude Code.**
+
+   Open a Claude session in the repo and ask it to investigate. Because
+   the Lab persists every run as JSON under `build/lab/runs/`, Claude
+   can read those without you copy-pasting numbers:
+
+   > "Read `build/lab/runs/latest.json`. Compare the per-fixture
+   > metrics for the four tallmilan-* fixtures vs the rest. Where does
+   > voter D over-fire? Suggest a threshold that keeps recall on
+   > blacksmith but cuts the tallmilan FPs."
+
+   Claude can also drive the CLI directly:
+
+   ```bash
+   uv run splitsmith lab rescore --universe build/lab/runs/latest.json --voter-d-threshold 0.32 --summary-only
+   ```
+
+   The summary-only output is small enough to inspect inline; the full
+   rescore (with `--save`) lands a new run JSON Claude can compare.
+
+3. **Iterate in two channels.**
+
+   - You: continue exploring in the UI. Slider changes don't write
+     anywhere -- they're scoped to the current cached universe.
+   - Claude: edits Python (e.g., `src/splitsmith/ensemble/voters.py`,
+     `scripts/build_ensemble_artifacts.py`, or feature engineering in
+     `src/splitsmith/ensemble/features.py`).
+
+   When Claude finishes a code change, it should:
+
+   - Run `uv run pytest -x -q` (the suite has 468 tests; CI gates this).
+   - Run `uv run splitsmith lab eval --summary-only` -- this rebuilds
+     the universe from scratch using the new code path, so the run
+     reflects Claude's actual changes.
+   - Compare the new `latest.json` with the previous run via `jq` /
+     `diff`.
+
+4. **Hot-reload the server when Claude changes Python.**
+
+   The FastAPI server doesn't reload on its own. After Claude edits
+   ensemble or lab code, restart `splitsmith ui` so the cached
+   `EnsembleRuntime` picks up the new module. The browser tab can
+   stay open; just hit Run eval again.
+
+   The SPA *does* hot-reload for TS / TSX edits -- the Vite dev
+   workflow under `src/splitsmith/ui_static/` works as normal.
+
+### Comparing two runs
+
+Two rescores diff cleanly:
+
+```bash
+diff <(jq '{config, summary, per_fixture: [.universe.fixtures[] | {slug, metrics}]}' \
+        build/lab/runs/<old>.json) \
+     <(jq '{config, summary, per_fixture: [.universe.fixtures[] | {slug, metrics}]}' \
+        build/lab/runs/<new>.json)
+```
+
+Or ask Claude to do it -- the JSON layout is stable, so a one-shot
+question like "compare the two most recent run JSONs and report which
+fixtures regressed" works well.
+
+### Things to avoid handing to Claude blind
+
+- *"Tune the thresholds for me"* -- this is exactly the loop the Lab
+  is designed for; you'll get better results sweeping in the UI than
+  by asking the model to guess.
+- *"Run eval against my new fixture and tell me if it's good"* --
+  Claude can run the CLI, but it can't *listen* to the WAV. The audit
+  step is yours; the eval step is Claude's.
+
+---
+
+## Reproducing and committing a tuning result
+
+When you find a config you like, capture it as YAML so it lives in git
+and can be replayed:
+
+```bash
+uv run splitsmith lab save-config \
+  --name tighter-d \
+  --note "Cut tallmilan FPs without losing blacksmith recall" \
+  --universe build/lab/runs/latest.json
+```
+
+That writes `configs/ensemble.tighter-d.yaml`:
+
+```yaml
+config:
+  consensus: 3
+  apriori_boost: 1.0
+  tolerance_ms: 75.0
+  use_expected_rounds: true
+  voter_a_floor_override: null
+  voter_b_threshold_override: null
+  voter_c_threshold_override: null
+  voter_d_threshold_override: 0.32
+name: tighter-d
+provenance:
+  built_at: 2026-05-03T...
+  config_hash: abc123abc123
+  fixtures: [stage-shots-blacksmith-2026-stage1, ...]
+  note: Cut tallmilan FPs without losing blacksmith recall
+  universe_path: build/lab/runs/latest.json
+summary:
+  precision: 0.92
+  recall: 0.99
+  f1: 0.954
+  ...
+```
+
+Commit it:
+
+```bash
+git add configs/ensemble.tighter-d.yaml
+git commit -m "tuning: tighter voter-D threshold for tallmilan stages"
+```
+
+In a PR description you can now say "this changes the voter-D threshold
+from `0.27` to `0.32`; metrics are at `configs/ensemble.tighter-d.yaml`"
+and reviewers can replay the same eval (after pulling the branch):
+
+```bash
+# Print the saved config back out as JSON.
+uv run splitsmith lab load-config configs/ensemble.tighter-d.yaml | jq .config
+```
+
+If you decide to *ship* a tuning (i.e. make it the default), the
+mechanism is `scripts/build_ensemble_artifacts.py`, not the YAML --
+the artifacts under `src/splitsmith/data/` are the production
+calibration. The YAML is for "I ran an experiment, here's the receipt".
+
+---
+
+## Reference
+
+### File layout
+
+```
+src/splitsmith/
+  lab/
+    __init__.py            # public exports
+    core.py                # pure functions (catalog, eval, rescore, promote, persist)
+  lab_cli.py               # `splitsmith lab` Typer subcommands
+  ui/
+    server.py              # /api/lab/* endpoints (last block before static-asset serving)
+  ui_static/src/
+    pages/Lab.tsx          # /lab route SPA page
+    pages/Audit.tsx        # PromoteFixtureButton at the bottom
+    components/AppShell.tsx# Lab nav entry
+    lib/api.ts             # LabFixtureRecord / LabEvalRun / api.runLabEval / etc.
+
+build/lab/runs/             # persisted EvalRun JSONs
+  <timestamp>-<hash>.json   # one per run (eval or rescore --save)
+  latest.json               # always the most recent
+
+configs/                    # committable YAML tuning snapshots
+  ensemble.<name>.yaml
+
+tests/fixtures/             # the audited fixtures the Lab evaluates against
+  *.json                    # audit ground truth (per-stage)
+  *.wav                     # sibling audio clip
+```
+
+### EvalConfig fields
+
+```python
+class EvalConfig(BaseModel):
+    consensus: int = 3                         # 1-5; keep when vote_total + boost >= K
+    apriori_boost: float = 1.0                 # >=0; added to top-K confidences when expected_rounds set
+    tolerance_ms: float = 75.0                 # truth-to-candidate match tolerance
+    use_expected_rounds: bool = True           # honor stage_rounds.expected from audit JSON
+    voter_a_floor_override: float | None = None  # else: calibration floor
+    voter_b_threshold_override: float | None = None  # else: calibration threshold
+    voter_c_threshold_override: float | None = None  # else: calibration threshold (or adaptive)
+    voter_d_threshold_override: float | None = None  # else: calibration threshold
+```
+
+### EvalRun JSON shape
+
+Top-level keys: `config`, `summary`, `universe`, `config_hash`, `built_at`.
+
+- `summary`: `{n_fixtures, n_truth, n_kept, true_positives, false_positives, false_negatives, precision, recall, f1}`.
+- `universe.fixtures[]`: per-fixture; each carries `candidates[]`,
+  `truth_times[]`, and `metrics`.
+- `universe.{voter_a_floor, voter_b_threshold, voter_c_threshold, voter_d_threshold}`:
+  the calibration thresholds the universe was scored against. Rescore
+  uses these unless an override is set in the new config.
+
+### Endpoints
+
+| Method | Path | Body | Notes |
+| --- | --- | --- | --- |
+| GET | `/api/lab/fixtures` | -- | Catalog walk; cheap, hits no models. |
+| POST | `/api/lab/eval` | `{slugs?, config?, persist?}` | Slow path. Caches universe server-side and (by default) writes `build/lab/runs/<...>.json`. |
+| POST | `/api/lab/rescore` | `{config}` | Uses last cached universe. 409 if no eval has run. |
+| POST | `/api/lab/promote` | `{stage_number, slug, overwrite?}` | Copies stage audit JSON + WAV into `tests/fixtures/`. |
+
+### CLI
+
+```
+splitsmith lab fixtures              # list catalog
+splitsmith lab eval                  # run full eval
+splitsmith lab rescore               # rescore from a saved run
+splitsmith lab promote               # promote a stage to a fixture
+splitsmith lab save-config           # write configs/ensemble.<name>.yaml
+splitsmith lab load-config <path>    # print a saved YAML as JSON
+```
+
+Run `splitsmith lab <cmd> --help` for per-command flags.

--- a/LAB.md
+++ b/LAB.md
@@ -90,7 +90,11 @@ cleanly across runs.
 
 ### 3. Drill into a fixture
 
-Click any row in the fixture table. A detail card appears below with:
+Click any row in the fixture table. The pencil icon at the right edge
+of each row deep-links into the review editor (`/review?fixture=...`)
+so you can re-label shots / edit the beep without leaving the SPA --
+the same shortcut is also available as a **Re-label** button on the
+fixture detail header. A detail card appears below with:
 
 - **Waveform** of the fixture's WAV. Pins overlay every kept candidate
   (green = TP, orange = FP, top-edge red = FN ground truth that no
@@ -210,6 +214,25 @@ review UI), and either:
 - run `splitsmith audit-apply` to finalize, or
 - promote-then-audit by opening it in the production UI's `/review`
   route and editing in place.
+
+### Re-labeling an existing fixture
+
+You don't have to promote a stage from scratch to fix labels. Two ways:
+
+- **From the Lab UI**: in the fixture table, click the pencil icon at
+  the right edge of any row, or open the detail card and click
+  **Re-label**. Either deep-links to `/review?fixture=<audit_path>` --
+  the same audit screen used for stages, but pointed at the fixture's
+  JSON. Drag markers, accept/reject candidates, retune the beep, save
+  with Cmd+S. Writes back atomically with a `.bak` of the previous
+  version next to the JSON. The Lab catalog and metrics refresh on the
+  next Run eval.
+- **From the CLI**: `uv run splitsmith review tests/fixtures/<slug>.json`
+  starts the production UI and opens the review tab on that file.
+
+Re-labeling never re-triggers calibration on its own. If you want the
+new labels to influence the shipped voter thresholds, hit **Rebuild
+calibration** after.
 
 ### After adding a fixture
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ pnpm build           # produces dist/ which the FastAPI backend serves
 pnpm dev             # Vite dev server on :5173, proxies /api to backend on :5174
 ```
 
+### `lab` -- algorithm Lab (fixtures, eval, tuning)
+
+The Lab is the algorithm-development surface. Lives at `/lab` in the UI and is mirrored as `splitsmith lab <cmd>` on the CLI. Fixture catalog, batch ensemble eval with per-fixture P/R/F1, live tuning sliders (cached-universe rescore in <100 ms), and a per-fixture diff overlay on the waveform. Tuning configs export to committable YAML; runs persist as deterministic JSON under `build/lab/runs/`.
+
+See [`LAB.md`](LAB.md) for the full guide -- end-to-end walk-through, fixture promotion, parameter tuning, and how to drive the loop in parallel with Claude Code.
+
+```bash
+uv run splitsmith lab fixtures           # list audited fixtures
+uv run splitsmith lab eval --summary-only
+uv run splitsmith lab rescore --universe build/lab/runs/latest.json --consensus 4 --summary-only
+uv run splitsmith lab promote --audit-json <project>/audit/stage4.json --audit-wav <project>/audio/stage4_audit.wav --slug stage-shots-myclub-2026-stage4
+```
+
 ### `review` -- audit a fixture in a local web UI
 
 Open a single-page browser UI for reviewing detected shots against the fixture's audio (and optional video). Marker pins on the waveform: click to toggle keep/reject, drag to fine-tune time, double-click empty waveform space to add a manual marker. Save (`Cmd+S`) writes back to the fixture JSON's `shots[]`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "PTH"]
 # Typer requires `typer.Option(...)` to be evaluated in the default; the B008
 # warning is a false positive for Typer-based CLIs.
 "src/splitsmith/cli.py" = ["B008"]
+"src/splitsmith/lab_cli.py" = ["B008"]
 # Scoreboard models intentionally mirror the documented `/api/v1/` wire shape
 # verbatim, which is mixed snake_case + camelCase. Translation to splitsmith's
 # snake_case happens in adapters, not in the parsed-response models.

--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import joblib
@@ -208,33 +209,36 @@ def _train_voter_c(universe: list[dict], target_recall: float):
     return clf, threshold
 
 
-def main() -> None:
-    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("--fixture", action="append", help="Calibration fixture stem (repeatable).")
-    p.add_argument("--target-recall", type=float, default=0.95)
-    p.add_argument("--tolerance-ms", type=float, default=75.0)
-    args = p.parse_args()
+def build_artifacts(
+    fixtures: list[str] | None = None,
+    *,
+    target_recall: float = 0.95,
+    tolerance_ms: float = 75.0,
+    log: Callable[[str], None] = print,
+) -> dict:
+    """Run the calibration build and write artifacts under ``DATA_DIR``.
 
-    fixtures = args.fixture or DEFAULT_FIXTURES
-    print(f"Calibrating ensemble over {len(fixtures)} fixture(s)...")
-    universe = _build_universe(fixtures, args.tolerance_ms)
+    Importable so the production UI's "Rebuild calibration" button can
+    drive the same code path as the CLI. Logs progress through ``log``;
+    returns the calibration dict that was written.
+    """
+    fixtures = list(fixtures) if fixtures else list(DEFAULT_FIXTURES)
+    log(f"Calibrating ensemble over {len(fixtures)} fixture(s)...")
+    universe = _build_universe(fixtures, tolerance_ms)
     n_total = len(universe)
     n_pos = sum(c["label"] for c in universe)
-    print(
+    log(
         f"Universe: {n_total} candidates, {n_pos} positives "
         f"(across {len({c['fixture'] for c in universe})} fixtures)"
     )
-
     voter_a = _voter_a_floor(universe)
     voter_b = _voter_b_threshold(universe)
     voter_d = _voter_d_threshold(universe)
-    clf, voter_c = _train_voter_c(universe, target_recall=args.target_recall)
-    print(f"Voter A floor (lowest positive confidence): {voter_a:.4f}")
-    print(f"Voter B threshold (lowest positive CLAP diff): {voter_b:.4f}")
-    print(
-        f"Voter C threshold (GBDT, target recall {args.target_recall*100:.0f} %): " f"{voter_c:.4f}"
-    )
-    print(f"Voter D threshold (lowest positive PANN gunshot_prob): {voter_d:.4f}")
+    clf, voter_c = _train_voter_c(universe, target_recall=target_recall)
+    log(f"Voter A floor (lowest positive confidence): {voter_a:.4f}")
+    log(f"Voter B threshold (lowest positive CLAP diff): {voter_b:.4f}")
+    log(f"Voter C threshold (GBDT, target recall {target_recall*100:.0f} %): {voter_c:.4f}")
+    log(f"Voter D threshold (lowest positive PANN gunshot_prob): {voter_d:.4f}")
 
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     cal_path = DATA_DIR / "ensemble_calibration.json"
@@ -245,8 +249,8 @@ def main() -> None:
         "voter_b_threshold": voter_b,
         "voter_c_threshold": voter_c,
         "voter_d_threshold": voter_d,
-        "voter_c_target_recall": args.target_recall,
-        "tolerance_ms": args.tolerance_ms,
+        "voter_c_target_recall": target_recall,
+        "tolerance_ms": tolerance_ms,
         "clap_prompts_shot": list(feat.CLAP_PROMPTS_SHOT),
         "clap_prompts": list(feat.CLAP_PROMPTS),
         "calibration_fixtures": [f for f in fixtures if any(c["fixture"] == f for c in universe)],
@@ -257,8 +261,22 @@ def main() -> None:
     }
     cal_path.write_text(json.dumps(cal, indent=2) + "\n")
     joblib.dump(clf, model_path)
-    print(f"\nWrote {cal_path}")
-    print(f"Wrote {model_path}")
+    log(f"Wrote {cal_path}")
+    log(f"Wrote {model_path}")
+    return cal
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--fixture", action="append", help="Calibration fixture stem (repeatable).")
+    p.add_argument("--target-recall", type=float, default=0.95)
+    p.add_argument("--tolerance-ms", type=float, default=75.0)
+    args = p.parse_args()
+    build_artifacts(
+        fixtures=args.fixture or None,
+        target_recall=args.target_recall,
+        tolerance_ms=args.tolerance_ms,
+    )
 
 
 if __name__ == "__main__":

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -48,6 +48,10 @@ app = typer.Typer(
 )
 console = Console()
 
+from .lab_cli import app as _lab_app  # noqa: E402
+
+app.add_typer(_lab_app, name="lab")
+
 
 # ---------------------------------------------------------------------------
 # Subcommands

--- a/src/splitsmith/lab/__init__.py
+++ b/src/splitsmith/lab/__init__.py
@@ -33,6 +33,7 @@ from .core import (
     promote_stage_to_fixture,
     rescore_universe,
     run_eval,
+    save_config_yaml,
     save_run,
 )
 
@@ -51,5 +52,6 @@ __all__ = [
     "promote_stage_to_fixture",
     "rescore_universe",
     "run_eval",
+    "save_config_yaml",
     "save_run",
 ]

--- a/src/splitsmith/lab/__init__.py
+++ b/src/splitsmith/lab/__init__.py
@@ -1,0 +1,55 @@
+"""Lab: fixture management + ensemble evaluation + tuning.
+
+Pure-functional core, used identically by the FastAPI ``/api/lab/*``
+endpoints and the ``splitsmith lab`` CLI subcommands. The module owns
+no global state -- every function takes the fixtures root + an optional
+pre-loaded ``EnsembleRuntime`` so callers can amortise model loads.
+
+The eval flow is deliberately split into two steps:
+
+* ``run_eval`` walks every fixture, runs detector + CLAP + PANN + GBDT,
+  builds the per-candidate ``EvalUniverse``, and scores it under the
+  current ``EnsembleConfig``. Slow (model-bound) on first call.
+* ``rescore_universe`` takes a cached ``EvalUniverse`` + a new config
+  and recomputes only votes / consensus / metrics. Fast (<100 ms for
+  the whole calibration set), which is what makes UI sliders feel live.
+
+Run records are persisted under ``build/lab/runs/`` as deterministic
+JSON so they're greppable, diffable, and Claude-Code-friendly.
+"""
+
+from .core import (
+    EvalCandidate,
+    EvalConfig,
+    EvalFixture,
+    EvalFixtureMetrics,
+    EvalRun,
+    EvalUniverse,
+    FixtureRecord,
+    PromoteRequest,
+    RunSummary,
+    list_fixtures,
+    load_run,
+    promote_stage_to_fixture,
+    rescore_universe,
+    run_eval,
+    save_run,
+)
+
+__all__ = [
+    "EvalCandidate",
+    "EvalConfig",
+    "EvalFixture",
+    "EvalFixtureMetrics",
+    "EvalRun",
+    "EvalUniverse",
+    "FixtureRecord",
+    "PromoteRequest",
+    "RunSummary",
+    "list_fixtures",
+    "load_run",
+    "promote_stage_to_fixture",
+    "rescore_universe",
+    "run_eval",
+    "save_run",
+]

--- a/src/splitsmith/lab/core.py
+++ b/src/splitsmith/lab/core.py
@@ -1,0 +1,579 @@
+"""Pure-function lab core.
+
+Used identically by ``/api/lab/*`` and ``splitsmith lab``. No FastAPI,
+no Typer, no globals. Heavy model loads are passed in; callers cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from ..beep_detect import load_audio
+from ..config import ShotDetectConfig
+from ..ensemble.api import (
+    EnsembleConfig,
+    EnsembleRuntime,
+    detect_shots_ensemble,
+)
+from ..shot_detect import detect_shots
+
+
+DEFAULT_FIXTURES_ROOT = Path(__file__).resolve().parents[3] / "tests" / "fixtures"
+DEFAULT_RUNS_ROOT = Path("build/lab/runs")
+LATEST_RUN_FILENAME = "latest.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixture catalog
+# ---------------------------------------------------------------------------
+
+
+class FixtureRecord(BaseModel):
+    """One audited fixture, as surfaced to the Lab UI / CLI."""
+
+    slug: str
+    audit_path: str
+    audio_path: str
+    has_audio: bool
+    n_shots: int
+    expected_rounds: int | None = None
+    stage_time_seconds: float | None = None
+    beep_time: float | None = None
+    source: str | None = None
+    audit_mtime: float
+    audio_mtime: float | None = None
+
+
+def list_fixtures(fixtures_root: Path | None = None) -> list[FixtureRecord]:
+    """Walk ``<fixtures_root>/*.json`` and pair each with its sibling WAV.
+
+    Skips backup/peaks artifacts (``*.before-promote``, ``*.peaks-*.json``)
+    and files that don't carry a ``shots`` array.
+    """
+    root = (fixtures_root or DEFAULT_FIXTURES_ROOT).resolve()
+    out: list[FixtureRecord] = []
+    if not root.is_dir():
+        return out
+    for json_path in sorted(root.glob("*.json")):
+        name = json_path.name
+        if name.endswith(".before-promote") or ".peaks-" in name:
+            continue
+        try:
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or "shots" not in payload:
+            continue
+        wav = json_path.with_suffix(".wav")
+        rounds = None
+        if isinstance(payload.get("stage_rounds"), dict):
+            rounds = payload["stage_rounds"].get("expected")
+        out.append(
+            FixtureRecord(
+                slug=json_path.stem,
+                audit_path=str(json_path),
+                audio_path=str(wav),
+                has_audio=wav.exists(),
+                n_shots=len(payload.get("shots", [])),
+                expected_rounds=rounds,
+                stage_time_seconds=payload.get("stage_time_seconds"),
+                beep_time=payload.get("beep_time"),
+                source=payload.get("source"),
+                audit_mtime=json_path.stat().st_mtime,
+                audio_mtime=wav.stat().st_mtime if wav.exists() else None,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Eval data shapes
+# ---------------------------------------------------------------------------
+
+
+class EvalConfig(BaseModel):
+    """Knobs the user can tune from the Lab UI."""
+
+    consensus: int = Field(default=3, ge=1, le=5)
+    apriori_boost: float = Field(default=1.0, ge=0.0)
+    tolerance_ms: float = Field(default=75.0, gt=0.0)
+    use_expected_rounds: bool = Field(
+        default=True,
+        description="Pass the audit's ``stage_rounds.expected`` into the ensemble (adaptive voter C + apriori boost).",
+    )
+    voter_a_floor_override: float | None = None
+    voter_b_threshold_override: float | None = None
+    voter_c_threshold_override: float | None = None
+    voter_d_threshold_override: float | None = None
+
+    def to_ensemble_config(self) -> EnsembleConfig:
+        return EnsembleConfig(consensus=self.consensus, apriori_boost=self.apriori_boost)
+
+
+class EvalCandidate(BaseModel):
+    """One candidate enriched with ground-truth label for diffing."""
+
+    candidate_number: int
+    time: float
+    ms_after_beep: int
+    confidence: float
+    peak_amplitude: float
+    score_c: float
+    clap_diff: float
+    gunshot_prob: float
+    vote_a: int
+    vote_b: int
+    vote_c: int
+    vote_d: int
+    vote_total: int
+    apriori_boost: float
+    ensemble_score: float
+    kept: bool
+    truth: int = Field(description="1 if matched to a ground-truth shot within tolerance, else 0.")
+    matched_shot_number: int | None = None
+
+
+class EvalFixtureMetrics(BaseModel):
+    """Precision / recall + per-voter contribution for one fixture."""
+
+    n_truth: int
+    n_kept: int
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    precision: float
+    recall: float
+    f1: float
+    voter_recall: dict[str, float] = Field(
+        description="Recall when only a single voter's vote is required (informational).",
+    )
+
+
+class EvalFixture(BaseModel):
+    """All eval state for one fixture: universe, metrics, diff lists.
+
+    The ``candidates`` list is the per-candidate cache used by
+    ``rescore_universe`` -- so a Lab session loads the universe once,
+    then sweeps consensus / apriori sliders without touching CLAP/PANN.
+    """
+
+    slug: str
+    audit_path: str
+    audio_path: str
+    expected_rounds: int | None = None
+    candidates: list[EvalCandidate]
+    truth_times: list[float]
+    metrics: EvalFixtureMetrics
+    audit_mtime: float
+    audio_mtime: float | None = None
+
+
+class EvalUniverse(BaseModel):
+    """Cached, model-output-bound layer (heavy to compute)."""
+
+    fixtures: list[EvalFixture]
+    voter_a_floor: float
+    voter_b_threshold: float
+    voter_c_threshold: float
+    voter_d_threshold: float
+    tolerance_ms: float
+
+
+class RunSummary(BaseModel):
+    """Aggregate metrics for a run (the headline numbers)."""
+
+    n_fixtures: int
+    n_truth: int
+    n_kept: int
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    precision: float
+    recall: float
+    f1: float
+
+
+class EvalRun(BaseModel):
+    """One full eval/rescore result. Persisted under build/lab/runs/."""
+
+    config: EvalConfig
+    summary: RunSummary
+    universe: EvalUniverse
+    config_hash: str
+    built_at: str
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _label_truth(
+    cand_times: np.ndarray,
+    truth_shots: list[dict[str, Any]],
+    tolerance_ms: float,
+) -> tuple[np.ndarray, list[int | None], list[float]]:
+    """Greedy nearest-time labelling. Returns (labels, matched_shot_number, truth_times)."""
+    labels = np.zeros(cand_times.size, dtype=np.int64)
+    matched: list[int | None] = [None] * cand_times.size
+    used: set[int] = set()
+    sorted_truth = sorted(truth_shots, key=lambda s: s.get("time", 0.0))
+    truth_times: list[float] = [float(s.get("time", 0.0)) for s in sorted_truth]
+    for s in sorted_truth:
+        t = float(s.get("time", 0.0))
+        best_i: int | None = None
+        best_d: float | None = None
+        for i, c in enumerate(cand_times):
+            if i in used:
+                continue
+            d = abs(float(c) - t) * 1000.0
+            if d <= tolerance_ms and (best_d is None or d < best_d):
+                best_i, best_d = i, d
+        if best_i is not None:
+            used.add(best_i)
+            labels[best_i] = 1
+            matched[best_i] = int(s.get("shot_number") or 0) or None
+    return labels, matched, truth_times
+
+
+def _metrics(
+    truth_times: list[float],
+    candidates: list[EvalCandidate],
+) -> EvalFixtureMetrics:
+    n_truth = len(truth_times)
+    kept = [c for c in candidates if c.kept]
+    n_kept = len(kept)
+    tp = sum(1 for c in kept if c.truth == 1)
+    fp = n_kept - tp
+    fn = n_truth - tp
+    precision = tp / n_kept if n_kept else 0.0
+    recall = tp / n_truth if n_truth else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    voter_recall: dict[str, float] = {}
+    if n_truth:
+        truth_caps = [c for c in candidates if c.truth == 1]
+        for key in ("vote_a", "vote_b", "vote_c", "vote_d"):
+            voter_recall[key] = sum(getattr(c, key) for c in truth_caps) / n_truth
+    else:
+        voter_recall = {"vote_a": 0.0, "vote_b": 0.0, "vote_c": 0.0, "vote_d": 0.0}
+    return EvalFixtureMetrics(
+        n_truth=n_truth,
+        n_kept=n_kept,
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        precision=round(precision, 4),
+        recall=round(recall, 4),
+        f1=round(f1, 4),
+        voter_recall={k: round(v, 4) for k, v in voter_recall.items()},
+    )
+
+
+def _summary(fixtures: list[EvalFixture]) -> RunSummary:
+    n_truth = sum(f.metrics.n_truth for f in fixtures)
+    n_kept = sum(f.metrics.n_kept for f in fixtures)
+    tp = sum(f.metrics.true_positives for f in fixtures)
+    fp = sum(f.metrics.false_positives for f in fixtures)
+    fn = sum(f.metrics.false_negatives for f in fixtures)
+    precision = tp / n_kept if n_kept else 0.0
+    recall = tp / n_truth if n_truth else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    return RunSummary(
+        n_fixtures=len(fixtures),
+        n_truth=n_truth,
+        n_kept=n_kept,
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        precision=round(precision, 4),
+        recall=round(recall, 4),
+        f1=round(f1, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Eval (heavy) and rescore (light)
+# ---------------------------------------------------------------------------
+
+
+def run_eval(
+    runtime: EnsembleRuntime,
+    *,
+    fixtures_root: Path | None = None,
+    slugs: list[str] | None = None,
+    config: EvalConfig | None = None,
+) -> EvalRun:
+    """Run the ensemble against fixtures and build a fresh ``EvalUniverse``.
+
+    Caller passes a pre-loaded ``runtime`` so model weights are
+    amortised across many calls (Lab UI loads once on first request).
+    """
+    cfg = config or EvalConfig()
+    cal = runtime.calibration
+    catalog = list_fixtures(fixtures_root)
+    if slugs:
+        wanted = set(slugs)
+        catalog = [f for f in catalog if f.slug in wanted]
+    catalog = [f for f in catalog if f.has_audio]
+
+    fixtures: list[EvalFixture] = []
+    ec = cfg.to_ensemble_config()
+    for fix in catalog:
+        audit = json.loads(Path(fix.audit_path).read_text(encoding="utf-8"))
+        audio, sr = load_audio(Path(fix.audio_path))
+        beep_time = float(audit.get("beep_time", 0.0))
+        stage_time = float(audit.get("stage_time_seconds", 0.0))
+        expected = fix.expected_rounds if cfg.use_expected_rounds else None
+
+        result = detect_shots_ensemble(
+            audio,
+            sr,
+            beep_time,
+            stage_time,
+            runtime,
+            expected_rounds=expected,
+            ensemble_config=ec,
+        )
+        cand_times = np.array([c.time for c in result.candidates], dtype=np.float64)
+        labels, matched, truth_times = _label_truth(
+            cand_times, audit.get("shots", []), cfg.tolerance_ms
+        )
+        candidates = [
+            EvalCandidate(
+                candidate_number=c.candidate_number,
+                time=c.time,
+                ms_after_beep=c.ms_after_beep,
+                confidence=c.confidence,
+                peak_amplitude=c.peak_amplitude,
+                score_c=c.score_c,
+                clap_diff=c.clap_diff,
+                gunshot_prob=c.gunshot_prob,
+                vote_a=c.vote_a,
+                vote_b=c.vote_b,
+                vote_c=c.vote_c,
+                vote_d=c.vote_d,
+                vote_total=c.vote_total,
+                apriori_boost=c.apriori_boost,
+                ensemble_score=c.ensemble_score,
+                kept=c.kept,
+                truth=int(labels[i]),
+                matched_shot_number=matched[i],
+            )
+            for i, c in enumerate(result.candidates)
+        ]
+        metrics = _metrics(truth_times, candidates)
+        fixtures.append(
+            EvalFixture(
+                slug=fix.slug,
+                audit_path=fix.audit_path,
+                audio_path=fix.audio_path,
+                expected_rounds=fix.expected_rounds,
+                candidates=candidates,
+                truth_times=truth_times,
+                metrics=metrics,
+                audit_mtime=fix.audit_mtime,
+                audio_mtime=fix.audio_mtime,
+            )
+        )
+
+    universe = EvalUniverse(
+        fixtures=fixtures,
+        voter_a_floor=cal.voter_a_floor,
+        voter_b_threshold=cal.voter_b_threshold,
+        voter_c_threshold=cal.voter_c_threshold,
+        voter_d_threshold=cal.voter_d_threshold,
+        tolerance_ms=cfg.tolerance_ms,
+    )
+    summary = _summary(fixtures)
+    return EvalRun(
+        config=cfg,
+        summary=summary,
+        universe=universe,
+        config_hash=_hash_config(cfg),
+        built_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def rescore_universe(universe: EvalUniverse, config: EvalConfig) -> EvalRun:
+    """Recompute votes / consensus / metrics from a cached universe.
+
+    Voter B/C/D get the calibrated thresholds (or per-voter overrides
+    if the config supplies them). Voter A uses the calibrated floor
+    (or the override). No model calls; sub-100 ms for the full set.
+    """
+    a_floor = (
+        config.voter_a_floor_override
+        if config.voter_a_floor_override is not None
+        else universe.voter_a_floor
+    )
+    b_thr = (
+        config.voter_b_threshold_override
+        if config.voter_b_threshold_override is not None
+        else universe.voter_b_threshold
+    )
+    c_thr = (
+        config.voter_c_threshold_override
+        if config.voter_c_threshold_override is not None
+        else universe.voter_c_threshold
+    )
+    d_thr = (
+        config.voter_d_threshold_override
+        if config.voter_d_threshold_override is not None
+        else universe.voter_d_threshold
+    )
+
+    rescored: list[EvalFixture] = []
+    for fix in universe.fixtures:
+        if not fix.candidates:
+            rescored.append(fix.model_copy(deep=True))
+            continue
+
+        confs = np.array([c.confidence for c in fix.candidates], dtype=np.float64)
+        clap_diff = np.array([c.clap_diff for c in fix.candidates], dtype=np.float64)
+        score_c = np.array([c.score_c for c in fix.candidates], dtype=np.float64)
+        gun = np.array([c.gunshot_prob for c in fix.candidates], dtype=np.float64)
+
+        vote_a = (confs >= a_floor).astype(np.int64)
+        vote_b = (clap_diff >= b_thr).astype(np.int64)
+        vote_d = (gun >= d_thr).astype(np.int64)
+
+        expected = fix.expected_rounds if config.use_expected_rounds else None
+        if expected and expected > 0:
+            slack = max(3, int(expected * 0.10 + 0.5))
+            target = expected + slack
+            if target >= score_c.size:
+                vote_c = np.ones_like(score_c, dtype=np.int64)
+            else:
+                vote_c = np.zeros_like(score_c, dtype=np.int64)
+                vote_c[np.argsort(-score_c)[:target]] = 1
+        else:
+            vote_c = (score_c >= c_thr).astype(np.int64)
+
+        boost = np.zeros_like(confs)
+        if expected and expected > 0:
+            top = np.argsort(-confs)[:expected]
+            boost[top] = config.apriori_boost
+        vote_total = vote_a + vote_b + vote_c + vote_d
+        ensemble_score = vote_total.astype(np.float64) + boost
+        kept_mask = ensemble_score >= config.consensus
+
+        new_cands: list[EvalCandidate] = []
+        for i, c in enumerate(fix.candidates):
+            new_cands.append(
+                c.model_copy(
+                    update={
+                        "vote_a": int(vote_a[i]),
+                        "vote_b": int(vote_b[i]),
+                        "vote_c": int(vote_c[i]),
+                        "vote_d": int(vote_d[i]),
+                        "vote_total": int(vote_total[i]),
+                        "apriori_boost": float(boost[i]),
+                        "ensemble_score": round(float(ensemble_score[i]), 2),
+                        "kept": bool(kept_mask[i]),
+                    }
+                )
+            )
+        metrics = _metrics(fix.truth_times, new_cands)
+        rescored.append(
+            fix.model_copy(update={"candidates": new_cands, "metrics": metrics})
+        )
+
+    new_universe = universe.model_copy(update={"fixtures": rescored, "tolerance_ms": config.tolerance_ms})
+    return EvalRun(
+        config=config,
+        summary=_summary(rescored),
+        universe=new_universe,
+        config_hash=_hash_config(config),
+        built_at=datetime.now(UTC).isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Promote
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PromoteRequest:
+    """Inputs for ``promote_stage_to_fixture``."""
+
+    audit_json_path: Path
+    audit_wav_path: Path
+    fixture_slug: str
+    fixtures_root: Path | None = None
+    overwrite: bool = False
+    extra_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def promote_stage_to_fixture(req: PromoteRequest) -> FixtureRecord:
+    """Copy a stage's audit JSON + sibling WAV into the fixtures dir.
+
+    Refuses to overwrite an existing fixture unless ``overwrite=True``.
+    Adds ``promoted_at`` + any ``extra_metadata`` to the JSON so the
+    fixture carries provenance.
+    """
+    root = (req.fixtures_root or DEFAULT_FIXTURES_ROOT).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    target_json = root / f"{req.fixture_slug}.json"
+    target_wav = root / f"{req.fixture_slug}.wav"
+    if target_json.exists() and not req.overwrite:
+        raise FileExistsError(f"fixture already exists: {target_json}")
+    if not req.audit_json_path.exists():
+        raise FileNotFoundError(f"audit JSON missing: {req.audit_json_path}")
+    if not req.audit_wav_path.exists():
+        raise FileNotFoundError(f"audit WAV missing: {req.audit_wav_path}")
+
+    payload = json.loads(req.audit_json_path.read_text(encoding="utf-8"))
+    payload["promoted_at"] = datetime.now(UTC).isoformat()
+    payload["promoted_from"] = str(req.audit_json_path)
+    if req.extra_metadata:
+        payload.setdefault("provenance", {}).update(req.extra_metadata)
+
+    tmp_json = target_json.with_suffix(".json.tmp")
+    tmp_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp_json.replace(target_json)
+    shutil.copy2(req.audit_wav_path, target_wav)
+    catalog = list_fixtures(root)
+    for rec in catalog:
+        if rec.slug == req.fixture_slug:
+            return rec
+    raise RuntimeError("fixture promote completed but record not found in catalog")
+
+
+# ---------------------------------------------------------------------------
+# Run persistence
+# ---------------------------------------------------------------------------
+
+
+def _hash_config(cfg: EvalConfig) -> str:
+    blob = json.dumps(cfg.model_dump(), sort_keys=True, ensure_ascii=True).encode()
+    return hashlib.sha256(blob).hexdigest()[:12]
+
+
+def save_run(run: EvalRun, *, runs_root: Path | None = None) -> Path:
+    """Persist a run as deterministic JSON + update the ``latest.json`` pointer."""
+    root = (runs_root or DEFAULT_RUNS_ROOT).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    stamp = run.built_at.replace(":", "").replace("-", "").replace(".", "")[:15]
+    target = root / f"{stamp}-{run.config_hash}.json"
+    blob = json.dumps(run.model_dump(mode="json"), indent=2, sort_keys=True, ensure_ascii=True)
+    target.write_text(blob + "\n", encoding="utf-8")
+    latest = root / LATEST_RUN_FILENAME
+    latest.write_text(blob + "\n", encoding="utf-8")
+    return target
+
+
+def load_run(path: Path) -> EvalRun:
+    """Read a persisted run JSON back into an ``EvalRun`` model."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return EvalRun.model_validate(payload)

--- a/src/splitsmith/lab/core.py
+++ b/src/splitsmith/lab/core.py
@@ -577,3 +577,41 @@ def load_run(path: Path) -> EvalRun:
     """Read a persisted run JSON back into an ``EvalRun`` model."""
     payload = json.loads(path.read_text(encoding="utf-8"))
     return EvalRun.model_validate(payload)
+
+
+def save_config_yaml(
+    *,
+    run: EvalRun,
+    name: str,
+    output_dir: Path | None = None,
+    note: str | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """Write ``configs/ensemble.<name>.yaml`` for a finished run.
+
+    Used by both the ``splitsmith lab save-config`` CLI and the
+    "Save as YAML" button in the Lab UI tuning panel. The YAML carries
+    the active ``EvalConfig``, the run's headline summary, and the
+    provenance needed to replay the result later.
+    """
+    import yaml  # local import: yaml is only needed in this code path
+
+    out_dir = (output_dir or Path("configs")).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = out_dir / f"ensemble.{name}.yaml"
+    if target.exists() and not overwrite:
+        raise FileExistsError(f"refusing to overwrite {target} (pass overwrite=True to force)")
+    payload = {
+        "name": name,
+        "config": run.config.model_dump(),
+        "summary": run.summary.model_dump(),
+        "provenance": {
+            "built_at": run.built_at,
+            "config_hash": run.config_hash,
+            "fixtures": [f.slug for f in run.universe.fixtures],
+            "note": note,
+        },
+    }
+    with target.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=True, default_flow_style=False)
+    return target

--- a/src/splitsmith/lab/core.py
+++ b/src/splitsmith/lab/core.py
@@ -18,14 +18,11 @@ import numpy as np
 from pydantic import BaseModel, Field
 
 from ..beep_detect import load_audio
-from ..config import ShotDetectConfig
 from ..ensemble.api import (
     EnsembleConfig,
     EnsembleRuntime,
     detect_shots_ensemble,
 )
-from ..shot_detect import detect_shots
-
 
 DEFAULT_FIXTURES_ROOT = Path(__file__).resolve().parents[3] / "tests" / "fixtures"
 DEFAULT_RUNS_ROOT = Path("build/lab/runs")
@@ -108,7 +105,10 @@ class EvalConfig(BaseModel):
     tolerance_ms: float = Field(default=75.0, gt=0.0)
     use_expected_rounds: bool = Field(
         default=True,
-        description="Pass the audit's ``stage_rounds.expected`` into the ensemble (adaptive voter C + apriori boost).",
+        description=(
+            "Pass the audit's ``stage_rounds.expected`` into the ensemble "
+            "(adaptive voter C + apriori boost)."
+        ),
     )
     voter_a_floor_override: float | None = None
     voter_b_threshold_override: float | None = None
@@ -484,11 +484,11 @@ def rescore_universe(universe: EvalUniverse, config: EvalConfig) -> EvalRun:
                 )
             )
         metrics = _metrics(fix.truth_times, new_cands)
-        rescored.append(
-            fix.model_copy(update={"candidates": new_cands, "metrics": metrics})
-        )
+        rescored.append(fix.model_copy(update={"candidates": new_cands, "metrics": metrics}))
 
-    new_universe = universe.model_copy(update={"fixtures": rescored, "tolerance_ms": config.tolerance_ms})
+    new_universe = universe.model_copy(
+        update={"fixtures": rescored, "tolerance_ms": config.tolerance_ms},
+    )
     return EvalRun(
         config=config,
         summary=_summary(rescored),

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -191,25 +191,16 @@ def save_config(
     if not universe_path.exists():
         raise typer.BadParameter(f"run JSON not found: {universe_path}")
     run = lab_module.load_run(universe_path)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    target = output_dir / f"ensemble.{name}.yaml"
-    if target.exists() and not overwrite:
-        raise typer.BadParameter(f"refusing to overwrite {target} (pass --overwrite to force)")
-    fixtures_used = [f.slug for f in run.universe.fixtures]
-    payload = {
-        "name": name,
-        "config": run.config.model_dump(),
-        "summary": run.summary.model_dump(),
-        "provenance": {
-            "built_at": run.built_at,
-            "config_hash": run.config_hash,
-            "universe_path": str(universe_path),
-            "fixtures": fixtures_used,
-            "note": note,
-        },
-    }
-    with target.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(payload, fh, sort_keys=True, default_flow_style=False)
+    try:
+        target = lab_module.save_config_yaml(
+            run=run,
+            name=name,
+            output_dir=output_dir,
+            note=note,
+            overwrite=overwrite,
+        )
+    except FileExistsError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     sys.stdout.write(str(target) + "\n")
 
 

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -1,0 +1,224 @@
+"""``splitsmith lab`` -- CLI mirror of the Lab UI surface.
+
+Every command shells through to ``splitsmith.lab`` so the JSON it
+prints is byte-identical to what the UI renders. Designed to be driven
+by Claude Code: outputs JSON to stdout, writes deterministic run
+records under ``build/lab/runs/`` for diff-based comparison.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+from . import lab as lab_module
+from .ensemble.api import load_ensemble_runtime
+
+app = typer.Typer(help="Algorithm lab: fixtures, eval, tuning.", no_args_is_help=True)
+
+
+def _emit(payload: Any, *, pretty: bool) -> None:
+    indent = 2 if pretty else None
+    sys.stdout.write(json.dumps(payload, indent=indent, sort_keys=True, ensure_ascii=True))
+    sys.stdout.write("\n")
+
+
+@app.command("fixtures")
+def fixtures(
+    fixtures_root: Path | None = typer.Option(
+        None, "--fixtures-root", help="Override the fixtures directory (default: tests/fixtures/)."
+    ),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """List audited fixtures available for eval."""
+    records = lab_module.list_fixtures(fixtures_root)
+    _emit([r.model_dump(mode="json") for r in records], pretty=pretty)
+
+
+@app.command("eval")
+def cmd_eval(
+    slug: list[str] = typer.Option(
+        None, "--slug", "-s", help="Restrict to specific fixture slugs (repeatable)."
+    ),
+    consensus: int = typer.Option(3, "--consensus", min=1, max=5),
+    apriori_boost: float = typer.Option(1.0, "--apriori-boost", min=0.0),
+    tolerance_ms: float = typer.Option(75.0, "--tolerance-ms", min=0.001),
+    no_expected_rounds: bool = typer.Option(
+        False,
+        "--no-expected-rounds",
+        help="Don't pass stage_rounds.expected into the ensemble (disables adaptive voter C + apriori boost).",
+    ),
+    save: bool = typer.Option(True, "--save/--no-save", help="Persist run under build/lab/runs/."),
+    summary_only: bool = typer.Option(
+        False,
+        "--summary-only",
+        help="Print only aggregate metrics + per-fixture P/R (no candidate-level detail).",
+    ),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """Run the ensemble against fixtures and report P/R per fixture."""
+    cfg = lab_module.EvalConfig(
+        consensus=consensus,
+        apriori_boost=apriori_boost,
+        tolerance_ms=tolerance_ms,
+        use_expected_rounds=not no_expected_rounds,
+    )
+    runtime = load_ensemble_runtime()
+    run = lab_module.run_eval(runtime, slugs=slug or None, config=cfg)
+    if save:
+        try:
+            target = lab_module.save_run(run)
+            sys.stderr.write(f"saved: {target}\n")
+        except OSError as exc:
+            sys.stderr.write(f"WARN: save_run failed: {exc}\n")
+    if summary_only:
+        payload = {
+            "config_hash": run.config_hash,
+            "summary": run.summary.model_dump(mode="json"),
+            "per_fixture": [
+                {
+                    "slug": f.slug,
+                    "n_truth": f.metrics.n_truth,
+                    "n_kept": f.metrics.n_kept,
+                    "precision": f.metrics.precision,
+                    "recall": f.metrics.recall,
+                    "f1": f.metrics.f1,
+                }
+                for f in run.universe.fixtures
+            ],
+        }
+        _emit(payload, pretty=pretty)
+    else:
+        _emit(run.model_dump(mode="json"), pretty=pretty)
+
+
+@app.command("rescore")
+def rescore(
+    universe_path: Path = typer.Option(
+        ...,
+        "--universe",
+        help="Path to a saved run JSON (e.g. build/lab/runs/latest.json).",
+    ),
+    consensus: int = typer.Option(3, "--consensus", min=1, max=5),
+    apriori_boost: float = typer.Option(1.0, "--apriori-boost", min=0.0),
+    no_expected_rounds: bool = typer.Option(False, "--no-expected-rounds"),
+    voter_a_floor: float | None = typer.Option(None, "--voter-a-floor"),
+    voter_b_threshold: float | None = typer.Option(None, "--voter-b-threshold"),
+    voter_c_threshold: float | None = typer.Option(None, "--voter-c-threshold"),
+    voter_d_threshold: float | None = typer.Option(None, "--voter-d-threshold"),
+    save: bool = typer.Option(True, "--save/--no-save"),
+    summary_only: bool = typer.Option(False, "--summary-only"),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """Rescore a cached eval universe under a new tuning config (no model calls)."""
+    prior = lab_module.load_run(universe_path)
+    cfg = lab_module.EvalConfig(
+        consensus=consensus,
+        apriori_boost=apriori_boost,
+        tolerance_ms=prior.universe.tolerance_ms,
+        use_expected_rounds=not no_expected_rounds,
+        voter_a_floor_override=voter_a_floor,
+        voter_b_threshold_override=voter_b_threshold,
+        voter_c_threshold_override=voter_c_threshold,
+        voter_d_threshold_override=voter_d_threshold,
+    )
+    run = lab_module.rescore_universe(prior.universe, cfg)
+    if save:
+        try:
+            target = lab_module.save_run(run)
+            sys.stderr.write(f"saved: {target}\n")
+        except OSError as exc:
+            sys.stderr.write(f"WARN: save_run failed: {exc}\n")
+    if summary_only:
+        payload = {
+            "config_hash": run.config_hash,
+            "summary": run.summary.model_dump(mode="json"),
+            "per_fixture": [
+                {
+                    "slug": f.slug,
+                    "precision": f.metrics.precision,
+                    "recall": f.metrics.recall,
+                    "f1": f.metrics.f1,
+                }
+                for f in run.universe.fixtures
+            ],
+        }
+        _emit(payload, pretty=pretty)
+    else:
+        _emit(run.model_dump(mode="json"), pretty=pretty)
+
+
+@app.command("promote")
+def promote(
+    audit_json: Path = typer.Option(..., "--audit-json", help="Path to <project>/audit/stage<N>.json."),
+    audit_wav: Path = typer.Option(..., "--audit-wav", help="Path to the stage's audit-clip WAV."),
+    slug: str = typer.Option(..., "--slug", help="Target fixture stem (e.g. stage-shots-foo-2026-stage4)."),
+    fixtures_root: Path | None = typer.Option(None, "--fixtures-root"),
+    overwrite: bool = typer.Option(False, "--overwrite"),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """Copy an in-project audit JSON + WAV into tests/fixtures/ as a new fixture."""
+    rec = lab_module.promote_stage_to_fixture(
+        lab_module.PromoteRequest(
+            audit_json_path=audit_json.expanduser().resolve(),
+            audit_wav_path=audit_wav.expanduser().resolve(),
+            fixture_slug=slug,
+            fixtures_root=fixtures_root.expanduser().resolve() if fixtures_root else None,
+            overwrite=overwrite,
+        )
+    )
+    _emit(rec.model_dump(mode="json"), pretty=pretty)
+
+
+@app.command("save-config")
+def save_config(
+    name: str = typer.Option(..., "--name", help="Slug for the YAML file (configs/ensemble.<slug>.yaml)."),
+    universe_path: Path = typer.Option(
+        Path("build/lab/runs/latest.json"),
+        "--universe",
+        help="Run JSON whose config + summary will be captured (defaults to latest run).",
+    ),
+    output_dir: Path = typer.Option(Path("configs"), "--output-dir"),
+    note: str | None = typer.Option(None, "--note", help="Free-text note saved alongside provenance."),
+    overwrite: bool = typer.Option(False, "--overwrite"),
+) -> None:
+    """Capture a run's config + headline metrics as committable YAML."""
+    if not universe_path.exists():
+        raise typer.BadParameter(f"run JSON not found: {universe_path}")
+    run = lab_module.load_run(universe_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / f"ensemble.{name}.yaml"
+    if target.exists() and not overwrite:
+        raise typer.BadParameter(f"refusing to overwrite {target} (pass --overwrite to force)")
+    fixtures_used = [f.slug for f in run.universe.fixtures]
+    payload = {
+        "name": name,
+        "config": run.config.model_dump(),
+        "summary": run.summary.model_dump(),
+        "provenance": {
+            "built_at": run.built_at,
+            "config_hash": run.config_hash,
+            "universe_path": str(universe_path),
+            "fixtures": fixtures_used,
+            "note": note,
+        },
+    }
+    with target.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=True, default_flow_style=False)
+    sys.stdout.write(str(target) + "\n")
+
+
+@app.command("load-config")
+def load_config(
+    path: Path = typer.Argument(..., exists=True, readable=True),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """Print a saved YAML config (config + provenance) as JSON."""
+    with path.open("r", encoding="utf-8") as fh:
+        payload = yaml.safe_load(fh)
+    _emit(payload, pretty=pretty)

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -51,7 +51,10 @@ def cmd_eval(
     no_expected_rounds: bool = typer.Option(
         False,
         "--no-expected-rounds",
-        help="Don't pass stage_rounds.expected into the ensemble (disables adaptive voter C + apriori boost).",
+        help=(
+            "Don't pass stage_rounds.expected into the ensemble "
+            "(disables adaptive voter C + apriori boost)."
+        ),
     ),
     save: bool = typer.Option(True, "--save/--no-save", help="Persist run under build/lab/runs/."),
     summary_only: bool = typer.Option(
@@ -155,9 +158,13 @@ def rescore(
 
 @app.command("promote")
 def promote(
-    audit_json: Path = typer.Option(..., "--audit-json", help="Path to <project>/audit/stage<N>.json."),
+    audit_json: Path = typer.Option(
+        ..., "--audit-json", help="Path to <project>/audit/stage<N>.json."
+    ),
     audit_wav: Path = typer.Option(..., "--audit-wav", help="Path to the stage's audit-clip WAV."),
-    slug: str = typer.Option(..., "--slug", help="Target fixture stem (e.g. stage-shots-foo-2026-stage4)."),
+    slug: str = typer.Option(
+        ..., "--slug", help="Target fixture stem (e.g. stage-shots-foo-2026-stage4)."
+    ),
     fixtures_root: Path | None = typer.Option(None, "--fixtures-root"),
     overwrite: bool = typer.Option(False, "--overwrite"),
     pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
@@ -177,14 +184,18 @@ def promote(
 
 @app.command("save-config")
 def save_config(
-    name: str = typer.Option(..., "--name", help="Slug for the YAML file (configs/ensemble.<slug>.yaml)."),
+    name: str = typer.Option(
+        ..., "--name", help="Slug for the YAML file (configs/ensemble.<slug>.yaml)."
+    ),
     universe_path: Path = typer.Option(
         Path("build/lab/runs/latest.json"),
         "--universe",
         help="Run JSON whose config + summary will be captured (defaults to latest run).",
     ),
     output_dir: Path = typer.Option(Path("configs"), "--output-dir"),
-    note: str | None = typer.Option(None, "--note", help="Free-text note saved alongside provenance."),
+    note: str | None = typer.Option(
+        None, "--note", help="Free-text note saved alongside provenance."
+    ),
     overwrite: bool = typer.Option(False, "--overwrite"),
 ) -> None:
     """Capture a run's config + headline metrics as committable YAML."""

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3409,6 +3409,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             except OSError as exc:
                 logger.warning("lab: save_run failed: %s", exc)
         _lab_universe_cache["universe"] = run.universe
+        _lab_universe_cache["last_run"] = run
         return JSONResponse(run.model_dump(mode="json"))
 
     @app.post("/api/lab/rescore")
@@ -3422,6 +3423,7 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             )
         run = lab_module.rescore_universe(universe, cfg)
         _lab_universe_cache["universe"] = run.universe
+        _lab_universe_cache["last_run"] = run
         return JSONResponse(run.model_dump(mode="json"))
 
     @app.post("/api/lab/promote")
@@ -3469,6 +3471,87 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return JSONResponse(rec.model_dump(mode="json"))
+
+    @app.post("/api/lab/save-config")
+    def lab_save_config(payload: dict[str, Any] = Body(...)) -> JSONResponse:  # noqa: B008
+        """Write a finished run's config + provenance to ``configs/<name>.yaml``.
+
+        Body: ``{name, note?, overwrite?}``. The active universe (the
+        most recent eval/rescore) provides the run; if no eval has run
+        in this server session we 409 so the user can't accidentally
+        save an empty config.
+        """
+        name = payload.get("name")
+        note = payload.get("note")
+        overwrite = bool(payload.get("overwrite", False))
+        if not isinstance(name, str) or not name.strip():
+            raise HTTPException(status_code=400, detail="payload must include non-empty 'name'")
+        universe = _lab_universe_cache.get("universe")
+        if universe is None:
+            raise HTTPException(
+                status_code=409,
+                detail="no cached eval universe; run /api/lab/eval first",
+            )
+        last_run = _lab_universe_cache.get("last_run")
+        if last_run is None:
+            raise HTTPException(
+                status_code=409,
+                detail="no cached run; rescore or run eval first",
+            )
+        try:
+            target = lab_module.save_config_yaml(
+                run=last_run,
+                name=name,
+                note=note if isinstance(note, str) else None,
+                overwrite=overwrite,
+            )
+        except FileExistsError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return JSONResponse({"path": str(target)})
+
+    @app.post("/api/lab/rebuild-calibration")
+    def lab_rebuild_calibration(
+        payload: dict[str, Any] = Body(default_factory=dict),  # noqa: B008
+    ) -> JSONResponse:
+        """Submit a job that re-runs ``scripts/build_ensemble_artifacts.py``.
+
+        Long-running (model-bound), so it goes through the JobRegistry
+        and the SPA polls /api/jobs/{id} like any other job. After it
+        completes the next /api/lab/eval call will pick up the new
+        thresholds because the cached EnsembleRuntime is invalidated.
+        """
+        target_recall = float(payload.get("target_recall", 0.95))
+        tolerance_ms = float(payload.get("tolerance_ms", 75.0))
+        fixtures = payload.get("fixtures")
+        if fixtures is not None and not isinstance(fixtures, list):
+            raise HTTPException(status_code=400, detail="'fixtures' must be a list of slugs or omitted")
+
+        def _run(handle: JobHandle) -> None:
+            # Import here to avoid pulling sklearn at server startup.
+            scripts_dir = Path(__file__).resolve().parents[3] / "scripts"
+            sys.path.insert(0, str(scripts_dir))
+            try:
+                import build_ensemble_artifacts as build_mod  # type: ignore[import-not-found]
+            finally:
+                sys.path.pop(0)
+
+            def log(msg: str) -> None:
+                handle.check_cancel()
+                handle.update(message=msg)
+
+            build_mod.build_artifacts(
+                fixtures=fixtures if fixtures else None,
+                target_recall=target_recall,
+                tolerance_ms=tolerance_ms,
+                log=log,
+            )
+            # Drop the cached runtime so the next eval reloads the new
+            # calibration JSON + GBDT model.
+            _lab_runtime_cache.pop("runtime", None)
+            handle.update(progress=1.0, message="calibration rebuilt")
+
+        job = state.jobs.submit(kind="rebuild_calibration", fn=_run)
+        return JSONResponse(job.model_dump(mode="json"))
 
     # ----------------------------------------------------------------------
     # Static asset serving (SPA)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3367,6 +3367,110 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         return JSONResponse({"ok": True})
 
     # ----------------------------------------------------------------------
+    # Lab: fixture management + ensemble eval + tuning
+    # ----------------------------------------------------------------------
+    #
+    # End-user-visible only via the /lab route in the SPA. Heavy CLAP/PANN
+    # runtime is loaded once on first /api/lab/eval call and cached on the
+    # FastAPI app instance so subsequent eval / rescore calls amortise it.
+
+    from .. import lab as lab_module
+
+    _lab_runtime_cache: dict[str, Any] = {}
+    _lab_universe_cache: dict[str, Any] = {}  # session: most recent run
+
+    def _get_lab_runtime() -> Any:
+        rt = _lab_runtime_cache.get("runtime")
+        if rt is None:
+            rt = ensemble_module.api.load_ensemble_runtime()
+            _lab_runtime_cache["runtime"] = rt
+        return rt
+
+    @app.get("/api/lab/fixtures")
+    def lab_fixtures() -> JSONResponse:
+        return JSONResponse(
+            [r.model_dump(mode="json") for r in lab_module.list_fixtures()]
+        )
+
+    @app.post("/api/lab/eval")
+    def lab_eval(payload: dict[str, Any] = Body(default_factory=dict)) -> JSONResponse:  # noqa: B008
+        slugs = payload.get("slugs")
+        cfg_payload = payload.get("config") or {}
+        cfg = lab_module.EvalConfig.model_validate(cfg_payload)
+        runtime = _get_lab_runtime()
+        run = lab_module.run_eval(
+            runtime,
+            slugs=slugs if isinstance(slugs, list) else None,
+            config=cfg,
+        )
+        if payload.get("persist", True):
+            try:
+                lab_module.save_run(run)
+            except OSError as exc:
+                logger.warning("lab: save_run failed: %s", exc)
+        _lab_universe_cache["universe"] = run.universe
+        return JSONResponse(run.model_dump(mode="json"))
+
+    @app.post("/api/lab/rescore")
+    def lab_rescore(payload: dict[str, Any] = Body(...)) -> JSONResponse:  # noqa: B008
+        cfg = lab_module.EvalConfig.model_validate(payload.get("config") or {})
+        universe = _lab_universe_cache.get("universe")
+        if universe is None:
+            raise HTTPException(
+                status_code=409,
+                detail="no cached eval universe; call /api/lab/eval first",
+            )
+        run = lab_module.rescore_universe(universe, cfg)
+        _lab_universe_cache["universe"] = run.universe
+        return JSONResponse(run.model_dump(mode="json"))
+
+    @app.post("/api/lab/promote")
+    def lab_promote(payload: dict[str, Any] = Body(...)) -> JSONResponse:  # noqa: B008
+        stage_n = payload.get("stage_number")
+        slug = payload.get("slug")
+        overwrite = bool(payload.get("overwrite", False))
+        if not isinstance(stage_n, int) or not isinstance(slug, str) or not slug:
+            raise HTTPException(
+                status_code=400,
+                detail="payload must include integer 'stage_number' and string 'slug'",
+            )
+        project = state.load()
+        try:
+            stg = project.stage(stage_n)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        audit_json = project.audit_path(state.project_root) / f"stage{stage_n}.json"
+        try:
+            audit_audio = _resolve_audit_audio(project, stage_n)
+        except HTTPException:
+            raise
+        audit_wav = audit_audio.audio_path
+        if not audit_json.exists() or not audit_wav.exists():
+            raise HTTPException(
+                status_code=409,
+                detail="stage has no audit JSON / WAV; run shot-detect first",
+            )
+        try:
+            rec = lab_module.promote_stage_to_fixture(
+                lab_module.PromoteRequest(
+                    audit_json_path=audit_json,
+                    audit_wav_path=audit_wav,
+                    fixture_slug=slug,
+                    overwrite=overwrite,
+                    extra_metadata={
+                        "project_root": str(state.project_root),
+                        "stage_number": stage_n,
+                        "stage_name": getattr(stg, "name", None),
+                    },
+                )
+            )
+        except FileExistsError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return JSONResponse(rec.model_dump(mode="json"))
+
+    # ----------------------------------------------------------------------
     # Static asset serving (SPA)
     # ----------------------------------------------------------------------
     #

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3388,12 +3388,12 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
 
     @app.get("/api/lab/fixtures")
     def lab_fixtures() -> JSONResponse:
-        return JSONResponse(
-            [r.model_dump(mode="json") for r in lab_module.list_fixtures()]
-        )
+        return JSONResponse([r.model_dump(mode="json") for r in lab_module.list_fixtures()])
 
     @app.post("/api/lab/eval")
-    def lab_eval(payload: dict[str, Any] = Body(default_factory=dict)) -> JSONResponse:  # noqa: B008
+    def lab_eval(
+        payload: dict[str, Any] = Body(default_factory=dict),  # noqa: B008
+    ) -> JSONResponse:
         slugs = payload.get("slugs")
         cfg_payload = payload.get("config") or {}
         cfg = lab_module.EvalConfig.model_validate(cfg_payload)
@@ -3524,7 +3524,10 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
         tolerance_ms = float(payload.get("tolerance_ms", 75.0))
         fixtures = payload.get("fixtures")
         if fixtures is not None and not isinstance(fixtures, list):
-            raise HTTPException(status_code=400, detail="'fixtures' must be a list of slugs or omitted")
+            raise HTTPException(
+                status_code=400,
+                detail="'fixtures' must be a list of slugs or omitted",
+            )
 
         def _run(handle: JobHandle) -> None:
             # Import here to avoid pulling sklearn at server startup.

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -7,6 +7,7 @@ import { Design } from "@/pages/Design";
 import { Export } from "@/pages/Export";
 import { Home } from "@/pages/Home";
 import { Ingest } from "@/pages/Ingest";
+import { Lab } from "@/pages/Lab";
 import { Review } from "@/pages/Review";
 
 export function App() {
@@ -21,6 +22,8 @@ export function App() {
             <Route path="audit/:stage" element={<Audit />} />
             <Route path="export" element={<Export />} />
             <Route path="export/:stage" element={<Export />} />
+            <Route path="lab" element={<Lab />} />
+            <Route path="lab/:slug" element={<Lab />} />
             <Route path="review" element={<Review />} />
             <Route path="_design" element={<Design />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/splitsmith/ui_static/src/components/AppShell.tsx
+++ b/src/splitsmith/ui_static/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Crosshair, FileBarChart, FolderInput, Home, Palette } from "lucide-react";
+import { Crosshair, FileBarChart, FlaskConical, FolderInput, Home, Palette } from "lucide-react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 
 import { JobsPanel } from "@/components/JobsPanel";
@@ -10,6 +10,7 @@ const NAV = [
   { to: "/ingest", label: "Ingest", icon: FolderInput },
   { to: "/audit", label: "Audit", icon: Crosshair },
   { to: "/export", label: "Export", icon: FileBarChart },
+  { to: "/lab", label: "Lab", icon: FlaskConical },
 ];
 
 export function AppShell() {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1010,6 +1010,12 @@ export const api = {
 
   promoteFixture: (payload: { stage_number: number; slug: string; overwrite?: boolean }) =>
     request<LabFixtureRecord>("/api/lab/promote", { method: "POST", json: payload }),
+
+  saveLabConfig: (payload: { name: string; note?: string; overwrite?: boolean }) =>
+    request<{ path: string }>("/api/lab/save-config", { method: "POST", json: payload }),
+
+  rebuildLabCalibration: (payload: { target_recall?: number; tolerance_ms?: number; fixtures?: string[] } = {}) =>
+    request<Job>("/api/lab/rebuild-calibration", { method: "POST", json: payload }),
 };
 
 export interface LabFixtureRecord {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -994,6 +994,121 @@ export const api = {
 
   fixtureVideoUrl: (videoPath: string) =>
     `/api/fixture/video?path=${encodeURIComponent(videoPath)}`,
+
+  // -----------------------------------------------------------------------
+  // Lab: fixture management + ensemble eval + tuning. Mirrors splitsmith.lab
+  // (the Python module) -- see src/splitsmith/lab/core.py for shapes.
+  // -----------------------------------------------------------------------
+
+  listLabFixtures: () => request<LabFixtureRecord[]>("/api/lab/fixtures"),
+
+  runLabEval: (payload: { slugs?: string[]; config?: Partial<LabEvalConfig>; persist?: boolean }) =>
+    request<LabEvalRun>("/api/lab/eval", { method: "POST", json: payload }),
+
+  rescoreLabUniverse: (config: Partial<LabEvalConfig>) =>
+    request<LabEvalRun>("/api/lab/rescore", { method: "POST", json: { config } }),
+
+  promoteFixture: (payload: { stage_number: number; slug: string; overwrite?: boolean }) =>
+    request<LabFixtureRecord>("/api/lab/promote", { method: "POST", json: payload }),
 };
+
+export interface LabFixtureRecord {
+  slug: string;
+  audit_path: string;
+  audio_path: string;
+  has_audio: boolean;
+  n_shots: number;
+  expected_rounds: number | null;
+  stage_time_seconds: number | null;
+  beep_time: number | null;
+  source: string | null;
+  audit_mtime: number;
+  audio_mtime: number | null;
+}
+
+export interface LabEvalConfig {
+  consensus: number;
+  apriori_boost: number;
+  tolerance_ms: number;
+  use_expected_rounds: boolean;
+  voter_a_floor_override: number | null;
+  voter_b_threshold_override: number | null;
+  voter_c_threshold_override: number | null;
+  voter_d_threshold_override: number | null;
+}
+
+export interface LabEvalCandidate {
+  candidate_number: number;
+  time: number;
+  ms_after_beep: number;
+  confidence: number;
+  peak_amplitude: number;
+  score_c: number;
+  clap_diff: number;
+  gunshot_prob: number;
+  vote_a: number;
+  vote_b: number;
+  vote_c: number;
+  vote_d: number;
+  vote_total: number;
+  apriori_boost: number;
+  ensemble_score: number;
+  kept: boolean;
+  truth: number;
+  matched_shot_number: number | null;
+}
+
+export interface LabEvalFixtureMetrics {
+  n_truth: number;
+  n_kept: number;
+  true_positives: number;
+  false_positives: number;
+  false_negatives: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  voter_recall: Record<string, number>;
+}
+
+export interface LabEvalFixture {
+  slug: string;
+  audit_path: string;
+  audio_path: string;
+  expected_rounds: number | null;
+  candidates: LabEvalCandidate[];
+  truth_times: number[];
+  metrics: LabEvalFixtureMetrics;
+  audit_mtime: number;
+  audio_mtime: number | null;
+}
+
+export interface LabRunSummary {
+  n_fixtures: number;
+  n_truth: number;
+  n_kept: number;
+  true_positives: number;
+  false_positives: number;
+  false_negatives: number;
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+export interface LabEvalUniverse {
+  fixtures: LabEvalFixture[];
+  voter_a_floor: number;
+  voter_b_threshold: number;
+  voter_c_threshold: number;
+  voter_d_threshold: number;
+  tolerance_ms: number;
+}
+
+export interface LabEvalRun {
+  config: LabEvalConfig;
+  summary: LabRunSummary;
+  universe: LabEvalUniverse;
+  config_hash: string;
+  built_at: string;
+}
 
 export { ApiError };

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -33,6 +33,7 @@ import {
   CheckCircle2,
   ChevronsRight,
   Crosshair,
+  FlaskConical,
   HelpCircle,
   ListChecks,
   Loader2,
@@ -1239,6 +1240,12 @@ export function Audit() {
                       <Save className="size-4" />
                     )}
                   </Button>
+                  {stageNumber != null && stage && (
+                    <PromoteFixtureButton
+                      stageNumber={stageNumber}
+                      defaultSlug={`stage-shots-${slugify(project?.name ?? "match")}-stage${stageNumber}`}
+                    />
+                  )}
                   <span className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
                     <span>{detectedCount} detected</span>
                     <span>{rejectedCount} rejected</span>
@@ -1840,4 +1847,107 @@ function formatTime(seconds: number): string {
   const s = Math.floor(seconds % 60);
   const ms = Math.floor((seconds - Math.floor(seconds)) * 1000);
   return `${m}:${s.toString().padStart(2, "0")}.${ms.toString().padStart(3, "0")}`;
+}
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "match";
+}
+
+interface PromoteFixtureButtonProps {
+  stageNumber: number;
+  defaultSlug: string;
+}
+
+function PromoteFixtureButton({ stageNumber, defaultSlug }: PromoteFixtureButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [slug, setSlug] = useState(defaultSlug);
+  const [overwrite, setOverwrite] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Refresh the suggested slug whenever the stage changes.
+  useEffect(() => {
+    setSlug(defaultSlug);
+    setResult(null);
+    setError(null);
+  }, [defaultSlug]);
+
+  const submit = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const rec = await api.promoteFixture({ stage_number: stageNumber, slug, overwrite });
+      setResult(rec.audit_path);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [stageNumber, slug, overwrite]);
+
+  return (
+    <div className="relative">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        title="Save audited stage as a test fixture"
+      >
+        <FlaskConical className="size-4" />
+      </Button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 w-72 rounded-md border border-border bg-popover p-3 shadow-md">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Promote to fixture
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Copies this stage's audit JSON + audit-clip WAV into tests/fixtures/.
+          </p>
+          <label className="mt-2 block text-[11px]">
+            <span className="text-muted-foreground">Slug</span>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              className="mt-1 w-full rounded border border-border bg-background px-2 py-1 font-mono text-xs"
+            />
+          </label>
+          <label className="mt-2 flex items-center gap-2 text-[11px]">
+            <input
+              type="checkbox"
+              checked={overwrite}
+              onChange={(e) => setOverwrite(e.target.checked)}
+            />
+            Overwrite if exists
+          </label>
+          {error && (
+            <div className="mt-2 rounded bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+              {error}
+            </div>
+          )}
+          {result && (
+            <div className="mt-2 rounded bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-700 dark:text-emerald-300">
+              Saved: <span className="font-mono">{result}</span>
+            </div>
+          )}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button size="sm" onClick={submit} disabled={busy || !slug.trim()}>
+              {busy ? <Loader2 className="size-3.5 animate-spin" /> : "Promote"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -24,9 +24,11 @@ import {
   Beaker,
   CheckCircle2,
   ChevronRight,
+  Hammer,
   Loader2,
   Play,
   RotateCcw,
+  Save,
   Settings2,
 } from "lucide-react";
 
@@ -42,6 +44,7 @@ import {
 } from "@/components/ui/card";
 import {
   api,
+  type Job,
   type LabEvalConfig,
   type LabEvalFixture,
   type LabEvalRun,
@@ -134,6 +137,8 @@ export function Lab() {
               cfg {run.config_hash}
             </Badge>
           )}
+          <SaveYamlButton run={run} />
+          <RebuildCalibrationButton onCompleted={() => setRun(null)} />
           <Button onClick={runEval} disabled={evalLoading}>
             {evalLoading ? (
               <Loader2 className="size-4 animate-spin" />
@@ -758,6 +763,250 @@ function CandidateTable({
         </table>
       </div>
     </details>
+  );
+}
+
+function SaveYamlButton({ run }: { run: LabEvalRun | null }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [note, setNote] = useState("");
+  const [overwrite, setOverwrite] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Suggest a slug derived from the active config hash so accidental
+  // double-clicks don't all collide on "ensemble.tuning.yaml".
+  useEffect(() => {
+    if (open && !name && run) {
+      setName(`tuning-${run.config_hash}`);
+    }
+  }, [open, name, run]);
+
+  const submit = useCallback(async () => {
+    if (!name.trim()) return;
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await api.saveLabConfig({ name: name.trim(), note: note.trim() || undefined, overwrite });
+      setResult(res.path);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [name, note, overwrite]);
+
+  return (
+    <div className="relative">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        disabled={!run}
+        title={run ? "Save current tuning as configs/ensemble.<name>.yaml" : "Run eval first"}
+      >
+        <Save className="size-4" />
+        Save as YAML
+      </Button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 w-80 rounded-md border border-border bg-popover p-3 shadow-md">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Save tuning
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Writes <span className="font-mono">configs/ensemble.&lt;name&gt;.yaml</span> with the active
+            config + summary + provenance. Replayable via <span className="font-mono">splitsmith lab load-config</span>.
+          </p>
+          <label className="mt-2 block text-[11px]">
+            <span className="text-muted-foreground">Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded border border-border bg-background px-2 py-1 font-mono text-xs"
+              placeholder="tighter-d"
+            />
+          </label>
+          <label className="mt-2 block text-[11px]">
+            <span className="text-muted-foreground">Note (optional)</span>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={2}
+              className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-xs"
+              placeholder="Why this tuning is interesting..."
+            />
+          </label>
+          <label className="mt-2 flex items-center gap-2 text-[11px]">
+            <input
+              type="checkbox"
+              checked={overwrite}
+              onChange={(e) => setOverwrite(e.target.checked)}
+            />
+            Overwrite if exists
+          </label>
+          {error && (
+            <div className="mt-2 rounded bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+              {error}
+            </div>
+          )}
+          {result && (
+            <div className="mt-2 rounded bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-700 dark:text-emerald-300">
+              Saved: <span className="font-mono">{result}</span>
+            </div>
+          )}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button size="sm" onClick={submit} disabled={busy || !name.trim()}>
+              {busy ? <Loader2 className="size-3.5 animate-spin" /> : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RebuildCalibrationButton({ onCompleted }: { onCompleted: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [targetRecall, setTargetRecall] = useState(0.95);
+  const [toleranceMs, setToleranceMs] = useState(75);
+  const [submitting, setSubmitting] = useState(false);
+  const [job, setJob] = useState<Job | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+
+  // Poll the active job until it leaves the running state so the user
+  // sees progress without leaving the Lab.
+  useEffect(() => {
+    if (!job || job.status === "succeeded" || job.status === "failed" || job.status === "cancelled") {
+      return;
+    }
+    let stopped = false;
+    const tick = async () => {
+      try {
+        const next = await api.getJob(job.id);
+        if (stopped) return;
+        setJob(next);
+        if (next.status === "succeeded") {
+          onCompleted();
+        }
+      } catch (err) {
+        if (!stopped) setError(String(err));
+      }
+    };
+    const id = window.setInterval(tick, 1000);
+    return () => {
+      stopped = true;
+      window.clearInterval(id);
+    };
+  }, [job, onCompleted]);
+
+  const submit = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const j = await api.rebuildLabCalibration({
+        target_recall: targetRecall,
+        tolerance_ms: toleranceMs,
+      });
+      setJob(j);
+      setConfirmed(false);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [targetRecall, toleranceMs]);
+
+  const running = job && (job.status === "pending" || job.status === "running");
+  return (
+    <div className="relative">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        disabled={!!running}
+        title="Re-run scripts/build_ensemble_artifacts.py and refresh shipped thresholds"
+      >
+        {running ? <Loader2 className="size-4 animate-spin" /> : <Hammer className="size-4" />}
+        Rebuild calibration
+      </Button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 w-80 rounded-md border border-border bg-popover p-3 shadow-md">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Rebuild calibration
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Refits voter thresholds + the GBDT against every audited fixture and overwrites
+            <span className="font-mono"> src/splitsmith/data/</span>. Slow (model-bound). After it
+            completes, the next eval picks up the new thresholds.
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Requires the CLAP / PANN feature caches under
+            <span className="font-mono"> tests/fixtures/.cache/</span> -- build them first via the
+            extract scripts if a new fixture's cache is missing.
+          </p>
+          <label className="mt-2 block text-[11px]">
+            <span className="text-muted-foreground">Target recall ({targetRecall.toFixed(2)})</span>
+            <input
+              type="range"
+              min={0.8}
+              max={1.0}
+              step={0.01}
+              value={targetRecall}
+              onChange={(e) => setTargetRecall(Number(e.target.value))}
+              className="mt-1 w-full"
+            />
+          </label>
+          <label className="mt-2 block text-[11px]">
+            <span className="text-muted-foreground">Tolerance ms ({toleranceMs.toFixed(0)})</span>
+            <input
+              type="range"
+              min={15}
+              max={150}
+              step={5}
+              value={toleranceMs}
+              onChange={(e) => setToleranceMs(Number(e.target.value))}
+              className="mt-1 w-full"
+            />
+          </label>
+          <label className="mt-2 flex items-center gap-2 text-[11px]">
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+            />
+            I understand this overwrites the shipped calibration
+          </label>
+          {error && (
+            <div className="mt-2 rounded bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+              {error}
+            </div>
+          )}
+          {job && (
+            <div className="mt-2 rounded bg-muted/50 px-2 py-1 text-[11px]">
+              <div className="flex items-center justify-between">
+                <span className="font-mono">{job.status}</span>
+                {job.message && <span className="text-muted-foreground">{job.message}</span>}
+              </div>
+            </div>
+          )}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button size="sm" onClick={submit} disabled={submitting || !!running || !confirmed}>
+              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : "Run rebuild"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -1,0 +1,766 @@
+/**
+ * Algorithm Lab: fixture catalog, batch eval, live tuning, per-fixture
+ * diff overlay. Mirrors the ``splitsmith.lab`` Python module + the
+ * ``splitsmith lab`` CLI; same backend endpoints back both.
+ *
+ * Slow path: POST /api/lab/eval runs CLAP + PANN + GBDT against every
+ * fixture (or a slug subset) and returns the per-candidate universe.
+ * Fast path: POST /api/lab/rescore takes the cached universe + a new
+ * EnsembleConfig and returns updated metrics in <100 ms -- that's what
+ * makes the consensus + threshold sliders feel live.
+ *
+ * Routing:
+ *   /lab          -- catalog + global metrics + tuning
+ *   /lab/:slug    -- detail drawer focused on one fixture (waveform diff)
+ *
+ * Zero impact on the production paths: the Lab nav entry is the only
+ * surface change to AppShell, and no existing route was modified.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  Beaker,
+  CheckCircle2,
+  ChevronRight,
+  Loader2,
+  Play,
+  RotateCcw,
+  Settings2,
+} from "lucide-react";
+
+import { Waveform } from "@/components/Waveform";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  api,
+  type LabEvalConfig,
+  type LabEvalFixture,
+  type LabEvalRun,
+  type LabFixtureRecord,
+  type PeaksResult,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_CONFIG: LabEvalConfig = {
+  consensus: 3,
+  apriori_boost: 1.0,
+  tolerance_ms: 75.0,
+  use_expected_rounds: true,
+  voter_a_floor_override: null,
+  voter_b_threshold_override: null,
+  voter_c_threshold_override: null,
+  voter_d_threshold_override: null,
+};
+
+export function Lab() {
+  const navigate = useNavigate();
+  const { slug } = useParams<{ slug?: string }>();
+  const [catalog, setCatalog] = useState<LabFixtureRecord[]>([]);
+  const [run, setRun] = useState<LabEvalRun | null>(null);
+  const [config, setConfig] = useState<LabEvalConfig>(DEFAULT_CONFIG);
+  const [evalLoading, setEvalLoading] = useState(false);
+  const [rescoreLoading, setRescoreLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .listLabFixtures()
+      .then(setCatalog)
+      .catch((err) => setError(String(err)));
+  }, []);
+
+  const runEval = useCallback(async () => {
+    setEvalLoading(true);
+    setError(null);
+    try {
+      const result = await api.runLabEval({ config, persist: true });
+      setRun(result);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setEvalLoading(false);
+    }
+  }, [config]);
+
+  // Live rescore: when the user moves a slider, hit /api/lab/rescore. Skip
+  // when we don't have a cached universe yet (the user must run eval at
+  // least once first).
+  useEffect(() => {
+    if (!run) return;
+    setRescoreLoading(true);
+    const id = window.setTimeout(async () => {
+      try {
+        const updated = await api.rescoreLabUniverse(config);
+        setRun(updated);
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setRescoreLoading(false);
+      }
+    }, 120);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config]);
+
+  const focused = useMemo(() => {
+    if (!run || !slug) return null;
+    return run.universe.fixtures.find((f) => f.slug === slug) ?? null;
+  }, [run, slug]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <Beaker className="size-5 text-primary" />
+            Algorithm Lab
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Fixture catalog, ensemble eval, and live tuning. End-user paths are unaffected.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {run && (
+            <Badge variant="outline" className="font-mono text-[10px]">
+              cfg {run.config_hash}
+            </Badge>
+          )}
+          <Button onClick={runEval} disabled={evalLoading}>
+            {evalLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Play className="size-4" />
+            )}
+            {run ? "Re-run eval" : "Run eval"}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="flex items-start gap-2 py-3 text-sm text-destructive">
+            <AlertCircle className="size-4 shrink-0" />
+            {error}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
+        <SummaryCard run={run} rescoreLoading={rescoreLoading} />
+        <TuningCard
+          config={config}
+          run={run}
+          onChange={(next) => setConfig({ ...config, ...next })}
+          onReset={() => setConfig(DEFAULT_CONFIG)}
+        />
+      </div>
+
+      <FixtureTable
+        catalog={catalog}
+        run={run}
+        activeSlug={slug ?? null}
+        onSelect={(s) => navigate(s ? `/lab/${s}` : "/lab")}
+      />
+
+      {focused && <FixtureDetail fixture={focused} onClose={() => navigate("/lab")} />}
+    </div>
+  );
+}
+
+function SummaryCard({
+  run,
+  rescoreLoading,
+}: {
+  run: LabEvalRun | null;
+  rescoreLoading: boolean;
+}) {
+  if (!run) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Run an eval</CardTitle>
+          <CardDescription>
+            Click "Run eval" to score the ensemble against every audited fixture.
+            First run is slow (loads CLAP + PANN); the universe is then cached so
+            slider tweaks rescore in &lt; 100 ms.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  const s = run.summary;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2">
+          Summary
+          {rescoreLoading && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
+        </CardTitle>
+        <CardDescription>
+          Across {s.n_fixtures} fixtures and {s.n_truth} ground-truth shots.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric label="Precision" value={fmtPct(s.precision)} />
+        <Metric label="Recall" value={fmtPct(s.recall)} />
+        <Metric label="F1" value={s.f1.toFixed(3)} />
+        <Metric label="TP / FP / FN" value={`${s.true_positives} / ${s.false_positives} / ${s.false_negatives}`} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-0.5 font-mono text-lg">{value}</div>
+    </div>
+  );
+}
+
+function TuningCard({
+  config,
+  run,
+  onChange,
+  onReset,
+}: {
+  config: LabEvalConfig;
+  run: LabEvalRun | null;
+  onChange: (patch: Partial<LabEvalConfig>) => void;
+  onReset: () => void;
+}) {
+  const cal = run?.universe;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2">
+          <Settings2 className="size-4" />
+          Tuning
+        </CardTitle>
+        <CardDescription>
+          Sliders rescore the cached universe live; "Run eval" refreshes the universe.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Slider
+          label={`Consensus K (${config.consensus} of 4)`}
+          value={config.consensus}
+          min={1}
+          max={4}
+          step={1}
+          onChange={(v) => onChange({ consensus: v })}
+        />
+        <Slider
+          label={`Apriori boost (${config.apriori_boost.toFixed(2)})`}
+          value={config.apriori_boost}
+          min={0}
+          max={2}
+          step={0.05}
+          onChange={(v) => onChange({ apriori_boost: v })}
+        />
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={config.use_expected_rounds}
+            onChange={(e) => onChange({ use_expected_rounds: e.target.checked })}
+          />
+          Use expected_rounds (adaptive voter C + apriori boost)
+        </label>
+        {cal && (
+          <details className="rounded border border-border/60 bg-muted/30 px-3 py-2 text-xs">
+            <summary className="cursor-pointer font-medium">Per-voter threshold overrides</summary>
+            <div className="mt-3 space-y-2">
+              <ThresholdRow
+                label="Voter A floor"
+                calibrated={cal.voter_a_floor}
+                value={config.voter_a_floor_override}
+                onChange={(v) => onChange({ voter_a_floor_override: v })}
+                min={0}
+                max={0.5}
+                step={0.001}
+              />
+              <ThresholdRow
+                label="Voter B threshold"
+                calibrated={cal.voter_b_threshold}
+                value={config.voter_b_threshold_override}
+                onChange={(v) => onChange({ voter_b_threshold_override: v })}
+                min={-0.05}
+                max={0.2}
+                step={0.001}
+              />
+              <ThresholdRow
+                label="Voter C threshold"
+                calibrated={cal.voter_c_threshold}
+                value={config.voter_c_threshold_override}
+                onChange={(v) => onChange({ voter_c_threshold_override: v })}
+                min={0}
+                max={1}
+                step={0.005}
+              />
+              <ThresholdRow
+                label="Voter D threshold"
+                calibrated={cal.voter_d_threshold}
+                value={config.voter_d_threshold_override}
+                onChange={(v) => onChange({ voter_d_threshold_override: v })}
+                min={0}
+                max={0.5}
+                step={0.001}
+              />
+            </div>
+          </details>
+        )}
+        <div className="flex items-center gap-2 pt-1">
+          <Button variant="ghost" size="sm" onClick={onReset}>
+            <RotateCcw className="size-3.5" />
+            Reset
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="block text-xs">
+      <div className="mb-1 font-medium text-foreground">{label}</div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full"
+      />
+    </label>
+  );
+}
+
+function ThresholdRow({
+  label,
+  calibrated,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+}: {
+  label: string;
+  calibrated: number;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  min: number;
+  max: number;
+  step: number;
+}) {
+  const active = value !== null;
+  const display = active ? value : calibrated;
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium">{label}</span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {active ? `override ${display.toFixed(4)}` : `calibrated ${calibrated.toFixed(4)}`}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={display}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="flex-1"
+        />
+        {active && (
+          <button
+            type="button"
+            className="text-[10px] text-muted-foreground hover:text-foreground"
+            onClick={() => onChange(null)}
+          >
+            clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FixtureTable({
+  catalog,
+  run,
+  activeSlug,
+  onSelect,
+}: {
+  catalog: LabFixtureRecord[];
+  run: LabEvalRun | null;
+  activeSlug: string | null;
+  onSelect: (slug: string | null) => void;
+}) {
+  const metricsBySlug = useMemo(() => {
+    const map = new Map<string, LabEvalFixture>();
+    run?.universe.fixtures.forEach((f) => map.set(f.slug, f));
+    return map;
+  }, [run]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Fixtures</CardTitle>
+        <CardDescription>
+          {catalog.length} audited fixtures. Click a row for the per-candidate diff.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60 text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th className="px-4 py-2 text-left font-medium">Slug</th>
+                <th className="px-3 py-2 text-right font-medium">Truth</th>
+                <th className="px-3 py-2 text-right font-medium">Kept</th>
+                <th className="px-3 py-2 text-right font-medium">P</th>
+                <th className="px-3 py-2 text-right font-medium">R</th>
+                <th className="px-3 py-2 text-right font-medium">F1</th>
+                <th className="px-3 py-2 text-right font-medium">FP</th>
+                <th className="px-3 py-2 text-right font-medium">FN</th>
+                <th className="w-8" />
+              </tr>
+            </thead>
+            <tbody>
+              {catalog.map((rec) => {
+                const m = metricsBySlug.get(rec.slug);
+                const active = rec.slug === activeSlug;
+                return (
+                  <tr
+                    key={rec.slug}
+                    className={cn(
+                      "cursor-pointer border-b border-border/40 hover:bg-muted/40",
+                      active && "bg-accent/40",
+                    )}
+                    onClick={() => onSelect(active ? null : rec.slug)}
+                  >
+                    <td className="px-4 py-2 font-mono text-xs">
+                      {rec.slug}
+                      {!rec.has_audio && (
+                        <Badge variant="destructive" className="ml-2 text-[10px]">
+                          no wav
+                        </Badge>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">{rec.n_shots}</td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? m.metrics.n_kept : "--"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? fmtPct(m.metrics.precision) : "--"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? fmtPct(m.metrics.recall) : "--"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? m.metrics.f1.toFixed(3) : "--"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? (
+                        <span className={m.metrics.false_positives ? "text-orange-500" : ""}>
+                          {m.metrics.false_positives}
+                        </span>
+                      ) : (
+                        "--"
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {m ? (
+                        <span className={m.metrics.false_negatives ? "text-red-500" : ""}>
+                          {m.metrics.false_negatives}
+                        </span>
+                      ) : (
+                        "--"
+                      )}
+                    </td>
+                    <td className="px-2 py-2 text-muted-foreground">
+                      <ChevronRight className="size-3.5" />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FixtureDetail({
+  fixture,
+  onClose,
+}: {
+  fixture: LabEvalFixture;
+  onClose: () => void;
+}) {
+  const [peaks, setPeaks] = useState<PeaksResult | null>(null);
+  const [time, setTime] = useState(0);
+
+  useEffect(() => {
+    setPeaks(null);
+    api
+      .getFixturePeaks(fixture.audit_path)
+      .then(setPeaks)
+      .catch(() => setPeaks(null));
+  }, [fixture.audit_path]);
+
+  const fps = fixture.candidates.filter((c) => c.kept && c.truth === 0);
+  const fns = fixture.truth_times.filter((t) => {
+    const matched = fixture.candidates.some((c) => c.truth === 1 && c.matched_shot_number !== null && Math.abs(c.time - t) < 0.001);
+    return !matched;
+  });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
+        <div>
+          <CardTitle className="font-mono text-base">{fixture.slug}</CardTitle>
+          <CardDescription>
+            {fixture.metrics.n_truth} ground-truth shots, {fixture.metrics.n_kept} kept --
+            P {fmtPct(fixture.metrics.precision)} / R {fmtPct(fixture.metrics.recall)} /
+            F1 {fixture.metrics.f1.toFixed(3)}
+          </CardDescription>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Close
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {peaks ? (
+          <Waveform
+            peaks={peaks.peaks}
+            duration={peaks.duration}
+            currentTime={time}
+            onScrub={setTime}
+            beepTime={peaks.beep_time}
+            height={140}
+          >
+            {/* Predicted shots (kept). Truth-positive (TP) green, false (FP) orange. */}
+            {fixture.candidates
+              .filter((c) => c.kept)
+              .map((c) => (
+                <Pin
+                  key={`p-${c.candidate_number}`}
+                  time={c.time}
+                  duration={peaks.duration}
+                  color={c.truth === 1 ? "var(--success, #22c55e)" : "#f97316"}
+                  label={c.truth === 1 ? "TP" : "FP"}
+                />
+              ))}
+            {/* Ground truth that no kept candidate matched (FN). */}
+            {fns.map((t, i) => (
+              <Pin
+                key={`fn-${i}`}
+                time={t}
+                duration={peaks.duration}
+                color="#ef4444"
+                label="FN"
+                top
+              />
+            ))}
+          </Waveform>
+        ) : (
+          <div className="flex h-[140px] items-center justify-center rounded border border-border/40 bg-muted/30 text-xs text-muted-foreground">
+            <Loader2 className="mr-2 size-4 animate-spin" /> loading waveform...
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <VoterRecallTable metrics={fixture.metrics} />
+          <DiffList fps={fps} fns={fns} />
+        </div>
+
+        <CandidateTable candidates={fixture.candidates} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Pin({
+  time,
+  duration,
+  color,
+  label,
+  top,
+}: {
+  time: number;
+  duration: number;
+  color: string;
+  label: string;
+  top?: boolean;
+}) {
+  const left = duration > 0 ? `${(time / duration) * 100}%` : "0%";
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{
+        left,
+        top: top ? 4 : undefined,
+        bottom: top ? undefined : 4,
+        width: 2,
+        height: 32,
+        background: color,
+        transform: "translateX(-1px)",
+      }}
+      title={`${label} @ ${time.toFixed(3)}s`}
+    />
+  );
+}
+
+function VoterRecallTable({ metrics }: { metrics: LabEvalFixture["metrics"] }) {
+  const order: Array<keyof typeof metrics.voter_recall> = ["vote_a", "vote_b", "vote_c", "vote_d"];
+  return (
+    <div className="rounded border border-border/60 p-3">
+      <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Per-voter recall on this fixture
+      </div>
+      <div className="grid grid-cols-4 gap-2 text-center">
+        {order.map((k) => (
+          <div key={String(k)}>
+            <div className="text-[10px] uppercase text-muted-foreground">{String(k).slice(-1).toUpperCase()}</div>
+            <div className="font-mono text-sm">{fmtPct(metrics.voter_recall[k as string] ?? 0)}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DiffList({
+  fps,
+  fns,
+}: {
+  fps: { time: number; ensemble_score: number; vote_total: number }[];
+  fns: number[];
+}) {
+  return (
+    <div className="rounded border border-border/60 p-3 text-xs">
+      <div className="mb-2 font-semibold uppercase tracking-wide text-muted-foreground">
+        Diffs
+      </div>
+      {fps.length === 0 && fns.length === 0 && (
+        <div className="flex items-center gap-1 text-success">
+          <CheckCircle2 className="size-3.5" /> no diffs
+        </div>
+      )}
+      {fps.length > 0 && (
+        <div className="mb-2">
+          <div className="text-[10px] uppercase text-orange-500">false positives ({fps.length})</div>
+          <ul className="mt-1 space-y-0.5 font-mono">
+            {fps.slice(0, 8).map((c, i) => (
+              <li key={`fp-${i}`}>{c.time.toFixed(3)}s -- vote {c.vote_total} (score {c.ensemble_score.toFixed(2)})</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {fns.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase text-red-500">false negatives ({fns.length})</div>
+          <ul className="mt-1 space-y-0.5 font-mono">
+            {fns.slice(0, 8).map((t, i) => (
+              <li key={`fn-${i}`}>{t.toFixed(3)}s</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CandidateTable({
+  candidates,
+}: {
+  candidates: LabEvalFixture["candidates"];
+}) {
+  return (
+    <details className="rounded border border-border/60">
+      <summary className="cursor-pointer px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Candidates ({candidates.length})
+      </summary>
+      <div className="max-h-72 overflow-y-auto">
+        <table className="w-full text-xs">
+          <thead className="sticky top-0 bg-card text-[10px] uppercase tracking-wide text-muted-foreground">
+            <tr className="border-b border-border/40">
+              <th className="px-2 py-1 text-left font-medium">#</th>
+              <th className="px-2 py-1 text-right font-medium">t (s)</th>
+              <th className="px-2 py-1 text-right font-medium">conf</th>
+              <th className="px-2 py-1 text-right font-medium">A</th>
+              <th className="px-2 py-1 text-right font-medium">B</th>
+              <th className="px-2 py-1 text-right font-medium">C</th>
+              <th className="px-2 py-1 text-right font-medium">D</th>
+              <th className="px-2 py-1 text-right font-medium">score</th>
+              <th className="px-2 py-1 text-center font-medium">kept</th>
+              <th className="px-2 py-1 text-center font-medium">truth</th>
+            </tr>
+          </thead>
+          <tbody>
+            {candidates.map((c) => {
+              const isTP = c.kept && c.truth === 1;
+              const isFP = c.kept && c.truth === 0;
+              const isFN = !c.kept && c.truth === 1;
+              return (
+                <tr
+                  key={c.candidate_number}
+                  className={cn(
+                    "border-b border-border/20 font-mono",
+                    isTP && "bg-emerald-500/5",
+                    isFP && "bg-orange-500/10",
+                    isFN && "bg-red-500/10",
+                  )}
+                >
+                  <td className="px-2 py-1">{c.candidate_number}</td>
+                  <td className="px-2 py-1 text-right">{c.time.toFixed(3)}</td>
+                  <td className="px-2 py-1 text-right">{c.confidence.toFixed(3)}</td>
+                  <td className="px-2 py-1 text-right">{c.vote_a}</td>
+                  <td className="px-2 py-1 text-right">{c.vote_b}</td>
+                  <td className="px-2 py-1 text-right">{c.vote_c}</td>
+                  <td className="px-2 py-1 text-right">{c.vote_d}</td>
+                  <td className="px-2 py-1 text-right">{c.ensemble_score.toFixed(2)}</td>
+                  <td className="px-2 py-1 text-center">{c.kept ? "Y" : ""}</td>
+                  <td className="px-2 py-1 text-center">{c.truth ? "Y" : ""}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+function fmtPct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   AlertCircle,
   Beaker,
@@ -26,6 +26,7 @@ import {
   ChevronRight,
   Hammer,
   Loader2,
+  Pencil,
   Play,
   RotateCcw,
   Save,
@@ -511,7 +512,18 @@ function FixtureTable({
                       )}
                     </td>
                     <td className="px-2 py-2 text-muted-foreground">
-                      <ChevronRight className="size-3.5" />
+                      <div className="flex items-center justify-end gap-1">
+                        <Link
+                          to={`/review?fixture=${encodeURIComponent(rec.audit_path)}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                          title="Re-label this fixture in the review editor"
+                          aria-label={`Re-label ${rec.slug}`}
+                        >
+                          <Pencil className="size-3.5" />
+                        </Link>
+                        <ChevronRight className="size-3.5" />
+                      </div>
                     </td>
                   </tr>
                 );
@@ -559,9 +571,20 @@ function FixtureDetail({
             F1 {fixture.metrics.f1.toFixed(3)}
           </CardDescription>
         </div>
-        <Button variant="ghost" size="sm" onClick={onClose}>
-          Close
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link
+              to={`/review?fixture=${encodeURIComponent(fixture.audit_path)}`}
+              title="Open this fixture in the review editor (re-label shots, edit beep, save in place)"
+            >
+              <Pencil className="size-3.5" />
+              Re-label
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="space-y-4">
         {peaks ? (


### PR DESCRIPTION
## Summary
- Adds a `/lab` route + `splitsmith lab` CLI mirror so fixture management, ensemble evaluation, and threshold tuning live in one place. End-user paths (Ingest, Audit, Export) are untouched; Lab is a separate sidebar entry plus an optional "Promote to fixture" popover on Audit.
- Backend: pure-function `splitsmith.lab` core (catalog / run_eval / rescore_universe / promote / persist), wired to `/api/lab/fixtures|eval|rescore|promote`. The heavy CLAP/PANN/GBDT pass runs once and produces a cached candidate universe; slider rescores hit numpy only and complete in <100ms.
- Frontend: catalog table with per-fixture P/R/F1, summary card, consensus + apriori sliders, per-voter threshold overrides, and a per-fixture detail with waveform overlay (TP/FP/FN pins), per-voter recall, FP/FN diff list, and candidate table colored by outcome.
- Claude-Code symmetry: every UI action has a CLI counterpart with identical JSON output, runs persist deterministically to `build/lab/runs/<stamp>-<hash>.json`, and tuning configs export to committable `configs/ensemble.<slug>.yaml`.

## Test plan
- [x] `uv run pytest -x -q` (468 passed, 1 skipped -- preexisting)
- [x] `npx tsc -p tsconfig.app.json` clean
- [x] `npm run build` succeeds
- [x] `splitsmith lab fixtures` lists the 12 audited fixtures
- [x] `/api/lab/fixtures` returns 200 from a fresh project
- [x] `/api/lab/rescore` returns 409 when no eval has run yet
- [x] `/api/lab/promote` returns 404 for unknown stage
- [ ] Manual: open `/lab`, click Run eval, sweep sliders, open a fixture detail, promote a stage from Audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)