### PR TITLE
lab: categorical labels for candidates (closes #86)

### DIFF
--- a/LAB.md
+++ b/LAB.md
@@ -215,6 +215,58 @@ review UI), and either:
 - promote-then-audit by opening it in the production UI's `/review`
   route and editing in place.
 
+### Categorical labeling (issue #86)
+
+Each candidate in the fixture catalog can carry a category label so eval can
+break down precision *by failure mode*:
+
+- **Rejected (FP) candidates**: optional ``reason`` --
+  ``cross_bay``, ``echo``, ``wind``, ``movement``, ``steel_ring``,
+  ``speech``, ``handling``, ``agc_artifact``, ``other``, ``unknown``.
+- **Kept (TP) candidates**: optional ``subclass`` -- ``paper``, ``steel``,
+  ``unknown``.
+
+How to label from the UI:
+
+1. Open a fixture's detail card in the Lab.
+2. The candidate table at the bottom now has a **label** column. Each
+   row shows a dropdown -- positives get the subclass options, rejected
+   candidates get the FP reasons.
+3. Picking a value auto-saves through ``POST /api/lab/labels``. The
+   detail card refreshes (eval re-runs in the background) so the
+   "Label breakdown" panel + the corpus-wide counts on the Summary card
+   update right away.
+4. Clear a label by selecting ``--``.
+
+How to label from the CLI:
+
+```bash
+uv run splitsmith lab label \
+  --audit-json tests/fixtures/stage-shots-myclub-2026-stage4.json \
+  --candidate 12 \
+  --reason cross_bay
+```
+
+Use ``--clear-reason`` / ``--clear-subclass`` to remove an existing
+label. Atomic write with a ``.bak`` backup of the prior JSON.
+
+What you get back, in eval output:
+
+- ``EvalRun.summary.fp_by_reason`` -- corpus-wide FP composition.
+- ``EvalRun.summary.positives_by_subclass`` -- corpus-wide TP composition.
+- ``EvalFixture.metrics.fp_by_reason`` / ``positives_by_subclass`` -- per fixture.
+
+Unlabeled FPs / positives are counted under the ``unlabeled`` key, so
+you can track labeling progress over time. The "Label breakdown" panel
+in the fixture detail and the summary card render these directly.
+
+> **Why bother labeling?** With 12 fixtures and ~1500-2000 negatives, you
+> don't have enough data for a clean multi-class classifier. But labels
+> still pay off in three ways: (1) measurement -- "of 35 surviving FPs,
+> 22 are cross_bay" beats "the user thinks cross-bay is the worst";
+> (2) hard negatives for binary specialist voters (cross-bay first); (3)
+> ready-to-go training set for #10 (vision) and #18 (community corpus).
+
 ### Re-labeling an existing fixture
 
 You don't have to promote a stage from scratch to fix labels. Two ways:
@@ -576,6 +628,7 @@ Top-level keys: `config`, `summary`, `universe`, `config_hash`, `built_at`.
 | POST | `/api/lab/eval` | `{slugs?, config?, persist?}` | Slow path. Caches universe server-side and (by default) writes `build/lab/runs/<...>.json`. |
 | POST | `/api/lab/rescore` | `{config}` | Uses last cached universe. 409 if no eval has run. |
 | POST | `/api/lab/promote` | `{stage_number, slug, overwrite?}` | Copies stage audit JSON + WAV into `tests/fixtures/`. |
+| POST | `/api/lab/labels` | `{audit_path, labels: [{candidate_number, reason?, subclass?}]}` | Patches categorical labels on a fixture's audit JSON. Drops the cached universe so the next eval reloads. |
 | POST | `/api/lab/save-config` | `{name, note?, overwrite?}` | Persists the active run's config + summary as `configs/ensemble.<name>.yaml`. 409 when no eval has run. |
 | POST | `/api/lab/rebuild-calibration` | `{target_recall?, tolerance_ms?, fixtures?}` | Submits a `rebuild_calibration` job that re-runs the calibration build script. Poll `/api/jobs/{id}` for progress. |
 

