### PR TITLE
lab: keyboard shortcuts for categorical labels

### DIFF
--- a/LAB.md
+++ b/LAB.md
@@ -228,15 +228,43 @@ break down precision *by failure mode*:
 
 How to label from the UI:
 
-1. Open a fixture's detail card in the Lab.
-2. The candidate table at the bottom now has a **label** column. Each
-   row shows a dropdown -- positives get the subclass options, rejected
-   candidates get the FP reasons.
+1. Open a fixture's detail card in the Lab (click a row in the
+   catalog table).
+2. Scroll to the **Candidates** table at the bottom of the detail
+   card. Each row has a dropdown in the ``label`` column -- positives
+   get the subclass options, rejected candidates get the FP reasons.
 3. Picking a value auto-saves through ``POST /api/lab/labels``. The
    detail card refreshes (eval re-runs in the background) so the
    "Label breakdown" panel + the corpus-wide counts on the Summary card
    update right away.
 4. Clear a label by selecting ``--``.
+
+**Keyboard shortcuts** (faster than the dropdown for the half-day
+labeling pass): click any row to select it (or ``J`` / ``K`` /
+arrow keys to navigate), then press a single key:
+
+| Key | Reason (rejected) | Subclass (TP) |
+| --- | --- | --- |
+| ``X`` | cross_bay | -- |
+| ``E`` | echo | -- |
+| ``W`` | wind | -- |
+| ``M`` | movement | -- |
+| ``S`` | steel_ring | steel |
+| ``H`` | handling | -- |
+| ``A`` | agc_artifact | -- |
+| ``Y`` | speech | -- |
+| ``O`` | other | -- |
+| ``U`` | unknown | unknown |
+| ``P`` | -- | paper |
+| ``0`` / ``Bksp`` | clear | clear |
+| ``J`` / ``↓`` | next row | -- |
+| ``K`` / ``↑`` | prev row | -- |
+| ``Esc`` | deselect | -- |
+
+The legend at the bottom of the fixture detail shows the active
+selection and the available shortcuts. Shortcuts are scoped to the
+selected row only and are silently ignored when an input / textarea
+has focus.
 
 How to label from the CLI:
 

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -553,6 +553,27 @@ function FixtureTable({
   );
 }
 
