### PR TITLE
Add per-camera selection UI for multi-cam exports (issue #54)

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -189,6 +189,31 @@ class RemovalPlan(BaseModel):
     audit_reset: bool = False  # caller-facing flag: did we wipe stage audit?
 
 
+class SecondaryExportStatus(BaseModel):
+    """Per-secondary-cam export status surfaced on the Analysis & Export
+    overview (issue #54).
+
+    Each entry maps a secondary :class:`StageVideo` on the stage to (a) its
+    eligibility to ride the multi-cam FCPXML (needs a beep + a reachable
+    source) and (b) the lossless trim that the last Generate produced for
+    it. The SPA renders one checkbox row per entry so the user can include
+    or exclude individual cams from the next export.
+    """
+
+    video_id: str
+    path: Path
+    label: str
+    has_beep: bool
+    beep_reviewed: bool
+    source_reachable: bool
+    # ``stage<N>_<slug>_cam_<video_id>_trimmed.mp4`` under ``exports/``,
+    # populated only when the file is actually present on disk; ``None``
+    # before the user runs Generate (or when the cam was excluded last
+    # time). The SPA uses this to drive the per-cam Reveal button.
+    trim_path: Path | None
+    trim_present: bool
+
+
 class StageExportStatus(BaseModel):
     """Per-stage audit + export status for the Analysis & Export overview.
 
@@ -236,6 +261,11 @@ class StageExportStatus(BaseModel):
     # so the user knows Generate will degrade (CSV/report only) without
     # having to click first. ``None`` when the stage has no primary.
     source_reachable: bool | None = None
+    # Multi-cam roster (issue #54). One entry per secondary :class:`StageVideo`
+    # on the stage (``role == "secondary"``), regardless of beep / source
+    # state -- the SPA renders disabled rows for cams that can't ship and
+    # explains why. Empty when the stage is single-cam.
+    secondaries: list[SecondaryExportStatus] = Field(default_factory=list)
 
 
 class StageMatchWindow(BaseModel):
@@ -497,8 +527,23 @@ class MatchProject(BaseModel):
             report_exists = report_p.exists()
             trim_exists = lossless_trim_p.exists()
             overlay_exists = overlay_p.exists()
+            # Per-cam lossless trims (issue #54) live next to the primary's
+            # trim under the same base; surface them to ``has_exports`` /
+            # ``last_export_at`` so a stage that's only had its secondaries
+            # generated still reads as exported.
+            sec_trim_paths = [
+                exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4"
+                for sv in stage.videos
+                if sv.role == "secondary"
+            ]
+            sec_trim_existing = [p for p in sec_trim_paths if p.exists()]
             has_exports = (
-                csv_exists or fcpxml_exists or report_exists or trim_exists or overlay_exists
+                csv_exists
+                or fcpxml_exists
+                or report_exists
+                or trim_exists
+                or overlay_exists
+                or bool(sec_trim_existing)
             )
             last_export_at: datetime | None = None
             if has_exports:
@@ -507,6 +552,7 @@ class MatchProject(BaseModel):
                     for p in (csv_p, fcpxml_p, report_p, lossless_trim_p, overlay_p)
                     if p.exists()
                 ]
+                mtimes.extend(p.stat().st_mtime for p in sec_trim_existing)
                 if mtimes:
                     last_export_at = datetime.fromtimestamp(max(mtimes), tz=UTC)
 
@@ -530,6 +576,30 @@ class MatchProject(BaseModel):
                 except OSError:
                     source_reachable = False
 
+            secondaries_status: list[SecondaryExportStatus] = []
+            for sv in stage.videos:
+                if sv.role != "secondary":
+                    continue
+                sec_trim = exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4"
+                sec_trim_exists = sec_trim.exists()
+                try:
+                    sec_src = self.resolve_video_path(root, sv.path)
+                    sec_reachable = sec_src.exists()
+                except OSError:
+                    sec_reachable = False
+                secondaries_status.append(
+                    SecondaryExportStatus(
+                        video_id=sv.video_id,
+                        path=sv.path,
+                        label=sv.path.name,
+                        has_beep=sv.beep_time is not None,
+                        beep_reviewed=sv.beep_reviewed,
+                        source_reachable=sec_reachable,
+                        trim_path=sec_trim if sec_trim_exists else None,
+                        trim_present=sec_trim_exists,
+                    )
+                )
+
             out.append(
                 StageExportStatus(
                     stage_number=stage.stage_number,
@@ -550,6 +620,7 @@ class MatchProject(BaseModel):
                     last_export_at=last_export_at,
                     ready_to_export=ready_to_export,
                     source_reachable=source_reachable,
+                    secondaries=secondaries_status,
                 )
             )
         return out

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -250,7 +250,7 @@ def _ensure_ui_built() -> None:
     npm = shutil.which("npm")
     if npm is None:
         logger.warning(
-            "ui_static/dist appears stale but npm is not on PATH; " "serving whatever is in dist/"
+            "ui_static/dist appears stale but npm is not on PATH; serving whatever is in dist/"
         )
         return
 
@@ -681,6 +681,14 @@ class ExportStageRequest(BaseModel):
     # slower than the other writers. The Analysis & Export checkbox
     # opts-in per stage.
     write_overlay: bool = False
+    # Multi-cam selection (issue #54). Allowlist of secondary
+    # ``video_id``s to ride the FCPXML / get their own lossless trim. The
+    # default ``None`` means "include every secondary with a beep" -- the
+    # legacy behaviour. An empty list excludes all secondaries; a non-empty
+    # list ships only the named cams (silently dropping any id not on the
+    # stage). Cams without a beep are still skipped regardless of selection
+    # since they can't be sync-aligned.
+    secondary_video_ids: list[str] | None = None
 
 
 class RevealRequest(BaseModel):
@@ -1273,7 +1281,9 @@ def create_app(
         for entry in candidates:
             try:
                 video = project.register_video(
-                    entry, state.project_root, link_mode=req.link_mode  # type: ignore[arg-type]
+                    entry,
+                    state.project_root,
+                    link_mode=req.link_mode,  # type: ignore[arg-type]
                 )
             except (FileNotFoundError, ValueError) as exc:
                 skipped.append(f"{entry.name}: {exc}")
@@ -3217,12 +3227,19 @@ def create_app(
         # alongside the primary so a single Generate click produces the
         # complete multi-cam timeline. Cams without a beep yet -- e.g.
         # registered but ingest didn't finish -- are silently skipped; the
-        # SPA's ingest screen flags those rows separately.
+        # SPA's ingest screen flags those rows separately. The Export page
+        # may also pass ``secondary_video_ids`` to restrict the roster to a
+        # subset (None = include every cam with a beep, the legacy default).
+        allowed_ids: set[str] | None = (
+            set(req.secondary_video_ids) if req.secondary_video_ids is not None else None
+        )
         secondaries: list[export_helpers.SecondaryExport] = []
         for sv in stg.videos:
             if sv.role != "secondary":
                 continue
             if sv.beep_time is None:
+                continue
+            if allowed_ids is not None and sv.video_id not in allowed_ids:
                 continue
             sec_source = proj.resolve_video_path(state.project_root, sv.path)
             secondaries.append(
@@ -4218,7 +4235,7 @@ def _print_active_jobs(app: FastAPI) -> None:
             bits.append(f"{round(j.progress * 100)}%")
         print(f"  - {' / '.join(bits)}", file=sys.stderr, flush=True)
     print(
-        "Press Ctrl-C again to force quit (in-flight ffmpeg / detection " "will be killed).",
+        "Press Ctrl-C again to force quit (in-flight ffmpeg / detection will be killed).",
         file=sys.stderr,
         flush=True,
     )

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -319,6 +319,25 @@ export interface MatchAnalysis {
   videos: VideoMatchAnalysisEntry[];
 }
 
+/** Per-secondary cam status surfaced on the Analysis & Export overview
+ *  (issue #54). Mirrors ``splitsmith.ui.project.SecondaryExportStatus``;
+ *  the Export page renders one checkbox row per entry so the user can
+ *  include / exclude individual cams from the next Generate. */
+export interface SecondaryExportStatus {
+  video_id: string;
+  path: string;
+  /** Display label (defaults to the basename of ``path``). */
+  label: string;
+  has_beep: boolean;
+  beep_reviewed: boolean;
+  source_reachable: boolean;
+  /** Path to the per-cam lossless trim under ``exports/`` -- only set
+   *  when the file is on disk. ``null`` before the user runs Generate
+   *  (or when the cam was excluded last time). */
+  trim_path: string | null;
+  trim_present: boolean;
+}
+
 /** Per-stage status row for the Analysis & Export overview (#17).
  *  Mirrors splitsmith.ui.project.StageExportStatus. The SPA renders one
  *  card per row; ``ready_to_export`` decides whether Generate is enabled.
@@ -349,6 +368,10 @@ export interface StageExportStatus {
   last_export_at: string | null;
   ready_to_export: boolean;
   source_reachable: boolean | null;
+  /** Multi-cam roster (issue #54). One entry per secondary on the stage,
+   *  including cams without a beep / unreachable cams (the SPA renders
+   *  those as disabled rows). Empty when the stage is single-cam. */
+  secondaries: SecondaryExportStatus[];
 }
 
 export interface ExportOverview {
@@ -363,6 +386,11 @@ export interface ExportStageRequestPayload {
   /** Render the per-frame PIL + ffmpeg overlay MOV (issue #45). Defaults
    *  off because it's the slowest writer; opt in per stage. */
   write_overlay?: boolean;
+  /** Allowlist of secondary ``video_id``s to include in the multi-cam
+   *  FCPXML / per-cam trims (issue #54). Omit (or pass ``null``) to keep
+   *  the legacy "every secondary with a beep" default; pass ``[]`` to
+   *  exclude all secondaries; pass a list to ship only the named cams. */
+  secondary_video_ids?: string[] | null;
 }
 
 export interface ExportStageResult {
@@ -970,6 +998,12 @@ export const api = {
         write_fcpxml: opts.write_fcpxml ?? true,
         write_report: opts.write_report ?? true,
         write_overlay: opts.write_overlay ?? false,
+        // ``undefined`` => omit (server picks the legacy "all cams with a
+        // beep" default); ``null`` / ``[]`` are forwarded as-is so the
+        // caller can explicitly exclude all secondaries.
+        ...(opts.secondary_video_ids !== undefined
+          ? { secondary_video_ids: opts.secondary_video_ids }
+          : {}),
       },
     }),
 

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -12,7 +12,7 @@
  * to the splits CSV on the next Generate.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   AlertCircle,
@@ -26,6 +26,7 @@ import {
   Loader2,
   PlayCircle,
   RefreshCw,
+  Video,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -45,6 +46,7 @@ import {
   type ExportOverview,
   type Job,
   type MatchProject,
+  type SecondaryExportStatus,
   type StageAudit,
   type StageExportStatus,
 } from "@/lib/api";
@@ -255,6 +257,36 @@ function StageActions({
   // Overlay (issue #45) defaults off: render is slower than the other
   // writers and most users only want it once per stage.
   const [overlay, setOverlay] = useState(false);
+  // Per-cam include/exclude (issue #54). Default-on when the cam is
+  // shippable (has a beep + source reachable); resyncs whenever the row
+  // refreshes from the overview so flipping a cam's role / detecting its
+  // beep doesn't leave stale state behind.
+  const eligibleCamIds = useMemo(
+    () =>
+      row.secondaries
+        .filter((s) => s.has_beep && s.source_reachable)
+        .map((s) => s.video_id),
+    [row.secondaries],
+  );
+  const [selectedCams, setSelectedCams] = useState<Set<string>>(
+    () => new Set(eligibleCamIds),
+  );
+  useEffect(() => {
+    setSelectedCams((prev) => {
+      const next = new Set<string>();
+      const eligible = new Set(eligibleCamIds);
+      for (const id of prev) {
+        if (eligible.has(id)) next.add(id);
+      }
+      for (const id of eligibleCamIds) {
+        // Newly eligible cams (e.g. user just confirmed the beep) opt in
+        // by default; the user can untick before clicking Generate.
+        if (!prev.has(id) && !next.has(id)) next.add(id);
+      }
+      return next;
+    });
+  }, [eligibleCamIds]);
+
   const [job, setJob] = useState<Job | null>(null);
 
   const sourceUnreachable = row.has_primary && row.source_reachable === false;
@@ -297,12 +329,19 @@ function StageActions({
   const generate = async () => {
     onError(null);
     try {
+      // Forward the per-cam allowlist only when the stage actually has
+      // secondaries -- on a single-cam stage we let the server keep its
+      // legacy "all eligible cams" default rather than sending an empty
+      // list that would explicitly suppress nothing.
       const submitted = await api.exportStage(row.stage_number, {
         write_trim: trim,
         write_csv: csv,
         write_fcpxml: fcpxml,
         write_report: reportFlag,
         write_overlay: overlay,
+        ...(row.secondaries.length > 0
+          ? { secondary_video_ids: Array.from(selectedCams) }
+          : {}),
       });
       setJob(submitted);
       const final = await api.pollJob(submitted.id, setJob);
@@ -448,6 +487,21 @@ function StageActions({
         </Button>
       </div>
 
+      <SecondariesPanel
+        secondaries={row.secondaries}
+        selected={selectedCams}
+        onToggle={(id, checked) =>
+          setSelectedCams((prev) => {
+            const next = new Set(prev);
+            if (checked) next.add(id);
+            else next.delete(id);
+            return next;
+          })
+        }
+        disabled={busy}
+        onReveal={reveal}
+      />
+
       <FileLinks row={row} onReveal={reveal} />
 
       {job ? (
@@ -462,6 +516,102 @@ function StageActions({
           <span className="text-muted-foreground">{job.message ?? job.status}</span>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function SecondariesPanel({
+  secondaries,
+  selected,
+  onToggle,
+  disabled,
+  onReveal,
+}: {
+  secondaries: SecondaryExportStatus[];
+  selected: Set<string>;
+  onToggle: (videoId: string, checked: boolean) => void;
+  disabled: boolean;
+  onReveal: (path: string | null) => void;
+}) {
+  if (secondaries.length === 0) return null;
+  const eligibleCount = secondaries.filter(
+    (s) => s.has_beep && s.source_reachable,
+  ).length;
+  const selectedCount = secondaries.filter(
+    (s) => s.has_beep && s.source_reachable && selected.has(s.video_id),
+  ).length;
+  return (
+    <div className="space-y-1 rounded-md border border-border/60 bg-muted/10 p-2 text-xs">
+      <div className="flex items-center gap-2 px-1 pb-1 text-muted-foreground">
+        <Video className="size-3.5" />
+        <span className="font-medium">
+          Secondary cams ({selectedCount} of {eligibleCount} selected)
+        </span>
+        <span className="text-[11px]">
+          -- each ships its own lossless trim and rides the multi-cam FCPXML
+          on lanes V1, V2, ...
+        </span>
+      </div>
+      {secondaries.map((s) => {
+        const eligible = s.has_beep && s.source_reachable;
+        const checked = selected.has(s.video_id);
+        const reason = !s.source_reachable
+          ? "Source unreachable -- reconnect external storage"
+          : !s.has_beep
+            ? "No beep yet -- detect or set the beep on the ingest screen"
+            : null;
+        return (
+          <div
+            key={s.video_id}
+            className={cn(
+              "flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/40 bg-background/40 px-2 py-1",
+              !eligible && "opacity-60",
+            )}
+          >
+            <label className="flex min-w-0 items-center gap-2">
+              <input
+                type="checkbox"
+                className="size-4 accent-primary"
+                checked={eligible && checked}
+                disabled={disabled || !eligible}
+                onChange={(e) => onToggle(s.video_id, e.target.checked)}
+                title={reason ?? "Include this cam in the next export"}
+              />
+              <span className="truncate font-mono">{s.label}</span>
+              {!s.has_beep ? (
+                <Badge variant="statusNotStarted" className="shrink-0">
+                  No beep
+                </Badge>
+              ) : !s.beep_reviewed ? (
+                <Badge variant="statusInProgress" className="shrink-0">
+                  Beep unreviewed
+                </Badge>
+              ) : null}
+              {!s.source_reachable ? (
+                <Badge variant="statusWarning" className="shrink-0 gap-1">
+                  <AlertCircle className="size-3" /> Source missing
+                </Badge>
+              ) : null}
+              {s.trim_present ? (
+                <Badge variant="statusComplete" className="shrink-0">
+                  Trim ready
+                </Badge>
+              ) : null}
+            </label>
+            {s.trim_path ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-2"
+                onClick={() => onReveal(s.trim_path)}
+                title="Reveal the per-cam trim in the OS file manager"
+              >
+                <FolderOpen className="size-3.5" />
+              </Button>
+            ) : null}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -473,3 +473,139 @@ def test_export_overview_status(tmp_path: Path) -> None:
     # ``raw/a.mp4`` doesn't exist on disk, mirroring the "USB unplugged"
     # case the SPA badges with "Source missing".
     assert row.source_reachable is False
+    # Single-cam stage -- secondaries roster is empty.
+    assert row.secondaries == []
+
+
+def test_export_overview_surfaces_secondaries(tmp_path: Path) -> None:
+    """Every secondary on the stage shows up in ``StageExportStatus.secondaries``,
+    flagged with beep / source / trim state so the SPA can render the multi-cam
+    panel without having to cross-reference the project + filesystem itself."""
+    from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.stages.append(
+        StageEntry(
+            stage_number=1,
+            stage_name="Stage 1 -- H1",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        )
+    )
+    # Primary present + processed so we land in the multi-cam-ready state.
+    primary_src = root / "raw" / "a.mp4"
+    primary_src.parent.mkdir(parents=True, exist_ok=True)
+    primary_src.write_bytes(b"")
+    project.stages[0].videos.extend(
+        [
+            StageVideo(
+                path=Path("raw/a.mp4"),
+                role="primary",
+                beep_time=1.0,
+                beep_reviewed=True,
+                processed={"beep": True, "shot_detect": True, "trim": True},
+            ),
+            # Eligible: beep + reachable source + a stale trim from a prior run.
+            StageVideo(
+                path=Path("raw/cam_ready.mp4"),
+                role="secondary",
+                beep_time=2.0,
+                beep_reviewed=True,
+            ),
+            # Beep set but unreviewed -- still eligible to ship; SPA flags it.
+            StageVideo(
+                path=Path("raw/cam_unreviewed.mp4"),
+                role="secondary",
+                beep_time=3.0,
+                beep_reviewed=False,
+            ),
+            # Source missing (no file on disk) -- ineligible.
+            StageVideo(
+                path=Path("raw/cam_missing.mp4"),
+                role="secondary",
+                beep_time=4.0,
+            ),
+            # No beep yet -- ineligible until the user runs detect / sets one.
+            StageVideo(
+                path=Path("raw/cam_no_beep.mp4"),
+                role="secondary",
+            ),
+            # Ignored videos must not leak into the secondaries roster.
+            StageVideo(path=Path("raw/cam_ignored.mp4"), role="ignored"),
+        ]
+    )
+    # Materialise the two cams whose sources should resolve, plus a stale
+    # per-cam trim for the "ready" one so we can prove ``trim_present`` /
+    # ``trim_path`` flow through.
+    (root / "raw" / "cam_ready.mp4").write_bytes(b"")
+    (root / "raw" / "cam_unreviewed.mp4").write_bytes(b"")
+    cam_ready_id = project.stages[0].videos[1].video_id
+    base = "stage1_stage-1-h1"
+    stale_trim = root / "exports" / f"{base}_cam_{cam_ready_id}_trimmed.mp4"
+    stale_trim.parent.mkdir(parents=True, exist_ok=True)
+    stale_trim.write_bytes(b"stale")
+
+    audit = root / "audit" / "stage1.json"
+    audit.write_text(
+        json.dumps(
+            _audit_payload(
+                shots=[
+                    {"shot_number": 1, "candidate_number": 1, "time": 5.5, "ms_after_beep": 500},
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    overview = project.export_overview(root)
+    row = overview[0]
+    by_path = {s.path.name: s for s in row.secondaries}
+    # Ignored videos are filtered; the four secondaries each get an entry.
+    assert set(by_path) == {
+        "cam_ready.mp4",
+        "cam_unreviewed.mp4",
+        "cam_missing.mp4",
+        "cam_no_beep.mp4",
+    }
+
+    ready = by_path["cam_ready.mp4"]
+    assert ready.has_beep and ready.source_reachable
+    assert ready.beep_reviewed is True
+    assert ready.trim_present and ready.trim_path == stale_trim
+
+    unreviewed = by_path["cam_unreviewed.mp4"]
+    assert unreviewed.has_beep and unreviewed.source_reachable
+    assert unreviewed.beep_reviewed is False
+    assert unreviewed.trim_present is False and unreviewed.trim_path is None
+
+    missing = by_path["cam_missing.mp4"]
+    assert missing.has_beep and missing.source_reachable is False
+
+    nobeep = by_path["cam_no_beep.mp4"]
+    assert nobeep.has_beep is False
+
+    # The stale per-cam trim alone is enough to flip ``has_exports`` true,
+    # since the SPA's "Exported" badge should reflect any export artefact
+    # on disk -- not just primary outputs.
+    assert row.has_exports is True
+    assert row.last_export_at is not None
+
+
+def test_export_stage_request_accepts_secondary_video_ids() -> None:
+    """``ExportStageRequest`` round-trips the new allowlist field. ``None``
+    keeps the legacy "include every cam with a beep" default; an empty list
+    forces zero secondaries; a populated list narrows to the named cams."""
+    from splitsmith.ui.server import ExportStageRequest
+
+    default = ExportStageRequest()
+    assert default.secondary_video_ids is None
+
+    explicit_none = ExportStageRequest.model_validate({"secondary_video_ids": None})
+    assert explicit_none.secondary_video_ids is None
+
+    empty = ExportStageRequest.model_validate({"secondary_video_ids": []})
+    assert empty.secondary_video_ids == []
+
+    subset = ExportStageRequest.model_validate({"secondary_video_ids": ["aaa", "bbb"]})
+    assert subset.secondary_video_ids == ["aaa", "bbb"]


### PR DESCRIPTION
## Summary
Implements a new "Secondary cams" panel on the Export page that allows users to selectively include or exclude individual secondary cameras from multi-cam exports. This addresses issue #54 by giving users fine-grained control over which cameras are included in the generated FCPXML and per-camera lossless trims.

## Key Changes

### Backend (Python)
- **New `SecondaryExportStatus` model** in `project.py`: Surfaces per-secondary-camera export status including beep state, source reachability, and trim file presence
- **Enhanced `StageExportStatus`**: Added `secondaries` field containing a roster of all secondary cameras on the stage
- **Updated `export_overview()` method**: Builds secondary camera status entries and includes per-camera trim files in export detection logic
- **Extended `ExportStageRequest`**: Added optional `secondary_video_ids` field to allow clients to specify which cameras to include (None = legacy "all with beep" default, empty list = exclude all, populated list = include only named cameras)
- **Updated `_run_export_for_stage()`**: Respects the `secondary_video_ids` allowlist when building the secondaries roster for export

### Frontend (React/TypeScript)
- **New `SecondariesPanel` component**: Renders a checkbox-based UI for selecting secondary cameras with visual indicators for:
  - Beep status (not set, unreviewed, or confirmed)
  - Source reachability (missing/unreachable sources are disabled)
  - Trim availability (shows when a per-camera trim is ready)
- **Enhanced `StageActions` component**: 
  - Added `useMemo` hook to track eligible cameras (those with beep + reachable source)
  - Added `useState` for managing selected camera set with smart defaults (newly eligible cams opt-in automatically)
  - Added `useEffect` to resync selection state when eligible cameras change
  - Passes `secondary_video_ids` to the export API only when the stage has secondaries
- **Updated API types** in `api.ts`: Added `SecondaryExportStatus` interface and `secondary_video_ids` field to `ExportStageRequestPayload`

### Tests
- **New test `test_export_overview_surfaces_secondaries()`**: Validates that secondary camera status is correctly surfaced with various states (eligible, unreviewed beep, missing source, no beep)
- **New test `test_export_stage_request_accepts_secondary_video_ids()`**: Verifies the request model correctly handles the allowlist field

## Notable Implementation Details

- **Smart defaults**: Newly eligible cameras (e.g., after beep detection) automatically opt-in; users can untick before generating
- **Backward compatibility**: Omitting `secondary_video_ids` preserves the legacy "include every camera with a beep" behavior
- **Disabled state handling**: Ineligible cameras (no beep or unreachable source) are rendered as disabled checkboxes with explanatory tooltips
- **Export detection**: Per-camera trim files now contribute to the `has_exports` flag, so stages with only secondary exports are correctly marked as exported
- **UI polish**: Uses existing badge variants and icons (Video icon from lucide-react) to maintain design consistency

https://claude.ai/code/session_01GxR2bPrDH66sGbpZBAHzRM