--- a/src/splitsmith/lab/__init__.py
+++ b/src/splitsmith/lab/__init__.py
@@ -19,6 +19,9 @@ JSON so they're greppable, diffable, and Claude-Code-friendly.
 """
 
 from .core import (
+    REASON_VALUES,
+    SUBCLASS_VALUES,
+    CandidateLabel,
     EvalCandidate,
     EvalConfig,
     EvalFixture,
@@ -28,6 +31,7 @@ from .core import (
     FixtureRecord,
     PromoteRequest,
     RunSummary,
+    apply_labels,
     list_fixtures,
     load_run,
     promote_stage_to_fixture,
@@ -38,6 +42,9 @@ from .core import (
 )
 
 __all__ = [
+    "REASON_VALUES",
+    "SUBCLASS_VALUES",
+    "CandidateLabel",
     "EvalCandidate",
     "EvalConfig",
     "EvalFixture",
@@ -47,6 +54,7 @@ __all__ = [
     "FixtureRecord",
     "PromoteRequest",
     "RunSummary",
+    "apply_labels",
     "list_fixtures",
     "load_run",
     "promote_stage_to_fixture",

--- a/src/splitsmith/lab/core.py
+++ b/src/splitsmith/lab/core.py
@@ -119,6 +119,23 @@ class EvalConfig(BaseModel):
         return EnsembleConfig(consensus=self.consensus, apriori_boost=self.apriori_boost)
 
 
+REASON_VALUES: tuple[str, ...] = (
+    "cross_bay",
+    "echo",
+    "wind",
+    "movement",
+    "steel_ring",
+    "speech",
+    "handling",
+    "agc_artifact",
+    "other",
+    "unknown",
+)
+SUBCLASS_VALUES: tuple[str, ...] = ("paper", "steel", "unknown")
+UNLABELED_REASON: str = "unlabeled"
+UNLABELED_SUBCLASS: str = "unlabeled"
+
+
 class EvalCandidate(BaseModel):
     """One candidate enriched with ground-truth label for diffing."""
 
@@ -140,6 +157,20 @@ class EvalCandidate(BaseModel):
     kept: bool
     truth: int = Field(description="1 if matched to a ground-truth shot within tolerance, else 0.")
     matched_shot_number: int | None = None
+    reason: str | None = Field(
+        default=None,
+        description=(
+            "Optional FP class for rejected candidates (issue #86). "
+            "One of REASON_VALUES; ``None`` when unlabeled."
+        ),
+    )
+    subclass: str | None = Field(
+        default=None,
+        description=(
+            "Optional positive subclass for kept candidates (issue #86). "
+            "One of SUBCLASS_VALUES; ``None`` when unlabeled."
+        ),
+    )
 
 
 class EvalFixtureMetrics(BaseModel):
@@ -155,6 +186,20 @@ class EvalFixtureMetrics(BaseModel):
     f1: float
     voter_recall: dict[str, float] = Field(
         description="Recall when only a single voter's vote is required (informational).",
+    )
+    fp_by_reason: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Surviving FPs grouped by ``reason`` label (issue #86). "
+            "Unlabeled FPs are counted under the ``unlabeled`` key."
+        ),
+    )
+    positives_by_subclass: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Kept TPs grouped by ``subclass`` label (issue #86). "
+            "Unlabeled positives are counted under ``unlabeled``."
+        ),
     )
 
 
@@ -200,6 +245,14 @@ class RunSummary(BaseModel):
     precision: float
     recall: float
     f1: float
+    fp_by_reason: dict[str, int] = Field(
+        default_factory=dict,
+        description="Corpus-wide FP counts by ``reason`` label (issue #86).",
+    )
+    positives_by_subclass: dict[str, int] = Field(
+        default_factory=dict,
+        description="Corpus-wide kept TP counts by ``subclass`` label (issue #86).",
+    )
 
 
 class EvalRun(BaseModel):
@@ -266,6 +319,21 @@ def _metrics(
             voter_recall[key] = sum(getattr(c, key) for c in truth_caps) / n_truth
     else:
         voter_recall = {"vote_a": 0.0, "vote_b": 0.0, "vote_c": 0.0, "vote_d": 0.0}
+
+    fp_by_reason: dict[str, int] = {}
+    for c in kept:
+        if c.truth == 1:
+            continue
+        key = c.reason or UNLABELED_REASON
+        fp_by_reason[key] = fp_by_reason.get(key, 0) + 1
+
+    positives_by_subclass: dict[str, int] = {}
+    for c in kept:
+        if c.truth != 1:
+            continue
+        key = c.subclass or UNLABELED_SUBCLASS
+        positives_by_subclass[key] = positives_by_subclass.get(key, 0) + 1
+
     return EvalFixtureMetrics(
         n_truth=n_truth,
         n_kept=n_kept,
@@ -276,6 +344,8 @@ def _metrics(
         recall=round(recall, 4),
         f1=round(f1, 4),
         voter_recall={k: round(v, 4) for k, v in voter_recall.items()},
+        fp_by_reason=fp_by_reason,
+        positives_by_subclass=positives_by_subclass,
     )
 
 
@@ -288,6 +358,15 @@ def _summary(fixtures: list[EvalFixture]) -> RunSummary:
     precision = tp / n_kept if n_kept else 0.0
     recall = tp / n_truth if n_truth else 0.0
     f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    fp_by_reason: dict[str, int] = {}
+    positives_by_subclass: dict[str, int] = {}
+    for f in fixtures:
+        for k, v in f.metrics.fp_by_reason.items():
+            fp_by_reason[k] = fp_by_reason.get(k, 0) + v
+        for k, v in f.metrics.positives_by_subclass.items():
+            positives_by_subclass[k] = positives_by_subclass.get(k, 0) + v
+
     return RunSummary(
         n_fixtures=len(fixtures),
         n_truth=n_truth,
@@ -298,7 +377,108 @@ def _summary(fixtures: list[EvalFixture]) -> RunSummary:
         precision=round(precision, 4),
         recall=round(recall, 4),
         f1=round(f1, 4),
+        fp_by_reason=fp_by_reason,
+        positives_by_subclass=positives_by_subclass,
     )
+
+
+def _time_key(t: float) -> float:
+    """Stable key for matching live candidates to stored audit entries.
+
+    Round to 3 decimals (1 ms): the audit JSON canonically rounds times to
+    4 decimals, so anything tighter than 1 ms is noise from float repr.
+    """
+    return round(float(t), 3)
+
+
+def _load_labels_from_audit(audit: dict[str, Any]) -> tuple[dict[float, str], dict[float, str]]:
+    """Extract ``reason`` (rejected) + ``subclass`` (kept) labels keyed by time."""
+    reason_by_time: dict[float, str] = {}
+    subclass_by_time: dict[float, str] = {}
+
+    pending = audit.get("_candidates_pending_audit") or {}
+    for c in pending.get("candidates", []):
+        t = c.get("time")
+        reason = c.get("reason")
+        if t is None or not isinstance(reason, str) or not reason:
+            continue
+        reason_by_time[_time_key(t)] = reason
+
+    for s in audit.get("shots", []):
+        t = s.get("time")
+        sub = s.get("subclass")
+        if t is None or not isinstance(sub, str) or not sub:
+            continue
+        subclass_by_time[_time_key(t)] = sub
+
+    return reason_by_time, subclass_by_time
+
+
+class CandidateLabel(BaseModel):
+    """One label patch to apply via :func:`apply_labels`."""
+
+    candidate_number: int
+    reason: str | None = Field(
+        default=None,
+        description="FP class for a rejected candidate; ``None`` clears any prior label.",
+    )
+    subclass: str | None = Field(
+        default=None,
+        description="Positive subclass for a kept candidate; ``None`` clears any prior label.",
+    )
+
+
+def apply_labels(audit_path: Path, labels: list[CandidateLabel]) -> dict[str, int]:
+    """Patch ``reason`` / ``subclass`` fields on a fixture audit JSON in place.
+
+    Atomic: writes a ``.tmp`` then renames; existing JSON is rotated to
+    ``.bak`` (replacing any prior backup). Mirrors the pattern in
+    ``/api/fixture/audit`` PUT.
+
+    Returns counts of fields actually changed:
+    ``{reason_set, reason_cleared, subclass_set, subclass_cleared}``.
+    Unknown candidate_numbers are silently skipped so a partial UI save
+    against a stale fixture doesn't fail the whole batch.
+    """
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    pending = audit.setdefault("_candidates_pending_audit", {})
+    cands = pending.setdefault("candidates", [])
+    cand_by_number = {int(c.get("candidate_number", -1)): c for c in cands}
+    shots = audit.setdefault("shots", [])
+    shot_by_cand_number = {int(s.get("candidate_number", -1)): s for s in shots}
+
+    counts = {"reason_set": 0, "reason_cleared": 0, "subclass_set": 0, "subclass_cleared": 0}
+    for label in labels:
+        # reason -> rejected candidate entry
+        target = cand_by_number.get(label.candidate_number)
+        if target is not None and label.reason is not None:
+            if label.reason not in REASON_VALUES:
+                raise ValueError(f"unknown reason: {label.reason!r}")
+            target["reason"] = label.reason
+            counts["reason_set"] += 1
+        elif target is not None and label.reason is None and "reason" in target:
+            target.pop("reason", None)
+            counts["reason_cleared"] += 1
+
+        # subclass -> kept shot entry
+        shot = shot_by_cand_number.get(label.candidate_number)
+        if shot is not None and label.subclass is not None:
+            if label.subclass not in SUBCLASS_VALUES:
+                raise ValueError(f"unknown subclass: {label.subclass!r}")
+            shot["subclass"] = label.subclass
+            counts["subclass_set"] += 1
+        elif shot is not None and label.subclass is None and "subclass" in shot:
+            shot.pop("subclass", None)
+            counts["subclass_cleared"] += 1
+
+    tmp = audit_path.with_suffix(audit_path.suffix + ".tmp")
+    backup = audit_path.with_suffix(audit_path.suffix + ".bak")
+    tmp.write_text(json.dumps(audit, indent=2) + "\n", encoding="utf-8")
+    if backup.exists():
+        backup.unlink()
+    audit_path.replace(backup)
+    tmp.replace(audit_path)
+    return counts
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +528,7 @@ def run_eval(
         labels, matched, truth_times = _label_truth(
             cand_times, audit.get("shots", []), cfg.tolerance_ms
         )
+        reason_by_time, subclass_by_time = _load_labels_from_audit(audit)
         candidates = [
             EvalCandidate(
                 candidate_number=c.candidate_number,
@@ -368,6 +549,8 @@ def run_eval(
                 kept=c.kept,
                 truth=int(labels[i]),
                 matched_shot_number=matched[i],
+                reason=reason_by_time.get(_time_key(c.time)),
+                subclass=subclass_by_time.get(_time_key(c.time)),
             )
             for i, c in enumerate(result.candidates)
         ]

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -215,6 +215,37 @@ def save_config(
     sys.stdout.write(str(target) + "\n")
 
 
+@app.command("label")
+def label(
+    audit_json: Path = typer.Option(..., "--audit-json", help="Path to a fixture's audit JSON."),
+    candidate: int = typer.Option(..., "--candidate", help="candidate_number to label."),
+    reason: str | None = typer.Option(
+        None,
+        "--reason",
+        help="One of REASON_VALUES; clear with --clear-reason.",
+    ),
+    subclass: str | None = typer.Option(
+        None,
+        "--subclass",
+        help="One of SUBCLASS_VALUES (paper/steel/unknown); clear with --clear-subclass.",
+    ),
+    clear_reason: bool = typer.Option(False, "--clear-reason"),
+    clear_subclass: bool = typer.Option(False, "--clear-subclass"),
+    pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
+) -> None:
+    """Patch one candidate's reason / subclass in a fixture audit JSON (issue #86)."""
+    payload = lab_module.CandidateLabel(
+        candidate_number=candidate,
+        reason=None if clear_reason else reason,
+        subclass=None if clear_subclass else subclass,
+    )
+    try:
+        counts = lab_module.apply_labels(audit_json.expanduser().resolve(), [payload])
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _emit({"path": str(audit_json), "counts": counts}, pretty=pretty)
+
+
 @app.command("load-config")
 def load_config(
     path: Path = typer.Argument(..., exists=True, readable=True),

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3472,6 +3472,58 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return JSONResponse(rec.model_dump(mode="json"))
 
+    @app.post("/api/lab/labels")
+    def lab_labels(payload: dict[str, Any] = Body(...)) -> JSONResponse:  # noqa: B008
+        """Apply categorical labels to a fixture's audit JSON (issue #86).
+
+        Body shape::
+
+            {
+              "audit_path": "...stage-shots-foo-2026-stage4.json",
+              "labels": [
+                {"candidate_number": 7,  "reason": "cross_bay"},
+                {"candidate_number": 14, "reason": null},
+                {"candidate_number": 22, "subclass": "steel"}
+              ]
+            }
+
+        Patches in place with a ``.bak`` backup; returns counts of fields
+        actually changed. Drops the cached eval universe so the next
+        ``/api/lab/eval`` rebuilds it with the fresh labels.
+        """
+        audit_path = payload.get("audit_path")
+        labels_payload = payload.get("labels")
+        if not isinstance(audit_path, str) or not audit_path:
+            raise HTTPException(
+                status_code=400,
+                detail="payload must include 'audit_path' (string)",
+            )
+        if not isinstance(labels_payload, list):
+            raise HTTPException(
+                status_code=400,
+                detail="payload must include 'labels' (list)",
+            )
+        try:
+            target = Path(audit_path).expanduser().resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"fixture not found: {audit_path}",
+            ) from exc
+        if not target.is_file():
+            raise HTTPException(status_code=400, detail=f"not a file: {target}")
+        try:
+            labels = [lab_module.CandidateLabel.model_validate(item) for item in labels_payload]
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"invalid labels: {exc}") from exc
+        try:
+            counts = lab_module.apply_labels(target, labels)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        _lab_universe_cache.pop("universe", None)
+        _lab_universe_cache.pop("last_run", None)
+        return JSONResponse({"path": str(target), "counts": counts})
+
     @app.post("/api/lab/save-config")
     def lab_save_config(payload: dict[str, Any] = Body(...)) -> JSONResponse:  # noqa: B008
         """Write a finished run's config + provenance to ``configs/<name>.yaml``.

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1014,6 +1014,15 @@ export const api = {
   saveLabConfig: (payload: { name: string; note?: string; overwrite?: boolean }) =>
     request<{ path: string }>("/api/lab/save-config", { method: "POST", json: payload }),
 
+  applyLabLabels: (payload: {
+    audit_path: string;
+    labels: { candidate_number: number; reason?: string | null; subclass?: string | null }[];
+  }) =>
+    request<{ path: string; counts: Record<string, number> }>("/api/lab/labels", {
+      method: "POST",
+      json: payload,
+    }),
+
   rebuildLabCalibration: (payload: { target_recall?: number; tolerance_ms?: number; fixtures?: string[] } = {}) =>
     request<Job>("/api/lab/rebuild-calibration", { method: "POST", json: payload }),
 };
@@ -1062,7 +1071,26 @@ export interface LabEvalCandidate {
   kept: boolean;
   truth: number;
   matched_shot_number: number | null;
+  reason: string | null;
+  subclass: string | null;
 }
+
+export const LAB_REASONS = [
+  "cross_bay",
+  "echo",
+  "wind",
+  "movement",
+  "steel_ring",
+  "speech",
+  "handling",
+  "agc_artifact",
+  "other",
+  "unknown",
+] as const;
+export type LabReason = (typeof LAB_REASONS)[number];
+
+export const LAB_SUBCLASSES = ["paper", "steel", "unknown"] as const;
+export type LabSubclass = (typeof LAB_SUBCLASSES)[number];
 
 export interface LabEvalFixtureMetrics {
   n_truth: number;
@@ -1074,6 +1102,8 @@ export interface LabEvalFixtureMetrics {
   recall: number;
   f1: number;
   voter_recall: Record<string, number>;
+  fp_by_reason: Record<string, number>;
+  positives_by_subclass: Record<string, number>;
 }
 
 export interface LabEvalFixture {
@@ -1098,6 +1128,8 @@ export interface LabRunSummary {
   precision: number;
   recall: number;
   f1: number;
+  fp_by_reason: Record<string, number>;
+  positives_by_subclass: Record<string, number>;
 }
 
 export interface LabEvalUniverse {

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -45,6 +45,8 @@ import {
 } from "@/components/ui/card";
 import {
   api,
+  LAB_REASONS,
+  LAB_SUBCLASSES,
   type Job,
   type LabEvalConfig,
   type LabEvalFixture,
@@ -177,7 +179,13 @@ export function Lab() {
         onSelect={(s) => navigate(s ? `/lab/${s}` : "/lab")}
       />
 
-      {focused && <FixtureDetail fixture={focused} onClose={() => navigate("/lab")} />}
+      {focused && (
+        <FixtureDetail
+          fixture={focused}
+          onClose={() => navigate("/lab")}
+          onLabelChanged={runEval}
+        />
+      )}
     </div>
   );
 }
@@ -215,11 +223,20 @@ function SummaryCard({
           Across {s.n_fixtures} fixtures and {s.n_truth} ground-truth shots.
         </CardDescription>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Metric label="Precision" value={fmtPct(s.precision)} />
-        <Metric label="Recall" value={fmtPct(s.recall)} />
-        <Metric label="F1" value={s.f1.toFixed(3)} />
-        <Metric label="TP / FP / FN" value={`${s.true_positives} / ${s.false_positives} / ${s.false_negatives}`} />
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Metric label="Precision" value={fmtPct(s.precision)} />
+          <Metric label="Recall" value={fmtPct(s.recall)} />
+          <Metric label="F1" value={s.f1.toFixed(3)} />
+          <Metric
+            label="TP / FP / FN"
+            value={`${s.true_positives} / ${s.false_positives} / ${s.false_negatives}`}
+          />
+        </div>
+        <LabelBreakdown
+          fpByReason={s.fp_by_reason}
+          positivesBySubclass={s.positives_by_subclass}
+        />
       </CardContent>
     </Card>
   );
@@ -539,12 +556,15 @@ function FixtureTable({
 function FixtureDetail({
   fixture,
   onClose,
+  onLabelChanged,
 }: {
   fixture: LabEvalFixture;
   onClose: () => void;
+  onLabelChanged: () => void;
 }) {
   const [peaks, setPeaks] = useState<PeaksResult | null>(null);
   const [time, setTime] = useState(0);
+  const [savingLabel, setSavingLabel] = useState<number | null>(null);
 
   useEffect(() => {
     setPeaks(null);
@@ -553,6 +573,27 @@ function FixtureDetail({
       .then(setPeaks)
       .catch(() => setPeaks(null));
   }, [fixture.audit_path]);
+
+  const handleLabel = useCallback(
+    async (
+      candidate_number: number,
+      patch: { reason?: string | null; subclass?: string | null },
+    ) => {
+      setSavingLabel(candidate_number);
+      try {
+        await api.applyLabLabels({
+          audit_path: fixture.audit_path,
+          labels: [{ candidate_number, ...patch }],
+        });
+        onLabelChanged();
+      } catch (err) {
+        console.error("label save failed", err);
+      } finally {
+        setSavingLabel(null);
+      }
+    },
+    [fixture.audit_path, onLabelChanged],
+  );
 
   const fps = fixture.candidates.filter((c) => c.kept && c.truth === 0);
   const fns = fixture.truth_times.filter((t) => {
@@ -631,7 +672,16 @@ function FixtureDetail({
           <DiffList fps={fps} fns={fns} />
         </div>
 
-        <CandidateTable candidates={fixture.candidates} />
+        <LabelBreakdown
+          fpByReason={fixture.metrics.fp_by_reason}
+          positivesBySubclass={fixture.metrics.positives_by_subclass}
+        />
+
+        <CandidateTable
+          candidates={fixture.candidates}
+          onLabel={handleLabel}
+          savingLabel={savingLabel}
+        />
       </CardContent>
     </Card>
   );
@@ -730,15 +780,22 @@ function DiffList({
 
 function CandidateTable({
   candidates,
+  onLabel,
+  savingLabel,
 }: {
   candidates: LabEvalFixture["candidates"];
+  onLabel: (
+    candidate_number: number,
+    patch: { reason?: string | null; subclass?: string | null },
+  ) => void;
+  savingLabel: number | null;
 }) {
   return (
-    <details className="rounded border border-border/60">
+    <details className="rounded border border-border/60" open>
       <summary className="cursor-pointer px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Candidates ({candidates.length})
+        Candidates ({candidates.length}) -- label rejected with FP class, kept with paper/steel
       </summary>
-      <div className="max-h-72 overflow-y-auto">
+      <div className="max-h-96 overflow-y-auto">
         <table className="w-full text-xs">
           <thead className="sticky top-0 bg-card text-[10px] uppercase tracking-wide text-muted-foreground">
             <tr className="border-b border-border/40">
@@ -752,6 +809,7 @@ function CandidateTable({
               <th className="px-2 py-1 text-right font-medium">score</th>
               <th className="px-2 py-1 text-center font-medium">kept</th>
               <th className="px-2 py-1 text-center font-medium">truth</th>
+              <th className="px-2 py-1 text-left font-medium">label</th>
             </tr>
           </thead>
           <tbody>
@@ -759,6 +817,7 @@ function CandidateTable({
               const isTP = c.kept && c.truth === 1;
               const isFP = c.kept && c.truth === 0;
               const isFN = !c.kept && c.truth === 1;
+              const saving = savingLabel === c.candidate_number;
               return (
                 <tr
                   key={c.candidate_number}
@@ -779,6 +838,13 @@ function CandidateTable({
                   <td className="px-2 py-1 text-right">{c.ensemble_score.toFixed(2)}</td>
                   <td className="px-2 py-1 text-center">{c.kept ? "Y" : ""}</td>
                   <td className="px-2 py-1 text-center">{c.truth ? "Y" : ""}</td>
+                  <td className="px-2 py-1">
+                    <LabelDropdown
+                      candidate={c}
+                      onChange={(patch) => onLabel(c.candidate_number, patch)}
+                      saving={saving}
+                    />
+                  </td>
                 </tr>
               );
             })}
@@ -786,6 +852,116 @@ function CandidateTable({
         </table>
       </div>
     </details>
+  );
+}
+
+function LabelDropdown({
+  candidate,
+  onChange,
+  saving,
+}: {
+  candidate: LabEvalFixture["candidates"][number];
+  onChange: (patch: { reason?: string | null; subclass?: string | null }) => void;
+  saving: boolean;
+}) {
+  // Kept positive (TP): edit subclass. Kept FP: edit reason. Rejected
+  // candidates aren't worth labelling -- they don't survive consensus
+  // so they don't pollute precision -- but we still let the user tag a
+  // reason for rejected ones if they want a record (e.g. for #87
+  // mining cross-references).
+  const isKept = candidate.kept;
+  const isPositive = candidate.truth === 1;
+  if (isKept && isPositive) {
+    return (
+      <div className="flex items-center gap-1">
+        <select
+          value={candidate.subclass ?? ""}
+          onChange={(e) => onChange({ subclass: e.target.value || null })}
+          className="rounded border border-border/60 bg-background px-1 py-0.5 text-[11px]"
+          disabled={saving}
+        >
+          <option value="">--</option>
+          {LAB_SUBCLASSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        {saving && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-1">
+      <select
+        value={candidate.reason ?? ""}
+        onChange={(e) => onChange({ reason: e.target.value || null })}
+        className={cn(
+          "rounded border border-border/60 bg-background px-1 py-0.5 text-[11px]",
+          isKept && !isPositive && "border-orange-400/60",
+        )}
+        disabled={saving}
+      >
+        <option value="">--</option>
+        {LAB_REASONS.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+      {saving && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+    </div>
+  );
+}
+
+function LabelBreakdown({
+  fpByReason,
+  positivesBySubclass,
+}: {
+  fpByReason: Record<string, number>;
+  positivesBySubclass: Record<string, number>;
+}) {
+  const fpEntries = Object.entries(fpByReason).filter(([, n]) => n > 0);
+  const subEntries = Object.entries(positivesBySubclass).filter(([, n]) => n > 0);
+  if (fpEntries.length === 0 && subEntries.length === 0) {
+    return null;
+  }
+  return (
+    <div className="rounded border border-border/60 p-3 text-xs">
+      <div className="mb-2 font-semibold uppercase tracking-wide text-muted-foreground">
+        Label breakdown
+      </div>
+      {fpEntries.length > 0 && (
+        <div className="mb-2">
+          <div className="text-[10px] uppercase text-orange-500">false positives by class</div>
+          <ul className="mt-1 grid grid-cols-2 gap-x-3 gap-y-0.5 font-mono">
+            {fpEntries
+              .sort((a, b) => b[1] - a[1])
+              .map(([k, n]) => (
+                <li key={k} className="flex justify-between">
+                  <span>{k}</span>
+                  <span className="text-muted-foreground">{n}</span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+      {subEntries.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase text-emerald-600">positives by subclass</div>
+          <ul className="mt-1 grid grid-cols-2 gap-x-3 gap-y-0.5 font-mono">
+            {subEntries
+              .sort((a, b) => b[1] - a[1])
+              .map(([k, n]) => (
+                <li key={k} className="flex justify-between">
+                  <span>{k}</span>
+                  <span className="text-muted-foreground">{n}</span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds the labeling layer described in #86: rejected candidates get an optional ``reason`` (cross_bay / echo / wind / movement / steel_ring / speech / handling / agc_artifact / other / unknown), kept candidates an optional ``subclass`` (paper / steel / unknown). Schema-additive; old fixtures stay valid.
- Eval now emits per-class breakdowns (per fixture and corpus-wide) so we can measure FP composition instead of guessing it.
- One-click labeling in the Lab UI: per-row dropdown in the candidate table, auto-saves through ``POST /api/lab/labels``, triggers a re-eval to refresh the breakdown panel.
- ``splitsmith lab label`` CLI for scripted / Claude-Code-driven labeling.
- LAB.md walks through the UI flow, the CLI, and the rationale.

## What unblocks
- Step 5 of #86: half-day labeling pass on the existing 12 fixtures. After that the per-class numbers tell us which specialist voter to build first (likely cross-bay).
- #10 visual classifier: the categorical labels become the negative-class breakdown the vision model evaluates against.
- #8 steel-aware detection: positive ``subclass`` labels are the prerequisite.
- #18 community corpus: exports carry these labels for free.

## Out of scope
- Multi-class classifier trained on the labels (data too thin at 12 fixtures).
- Specialist binary voters (separate issues per category once labels exist).
- No change to the production pipeline -- labels are eval-only metadata.

## Test plan
- [x] ``uv run pytest -x -q`` (475 passed, 1 skipped)
- [x] ``ruff check src/splitsmith`` clean, ``black --check src`` clean
- [x] ``npx tsc -p tsconfig.app.json`` clean, ``npm run build`` green
- [x] TestClient smoke: POST /api/lab/labels writes both ``reason`` (rejected) and ``subclass`` (kept), persists across read, validates the enum (400 on unknown values), supports null clears, .bak backup created
- [ ] Manual: open ``/lab``, run eval, click into a fixture, label one TP as ``paper`` and one FP as ``cross_bay``; verify the Label breakdown panel updates and the Summary card reflects corpus totals after the auto re-eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)