+// Single-key shortcuts when a candidate row is selected.
+// For rejected (FP / not-kept) candidates: set ``reason``.
+// For kept positives (TP): set ``subclass`` (paper/steel/unknown).
+const REASON_SHORTCUTS: Record<string, string> = {
+  x: "cross_bay",
+  e: "echo",
+  w: "wind",
+  m: "movement",
+  s: "steel_ring",
+  h: "handling",
+  a: "agc_artifact",
+  y: "speech", // mnemonic: spYech (s is steel_ring)
+  o: "other",
+  u: "unknown",
+};
+const SUBCLASS_SHORTCUTS: Record<string, string> = {
+  p: "paper",
+  s: "steel",
+  u: "unknown",
+};
+
 function FixtureDetail({
   fixture,
   onClose,
@@ -565,9 +586,11 @@ function FixtureDetail({
   const [peaks, setPeaks] = useState<PeaksResult | null>(null);
   const [time, setTime] = useState(0);
   const [savingLabel, setSavingLabel] = useState<number | null>(null);
+  const [selectedCn, setSelectedCn] = useState<number | null>(null);
 
   useEffect(() => {
     setPeaks(null);
+    setSelectedCn(null);
     api
       .getFixturePeaks(fixture.audit_path)
       .then(setPeaks)
@@ -594,6 +617,71 @@ function FixtureDetail({
     },
     [fixture.audit_path, onLabelChanged],
   );
+
+  // Keyboard shortcuts: row selection + label assignment.
+  useEffect(() => {
+    function isTypingTarget(t: EventTarget | null): boolean {
+      if (!(t instanceof HTMLElement)) return false;
+      if (t.isContentEditable) return true;
+      const tag = t.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(e.target)) return;
+      const cands = fixture.candidates;
+      if (cands.length === 0) return;
+      const idx = selectedCn != null ? cands.findIndex((c) => c.candidate_number === selectedCn) : -1;
+
+      // Navigation: j/k or ArrowDown/Up. Wraps at edges.
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = idx < 0 ? 0 : Math.min(cands.length - 1, idx + 1);
+        setSelectedCn(cands[next].candidate_number);
+        return;
+      }
+      if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const next = idx < 0 ? cands.length - 1 : Math.max(0, idx - 1);
+        setSelectedCn(cands[next].candidate_number);
+        return;
+      }
+      if (e.key === "Escape") {
+        setSelectedCn(null);
+        return;
+      }
+      if (idx < 0) return;
+      const c = cands[idx];
+
+      // Clear: 0 or Backspace.
+      if (e.key === "0" || e.key === "Backspace") {
+        e.preventDefault();
+        if (c.kept && c.truth === 1) {
+          handleLabel(c.candidate_number, { subclass: null });
+        } else {
+          handleLabel(c.candidate_number, { reason: null });
+        }
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+      if (c.kept && c.truth === 1) {
+        const sub = SUBCLASS_SHORTCUTS[key];
+        if (sub) {
+          e.preventDefault();
+          handleLabel(c.candidate_number, { subclass: sub });
+        }
+      } else {
+        const reason = REASON_SHORTCUTS[key];
+        if (reason) {
+          e.preventDefault();
+          handleLabel(c.candidate_number, { reason });
+        }
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [fixture.candidates, selectedCn, handleLabel]);
 
   const fps = fixture.candidates.filter((c) => c.kept && c.truth === 0);
   const fns = fixture.truth_times.filter((t) => {
@@ -681,7 +769,10 @@ function FixtureDetail({
           candidates={fixture.candidates}
           onLabel={handleLabel}
           savingLabel={savingLabel}
+          selectedCn={selectedCn}
+          onSelect={setSelectedCn}
         />
+        <KeyboardLegend selectedCn={selectedCn} />
       </CardContent>
     </Card>
   );
@@ -782,6 +873,8 @@ function CandidateTable({
   candidates,
   onLabel,
   savingLabel,
+  selectedCn,
+  onSelect,
 }: {
   candidates: LabEvalFixture["candidates"];
   onLabel: (
@@ -789,11 +882,22 @@ function CandidateTable({
     patch: { reason?: string | null; subclass?: string | null },
   ) => void;
   savingLabel: number | null;
+  selectedCn: number | null;
+  onSelect: (cn: number | null) => void;
 }) {
+  // Auto-scroll the selected row into view when it changes via keyboard nav.
+  useEffect(() => {
+    if (selectedCn == null) return;
+    const el = document.querySelector(`[data-cn="${selectedCn}"]`);
+    if (el && "scrollIntoView" in el) {
+      (el as HTMLElement).scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [selectedCn]);
+
   return (
     <details className="rounded border border-border/60" open>
       <summary className="cursor-pointer px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Candidates ({candidates.length}) -- label rejected with FP class, kept with paper/steel
+        Candidates ({candidates.length}) -- click a row + use shortcut keys (or the dropdown)
       </summary>
       <div className="max-h-96 overflow-y-auto">
         <table className="w-full text-xs">
@@ -818,15 +922,19 @@ function CandidateTable({
               const isFP = c.kept && c.truth === 0;
               const isFN = !c.kept && c.truth === 1;
               const saving = savingLabel === c.candidate_number;
+              const selected = selectedCn === c.candidate_number;
               return (
                 <tr
                   key={c.candidate_number}
+                  data-cn={c.candidate_number}
                   className={cn(
-                    "border-b border-border/20 font-mono",
+                    "cursor-pointer border-b border-border/20 font-mono",
                     isTP && "bg-emerald-500/5",
                     isFP && "bg-orange-500/10",
                     isFN && "bg-red-500/10",
+                    selected && "outline outline-2 outline-primary/70",
                   )}
+                  onClick={() => onSelect(selected ? null : c.candidate_number)}
                 >
                   <td className="px-2 py-1">{c.candidate_number}</td>
                   <td className="px-2 py-1 text-right">{c.time.toFixed(3)}</td>
@@ -1205,6 +1313,38 @@ function RebuildCalibrationButton({ onCompleted }: { onCompleted: () => void }) 
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function KeyboardLegend({ selectedCn }: { selectedCn: number | null }) {
+  return (
+    <div
+      className={cn(
+        "rounded border border-border/60 px-3 py-2 text-[11px] text-muted-foreground",
+        selectedCn != null && "border-primary/60 bg-primary/5 text-foreground",
+      )}
+    >
+      <div className="mb-1 font-semibold uppercase tracking-wide">
+        Keyboard {selectedCn != null ? `(row #${selectedCn} selected)` : "(click or J/K to select a row)"}
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-0.5 font-mono text-[10px] sm:grid-cols-4">
+        <span><kbd>J</kbd> / <kbd>↓</kbd> next</span>
+        <span><kbd>K</kbd> / <kbd>↑</kbd> prev</span>
+        <span><kbd>Esc</kbd> deselect</span>
+        <span><kbd>0</kbd> / <kbd>Bksp</kbd> clear</span>
+        <span><kbd>X</kbd> cross_bay</span>
+        <span><kbd>E</kbd> echo</span>
+        <span><kbd>W</kbd> wind</span>
+        <span><kbd>M</kbd> movement</span>
+        <span><kbd>S</kbd> steel_ring / steel</span>
+        <span><kbd>H</kbd> handling</span>
+        <span><kbd>A</kbd> agc_artifact</span>
+        <span><kbd>Y</kbd> speech</span>
+        <span><kbd>O</kbd> other</span>
+        <span><kbd>U</kbd> unknown</span>
+        <span><kbd>P</kbd> paper (TP only)</span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Closes the gap from #94: the Lab fixture detail's Candidates table now supports row selection + single-key label assignment instead of forcing the dropdown for every row.

- Click a row (or ``J`` / ``K`` / arrows) to select it.
- ``X`` cross_bay, ``E`` echo, ``W`` wind, ``M`` movement, ``S`` steel_ring (or steel for kept TPs), ``H`` handling, ``A`` agc_artifact, ``Y`` speech, ``O`` other, ``U`` unknown, ``P`` paper (TPs only).
- ``0`` / ``Backspace`` clears, ``Esc`` deselects.
- Shortcuts ignore inputs / textareas / contenteditable targets so they don't fight with the dropdown or other typing surfaces.
- KeyboardLegend below the Candidates table shows the active selection + keymap.
- LAB.md gains a shortcut table.

Sized for the half-day labeling pass on the existing 12 fixtures.

## Test plan
- [x] ``npx tsc -p tsconfig.app.json`` clean
- [x] ``npm run build`` green
- [ ] Manual: open ``/lab``, run eval, click into a fixture, click a candidate row, press ``X`` -> reason flips to ``cross_bay`` and the breakdown panel updates after the auto re-eval; press ``J`` to move to the next row, ``0`` to clear, ``Esc`` to deselect

🤖 Generated with [Claude Code](https://claude.com/claude-code)