### PR TITLE
lab: pre-eval lite detail card with waveform

### DIFF
--- a/LAB.md
+++ b/LAB.md
@@ -90,11 +90,23 @@ cleanly across runs.
 
 ### 3. Drill into a fixture
 
-Click any row in the fixture table. The pencil icon at the right edge
-of each row deep-links into the review editor (`/review?fixture=...`)
-so you can re-label shots / edit the beep without leaving the SPA --
-the same shortcut is also available as a **Re-label** button on the
-fixture detail header. A detail card appears below with:
+Click any row in the fixture table. Two flavours of detail card render
+depending on whether eval has run:
+
+- **Before Run eval (lite view).** Just the waveform + ground-truth
+  shot pins, the audit metadata (beep time, expected rounds), and the
+  Re-label / Run eval / Close actions. Useful for sanity-checking a
+  newly-promoted fixture before paying the model-load cost.
+- **After Run eval (full view).** The waveform with TP/FP/FN diff
+  pins, per-voter recall, the diff list, the label breakdown, and the
+  candidate table with categorical-label shortcuts. Diffs and labels
+  need the per-candidate feature universe so they only appear here.
+
+The pencil icon at the right edge of each row deep-links into the
+review editor (`/review?fixture=...`) so you can re-label shots / edit
+the beep without leaving the SPA -- the same shortcut is also
+available as a **Re-label** button on the fixture detail header. The
+full (post-eval) detail card adds:
 
 - **Waveform** of the fixture's WAV. Pins overlay every kept candidate
   (green = TP, orange = FP, top-edge red = FN ground truth that no

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3390,6 +3390,20 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     def lab_fixtures() -> JSONResponse:
         return JSONResponse([r.model_dump(mode="json") for r in lab_module.list_fixtures()])
 
+    @app.get("/api/lab/last-run")
+    def lab_last_run() -> JSONResponse:
+        """Return the most recent eval/rescore in this server session.
+
+        Lets the SPA hydrate after a navigation away from /lab so
+        clicking around doesn't wipe the eval state. 404 when no eval
+        has been run yet (or when /api/lab/labels invalidated the
+        cache).
+        """
+        last_run = _lab_universe_cache.get("last_run")
+        if last_run is None:
+            raise HTTPException(status_code=404, detail="no eval has been run yet")
+        return JSONResponse(last_run.model_dump(mode="json"))
+
     @app.post("/api/lab/eval")
     def lab_eval(
         payload: dict[str, Any] = Body(default_factory=dict),  # noqa: B008

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1002,6 +1002,10 @@ export const api = {
 
   listLabFixtures: () => request<LabFixtureRecord[]>("/api/lab/fixtures"),
 
+  /** Hydrate the Lab page after a navigation: returns the most recent
+   *  eval/rescore in this server session, or 404 when none has run. */
+  getLastLabRun: () => request<LabEvalRun>("/api/lab/last-run"),
+
   runLabEval: (payload: { slugs?: string[]; config?: Partial<LabEvalConfig>; persist?: boolean }) =>
     request<LabEvalRun>("/api/lab/eval", { method: "POST", json: payload }),
 

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -83,6 +83,17 @@ export function Lab() {
       .listLabFixtures()
       .then(setCatalog)
       .catch((err) => setError(String(err)));
+    // Hydrate from the server's most-recent run cache so navigating
+    // away from /lab and back doesn't wipe the eval state.
+    api
+      .getLastLabRun()
+      .then((r) => {
+        setRun(r);
+        setConfig(r.config);
+      })
+      .catch(() => {
+        // 404 = no eval has run yet; that's the normal first-load case.
+      });
   }, []);
 
   const runEval = useCallback(async () => {

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -53,6 +53,7 @@ import {
   type LabEvalRun,
   type LabFixtureRecord,
   type PeaksResult,
+  type StageAudit,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -179,14 +180,134 @@ export function Lab() {
         onSelect={(s) => navigate(s ? `/lab/${s}` : "/lab")}
       />
 
-      {focused && (
+      {focused ? (
         <FixtureDetail
           fixture={focused}
           onClose={() => navigate("/lab")}
           onLabelChanged={runEval}
         />
-      )}
+      ) : slug ? (
+        <FixtureDetailLite
+          record={catalog.find((r) => r.slug === slug) ?? null}
+          onClose={() => navigate("/lab")}
+          onRunEval={runEval}
+          evalLoading={evalLoading}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function FixtureDetailLite({
+  record,
+  onClose,
+  onRunEval,
+  evalLoading,
+}: {
+  record: LabFixtureRecord | null;
+  onClose: () => void;
+  onRunEval: () => void;
+  evalLoading: boolean;
+}) {
+  const [peaks, setPeaks] = useState<PeaksResult | null>(null);
+  const [audit, setAudit] = useState<StageAudit | null>(null);
+  const [time, setTime] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!record) return;
+    setPeaks(null);
+    setAudit(null);
+    setError(null);
+    Promise.all([
+      api.getFixturePeaks(record.audit_path),
+      api.getFixtureAudit(record.audit_path),
+    ])
+      .then(([p, a]) => {
+        setPeaks(p);
+        setAudit(a);
+      })
+      .catch((err) => setError(String(err)));
+  }, [record]);
+
+  if (!record) {
+    return (
+      <Card>
+        <CardContent className="py-4 text-sm text-muted-foreground">
+          Fixture not found in the catalog.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const shotTimes = audit?.shots?.map((s) => s.time) ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
+        <div>
+          <CardTitle className="font-mono text-base">{record.slug}</CardTitle>
+          <CardDescription>
+            {record.n_shots} ground-truth shots
+            {record.expected_rounds != null && ` · expected ${record.expected_rounds}`}
+            {record.beep_time != null && ` · beep ${record.beep_time.toFixed(3)}s`}
+            {" · pre-eval view (waveform + ground truth only)"}
+          </CardDescription>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link
+              to={`/review?fixture=${encodeURIComponent(record.audit_path)}`}
+              title="Open in the review editor"
+            >
+              <Pencil className="size-3.5" />
+              Re-label
+            </Link>
+          </Button>
+          <Button size="sm" onClick={onRunEval} disabled={evalLoading}>
+            {evalLoading ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+            Run eval
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {error && (
+          <div className="rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>
+        )}
+        {peaks ? (
+          <Waveform
+            peaks={peaks.peaks}
+            duration={peaks.duration}
+            currentTime={time}
+            onScrub={setTime}
+            beepTime={peaks.beep_time}
+            height={140}
+          >
+            {shotTimes.map((t, i) => (
+              <Pin
+                key={`gt-${i}`}
+                time={t}
+                duration={peaks.duration}
+                color="var(--success, #22c55e)"
+                label={`shot ${i + 1}`}
+              />
+            ))}
+          </Waveform>
+        ) : (
+          <div className="flex h-[140px] items-center justify-center rounded border border-border/40 bg-muted/30 text-xs text-muted-foreground">
+            <Loader2 className="mr-2 size-4 animate-spin" /> loading waveform...
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          Diffs (TP/FP/FN), the per-voter breakdown, the candidate table, and label
+          shortcuts only render after Run eval -- they need the per-candidate feature
+          universe (CLAP / PANN / GBDT) which is built by eval.
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
Clicking a fixture row no longer requires Run eval to access the waveform. When no eval result is cached for that fixture, the Lab renders a slim detail card built from the audit JSON + peaks endpoints alone -- waveform, ground-truth shot pins, beep / expected-rounds metadata, Re-label deep link, and a Run-eval button to upgrade to the full diff/label view.

Useful for sanity-checking a newly-promoted fixture (beep position, shot windows, audio quality) before paying the CLAP/PANN load cost. Diffs, per-voter recall, label dropdowns, and keyboard shortcuts all still require eval since they depend on the per-candidate feature universe.

## Test plan
- [x] ``npx tsc -p tsconfig.app.json`` clean
- [x] ``npm run build`` green
- [ ] Manual: open ``/lab`` on a project where eval has not run; click a fixture row and confirm the waveform + ground-truth pins render; click Re-label / Run eval and confirm both upgrade paths work; after eval completes, the detail card swaps to the full view automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)