### PR TITLE
ingest: secondaries get the same waveform picker as primaries

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2586,6 +2586,44 @@ def create_app(
         except audio_helpers.AudioExtractionError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+    def _resolve_video_audio(
+        project: MatchProject, stage_number: int, video: StageVideo
+    ) -> audio_helpers.AuditAudioResult:
+        """Per-video version of :func:`_resolve_audit_audio`.
+
+        Primary delegates to the audit-audio resolver so the existing
+        cache + trim-clip preference is preserved. Non-primary returns
+        the full per-cam WAV (``stage<N>_cam_<vid>.wav``) -- there's no
+        per-secondary trim clip, and the picker needs the whole clip
+        anyway so the user can find the buzzer / first shot regardless
+        of where the current beep estimate sits.
+
+        ``beep_in_clip`` mirrors the primary path: the WAV is full source
+        time, so it's just ``video.beep_time`` (no trim offset). Audit
+        callers that need clip-local time should keep using the primary
+        endpoint -- this resolver is for the per-video beep picker.
+        """
+        if video.role == "primary":
+            return _resolve_audit_audio(project, stage_number)
+        source = project.resolve_video_path(state.project_root, video.path)
+        try:
+            audio_path = audio_helpers.ensure_video_audio(
+                state.project_root,
+                stage_number,
+                video,
+                source,
+                project=project,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except audio_helpers.AudioExtractionError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return audio_helpers.AuditAudioResult(
+            audio_path=audio_path,
+            beep_in_clip=video.beep_time,
+            trimmed=False,
+        )
+
     def _serve_beep_preview(
         project: MatchProject,
         stage_number: int,
@@ -2684,6 +2722,45 @@ def create_app(
         """
         project = state.load()
         audit = _resolve_audit_audio(project, stage_number)
+        peaks = waveform_helpers.ensure_peaks(audit.audio_path, bins)
+        payload = peaks.model_dump(mode="json")
+        payload["beep_time"] = audit.beep_in_clip
+        payload["trimmed"] = audit.trimmed
+        return JSONResponse(payload)
+
+    @app.get("/api/stages/{stage_number}/videos/{video_id}/audio")
+    def video_audio(stage_number: int, video_id: str) -> FileResponse:
+        """Serve ``video``'s WAV for the per-video beep picker.
+
+        Primary forwards to the legacy stage audio resolver so the
+        trimmed audit clip is preferred. Secondary returns the full
+        per-cam WAV (``stage<N>_cam_<vid>.wav``) -- no per-secondary
+        trim clip exists yet, and the picker needs the entire clip so
+        the user can find the buzzer / first-shot regardless of where
+        the current beep estimate is.
+        """
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        result = _resolve_video_audio(project, stage_number, video)
+        return FileResponse(
+            result.audio_path,
+            media_type="audio/wav",
+            filename=result.audio_path.name,
+        )
+
+    @app.get("/api/stages/{stage_number}/videos/{video_id}/peaks")
+    def video_peaks(
+        stage_number: int,
+        video_id: str,
+        bins: int = Query(default=1200, ge=16, le=8192),
+    ) -> JSONResponse:
+        """Return ``bins`` peak magnitudes for ``video``'s WAV.
+
+        Same shape as ``/api/stages/{n}/peaks`` so the SPA's waveform
+        picker can take the same path for primary + secondary -- the
+        only thing that varies between roles is the URL.
+        """
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        audit = _resolve_video_audio(project, stage_number, video)
         peaks = waveform_helpers.ensure_peaks(audit.audio_path, bins)
         payload = peaks.model_dump(mode="json")
         payload["beep_time"] = audit.beep_in_clip

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -238,22 +238,14 @@ export function BeepSection({
             Cancel
           </Button>
         </div>
-        {isPrimary ? (
-          <BeepWaveformPicker
-            stageNumber={stageNumber}
-            videoId={videoId}
-            primaryBeepTime={video.beep_time}
-            draftSourceTime={draftValid ? draftSourceTime : null}
-            onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
-            setError={setError}
-          />
-        ) : (
-          <SecondaryScrubPicker
-            videoPath={video.path}
-            initialTime={draftValid ? draftSourceTime : video.beep_time ?? 0}
-            onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
-          />
-        )}
+        <BeepWaveformPicker
+          stageNumber={stageNumber}
+          videoId={videoId}
+          videoBeepTime={video.beep_time}
+          draftSourceTime={draftValid ? draftSourceTime : null}
+          onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
+          setError={setError}
+        />
       </div>
     );
   }
@@ -421,25 +413,29 @@ export function BeepSection({
  *    5. Zoom controls (in / out) feed pixelsPerSecond to the Waveform so
  *       the user can see sub-frame detail near the beep.
  *
- *  Time conversion: /audio + /peaks serve clip-local time (the trimmed
- *  audit clip when cached, the full primary WAV otherwise). The picker's
- *  draft is in source time. ``offset = primary.beep_time - peaks.beep_time``
- *  bridges the two -- zero when the WAV is full source, equal to the trim
- *  start when it's a trimmed audit clip.
+ *  Time conversion: /audio + /peaks serve clip-local time. For the
+ *  primary, this is the trimmed audit clip when cached (so peaks.beep_time
+ *  is the in-clip position) or the full primary WAV otherwise. For
+ *  secondaries it's always the full per-cam WAV (no per-secondary trim
+ *  exists). The picker's draft is in source time;
+ *  ``offset = videoBeepTime - peaks.beep_time`` bridges the two -- zero
+ *  when the WAV is full source, equal to the trim start when it's a
+ *  trimmed audit clip.
  *
- *  Secondary cameras don't have a project-level waveform endpoint and
- *  fall back to the numeric input + preview clip in BeepSection. */
+ *  Generic over role: peaks + audio come from per-video endpoints
+ *  (`/api/stages/{n}/videos/{vid}/...`) so primary and secondary use the
+ *  same component, the same controls, and the same snap-to-beep flow. */
 function BeepWaveformPicker({
   stageNumber,
   videoId,
-  primaryBeepTime,
+  videoBeepTime,
   draftSourceTime,
   onPick,
   setError,
 }: {
   stageNumber: number;
   videoId: string;
-  primaryBeepTime: number | null;
+  videoBeepTime: number | null;
   draftSourceTime: number | null;
   onPick: (sourceTime: number) => void;
   setError: (msg: string | null) => void;
@@ -460,7 +456,7 @@ function BeepWaveformPicker({
     setLoading(true);
     setUnavailable(false);
     api
-      .getStagePeaks(stageNumber)
+      .getVideoPeaks(stageNumber, videoId)
       .then((p) => {
         if (cancelled) return;
         setPeaks(p);
@@ -475,15 +471,15 @@ function BeepWaveformPicker({
     return () => {
       cancelled = true;
     };
-  }, [stageNumber]);
+  }, [stageNumber, videoId]);
 
   // Source-time <-> clip-time bridge. Zero when the WAV is the full
-  // primary; equal to the trim window's start when the audit clip is
-  // cached.
+  // source; equal to the trim window's start when an audit clip is
+  // cached for the primary.
   const offset = useMemo(() => {
-    if (primaryBeepTime == null || !peaks || peaks.beep_time == null) return 0;
-    return primaryBeepTime - peaks.beep_time;
-  }, [primaryBeepTime, peaks]);
+    if (videoBeepTime == null || !peaks || peaks.beep_time == null) return 0;
+    return videoBeepTime - peaks.beep_time;
+  }, [videoBeepTime, peaks]);
 
   // The draft (in source coords) becomes a dashed marker on the
   // waveform. Falls back to the auto-detected beep when no draft yet.
@@ -655,7 +651,7 @@ function BeepWaveformPicker({
       />
       <audio
         ref={audioRef}
-        src={api.stageAudioUrl(stageNumber)}
+        src={api.videoAudioUrl(stageNumber, videoId)}
         preload="metadata"
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
@@ -695,80 +691,6 @@ function BeepWaveformPicker({
   );
 }
 
-/** Inline video scrub + "use current time" picker for secondaries.
- *
- *  The primary gets a waveform picker because we already cache stage-level
- *  audio peaks for it; secondaries don't have that, but they DO have their
- *  own video stream. Letting the user scrub the secondary's actual footage
- *  and click "Use current time" is good enough to find the buzzer or
- *  first-shot moment by ear / eye, which is the core thing the manual
- *  override needs to support when in-stream beep detection fails (e.g.
- *  iPhone tripod cam where the buzzer isn't a sustained 2-5 kHz tone). */
-function SecondaryScrubPicker({
-  videoPath,
-  initialTime,
-  onPick,
-}: {
-  videoPath: string;
-  initialTime: number;
-  onPick: (sourceTime: number) => void;
-}) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-
-  // Seek to the current draft time when the user reopens the editor or
-  // edits the numeric input -- the video should follow, so they can verify
-  // the time they typed lands on the right frame.
-  useEffect(() => {
-    const el = videoRef.current;
-    if (!el) return;
-    if (!Number.isFinite(initialTime) || initialTime < 0) return;
-    if (Math.abs(el.currentTime - initialTime) < 0.05) return;
-    try {
-      el.currentTime = initialTime;
-    } catch {
-      // Some browsers throw if metadata isn't loaded yet; the
-      // loadedmetadata handler below will retry.
-    }
-  }, [initialTime]);
-
-  return (
-    <div className="space-y-2">
-      <video
-        ref={videoRef}
-        src={api.videoStreamUrl(videoPath)}
-        controls
-        preload="metadata"
-        className="block w-full max-h-[40vh] rounded bg-black"
-        onLoadedMetadata={(e) => {
-          if (Number.isFinite(initialTime) && initialTime >= 0) {
-            try {
-              e.currentTarget.currentTime = initialTime;
-            } catch {
-              // Source might not support seeking before first decode;
-              // ignored (the user can still scrub manually).
-            }
-          }
-        }}
-      />
-      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Button
-          size="sm"
-          variant="secondary"
-          type="button"
-          onClick={() => {
-            const el = videoRef.current;
-            if (!el) return;
-            onPick(el.currentTime);
-          }}
-        >
-          <Crosshair />
-          Use current time
-        </Button>
-        <span>Scrub to the buzzer (or first audible shot) and click to set the draft.</span>
-      </div>
-    </div>
-  );
-}
 
 function SnapProposal({
   proposal,

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -932,6 +932,12 @@ export const api = {
 
   stageAudioUrl: (stageNumber: number) => `/api/stages/${stageNumber}/audio`,
 
+  /** Per-video WAV URL. Primary forwards to the legacy stage audio
+   *  endpoint (trimmed audit clip preferred); secondary serves the full
+   *  per-cam WAV so the picker has the whole clip to scrub. */
+  videoAudioUrl: (stageNumber: number, videoId: string) =>
+    `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/audio`,
+
   /** URL for a tiny MP4 around a beep timestamp (#27, #22). ``t`` is
    *  passed to the server (which centres the clip there) AND ms-rounded
    *  into the cache key, so each distinct ``t`` gets its own MP4. The
@@ -950,6 +956,13 @@ export const api = {
 
   getStagePeaks: (stageNumber: number, bins = 1200) =>
     request<PeaksResult>(`/api/stages/${stageNumber}/peaks?bins=${bins}`),
+
+  /** Per-video peaks. Same payload shape as the stage endpoint so the
+   *  waveform picker takes the same code path for every role. */
+  getVideoPeaks: (stageNumber: number, videoId: string, bins = 1200) =>
+    request<PeaksResult>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/peaks?bins=${bins}`,
+    ),
 
   /** Returns the saved audit JSON for a stage, or null when none exists yet. */
   getStageAudit: async (stageNumber: number): Promise<StageAudit | null> => {

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1717,28 +1717,25 @@ function UnassignedVideoCard({
       className="rounded-md border border-border bg-muted/40 p-3"
     >
       <div className="flex flex-col gap-3 sm:flex-row">
-        {/* Inline video with thumbnail poster -- click the native play
-            control to start. No JS state machine: the <video> element
-            already gives us pause / scrub / fullscreen for free, and
-            using the cached thumbnail as a poster avoids the network
-            round-trip browsers do otherwise. */}
+        {/* Inline video with the cached JPG as poster -- click the native
+            play control to start. The <video> element renders as soon as
+            we know the source URL (no waiting on the probe round-trip);
+            the thumbnail just upgrades the poster image when it arrives.
+            preload="metadata" pulls the moov atom so browsers can fall
+            back to the first frame as a poster while the JPG loads. */}
         <div className="relative w-full shrink-0 overflow-hidden rounded bg-black/40 sm:w-48 aspect-video">
-          {meta ? (
-            <video
-              src={api.videoStreamUrl(video.path)}
-              poster={meta.thumbnail_url ?? undefined}
-              controls
-              preload="none"
-              className="h-full w-full"
-              // Stop drag events bubbling to DraggableVideoRow so the
-              // user can scrub the timeline without accidentally
-              // dragging the row out of the unassigned tray.
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={(e) => e.stopPropagation()}
-            />
-          ) : (
-            <Skeleton className="h-full w-full rounded-none" />
-          )}
+          <video
+            src={api.videoStreamUrl(video.path)}
+            poster={meta?.thumbnail_url ?? undefined}
+            controls
+            preload="metadata"
+            className="h-full w-full"
+            // Stop drag events bubbling to DraggableVideoRow so the
+            // user can scrub the timeline without accidentally
+            // dragging the row out of the unassigned tray.
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          />
         </div>
 
         {/* Metadata */}

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1465,6 +1465,84 @@ def test_peaks_endpoint_uses_trimmed_audio_when_present(tmp_path: Path, monkeypa
     assert body["duration"] == pytest.approx(1.0)
 
 
+def test_video_peaks_endpoint_serves_secondary_full_wav(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The per-video peaks endpoint resolves the secondary's own WAV
+    (``stage<N>_cam_<vid>.wav``) and returns the same payload shape as
+    the stage-level endpoint, so the SPA's waveform picker can take the
+    same code path for primary + secondary."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_secondary(tmp_path)
+    project_root = tmp_path / "match"
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    sec_id = _video_id_for(client, 1, "secondary")
+    sec_wav = audio_dir / f"stage1_cam_{sec_id}.wav"
+    audio = np.zeros(48_000, dtype="float32")
+    audio[10_000:11_000] = 0.5
+    sf.write(sec_wav, audio, 48_000)
+
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake_ensure_video(root, n, video, source, **kwargs):  # type: ignore[no-untyped-def]
+        return sec_wav
+
+    monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
+
+    # Set a beep_time on the secondary so beep_time is reflected in the payload.
+    proj = client.post(
+        f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": 0.42}
+    ).json()
+    assert next(v for v in proj["stages"][0]["videos"] if v["video_id"] == sec_id)[
+        "beep_time"
+    ] == pytest.approx(0.42)
+
+    resp = client.get(f"/api/stages/1/videos/{sec_id}/peaks?bins=64")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bins"] == 64
+    assert len(body["peaks"]) == 64
+    # No per-secondary trim exists -> trimmed=False, beep_time = source time.
+    assert body["trimmed"] is False
+    assert body["beep_time"] == pytest.approx(0.42)
+
+
+def test_video_audio_endpoint_serves_secondary_wav(tmp_path: Path, monkeypatch) -> None:
+    """The per-video audio endpoint returns the secondary's own WAV bytes."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    project_root = tmp_path / "match"
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    sec_id = _video_id_for(client, 1, "secondary")
+    sec_wav = audio_dir / f"stage1_cam_{sec_id}.wav"
+    sec_wav.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00" + b"\x00" * 16)
+
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake_ensure_video(root, n, video, source, **kwargs):  # type: ignore[no-untyped-def]
+        return sec_wav
+
+    monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
+
+    resp = client.get(f"/api/stages/1/videos/{sec_id}/audio")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/wav"
+    assert resp.content.startswith(b"RIFF")
+
+
+def test_video_peaks_endpoint_404_for_unknown_video(tmp_path: Path) -> None:
+    """The per-video endpoint 404s when video_id isn't on the stage --
+    same shape as the per-video beep endpoints."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    resp = client.get("/api/stages/1/videos/deadbeef0000/peaks")
+    assert resp.status_code == 404
+
+
 def test_peaks_endpoint_falls_back_to_full_when_no_trim(tmp_path: Path, monkeypatch) -> None:
     """No trimmed file -> /peaks serves the full primary WAV. Response says
     trimmed=false so the SPA can hint that the user is on an untrimmed clip."""


### PR DESCRIPTION
## Summary
- Replaces the `SecondaryScrubPicker` detour with the real fix: secondaries get the **same** `BeepWaveformPicker` primaries already use. Same waveform, same scrub, same snap-to-beep, same zoom, same audio scrubber.
- Backend: new `_resolve_video_audio` (primary delegates to the existing audit-audio resolver so the trimmed-clip preference is preserved; secondary returns the full per-cam WAV `stage<N>_cam_<vid>.wav`) and two new endpoints with the same payload shape as the stage-level ones:
  - `GET /api/stages/{n}/videos/{vid}/audio`
  - `GET /api/stages/{n}/videos/{vid}/peaks?bins=N`
- Frontend: `BeepWaveformPicker` parametrized on `videoId` (URLs build from per-video endpoints); `primaryBeepTime` prop renamed to `videoBeepTime` since the source-time-vs-clip-time offset bridge is generic. `BeepSection` renders the picker for both roles; `SecondaryScrubPicker` deleted.
- Drive-by: the unassigned-tray row was rendering a forever-pulsating Skeleton when the probe round-trip was slow or `thumbnail_url` was null. The `<video>` now renders as soon as the source URL is known; the cached JPG upgrades into the `poster` when the probe completes, and `preload=\"metadata\"` lets the browser fall back to the first frame in the meantime.

## Test plan
- [x] `pytest tests/test_ui_server.py` -- 152 passed (3 new tests for the per-video peaks + audio endpoints).
- [x] `pnpm typecheck` -- clean.
- [x] `pnpm build` -- bundles cleanly.
- [ ] Manual: open Ingest, find a secondary that lacks a beep, click \"Set manually\", confirm the waveform renders + scrubbing + snap-to-beep all work the way they do for the primary. Confirm the unassigned-tray rows no longer show the grey pulsating skeleton -- the `<video>` element appears immediately and the thumbnail upgrades into the poster when the probe finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)