### PR TITLE
ui: project picker route + unbound-mode server

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -245,10 +245,13 @@ def review(
 
 @app.command()
 def ui(
-    project: Path = typer.Option(
-        ...,
+    project: Path | None = typer.Option(
+        None,
         "--project",
-        help="Match-project root directory. Created (with subdirs) if missing.",
+        help=(
+            "Match-project root directory. Created (with subdirs) if missing. "
+            "Omit to boot the picker; pass --last to reopen the most recent."
+        ),
     ),
     project_name: str | None = typer.Option(
         None,
@@ -257,6 +260,11 @@ def ui(
             "Display name for the match. Defaults to the project directory's "
             "basename. Ignored if the project already has a name on disk."
         ),
+    ),
+    last: bool = typer.Option(
+        False,
+        "--last",
+        help="Open the most-recently-opened project. Errors if the recent list is empty.",
     ),
     host: str = typer.Option("127.0.0.1", "--host"),
     port: int = typer.Option(5174, "--port"),
@@ -276,16 +284,33 @@ def ui(
     The UI is a localhost SPA driven by a FastAPI backend that orchestrates
     the existing engine modules unchanged. State persists to disk under
     ``--project`` so closing the browser and re-running resumes where you
-    left off.
+    left off. With no ``--project`` (and no ``--last``), the server boots
+    "unbound" -- the SPA renders a picker drawn from
+    ``~/.splitsmith/projects.json`` and binds in-memory once the user picks.
     """
+    from . import user_config
     from .ui.server import serve
 
-    project = project.expanduser().resolve()
-    name = project_name or project.name or "match"
+    if last:
+        if project is not None:
+            raise typer.BadParameter("--last and --project are mutually exclusive")
+        recents = user_config.get_recent_projects()
+        if not recents:
+            raise typer.BadParameter("no recent projects to reopen; run with --project")
+        project = Path(recents[0].path)
+
+    resolved: Path | None = None
+    name: str | None = None
+    if project is not None:
+        resolved = project.expanduser().resolve()
+        name = project_name or resolved.name or "match"
 
     url = f"http://{host}:{port}/"
     console.print(f"[green]splitsmith UI[/]: [bold]{url}[/]   (Ctrl+C to stop)")
-    console.print(f"  project: {project}")
+    if resolved is not None:
+        console.print(f"  project: {resolved}")
+    else:
+        console.print("  project: [dim]none -- showing picker[/]")
     if lab:
         console.print("  [cyan]Algorithm Lab[/] enabled")
 
@@ -296,7 +321,7 @@ def ui(
 
     try:
         serve(
-            project_root=project,
+            project_root=resolved,
             project_name=name,
             host=host,
             port=port,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -43,13 +43,19 @@ Endpoints (locked v1 surface):
   GET  /api/fixture/video?path=...  -- serve a fixture-bound video file (Range)
   GET  /api/user/recent-projects    -- recently-opened MatchProject roots (#75)
   POST /api/user/recent-projects/forget -- drop one entry from the list
+  POST /api/user/recent-projects/bind   -- switch the in-memory project
+  POST /api/user/recent-projects/unbind -- drop the bound project (back to picker)
   GET  /api/user/scoreboard-identity -- saved SSI identity (404 if none)
   PUT  /api/user/scoreboard-identity -- write the SSI identity
 
 Design notes:
 - Localhost only. No auth, no CORS configuration beyond what Vite needs in dev.
-- The server holds a single ``MatchProject`` open at a time, identified by
-  ``project_root`` at startup. Multi-project orchestration lives in the SPA.
+- The server holds at most one ``MatchProject`` open at a time. The
+  binding can be set at startup (``--project``) or chosen at runtime via
+  the SPA picker (POST /api/user/recent-projects/bind). When unbound,
+  every project-bound endpoint returns 409 ``no_project`` and the SPA
+  redirects to its picker route. Multi-project orchestration lives in
+  the SPA.
 - All on-disk mutations go through the project model's atomic save.
 - The server re-loads the project from disk for every request (no caching), so
   external edits are visible without restart.
@@ -444,15 +450,74 @@ def _raise_scoreboard_http(exc: ScoreboardError) -> None:
     raise HTTPException(status_code=500, detail=str(exc))
 
 
+def _no_project_error() -> HTTPException:
+    """Raised by :class:`AppState` when an endpoint that needs a bound
+    project is hit while the server is in unbound (picker) mode.
+
+    The SPA inspects ``detail.code == "no_project"`` to redirect to the
+    picker route instead of rendering a generic error.
+    """
+    return HTTPException(
+        status_code=409,
+        detail={
+            "code": "no_project",
+            "message": (
+                "No project is currently open. Pick one from the project "
+                "list (POST /api/user/recent-projects/bind) or restart "
+                "with `splitsmith ui --project <path>`."
+            ),
+        },
+    )
+
+
 @dataclass
 class AppState:
-    """Per-process state. One project root per server instance."""
+    """Per-process state. Holds at most one bound project at a time.
 
-    project_root: Path
+    The server can boot without a project (``splitsmith ui`` with no
+    ``--project`` arg). In that mode every project-bound endpoint raises
+    409 ``no_project`` via the :attr:`project_root` property; the SPA
+    renders the picker route until the user binds via
+    ``POST /api/user/recent-projects/bind``.
+    """
+
+    _project_root: Path | None = None
+    _project_name: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
 
+    @property
+    def project_root(self) -> Path:
+        """Bound project root. Raises 409 ``no_project`` when unbound.
+
+        Property indirection means every existing call-site
+        (``state.project_root``) gets the right behaviour automatically
+        without auditing 80+ usages -- FastAPI translates the
+        HTTPException into a structured response the SPA recognises.
+        """
+        if self._project_root is None:
+            raise _no_project_error()
+        return self._project_root
+
+    @property
+    def is_bound(self) -> bool:
+        return self._project_root is not None
+
+    @property
+    def project_name(self) -> str | None:
+        return self._project_name
+
+    def bind(self, root: Path, name: str) -> None:
+        self._project_root = root
+        self._project_name = name
+
+    def unbind(self) -> None:
+        self._project_root = None
+        self._project_name = None
+
     def load(self) -> MatchProject:
-        return MatchProject.load(self.project_root)
+        if self._project_root is None:
+            raise _no_project_error()
+        return MatchProject.load(self._project_root)
 
 
 # Module-level cache for the 4-voter ensemble runtime (issue #31). Heavy
@@ -481,9 +546,22 @@ def _get_ensemble_runtime() -> ensemble_module.EnsembleRuntime:
 
 class HealthResponse(BaseModel):
     status: str = "ok"
-    project_name: str
-    project_root: str
-    schema_version: int
+    bound: bool
+    project_name: str | None = None
+    project_root: str | None = None
+    schema_version: int | None = None
+
+
+class BindRecentProjectRequest(BaseModel):
+    """Body for POST /api/user/recent-projects/bind.
+
+    The server binds in-memory only; on next launch the user reopens via
+    the same picker. ``name`` is optional -- the server reads the
+    on-disk display name from ``project.json`` when available.
+    """
+
+    path: str
+    name: str | None = None
 
 
 # Request bodies ----------------------------------------------------------
@@ -773,40 +851,63 @@ class FsListing(BaseModel):
     suggested_starts: list[SuggestedStart]
 
 
+def _bind_project_to_state(
+    state: AppState,
+    root: Path,
+    fallback_name: str,
+) -> str:
+    """Initialise ``root`` on disk if needed, load its env files, record
+    the open in ``~/.splitsmith/projects.json``, and bind it on ``state``.
+
+    Used both at startup (when ``--project`` was passed) and at runtime
+    (when the SPA POSTs to /api/user/recent-projects/bind). Returns the
+    on-disk display name so the caller can echo it back.
+    """
+    MatchProject.init(root, name=fallback_name)
+    resolved = root.resolve()
+    loaded_env = _load_env_files(resolved)
+    if loaded_env:
+        logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
+    try:
+        loaded_project = MatchProject.load(resolved)
+        recorded_name = loaded_project.name or fallback_name
+    except Exception:  # pragma: no cover -- defensive: never block boot
+        recorded_name = fallback_name
+    user_config.record_project_open(resolved, recorded_name)
+    state.bind(resolved, recorded_name)
+    return recorded_name
+
+
 def create_app(
     *,
-    project_root: Path,
-    project_name: str,
+    project_root: Path | None = None,
+    project_name: str | None = None,
     lab_enabled: bool = False,
 ) -> FastAPI:
-    """Create the FastAPI app bound to a single match project on disk.
+    """Create the FastAPI app, optionally pre-bound to one match project.
 
-    The project is initialized on first call (idempotent), then the app keeps
-    the root path and re-loads on every request that needs it. We avoid
-    caching the model in memory so external edits to ``project.json`` are
-    visible without restarting the server.
+    When ``project_root`` is omitted the server boots **unbound**: the
+    picker endpoints (recent projects, fs/list, project bind) work; every
+    other project-bound endpoint returns 409 ``no_project`` so the SPA
+    can redirect to its picker route. The user binds a project at runtime
+    via POST /api/user/recent-projects/bind.
+
+    When bound, the project is initialised on first call (idempotent),
+    then the app keeps the root path and re-loads on every request. We
+    avoid caching the model in memory so external edits to
+    ``project.json`` are visible without restart.
 
     ``lab_enabled`` gates the ``/api/lab/*`` routes (and the SPA reads
     ``/api/server/features`` on mount to know whether to show the Lab
     nav entry). Hidden by default; opt in via ``splitsmith ui --lab``.
     """
-    MatchProject.init(project_root, name=project_name)
-    resolved_root = project_root.resolve()
-    state = AppState(project_root=resolved_root)
-    loaded_env = _load_env_files(resolved_root)
-    if loaded_env:
-        logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
-
-    # Record this open in the global recent-projects list (issue #75). The
-    # disk name on the project may differ from ``project_name`` -- prefer
-    # whatever ``MatchProject.init`` settled on so re-opens don't flip the
-    # display name based on which CLI invocation got there first.
-    try:
-        loaded_project = MatchProject.load(resolved_root)
-        recorded_name = loaded_project.name or project_name
-    except Exception:  # pragma: no cover -- defensive: never block boot
-        recorded_name = project_name
-    user_config.record_project_open(resolved_root, recorded_name)
+    state = AppState()
+    if project_root is not None:
+        _bind_project_to_state(
+            state,
+            project_root,
+            fallback_name=project_name or project_root.name or "match",
+        )
 
     app = FastAPI(
         title="splitsmith UI",
@@ -851,8 +952,11 @@ def create_app(
 
     @app.get("/api/health", response_model=HealthResponse)
     def health() -> HealthResponse:
+        if not state.is_bound:
+            return HealthResponse(bound=False)
         project = state.load()
         return HealthResponse(
+            bound=True,
             project_name=project.name,
             project_root=str(state.project_root),
             schema_version=project.schema_version,
@@ -3632,6 +3736,54 @@ def create_app(
             }
         )
 
+    @app.post("/api/user/recent-projects/bind")
+    def bind_recent_project(req: BindRecentProjectRequest) -> HealthResponse:
+        """Switch the in-memory project. Used by the SPA picker route.
+
+        Accepts a path that already exists on disk (a previously-opened
+        project) or a fresh path -- ``MatchProject.init`` is idempotent
+        and will scaffold the subdirs if missing. The ``last_opened_at``
+        timestamp is bumped so the picker re-orders to the top.
+        """
+        target = Path(req.path).expanduser()
+        if not target.exists():
+            # Conservative default: don't silently scaffold a brand-new
+            # project on a typo. The dedicated "create" flow can pass a
+            # ``create=true`` body once we wire it.
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "project_path_missing",
+                    "message": f"Project path does not exist: {target}",
+                },
+            )
+        try:
+            recorded = _bind_project_to_state(
+                state,
+                target,
+                fallback_name=req.name or target.name or "match",
+            )
+        except OSError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        project = state.load()
+        return HealthResponse(
+            bound=True,
+            project_name=recorded,
+            project_root=str(state.project_root),
+            schema_version=project.schema_version,
+        )
+
+    @app.post("/api/user/recent-projects/unbind")
+    def unbind_recent_project() -> HealthResponse:
+        """Drop the bound project so the SPA returns to the picker.
+
+        Equivalent to a `splitsmith ui` boot with no ``--project``;
+        useful when the user wants to switch projects without leaving
+        the browser tab.
+        """
+        state.unbind()
+        return HealthResponse(bound=False)
+
     @app.get("/api/user/scoreboard-identity")
     def get_scoreboard_identity() -> JSONResponse:
         identity = user_config.load_scoreboard_identity()
@@ -4380,8 +4532,8 @@ def _count_videos_shallow(directory: Path, *, cap: int = 200) -> int:
 
 def serve(
     *,
-    project_root: Path,
-    project_name: str,
+    project_root: Path | None = None,
+    project_name: str | None = None,
     host: str = "127.0.0.1",
     port: int = 5174,
     reload: bool = False,

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -8,6 +8,7 @@ import { Export } from "@/pages/Export";
 import { Home } from "@/pages/Home";
 import { Ingest } from "@/pages/Ingest";
 import { Lab } from "@/pages/Lab";
+import { Pick } from "@/pages/Pick";
 import { Review } from "@/pages/Review";
 
 export function App() {
@@ -15,6 +16,10 @@ export function App() {
     <ThemeProvider>
       <BrowserRouter>
         <Routes>
+          {/* Picker lives outside AppShell -- it has its own header and
+              runs whether or not a project is bound. AppShell redirects
+              here when it sees /api/health.bound === false. */}
+          <Route path="pick" element={<Pick />} />
           <Route element={<AppShell />}>
             <Route index element={<Home />} />
             <Route path="ingest" element={<Ingest />} />

--- a/src/splitsmith/ui_static/src/components/AppShell.tsx
+++ b/src/splitsmith/ui_static/src/components/AppShell.tsx
@@ -1,10 +1,18 @@
-import { Crosshair, FileBarChart, FlaskConical, FolderInput, Home, Palette } from "lucide-react";
+import {
+  Crosshair,
+  FileBarChart,
+  FlaskConical,
+  FolderInput,
+  Home,
+  Palette,
+  Repeat,
+} from "lucide-react";
 import { useEffect, useState } from "react";
-import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { Navigate, NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { JobsPanel } from "@/components/JobsPanel";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { api } from "@/lib/api";
+import { api, type ServerHealth } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -48,6 +56,35 @@ export function AppShell() {
     };
   }, []);
   const nav = labEnabled ? [...BASE_NAV, LAB_NAV] : BASE_NAV;
+
+  // Server bind-state. When the user launches ``splitsmith ui`` with no
+  // ``--project`` the server boots unbound; we redirect to /pick so the
+  // user can choose. The fixture-mode (review) branch keeps working
+  // since /review boots its own throwaway project that always reads as
+  // bound. Null while loading; ``null`` skips the redirect to avoid a
+  // flicker through /pick on bound boots.
+  const [health, setHealth] = useState<ServerHealth | null>(null);
+  useEffect(() => {
+    if (fixtureMode) return;
+    let alive = true;
+    api
+      .getHealth()
+      .then((h) => {
+        if (alive) setHealth(h);
+      })
+      .catch(() => {
+        // Network failure: keep rendering the shell rather than yanking
+        // the user to /pick on a transient hiccup.
+        if (alive) setHealth(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [fixtureMode]);
+
+  if (!fixtureMode && health && !health.bound) {
+    return <Navigate to="/pick" replace />;
+  }
 
   return (
     <div className="flex min-h-screen bg-background text-foreground">
@@ -107,7 +144,7 @@ export function AppShell() {
               splitsmith review
             </div>
           ) : (
-            <ProjectHeader />
+            <ProjectHeader health={health} />
           )}
           <div className="flex items-center gap-2">
             <ThemeToggle />
@@ -122,9 +159,43 @@ export function AppShell() {
   );
 }
 
-function ProjectHeader() {
-  // Project name is fetched from /api/health; for the v1 shell we keep this
-  // simple and let pages render their own headings. A future iteration can
-  // surface the active project name here once the project context is wired.
-  return <div className="text-sm text-muted-foreground">Production UI v1 (Sub 1)</div>;
+function ProjectHeader({ health }: { health: ServerHealth | null }) {
+  const navigate = useNavigate();
+  const [switching, setSwitching] = useState(false);
+
+  async function switchProject() {
+    setSwitching(true);
+    try {
+      await api.unbindProject();
+    } catch {
+      // Best-effort: even if unbind fails the picker can re-bind a
+      // different project on top.
+    }
+    navigate("/pick");
+  }
+
+  if (!health || !health.bound) {
+    return <div className="text-sm text-muted-foreground">splitsmith</div>;
+  }
+
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <div className="flex flex-col leading-tight">
+        <span className="font-medium tracking-tight">{health.project_name}</span>
+        <span className="font-mono text-xs text-muted-foreground truncate max-w-[420px]">
+          {health.project_root}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={switchProject}
+        disabled={switching}
+        className="flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+        title="Switch to a different project"
+      >
+        <Repeat className="size-3.5" />
+        Switch
+      </button>
+    </div>
+  );
 }

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -552,6 +552,37 @@ export function asSourceUnreachable(err: unknown): SourceUnreachableDetail | nul
   return body as SourceUnreachableDetail;
 }
 
+/** True when ``err`` is the structured 409 the server raises whenever a
+ *  project-bound endpoint is hit while the server is unbound (picker
+ *  mode). The SPA listens for this to redirect to /pick.
+ */
+export function isNoProjectError(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status !== 409) return false;
+  const body = err.body;
+  if (!body || typeof body !== "object") return false;
+  return (body as { code?: unknown }).code === "no_project";
+}
+
+/** Server health snapshot. ``bound === false`` means no project is open --
+ *  the SPA renders the picker until the user selects one. */
+export interface ServerHealth {
+  status: string;
+  bound: boolean;
+  project_name: string | null;
+  project_root: string | null;
+  schema_version: number | null;
+}
+
+/** One entry from ``GET /api/user/recent-projects``. ``last_opened_at``
+ *  is an ISO-8601 UTC timestamp the picker uses to sort. ``path`` is
+ *  resolved server-side; we don't normalise it client-side. */
+export interface RecentProject {
+  path: string;
+  name: string;
+  last_opened_at: string;
+}
+
 class ApiError extends Error {
   constructor(
     public status: number,
@@ -885,6 +916,39 @@ export const api = {
    *  surfaces the ``lab`` flag so the SPA can hide the Lab nav entry
    *  unless ``splitsmith ui --lab`` was passed. */
   getServerFeatures: () => request<{ lab: boolean }>("/api/server/features"),
+
+  /** Server health + bind state. The picker route polls this on mount
+   *  to decide whether the user landed in unbound mode (boot with no
+   *  ``--project``) or whether a project is already open. */
+  getHealth: () => request<ServerHealth>("/api/health"),
+
+  /** Recent-projects list, most-recent first. Drives the picker. */
+  getRecentProjects: () =>
+    request<{ projects: RecentProject[] }>("/api/user/recent-projects").then(
+      (r) => r.projects,
+    ),
+
+  /** Drop one entry from the recent list (forget). Returns the updated
+   *  list so the picker can re-render without a follow-up GET. */
+  forgetRecentProject: (path: string) =>
+    request<{ removed: boolean; projects: RecentProject[] }>(
+      "/api/user/recent-projects/forget",
+      { method: "POST", json: { path } },
+    ),
+
+  /** Switch the in-memory project. The picker calls this when the user
+   *  selects an entry; the server updates ``last_opened_at`` and binds.
+   */
+  bindProject: (path: string, name?: string) =>
+    request<ServerHealth>("/api/user/recent-projects/bind", {
+      method: "POST",
+      json: { path, name },
+    }),
+
+  /** Drop the bound project so the SPA returns to the picker (Cmd+P
+   *  "Switch project..." path). */
+  unbindProject: () =>
+    request<ServerHealth>("/api/user/recent-projects/unbind", { method: "POST" }),
 
   listJobs: () => request<Job[]>("/api/jobs"),
   getJob: (jobId: string) => request<Job>(`/api/jobs/${encodeURIComponent(jobId)}`),

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -1,0 +1,334 @@
+import { Crosshair, FolderOpen, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { ApiError, api, type RecentProject } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/** Project picker route (/pick).
+ *
+ * Rendered when ``splitsmith ui`` boots without ``--project`` so the
+ * server is unbound, and reachable from any bound state via the header
+ * "Switch project..." action. The picker reads
+ * ``GET /api/user/recent-projects``, lets the user filter / pick / forget
+ * entries, then binds the chosen project via
+ * ``POST /api/user/recent-projects/bind`` and routes to the home page.
+ *
+ * Keyboard model: ArrowUp/Down moves selection, Enter opens, Cmd/Ctrl+
+ * Backspace forgets the selected entry. The filter input owns focus; the
+ * page-level keydown listener handles arrows + Enter even when the input
+ * has focus so users don't have to mouse around.
+ */
+export function Pick() {
+  const navigate = useNavigate();
+  const [recents, setRecents] = useState<RecentProject[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [opening, setOpening] = useState<string | null>(null);
+  const [openPath, setOpenPath] = useState("");
+  const filterInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .getRecentProjects()
+      .then((rs) => {
+        if (alive) setRecents(rs);
+      })
+      .catch((e: unknown) => {
+        if (alive) setError(e instanceof ApiError ? e.detail : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Auto-focus the filter on mount: most users either type to find or
+  // hit Enter to open the most-recent.
+  useEffect(() => {
+    filterInputRef.current?.focus();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!recents) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return recents;
+    return recents.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) || r.path.toLowerCase().includes(q),
+    );
+  }, [recents, filter]);
+
+  // Keep selection in range as the filter narrows the list.
+  useEffect(() => {
+    if (selectedIdx >= filtered.length) {
+      setSelectedIdx(Math.max(0, filtered.length - 1));
+    }
+  }, [filtered.length, selectedIdx]);
+
+  async function open(target: RecentProject) {
+    setOpening(target.path);
+    setError(null);
+    try {
+      await api.bindProject(target.path, target.name);
+      navigate("/", { replace: true });
+    } catch (e: unknown) {
+      setOpening(null);
+      setError(e instanceof ApiError ? e.detail : String(e));
+    }
+  }
+
+  async function forget(target: RecentProject) {
+    try {
+      const resp = await api.forgetRecentProject(target.path);
+      setRecents(resp.projects);
+    } catch (e: unknown) {
+      setError(e instanceof ApiError ? e.detail : String(e));
+    }
+  }
+
+  async function openExplicitPath() {
+    const trimmed = openPath.trim();
+    if (!trimmed) return;
+    setOpening(trimmed);
+    setError(null);
+    try {
+      await api.bindProject(trimmed);
+      navigate("/", { replace: true });
+    } catch (e: unknown) {
+      setOpening(null);
+      setError(e instanceof ApiError ? e.detail : String(e));
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (filtered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      void open(filtered[selectedIdx]);
+    } else if ((e.metaKey || e.ctrlKey) && e.key === "Backspace") {
+      e.preventDefault();
+      void forget(filtered[selectedIdx]);
+    }
+  }
+
+  return (
+    <div
+      className="flex min-h-screen flex-col bg-background text-foreground"
+      onKeyDown={onKeyDown}
+    >
+      <header className="flex h-14 items-center gap-3 border-b border-border px-6">
+        <Crosshair className="size-5 text-primary" />
+        <div className="flex flex-col">
+          <div className="text-sm font-semibold tracking-tight">splitsmith</div>
+          <div className="text-xs text-muted-foreground">
+            Pick a match project to open
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-8">
+        <div className="space-y-4">
+          <input
+            ref={filterInputRef}
+            type="text"
+            value={filter}
+            onChange={(e) => {
+              setFilter(e.target.value);
+              setSelectedIdx(0);
+            }}
+            placeholder="Filter by name or path..."
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background focus:ring-2 focus:ring-ring"
+          />
+
+          {error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          {recents === null ? (
+            <div className="text-sm text-muted-foreground">Loading...</div>
+          ) : filtered.length === 0 ? (
+            <EmptyState hasRecents={recents.length > 0} filtering={!!filter} />
+          ) : (
+            <ul className="divide-y divide-border rounded-md border border-border bg-card">
+              {filtered.map((r, idx) => (
+                <ProjectRow
+                  key={r.path}
+                  project={r}
+                  selected={idx === selectedIdx}
+                  busy={opening === r.path}
+                  onOpen={() => open(r)}
+                  onForget={() => forget(r)}
+                  onHover={() => setSelectedIdx(idx)}
+                />
+              ))}
+            </ul>
+          )}
+
+          <div className="rounded-md border border-border bg-card p-4">
+            <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+              <FolderOpen className="size-4" />
+              Open a folder by path
+            </div>
+            <p className="mb-2 text-xs text-muted-foreground">
+              Paste an absolute path to a project directory. The folder
+              must already exist; new projects are created via the CLI
+              for now.
+            </p>
+            <form
+              className="flex gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void openExplicitPath();
+              }}
+            >
+              <input
+                type="text"
+                value={openPath}
+                onChange={(e) => setOpenPath(e.target.value)}
+                placeholder="/Users/you/matches/..."
+                className="flex-1 rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs outline-none focus:ring-2 focus:ring-ring"
+              />
+              <Button type="submit" size="sm" disabled={!openPath.trim()}>
+                Open
+              </Button>
+            </form>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
+            <kbd className="rounded border border-border bg-muted px-1">Up</kbd>
+            /
+            <kbd className="rounded border border-border bg-muted px-1">Down</kbd>{" "}
+            to select,{" "}
+            <kbd className="rounded border border-border bg-muted px-1">
+              Enter
+            </kbd>{" "}
+            to open,{" "}
+            <kbd className="rounded border border-border bg-muted px-1">
+              Cmd
+            </kbd>
+            +
+            <kbd className="rounded border border-border bg-muted px-1">
+              Backspace
+            </kbd>{" "}
+            to forget.
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ProjectRow({
+  project,
+  selected,
+  busy,
+  onOpen,
+  onForget,
+  onHover,
+}: {
+  project: RecentProject;
+  selected: boolean;
+  busy: boolean;
+  onOpen: () => void;
+  onForget: () => void;
+  onHover: () => void;
+}) {
+  const lastOpened = useMemo(
+    () => formatRelative(new Date(project.last_opened_at)),
+    [project.last_opened_at],
+  );
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-3 px-4 py-3 transition-colors",
+        selected ? "bg-accent" : "hover:bg-accent/40",
+      )}
+      onMouseEnter={onHover}
+      onClick={onOpen}
+      role="button"
+      tabIndex={-1}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="font-medium tracking-tight truncate">
+          {project.name}
+        </div>
+        <div className="font-mono text-xs text-muted-foreground truncate">
+          {project.path}
+        </div>
+      </div>
+      <div className="text-xs text-muted-foreground whitespace-nowrap">
+        {busy ? "opening..." : `opened ${lastOpened}`}
+      </div>
+      <button
+        type="button"
+        title="Forget this project"
+        className="rounded p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+        onClick={(e) => {
+          e.stopPropagation();
+          onForget();
+        }}
+      >
+        <Trash2 className="size-4" />
+      </button>
+    </li>
+  );
+}
+
+function EmptyState({
+  hasRecents,
+  filtering,
+}: {
+  hasRecents: boolean;
+  filtering: boolean;
+}) {
+  if (filtering) {
+    return (
+      <div className="rounded-md border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+        No projects match the filter.
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+      {hasRecents
+        ? "All projects filtered out."
+        : (
+            <>
+              No projects yet. Open one by pasting a path below, or run{" "}
+              <code className="font-mono text-xs">
+                splitsmith ui --project &lt;path&gt;
+              </code>{" "}
+              from your shell.
+            </>
+          )}
+    </div>
+  );
+}
+
+/** Compact relative time ("2 min ago", "3 days ago"). Intentionally
+ *  small -- a heavy date library isn't worth pulling in for one row. */
+function formatRelative(then: Date): string {
+  const now = Date.now();
+  const ms = now - then.getTime();
+  const sec = Math.round(ms / 1000);
+  if (sec < 45) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 45) return `${min} min ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr} hr ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day} day${day === 1 ? "" : "s"} ago`;
+  return then.toLocaleDateString();
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,33 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 @pytest.fixture
 def fixtures_dir() -> Path:
     return FIXTURES_DIR
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_config(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Redirect ``~/.splitsmith/`` to a per-test tmp dir for every test.
+
+    Without this, ``create_app`` (and anything else that calls
+    ``user_config.record_project_open`` / writes scoreboard identity)
+    persists test-only entries into the developer's real
+    ``~/.splitsmith/projects.json``. The 50-entry cap then evicts the
+    user's actual matches off the back of the list, which surfaces in
+    the picker as "only `Beep Match` and `x`, no real projects".
+
+    Tests that need to inspect the on-disk projects.json can read the
+    returned path; the existing per-test ``_user_config_home`` fixture
+    in ``test_ui_server.py`` continues to work since it overrides the
+    same env var with a deterministic name.
+    """
+    import os
+
+    home = tmp_path_factory.mktemp("user-config")
+    prev = os.environ.get("SPLITSMITH_HOME")
+    os.environ["SPLITSMITH_HOME"] = str(home)
+    try:
+        yield home
+    finally:
+        if prev is None:
+            os.environ.pop("SPLITSMITH_HOME", None)
+        else:
+            os.environ["SPLITSMITH_HOME"] = prev

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4031,6 +4031,90 @@ def test_forget_recent_project_endpoint(tmp_path: Path, _user_config_home: Path)
     assert [p["name"] for p in body["projects"]] == ["Beta"]
 
 
+def test_unbound_create_app_health_reports_unbound() -> None:
+    """`splitsmith ui` with no --project boots unbound; /api/health
+    reports it so the SPA can route to the picker."""
+    app = create_app()
+    client = TestClient(app)
+
+    body = client.get("/api/health").json()
+    assert body["bound"] is False
+    assert body["project_name"] is None
+    assert body["project_root"] is None
+
+
+def test_unbound_project_endpoints_return_409_no_project(tmp_path: Path) -> None:
+    """Every project-bound route returns the structured 409 the SPA
+    listens for to redirect to the picker."""
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.get("/api/project")
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["code"] == "no_project"
+
+
+def test_bind_recent_project_switches_in_memory(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    """The picker POSTs to /bind to switch the active project without a
+    server restart. Subsequent /api/health reflects the new binding and
+    the recent-projects list bumps the entry to the top.
+    """
+    from splitsmith import user_config
+
+    alpha = tmp_path / "alpha"
+    create_app(project_root=alpha, project_name="Alpha")
+    # Now boot unbound and bind via the endpoint.
+    app = create_app()
+    client = TestClient(app)
+
+    assert client.get("/api/health").json()["bound"] is False
+
+    resp = client.post(
+        "/api/user/recent-projects/bind",
+        json={"path": str(alpha.resolve())},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bound"] is True
+    assert body["project_name"] == "Alpha"
+
+    # Subsequent project endpoints now work.
+    assert client.get("/api/project").status_code == 200
+
+    # Recent-projects list bumped Alpha to the top.
+    recent = user_config.get_recent_projects()
+    assert recent[0].name == "Alpha"
+
+
+def test_bind_recent_project_404_when_path_missing(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/user/recent-projects/bind",
+        json={"path": str(tmp_path / "does-not-exist")},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "project_path_missing"
+
+
+def test_unbind_returns_to_unbound_state(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+
+    assert client.get("/api/health").json()["bound"] is True
+    resp = client.post("/api/user/recent-projects/unbind")
+    assert resp.status_code == 200
+    assert resp.json()["bound"] is False
+    assert client.get("/api/project").status_code == 409
+
+
 def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4055,9 +4055,7 @@ def test_unbound_project_endpoints_return_409_no_project(tmp_path: Path) -> None
     assert detail["code"] == "no_project"
 
 
-def test_bind_recent_project_switches_in_memory(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_bind_recent_project_switches_in_memory(tmp_path: Path, _user_config_home: Path) -> None:
     """The picker POSTs to /bind to switch the active project without a
     server restart. Subsequent /api/health reflects the new binding and
     the recent-projects list bumps the entry to the top.
@@ -4089,9 +4087,7 @@ def test_bind_recent_project_switches_in_memory(
     assert recent[0].name == "Alpha"
 
 
-def test_bind_recent_project_404_when_path_missing(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_bind_recent_project_404_when_path_missing(tmp_path: Path, _user_config_home: Path) -> None:
     app = create_app()
     client = TestClient(app)
     resp = client.post(
@@ -4102,9 +4098,7 @@ def test_bind_recent_project_404_when_path_missing(
     assert resp.json()["detail"]["code"] == "project_path_missing"
 
 
-def test_unbind_returns_to_unbound_state(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_unbind_returns_to_unbound_state(tmp_path: Path, _user_config_home: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- ``splitsmith ui`` can now boot without ``--project``: the server binds at most one project at a time, and with no startup arg the SPA's new ``/pick`` route renders a picker over ``~/.splitsmith/projects.json``. Picking an entry POSTs to a new ``/api/user/recent-projects/bind`` endpoint to switch in-memory; unbinding from the header's "Switch" action returns to the picker without a restart.
- Server-side, ``AppState.project_root`` becomes a property that raises a structured ``409 {"code":"no_project"}`` when unbound, so the existing ~80 call-sites stay untouched. ``/api/health`` now exposes ``bound`` plus nullable project fields; new ``bind`` / ``unbind`` endpoints flip the binding.
- CLI gets ``--last`` to reopen the most recently-opened project; the existing ``--project`` is now optional.
- Pick page UX: filter (auto-focused), arrow-key navigation, Enter to open, Cmd+Backspace to forget, "open by path" form, relative-time "opened N min ago".
- Test isolation: autouse ``conftest.py`` fixture redirects ``~/.splitsmith/`` to a per-test tmpdir for **every** test. Without this the existing ``record_project_open`` call at ``create_app`` time was leaking test entries into the developer's real ``projects.json`` and evicting actual projects past the 50-entry cap (``Beep Match`` and ``x`` only -- the picker exposed this).

## Out of scope
- "Clean up missing projects" sweep -- entries with stale paths still show up; flagging stale rows + cleanup affordance is a follow-up.
- "New project..." form -- the picker only opens existing dirs.
- Global 409 interceptor in the API client -- only the AppShell's health probe routes to ``/pick`` today; if a user lands on ``/audit`` while unbound the page still surfaces its own error.

## Test plan
- [x] ``uv run pytest tests/test_ui_server.py`` (160 passing, 5 new)
- [x] ``npm run build`` in ``ui_static/`` (clean)
- [x] ``npx tsc --noEmit`` (clean)
- [ ] Boot ``splitsmith ui`` (no args) -> picker appears, lists Tallmilan 2026, opens it, header shows the project + Switch button
- [ ] Click Switch -> returns to picker; reopen the same project from the picker
- [ ] ``splitsmith ui --project /Users/mathias/matches/tallmilan-2026`` still works as before
- [ ] ``splitsmith ui --last`` reopens the most-recently-opened project

🤖 Generated with [Claude Code](https://claude.com/claude-code)