### PR TITLE
ingest: thumbnail-as-poster preview + manual-beep scrub picker

### DIFF
--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -248,11 +248,11 @@ export function BeepSection({
             setError={setError}
           />
         ) : (
-          <div className="text-xs text-muted-foreground">
-            Tip: scrub the preview clip below the section header after Apply --
-            secondaries don't have a project-level waveform yet (the audit
-            timeline is anchored to the primary's audio).
-          </div>
+          <SecondaryScrubPicker
+            videoPath={video.path}
+            initialTime={draftValid ? draftSourceTime : video.beep_time ?? 0}
+            onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
+          />
         )}
       </div>
     );
@@ -691,6 +691,81 @@ function BeepWaveformPicker({
           onDismiss={dismissProposal}
         />
       ) : null}
+    </div>
+  );
+}
+
+/** Inline video scrub + "use current time" picker for secondaries.
+ *
+ *  The primary gets a waveform picker because we already cache stage-level
+ *  audio peaks for it; secondaries don't have that, but they DO have their
+ *  own video stream. Letting the user scrub the secondary's actual footage
+ *  and click "Use current time" is good enough to find the buzzer or
+ *  first-shot moment by ear / eye, which is the core thing the manual
+ *  override needs to support when in-stream beep detection fails (e.g.
+ *  iPhone tripod cam where the buzzer isn't a sustained 2-5 kHz tone). */
+function SecondaryScrubPicker({
+  videoPath,
+  initialTime,
+  onPick,
+}: {
+  videoPath: string;
+  initialTime: number;
+  onPick: (sourceTime: number) => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  // Seek to the current draft time when the user reopens the editor or
+  // edits the numeric input -- the video should follow, so they can verify
+  // the time they typed lands on the right frame.
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+    if (!Number.isFinite(initialTime) || initialTime < 0) return;
+    if (Math.abs(el.currentTime - initialTime) < 0.05) return;
+    try {
+      el.currentTime = initialTime;
+    } catch {
+      // Some browsers throw if metadata isn't loaded yet; the
+      // loadedmetadata handler below will retry.
+    }
+  }, [initialTime]);
+
+  return (
+    <div className="space-y-2">
+      <video
+        ref={videoRef}
+        src={api.videoStreamUrl(videoPath)}
+        controls
+        preload="metadata"
+        className="block w-full max-h-[40vh] rounded bg-black"
+        onLoadedMetadata={(e) => {
+          if (Number.isFinite(initialTime) && initialTime >= 0) {
+            try {
+              e.currentTarget.currentTime = initialTime;
+            } catch {
+              // Source might not support seeking before first decode;
+              // ignored (the user can still scrub manually).
+            }
+          }
+        }}
+      />
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <Button
+          size="sm"
+          variant="secondary"
+          type="button"
+          onClick={() => {
+            const el = videoRef.current;
+            if (!el) return;
+            onPick(el.currentTime);
+          }}
+        >
+          <Crosshair />
+          Use current time
+        </Button>
+        <span>Scrub to the buzzer (or first audible shot) and click to set the draft.</span>
+      </div>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -30,7 +30,6 @@ import {
   User,
   Video as VideoIcon,
   WifiOff,
-  X,
   XCircle,
 } from "lucide-react";
 
@@ -1626,10 +1625,10 @@ function UnassignedSection({
           Unassigned videos · {project.unassigned_videos.length}
         </CardTitle>
         <CardDescription>
-          Hover any thumbnail for a quick still, or click Preview to scrub the
-          actual clip. Drag a row onto a stage card to assign, or back here to
-          unassign. Trash removes the video from the project (cache is cleared;
-          the original source on USB / external storage is never touched).
+          Hit play on any row to scrub the clip. Drag a row onto a stage card
+          to assign, or back here to unassign. Trash removes the video from
+          the project (cache is cleared; the original source on USB / external
+          storage is never touched).
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2">
@@ -1677,7 +1676,6 @@ function UnassignedVideoCard({
   onRemove: (video: StageVideo, stage: StageEntry | null) => void;
 }) {
   const [meta, setMeta] = useState<FsProbeResponse | null>(null);
-  const [showPreview, setShowPreview] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -1719,51 +1717,25 @@ function UnassignedVideoCard({
       className="rounded-md border border-border bg-muted/40 p-3"
     >
       <div className="flex flex-col gap-3 sm:flex-row">
-        {/* Thumbnail / inline preview */}
+        {/* Inline video with thumbnail poster -- click the native play
+            control to start. No JS state machine: the <video> element
+            already gives us pause / scrub / fullscreen for free, and
+            using the cached thumbnail as a poster avoids the network
+            round-trip browsers do otherwise. */}
         <div className="relative w-full shrink-0 overflow-hidden rounded bg-black/40 sm:w-48 aspect-video">
-          {showPreview ? (
-            <>
-              <video
-                src={api.videoStreamUrl(video.path)}
-                controls
-                autoPlay
-                preload="metadata"
-                className="h-full w-full"
-              />
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowPreview(false);
-                }}
-                className="absolute right-1 top-1 rounded bg-black/70 p-1 text-white hover:bg-black/90"
-                title="Close preview"
-                aria-label="Close preview"
-              >
-                <X className="size-3.5" />
-              </button>
-            </>
-          ) : meta?.thumbnail_url ? (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowPreview(true);
-              }}
-              className="group relative block h-full w-full"
-              title="Click to play preview"
-              aria-label="Play preview"
-            >
-              <img
-                src={meta.thumbnail_url}
-                alt={`${filename} thumbnail`}
-                className="h-full w-full object-cover"
-                draggable={false}
-              />
-              <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30 opacity-0 transition-opacity group-hover:opacity-100">
-                <PlayCircle className="size-10 text-white drop-shadow" />
-              </span>
-            </button>
+          {meta ? (
+            <video
+              src={api.videoStreamUrl(video.path)}
+              poster={meta.thumbnail_url ?? undefined}
+              controls
+              preload="none"
+              className="h-full w-full"
+              // Stop drag events bubbling to DraggableVideoRow so the
+              // user can scrub the timeline without accidentally
+              // dragging the row out of the unassigned tray.
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+            />
           ) : (
             <Skeleton className="h-full w-full rounded-none" />
           )}
@@ -1860,22 +1832,6 @@ function UnassignedVideoCard({
 
         {/* Actions */}
         <div className="flex shrink-0 flex-row flex-wrap gap-1 sm:flex-col sm:items-end">
-          <Button
-            size="sm"
-            variant={showPreview ? "secondary" : "outline"}
-            onClick={() => setShowPreview((v) => !v)}
-            title={showPreview ? "Hide preview" : "Play inline preview"}
-          >
-            {showPreview ? (
-              <>
-                <X className="mr-1" /> Close
-              </>
-            ) : (
-              <>
-                <PlayCircle className="mr-1" /> Preview
-              </>
-            )}
-          </Button>
           <div className="flex flex-wrap gap-1 sm:justify-end">
             {stagesOrdered.map((s) => {
               const isSuggested = suggestedSet.has(s.stage_number);


### PR DESCRIPTION
## Summary
- The unassigned-tray row had a separate Preview / Close button that toggled an autoplay clip. Replaced with a single inline `<video>` using the cached thumbnail as `poster` and `preload=\"none\"` -- click the native play control to start; pause / scrub / fullscreen come for free. `stopPropagation` on the video's mouse events keeps the row draggable while the user scrubs the timeline.
- Manual-beep editing for secondaries was effectively broken: the editor showed only a numeric input and a tip saying \"scrub the preview clip after Apply\". Required knowing the timestamp before the user could verify it. Added a `SecondaryScrubPicker` -- inline `<video controls>` of the secondary's own footage with a \"Use current time\" button that fills the draft. Critical when in-stream beep detection fails on a non-headcam (iPhone tripod, RO-position) and cross-correlation alignment can't recover either.

## Test plan
- [x] `pnpm typecheck` -- clean.
- [x] `pnpm build` -- bundles, no warnings introduced.
- [ ] Manual: open Ingest, see the unassigned tray rows render with a video element + thumbnail poster, click play to confirm scrubbing without auto-play. Drag a row -- the video doesn't intercept. Assign a video as secondary, click \"Set manually\" on a secondary that has no detected beep, scrub the inline video, click \"Use current time\", confirm the numeric draft updates and Apply persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)