### PR TITLE
lab: step-through labeling with audio snippets (closes #98)

### DIFF
--- a/LAB.md
+++ b/LAB.md
@@ -251,9 +251,28 @@ How to label from the UI:
    update right away.
 4. Clear a label by selecting ``--``.
 
-**Keyboard shortcuts** (faster than the dropdown for the half-day
-labeling pass): click any row to select it (or ``J`` / ``K`` /
-arrow keys to navigate), then press a single key:
+**Step-through mode** (issue #98 -- by far the fastest path for a
+labeling pass): in the fixture detail card, click **Step through**.
+The candidate table is replaced with a list + an audio player that
+**auto-plays a short snippet of each candidate's audio** as you
+focus it. Loop is on by default; pre-roll / post-roll lengths are
+sliders.
+
+- Filter to "Rejected only" (default) so you skip TPs.
+- Sort by "Ensemble score asc" (default) so the borderline FPs land
+  first -- the labels matter most there.
+- Pressing a label key both saves AND advances to the next candidate.
+- "Pre-cache all" submits a job that materialises every candidate's
+  snippet up front; the corpus-wide pre-cache for 12 fixtures is
+  under 10 seconds total.
+
+The snippet endpoint is ``GET /api/lab/snippet?audit_path=&candidate_number=&pre_ms=&post_ms=``;
+files cache under ``tests/fixtures/.cache/<slug>_snippets/`` and
+build on demand.
+
+**Keyboard shortcuts** (work in both modes): click any row to select
+it (or ``J`` / ``K`` / arrow keys to navigate), then press a single
+key:
 
 | Key | Reason (rejected) | Subclass (TP) |
 | --- | --- | --- |
@@ -669,6 +688,8 @@ Top-level keys: `config`, `summary`, `universe`, `config_hash`, `built_at`.
 | POST | `/api/lab/rescore` | `{config}` | Uses last cached universe. 409 if no eval has run. |
 | POST | `/api/lab/promote` | `{stage_number, slug, overwrite?}` | Copies stage audit JSON + WAV into `tests/fixtures/`. |
 | POST | `/api/lab/labels` | `{audit_path, labels: [{candidate_number, reason?, subclass?}]}` | Patches categorical labels on a fixture's audit JSON. Drops the cached universe so the next eval reloads. |
+| GET | `/api/lab/snippet?audit_path=&candidate_number=&pre_ms=&post_ms=` | -- | Per-candidate audio snippet (built-on-demand + cached under `tests/fixtures/.cache/<slug>_snippets/`). |
+| POST | `/api/lab/snippets/precache` | `{audit_path, pre_ms?, post_ms?}` | Submits a job that materialises every candidate's snippet for a fixture. Poll `/api/jobs/{id}`. |
 | POST | `/api/lab/save-config` | `{name, note?, overwrite?}` | Persists the active run's config + summary as `configs/ensemble.<name>.yaml`. 409 when no eval has run. |
 | POST | `/api/lab/rebuild-calibration` | `{target_recall?, tolerance_ms?, fixtures?}` | Submits a `rebuild_calibration` job that re-runs the calibration build script. Poll `/api/jobs/{id}` for progress. |
 

--- a/src/splitsmith/lab/__init__.py
+++ b/src/splitsmith/lab/__init__.py
@@ -40,8 +40,16 @@ from .core import (
     save_config_yaml,
     save_run,
 )
+from .snippet import (
+    DEFAULT_POST_MS,
+    DEFAULT_PRE_MS,
+    extract_snippet,
+    precache_all,
+)
 
 __all__ = [
+    "DEFAULT_POST_MS",
+    "DEFAULT_PRE_MS",
     "REASON_VALUES",
     "SUBCLASS_VALUES",
     "CandidateLabel",
@@ -55,8 +63,10 @@ __all__ = [
     "PromoteRequest",
     "RunSummary",
     "apply_labels",
+    "extract_snippet",
     "list_fixtures",
     "load_run",
+    "precache_all",
     "promote_stage_to_fixture",
     "rescore_universe",
     "run_eval",

--- a/src/splitsmith/lab/snippet.py
+++ b/src/splitsmith/lab/snippet.py
@@ -1,0 +1,146 @@
+"""Per-candidate audio snippet extraction (issue #98).
+
+Used by the Lab "Step-through" labeling flow: each candidate becomes a
+short on-disk WAV the SPA can autoplay/loop, so labeling runs at the
+user's typing speed instead of waveform-scrubbing speed.
+
+Cache layout::
+
+    tests/fixtures/.cache/<slug>_snippets/cand<NNN>_pre<P>_post<Q>.wav
+
+The cache lives next to the existing CLAP / PANN feature caches; it is
+git-ignored and rebuilt on demand.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+DEFAULT_PRE_MS = 100
+DEFAULT_POST_MS = 300
+CACHE_SUBDIR_SUFFIX = "_snippets"
+
+
+def _snippet_dir(audit_path: Path) -> Path:
+    """Cache dir for a fixture's snippets, sibling to the audit JSON."""
+    fixtures_dir = audit_path.parent
+    cache_root = fixtures_dir / ".cache"
+    return cache_root / f"{audit_path.stem}{CACHE_SUBDIR_SUFFIX}"
+
+
+def _snippet_path(audit_path: Path, candidate_number: int, pre_ms: int, post_ms: int) -> Path:
+    return _snippet_dir(audit_path) / f"cand{candidate_number:03d}_pre{pre_ms}_post{post_ms}.wav"
+
+
+def _candidate_time(audit_path: Path, candidate_number: int) -> float:
+    """Resolve a candidate's time from the audit JSON.
+
+    Looks at ``_candidates_pending_audit.candidates[]`` first; falls
+    back to ``shots[]`` so kept positives also have snippets without
+    duplicating the candidate row in both places.
+    """
+    payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    pending = payload.get("_candidates_pending_audit") or {}
+    for c in pending.get("candidates", []):
+        if int(c.get("candidate_number", -1)) == candidate_number:
+            return float(c["time"])
+    for s in payload.get("shots", []):
+        if int(s.get("candidate_number", -1)) == candidate_number:
+            return float(s["time"])
+    raise KeyError(f"candidate_number {candidate_number} not found in {audit_path}")
+
+
+def extract_snippet(
+    audit_path: Path,
+    candidate_number: int,
+    *,
+    pre_ms: int = DEFAULT_PRE_MS,
+    post_ms: int = DEFAULT_POST_MS,
+    audio_path: Path | None = None,
+) -> Path:
+    """Materialise the snippet WAV for one candidate. Idempotent + cached.
+
+    ``audio_path`` defaults to the audit JSON's sibling WAV
+    (``audit_path.with_suffix(".wav")``); pass an override when the
+    fixture's audio lives elsewhere.
+    """
+    target = _snippet_path(audit_path, candidate_number, pre_ms, post_ms)
+    if target.exists():
+        return target
+
+    src = audio_path or audit_path.with_suffix(".wav")
+    if not src.exists():
+        raise FileNotFoundError(f"fixture audio not found: {src}")
+    t = _candidate_time(audit_path, candidate_number)
+
+    audio, sr = sf.read(src, always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    n = audio.shape[0]
+    start = max(0, int(round((t - pre_ms / 1000.0) * sr)))
+    end = min(n, int(round((t + post_ms / 1000.0) * sr)))
+    if end <= start:
+        raise ValueError(f"empty snippet window for candidate {candidate_number} at t={t}")
+    clip = np.ascontiguousarray(audio[start:end], dtype=np.float32)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    sf.write(tmp, clip, sr, subtype="PCM_16", format="WAV")
+    tmp.replace(target)
+    return target
+
+
+def precache_all(
+    audit_path: Path,
+    *,
+    pre_ms: int = DEFAULT_PRE_MS,
+    post_ms: int = DEFAULT_POST_MS,
+    audio_path: Path | None = None,
+    progress: Callable[[int, int, int], None] | None = None,
+) -> int:
+    """Build snippets for every candidate in a fixture. Returns count.
+
+    Loads the audio once to amortise the read cost across all
+    candidates. Calls ``progress(i, total, candidate_number)`` after
+    each write when provided -- shaped to feed JobRegistry.update().
+    """
+    payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    pending = payload.get("_candidates_pending_audit") or {}
+    candidates = pending.get("candidates", [])
+    src = audio_path or audit_path.with_suffix(".wav")
+    if not src.exists():
+        raise FileNotFoundError(f"fixture audio not found: {src}")
+    audio, sr = sf.read(src, always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    n = audio.shape[0]
+
+    out_dir = _snippet_dir(audit_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pre_n = int(round(pre_ms / 1000.0 * sr))
+    post_n = int(round(post_ms / 1000.0 * sr))
+    total = len(candidates)
+    for i, c in enumerate(candidates):
+        cn = int(c.get("candidate_number", -1))
+        t = float(c.get("time", -1.0))
+        if cn < 0 or t < 0:
+            continue
+        target = _snippet_path(audit_path, cn, pre_ms, post_ms)
+        if not target.exists():
+            idx = int(round(t * sr))
+            start = max(0, idx - pre_n)
+            end = min(n, idx + post_n)
+            if end > start:
+                clip = np.ascontiguousarray(audio[start:end], dtype=np.float32)
+                tmp = target.with_suffix(target.suffix + ".tmp")
+                sf.write(tmp, clip, sr, subtype="PCM_16", format="WAV")
+                tmp.replace(target)
+        if progress is not None:
+            progress(i + 1, total, cn)
+    return total

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3390,6 +3390,64 @@ def create_app(*, project_root: Path, project_name: str) -> FastAPI:
     def lab_fixtures() -> JSONResponse:
         return JSONResponse([r.model_dump(mode="json") for r in lab_module.list_fixtures()])
 
+    @app.get("/api/lab/snippet")
+    def lab_snippet(
+        audit_path: str = Query(...),
+        candidate_number: int = Query(..., ge=1),
+        pre_ms: int = Query(default=lab_module.DEFAULT_PRE_MS, ge=0, le=2000),
+        post_ms: int = Query(default=lab_module.DEFAULT_POST_MS, ge=0, le=2000),
+    ) -> FileResponse:
+        """Serve the per-candidate snippet WAV (issue #98).
+
+        Builds-on-first-request and caches under the fixture's
+        ``.cache/<slug>_snippets/`` directory.
+        """
+        try:
+            fixture_json = Path(audit_path).expanduser().resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise HTTPException(status_code=404, detail=f"fixture not found: {audit_path}") from exc
+        try:
+            target = lab_module.extract_snippet(
+                fixture_json,
+                candidate_number,
+                pre_ms=pre_ms,
+                post_ms=post_ms,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (ValueError, FileNotFoundError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return FileResponse(target, media_type="audio/wav", filename=target.name)
+
+    @app.post("/api/lab/snippets/precache")
+    def lab_snippets_precache(
+        payload: dict[str, Any] = Body(...),  # noqa: B008
+    ) -> JSONResponse:
+        """Submit a job that materialises every candidate snippet for a fixture."""
+        audit_path = payload.get("audit_path")
+        pre_ms = int(payload.get("pre_ms", lab_module.DEFAULT_PRE_MS))
+        post_ms = int(payload.get("post_ms", lab_module.DEFAULT_POST_MS))
+        if not isinstance(audit_path, str) or not audit_path:
+            raise HTTPException(
+                status_code=400,
+                detail="payload must include 'audit_path' (string)",
+            )
+        try:
+            target = Path(audit_path).expanduser().resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            raise HTTPException(status_code=404, detail=f"fixture not found: {audit_path}") from exc
+
+        def _run(handle: JobHandle) -> None:
+            def progress(i: int, total: int, _cn: int) -> None:
+                handle.check_cancel()
+                handle.update(progress=i / total if total else 1.0, message=f"{i}/{total}")
+
+            n = lab_module.precache_all(target, pre_ms=pre_ms, post_ms=post_ms, progress=progress)
+            handle.update(progress=1.0, message=f"cached {n} snippets")
+
+        job = state.jobs.submit(kind="snippet_precache", fn=_run)
+        return JSONResponse(job.model_dump(mode="json"))
+
     @app.get("/api/lab/last-run")
     def lab_last_run() -> JSONResponse:
         """Return the most recent eval/rescore in this server session.

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1027,6 +1027,25 @@ export const api = {
       json: payload,
     }),
 
+  /** URL of the per-candidate snippet WAV. Static-ish: built-on-demand
+   *  + cached server-side. Use directly as ``<audio src=...>``. */
+  labSnippetUrl: (
+    audit_path: string,
+    candidate_number: number,
+    opts?: { pre_ms?: number; post_ms?: number },
+  ) => {
+    const params = new URLSearchParams({
+      audit_path,
+      candidate_number: String(candidate_number),
+    });
+    if (opts?.pre_ms != null) params.set("pre_ms", String(opts.pre_ms));
+    if (opts?.post_ms != null) params.set("post_ms", String(opts.post_ms));
+    return `/api/lab/snippet?${params.toString()}`;
+  },
+
+  precacheLabSnippets: (payload: { audit_path: string; pre_ms?: number; post_ms?: number }) =>
+    request<Job>("/api/lab/snippets/precache", { method: "POST", json: payload }),
+
   rebuildLabCalibration: (payload: { target_recall?: number; tolerance_ms?: number; fixtures?: string[] } = {}) =>
     request<Job>("/api/lab/rebuild-calibration", { method: "POST", json: payload }),
 };

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -17,7 +17,7 @@
  * surface change to AppShell, and no existing route was modified.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   AlertCircle,
@@ -25,9 +25,11 @@ import {
   CheckCircle2,
   ChevronRight,
   Hammer,
+  Headphones,
   Loader2,
   Pencil,
   Play,
+  Repeat,
   RotateCcw,
   Save,
   Settings2,
@@ -719,10 +721,12 @@ function FixtureDetail({
   const [time, setTime] = useState(0);
   const [savingLabel, setSavingLabel] = useState<number | null>(null);
   const [selectedCn, setSelectedCn] = useState<number | null>(null);
+  const [stepThrough, setStepThrough] = useState(false);
 
   useEffect(() => {
     setPeaks(null);
     setSelectedCn(null);
+    setStepThrough(false);
     api
       .getFixturePeaks(fixture.audit_path)
       .then(setPeaks)
@@ -749,6 +753,15 @@ function FixtureDetail({
     },
     [fixture.audit_path, onLabelChanged],
   );
+
+  // Step-through can register a "what's the next candidate after this
+  // one in my filter+sort?" resolver. Used by the keyboard handler to
+  // auto-advance after a label key. The candidate table doesn't set
+  // this, so labels in that mode just stay on the current row.
+  const advanceRef = useRef<((cn: number) => number | null) | null>(null);
+  const setAdvancer = useCallback((fn: ((cn: number) => number | null) | null) => {
+    advanceRef.current = fn;
+  }, []);
 
   // Keyboard shortcuts: row selection + label assignment.
   useEffect(() => {
@@ -785,6 +798,11 @@ function FixtureDetail({
       if (idx < 0) return;
       const c = cands[idx];
 
+      const advance = () => {
+        const next = advanceRef.current?.(c.candidate_number);
+        if (next != null) setSelectedCn(next);
+      };
+
       // Clear: 0 or Backspace.
       if (e.key === "0" || e.key === "Backspace") {
         e.preventDefault();
@@ -793,6 +811,7 @@ function FixtureDetail({
         } else {
           handleLabel(c.candidate_number, { reason: null });
         }
+        advance();
         return;
       }
 
@@ -802,12 +821,14 @@ function FixtureDetail({
         if (sub) {
           e.preventDefault();
           handleLabel(c.candidate_number, { subclass: sub });
+          advance();
         }
       } else {
         const reason = REASON_SHORTCUTS[key];
         if (reason) {
           e.preventDefault();
           handleLabel(c.candidate_number, { reason });
+          advance();
         }
       }
     }
@@ -897,13 +918,41 @@ function FixtureDetail({
           positivesBySubclass={fixture.metrics.positives_by_subclass}
         />
 
-        <CandidateTable
-          candidates={fixture.candidates}
-          onLabel={handleLabel}
-          savingLabel={savingLabel}
-          selectedCn={selectedCn}
-          onSelect={setSelectedCn}
-        />
+        <div className="flex items-center gap-2">
+          <Button
+            variant={stepThrough ? "default" : "outline"}
+            size="sm"
+            onClick={() => setStepThrough((v) => !v)}
+            title="Toggle step-through labeling mode (audio snippets + autoplay)"
+          >
+            <Headphones className="size-3.5" />
+            {stepThrough ? "Exit step-through" : "Step through"}
+          </Button>
+          {stepThrough && (
+            <span className="text-[11px] text-muted-foreground">
+              Click a candidate or use J/K. Snippet autoplays; press a label key to save and advance.
+            </span>
+          )}
+        </div>
+
+        {stepThrough ? (
+          <StepThroughPanel
+            fixture={fixture}
+            selectedCn={selectedCn}
+            onSelect={setSelectedCn}
+            registerAdvancer={setAdvancer}
+            savingLabel={savingLabel}
+            onLabel={handleLabel}
+          />
+        ) : (
+          <CandidateTable
+            candidates={fixture.candidates}
+            onLabel={handleLabel}
+            savingLabel={savingLabel}
+            selectedCn={selectedCn}
+            onSelect={setSelectedCn}
+          />
+        )}
         <KeyboardLegend selectedCn={selectedCn} />
       </CardContent>
     </Card>
@@ -1447,6 +1496,326 @@ function RebuildCalibrationButton({ onCompleted }: { onCompleted: () => void }) 
       )}
     </div>
   );
+}
+
+type StepFilter = "rejected_only" | "fps_only" | "unlabeled_only" | "all";
+type StepSort = "ensemble_score_asc" | "chronological" | "confidence_asc";
+
+function StepThroughPanel({
+  fixture,
+  selectedCn,
+  onSelect,
+  registerAdvancer,
+  savingLabel,
+  onLabel,
+}: {
+  fixture: LabEvalFixture;
+  selectedCn: number | null;
+  onSelect: (cn: number | null) => void;
+  registerAdvancer: (fn: ((cn: number) => number | null) | null) => void;
+  savingLabel: number | null;
+  onLabel: (
+    cn: number,
+    patch: { reason?: string | null; subclass?: string | null },
+  ) => void;
+}) {
+  const [filter, setFilter] = useState<StepFilter>("rejected_only");
+  const [sort, setSort] = useState<StepSort>("ensemble_score_asc");
+  const [preMs, setPreMs] = useState(100);
+  const [postMs, setPostMs] = useState(300);
+  const [loop, setLoop] = useState(true);
+  const [precaching, setPrecaching] = useState(false);
+
+  const ordered = useMemo(() => {
+    let list = [...fixture.candidates];
+    if (filter === "rejected_only") {
+      list = list.filter((c) => !c.kept);
+    } else if (filter === "fps_only") {
+      list = list.filter((c) => c.kept && c.truth === 0);
+    } else if (filter === "unlabeled_only") {
+      list = list.filter((c) => {
+        if (c.kept && c.truth === 1) return c.subclass == null;
+        return c.reason == null;
+      });
+    }
+    list.sort((a, b) => {
+      if (sort === "ensemble_score_asc") return a.ensemble_score - b.ensemble_score;
+      if (sort === "confidence_asc") return a.confidence - b.confidence;
+      return a.time - b.time;
+    });
+    return list;
+  }, [fixture.candidates, filter, sort]);
+
+  // Register the auto-advance resolver: given the current cn, return
+  // the next cn in the active filter+sort or null at the end.
+  useEffect(() => {
+    registerAdvancer((cn) => {
+      const idx = ordered.findIndex((c) => c.candidate_number === cn);
+      if (idx < 0 || idx >= ordered.length - 1) return null;
+      return ordered[idx + 1].candidate_number;
+    });
+    return () => registerAdvancer(null);
+  }, [ordered, registerAdvancer]);
+
+  // Default selection: first item in the active list.
+  useEffect(() => {
+    if (ordered.length === 0) return;
+    if (selectedCn == null || !ordered.some((c) => c.candidate_number === selectedCn)) {
+      onSelect(ordered[0].candidate_number);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ordered]);
+
+  const current = useMemo(
+    () => ordered.find((c) => c.candidate_number === selectedCn) ?? null,
+    [ordered, selectedCn],
+  );
+
+  const idxInList = current
+    ? ordered.findIndex((c) => c.candidate_number === current.candidate_number)
+    : -1;
+
+  const onPrecache = useCallback(async () => {
+    setPrecaching(true);
+    try {
+      await api.precacheLabSnippets({
+        audit_path: fixture.audit_path,
+        pre_ms: preMs,
+        post_ms: postMs,
+      });
+    } catch (err) {
+      console.error("precache failed", err);
+    } finally {
+      setPrecaching(false);
+    }
+  }, [fixture.audit_path, preMs, postMs]);
+
+  return (
+    <div className="rounded border border-primary/40 bg-primary/5 p-3">
+      <div className="mb-3 flex flex-wrap items-end gap-3 text-[11px]">
+        <label className="flex flex-col gap-1">
+          <span className="font-medium text-muted-foreground">Filter</span>
+          <select
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as StepFilter)}
+            className="rounded border border-border bg-background px-1 py-0.5"
+          >
+            <option value="rejected_only">Rejected only (recommended)</option>
+            <option value="fps_only">FPs only (kept negatives)</option>
+            <option value="unlabeled_only">Unlabeled only</option>
+            <option value="all">All candidates</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="font-medium text-muted-foreground">Sort</span>
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as StepSort)}
+            className="rounded border border-border bg-background px-1 py-0.5"
+          >
+            <option value="ensemble_score_asc">Ensemble score asc (borderline first)</option>
+            <option value="confidence_asc">Confidence asc</option>
+            <option value="chronological">Chronological</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="font-medium text-muted-foreground">Pre ms ({preMs})</span>
+          <input
+            type="range"
+            min={0}
+            max={500}
+            step={10}
+            value={preMs}
+            onChange={(e) => setPreMs(Number(e.target.value))}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="font-medium text-muted-foreground">Post ms ({postMs})</span>
+          <input
+            type="range"
+            min={50}
+            max={800}
+            step={10}
+            value={postMs}
+            onChange={(e) => setPostMs(Number(e.target.value))}
+          />
+        </label>
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={loop} onChange={(e) => setLoop(e.target.checked)} />
+          <Repeat className="size-3.5" /> Loop
+        </label>
+        <Button variant="outline" size="sm" onClick={onPrecache} disabled={precaching}>
+          {precaching ? <Loader2 className="size-3 animate-spin" /> : null}
+          Pre-cache all
+        </Button>
+        <span className="ml-auto text-muted-foreground">
+          {idxInList + 1} / {ordered.length}
+          {ordered.length === 0 && " (no candidates match filter)"}
+        </span>
+      </div>
+
+      {current ? (
+        <SnippetPlayer
+          fixture={fixture}
+          candidate={current}
+          loop={loop}
+          preMs={preMs}
+          postMs={postMs}
+        />
+      ) : (
+        <div className="rounded border border-dashed border-border/60 px-4 py-6 text-center text-xs text-muted-foreground">
+          Adjust the filter or run eval to populate the candidate list.
+        </div>
+      )}
+
+      {/* Compact list -- shows position in the queue + assigned labels. */}
+      <div className="mt-3 max-h-60 overflow-y-auto rounded border border-border/60 bg-background/50">
+        <table className="w-full text-[11px]">
+          <tbody>
+            {ordered.map((c) => {
+              const sel = c.candidate_number === selectedCn;
+              const saving = savingLabel === c.candidate_number;
+              const label = c.kept && c.truth === 1 ? c.subclass : c.reason;
+              return (
+                <tr
+                  key={c.candidate_number}
+                  className={cn(
+                    "cursor-pointer border-b border-border/30 font-mono",
+                    sel && "bg-primary/15 outline outline-1 outline-primary/60",
+                    !sel && c.kept && c.truth === 1 && "bg-emerald-500/5",
+                    !sel && c.kept && c.truth === 0 && "bg-orange-500/10",
+                  )}
+                  onClick={() => onSelect(c.candidate_number)}
+                >
+                  <td className="px-2 py-0.5">#{c.candidate_number}</td>
+                  <td className="px-2 py-0.5 text-right text-muted-foreground">
+                    {c.time.toFixed(3)}s
+                  </td>
+                  <td className="px-2 py-0.5 text-right text-muted-foreground">
+                    score {c.ensemble_score.toFixed(2)}
+                  </td>
+                  <td className="px-2 py-0.5 text-right">
+                    {label ? (
+                      <span className="rounded bg-muted px-1">{label}</span>
+                    ) : (
+                      <span className="text-muted-foreground">--</span>
+                    )}
+                  </td>
+                  <td className="w-4">
+                    {saving && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {current && (
+        <div className="mt-3 flex flex-wrap gap-1 text-[10px]">
+          {(current.kept && current.truth === 1 ? LAB_SUBCLASSES : LAB_REASONS).map((label) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() =>
+                current.kept && current.truth === 1
+                  ? onLabel(current.candidate_number, { subclass: label })
+                  : onLabel(current.candidate_number, { reason: label })
+              }
+              className="rounded border border-border/60 bg-background px-2 py-0.5 hover:bg-accent"
+            >
+              {label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              current.kept && current.truth === 1
+                ? onLabel(current.candidate_number, { subclass: null })
+                : onLabel(current.candidate_number, { reason: null })
+            }
+            className="rounded border border-border/60 bg-background px-2 py-0.5 text-muted-foreground hover:bg-accent"
+          >
+            clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SnippetPlayer({
+  fixture,
+  candidate,
+  loop,
+  preMs,
+  postMs,
+}: {
+  fixture: LabEvalFixture;
+  candidate: LabEvalFixture["candidates"][number];
+  loop: boolean;
+  preMs: number;
+  postMs: number;
+}) {
+  const url = api.labSnippetUrl(fixture.audit_path, candidate.candidate_number, {
+    pre_ms: preMs,
+    post_ms: postMs,
+  });
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Re-mount on candidate change so the snippet auto-loads + autoplays.
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    el.load();
+    const tryPlay = () => {
+      el.play().catch(() => {
+        // Autoplay can be blocked until first user interaction; ignore.
+      });
+    };
+    tryPlay();
+  }, [url]);
+
+  const labelText =
+    candidate.kept && candidate.truth === 1 ? candidate.subclass : candidate.reason;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-xs">
+        <div>
+          <span className="font-mono">#{candidate.candidate_number}</span>
+          {" · "}
+          <span className="text-muted-foreground">
+            t={candidate.time.toFixed(3)}s · conf {candidate.confidence.toFixed(3)} · score{" "}
+            {candidate.ensemble_score.toFixed(2)}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={cn("rounded px-2 py-0.5 font-mono text-[10px]", outcomeColor(candidate))}>
+            {outcomeLabel(candidate)}
+          </span>
+          {labelText && (
+            <span className="rounded bg-muted px-2 py-0.5 font-mono text-[10px]">
+              {labelText}
+            </span>
+          )}
+        </div>
+      </div>
+      <audio ref={audioRef} src={url} controls loop={loop} className="w-full" preload="auto" />
+    </div>
+  );
+}
+
+function outcomeLabel(c: LabEvalFixture["candidates"][number]): string {
+  if (c.kept && c.truth === 1) return "TP";
+  if (c.kept && c.truth === 0) return "FP";
+  if (!c.kept && c.truth === 1) return "FN";
+  return "TN";
+}
+function outcomeColor(c: LabEvalFixture["candidates"][number]): string {
+  if (c.kept && c.truth === 1) return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300";
+  if (c.kept && c.truth === 0) return "bg-orange-500/20 text-orange-700 dark:text-orange-300";
+  if (!c.kept && c.truth === 1) return "bg-red-500/20 text-red-700 dark:text-red-300";
+  return "bg-muted text-muted-foreground";
 }
 
 function KeyboardLegend({ selectedCn }: { selectedCn: number | null }) {

--- a/tests/fixtures/stage-shots-blacksmith-2026-stage1.json
+++ b/tests/fixtures/stage-shots-blacksmith-2026-stage1.json
@@ -524,7 +524,8 @@
         "time": 13.3566,
         "ms_after_beep": 12857.0,
         "peak_amplitude": 0.0878,
-        "confidence": 0.014
+        "confidence": 0.014,
+        "reason": "wind"
       },
       {
         "candidate_number": 36,


### PR DESCRIPTION
## Summary
A fundamentally faster labeling flow before the half-day labeling pass on the existing 12 fixtures. Each candidate becomes a short on-disk WAV the SPA autoplays / loops, so the user labels at *typing speed* instead of waveform-scrubbing speed. Anecdotally ~3 s per candidate vs ~10-15 s today; for the corpus that's an afternoon vs a week.

- Backend: ``splitsmith.lab.snippet.extract_snippet`` + ``precache_all`` -- 125-candidate fixture pre-caches in ~60 ms locally.
- Endpoints: ``GET /api/lab/snippet`` (built-on-demand + cached + Range); ``POST /api/lab/snippets/precache`` (job-backed, streams progress).
- SPA: new "Step through" toggle on the Lab fixture detail. Filter (rejected only by default) + sort (ensemble_score asc -- borderline first), pre/post-ms sliders, loop. Reuses PR #95's keyboard handler with an auto-advance: pressing ``X`` saves and moves to the next candidate's snippet in one keypress.
- LAB.md walk-through + endpoint reference.

Closes #98.

## Stacked on
PR #96 (pre-eval lite detail + ``/api/lab/last-run`` hydration). The diff collapses once #96 lands.

## Test plan
- [x] ``uv run pytest -x -q`` (475 passed, 1 skipped)
- [x] ``ruff check`` / ``black --check`` clean
- [x] ``npx tsc -p tsconfig.app.json`` clean, ``npm run build`` green
- [x] TestClient: GET /api/lab/snippet returns 200 + audio/wav + non-zero bytes; 404 for unknown candidate_number; POST precache returns a Job snapshot
- [ ] Manual: click "Step through" on a fixture detail, confirm the audio autoplays, press a label key and verify it saves + advances + starts the next snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)