### PR TITLE
ingest: cross-align sanity check + soft-fail UI surfacing

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -114,12 +114,23 @@ class StageVideo(BaseModel):
     # this False) so the SPA can surface "align manually" instead of an error
     # toast for secondaries. Cleared whenever ``beep_time`` is set or wiped.
     beep_auto_detect_failed: bool = False
-    # Diagnostic confidence from ``cross_align.align_secondary_to_primary``
-    # when ``beep_source == "aligned"``. Peak-to-runner-up ratio of the
-    # cross-correlation against the primary's landmark audio; >= 1.5 is the
-    # accept threshold. Surfaced so the SPA can flag low-confidence
-    # alignments for the user to double-check before marking reviewed.
+    # Diagnostic confidence from ``cross_align.align_secondary_to_primary``.
+    # Peak-to-runner-up ratio of the cross-correlation against the primary's
+    # landmark audio. Populated whenever cross-align ran on a secondary --
+    # both when in-stream detection failed AND we promoted the alignment
+    # (``beep_source == "aligned"``), and as a sanity check when in-stream
+    # succeeded (``beep_source == "auto"``) to catch the in-stream detector
+    # locking onto a steel-strike-as-beep. >= 1.10 is the accept floor on
+    # in-stream-failed pairs (calibrated empirically; see server.py).
     beep_alignment_confidence: float | None = None
+    # Disagreement between in-stream detection and cross-correlation
+    # alignment, in milliseconds. Populated when both ran successfully on
+    # a secondary (``beep_source == "auto"`` AND cross-align cleared the
+    # confidence floor). The SPA uses this to flag suspected steel-strike
+    # mis-detections: if in-stream snapped to a non-beep transient, its
+    # answer disagrees with the cross-correlation by hundreds of ms or
+    # more. Null when only one of the two methods produced a result.
+    beep_alignment_delta_ms: float | None = None
     # Ranked alternative candidates from the most recent auto-detection run
     # (silence-preference score, descending). The production UI offers these
     # as one-click alternatives to the auto-winner so the user rarely has to
@@ -1149,6 +1160,7 @@ class MatchProject(BaseModel):
         new_primary.beep_reviewed = False
         new_primary.beep_auto_detect_failed = False
         new_primary.beep_alignment_confidence = None
+        new_primary.beep_alignment_delta_ms = None
 
         if backup_audit:
             audit_file = self.audit_path(root) / f"stage{stage_number}.json"
@@ -1255,6 +1267,7 @@ class MatchProject(BaseModel):
                     v.beep_reviewed = False
                     v.beep_auto_detect_failed = False
                     v.beep_alignment_confidence = None
+                    v.beep_alignment_delta_ms = None
 
         return RemovalPlan(
             video_path=video.path,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1554,14 +1554,19 @@ def create_app(
             )
         return project, stage, video
 
-    # Cross-cam alignment is accepted only when the peak-to-runner-up ratio
-    # of the cross-correlation clears this threshold. 1.0 means the
-    # landmark wasn't distinctive (envelope is flat or the secondary
-    # doesn't actually overlap with the primary). 1.5 was chosen because
-    # synthetic same-stage pairs return ~6 while same-mic non-overlapping
-    # iPhone clips return ~1.0-1.1; a 50% margin keeps the false-accept
-    # rate near zero on the short envelope vectors at 200 Hz.
-    _align_confidence_floor = 1.5
+    # Cross-cam alignment is accepted as a *suggestion* (beep_source="aligned",
+    # beep_reviewed=False so the SPA forces the user to verify on the waveform
+    # picker) when the peak-to-runner-up ratio of the cross-correlation clears
+    # this threshold. 1.0 means the landmark wasn't distinctive at all.
+    # Empirically calibrated on tallmilan-2026 secondaries: same-stage pairs
+    # where in-stream detection independently succeeded land at 1.23-1.34, and
+    # plausible alignments on the in-stream-failed pairs land at 1.15-1.31.
+    # Same-mic non-overlapping clips sit at ~1.00. 1.10 leaves a slim margin
+    # over the floor while still surfacing real alignments. False positives
+    # are caught by the user in the picker before "Mark reviewed"; false
+    # negatives mean the user starts from the auto-detect-failed state and
+    # places the marker by hand, which is the same UX as before this change.
+    _align_confidence_floor = 1.10
 
     def _try_align_secondary_to_primary(
         proj: MatchProject,
@@ -1570,9 +1575,12 @@ def create_app(
         handle: JobHandle,
     ) -> cross_align.CrossAlignResult | None:
         """Attempt cross-correlation alignment of ``video`` against the stage's
-        primary. Returns the result when confidence clears the floor; ``None``
-        when alignment isn't possible (no primary, no primary beep_time, audio
-        not cached, correlation too weak).
+        primary. Returns the raw result whenever cross-correlation could be
+        computed (so the caller can save ``confidence`` as a diagnostic even
+        below the auto-accept floor); returns ``None`` only when alignment
+        isn't possible at all (no primary, no primary beep_time, audio not
+        cached, landmark window too narrow). Threshold comparison happens at
+        the call site so a low-confidence result can still inform the UI.
 
         Run only on the secondary soft-fail path -- when in-stream beep
         detection has already raised ``BeepNotFoundError``. Cheap (envelope
@@ -1611,15 +1619,6 @@ def create_app(
                 stage.stage_number,
                 video.video_id,
                 exc,
-            )
-            return None
-        if result.confidence < _align_confidence_floor:
-            logger.info(
-                "cross-align rejected for stage %d video %s: conf %.2f < %.2f",
-                stage.stage_number,
-                video.video_id,
-                result.confidence,
-                _align_confidence_floor,
             )
             return None
         return result
@@ -1684,23 +1683,38 @@ def create_app(
             video.beep_candidates = []
             video.beep_reviewed = False
             video.processed["beep"] = True
-            if aligned is not None:
+            # Surface the cross-correlation confidence whenever we got one,
+            # even if we don't promote the suggestion. Lets the UI tell the
+            # difference between "never tried" and "tried, sub-floor result".
+            video.beep_alignment_confidence = (
+                aligned.confidence if aligned is not None else None
+            )
+            # Delta is only meaningful when both in-stream AND cross-align
+            # produced timestamps. In-stream failed here, so wipe it.
+            video.beep_alignment_delta_ms = None
+            if aligned is not None and aligned.confidence >= _align_confidence_floor:
                 handle.update(
                     progress=0.55,
-                    message=f"Aligned to primary (conf {aligned.confidence:.1f})",
+                    message=f"Aligned to primary (conf {aligned.confidence:.2f}); verify on waveform",
                 )
                 video.beep_time = aligned.secondary_beep_time
                 video.beep_source = "aligned"
-                video.beep_alignment_confidence = aligned.confidence
                 video.beep_auto_detect_failed = False
                 # Treat as "we have a usable beep_time": fall through to
                 # the trim block below.
                 beep = aligned
             else:
-                handle.update(progress=0.55, message="No beep detected; align manually")
+                if aligned is not None:
+                    logger.info(
+                        "cross-align below floor for stage %d video %s: conf %.2f < %.2f",
+                        stage_number,
+                        video.video_id,
+                        aligned.confidence,
+                        _align_confidence_floor,
+                    )
+                handle.update(progress=0.55, message="No beep detected; pick on waveform")
                 video.beep_time = None
                 video.beep_source = "auto"
-                video.beep_alignment_confidence = None
                 video.beep_auto_detect_failed = True
                 video.processed["trim"] = False
                 beep = None
@@ -1713,11 +1727,31 @@ def create_app(
             video.beep_candidates = list(beep.candidates)
             video.beep_auto_detect_failed = False
             video.beep_alignment_confidence = None
+            video.beep_alignment_delta_ms = None
             video.processed["beep"] = True
             # Auto-detected beeps need explicit user review (#71). Reset
             # the flag here so a re-detect on a previously reviewed video
             # invalidates the prior approval.
             video.beep_reviewed = False
+            # Sanity check: when in-stream succeeded on a secondary, ALSO
+            # run cross-correlation against the primary. If the two
+            # methods disagree by more than ~250 ms it usually means the
+            # in-stream detector locked onto something that wasn't the
+            # buzzer (a steel-strike that resembles a tone, an early
+            # range-officer command, etc.). The delta is surfaced in the
+            # SPA so the user can compare both candidates on the
+            # waveform before marking reviewed. Never overrides the
+            # in-stream result -- in-stream has frequency-domain
+            # information cross-align doesn't, so when they agree we
+            # trust the in-stream answer; when they disagree we let the
+            # user decide.
+            if video.role != "primary":
+                check = _try_align_secondary_to_primary(proj, stg, video, handle)
+                if check is not None and check.confidence >= _align_confidence_floor:
+                    video.beep_alignment_confidence = check.confidence
+                    video.beep_alignment_delta_ms = (
+                        beep.time - check.secondary_beep_time
+                    ) * 1000.0
 
         trimmed_ok = False
         if beep is not None and stg.time_seconds > 0:
@@ -1768,6 +1802,7 @@ def create_app(
             v_fresh.beep_reviewed = video.beep_reviewed
             v_fresh.beep_auto_detect_failed = video.beep_auto_detect_failed
             v_fresh.beep_alignment_confidence = video.beep_alignment_confidence
+            v_fresh.beep_alignment_delta_ms = video.beep_alignment_delta_ms
             v_fresh.processed["beep"] = True
             if trimmed_ok:
                 v_fresh.processed["trim"] = True
@@ -2354,6 +2389,7 @@ def create_app(
             video.beep_candidates = []
             video.beep_auto_detect_failed = False
             video.beep_alignment_confidence = None
+            video.beep_alignment_delta_ms = None
             video.processed["beep"] = False
             video.processed["trim"] = False
             video.beep_reviewed = False
@@ -2367,6 +2403,7 @@ def create_app(
             video.beep_candidates = []
             video.beep_auto_detect_failed = False
             video.beep_alignment_confidence = None
+            video.beep_alignment_delta_ms = None
             video.processed["beep"] = True
             video.processed["trim"] = False
             # Manual beep entry implies the user looked at the
@@ -2438,6 +2475,7 @@ def create_app(
         video.beep_duration_ms = chosen.duration_ms
         video.beep_auto_detect_failed = False
         video.beep_alignment_confidence = None
+        video.beep_alignment_delta_ms = None
         video.processed["beep"] = True
         video.processed["trim"] = False
         # Switching candidate is a fresh claim about which moment is

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -498,6 +498,8 @@ export function BeepSection({
       </div>
       {disagreement && crossAlignSuggestion != null ? (
         <AlignmentDisagreement
+          stageNumber={stageNumber}
+          videoId={videoId}
           inStreamTime={video.beep_time!}
           crossAlignTime={crossAlignSuggestion}
           deltaMs={deltaMs!}
@@ -825,6 +827,8 @@ function BeepWaveformPicker({
       </div>
       {proposal != null ? (
         <SnapProposal
+          stageNumber={stageNumber}
+          videoId={videoId}
           proposal={proposal}
           onAccept={acceptProposal}
           onDismiss={dismissProposal}
@@ -836,10 +840,14 @@ function BeepWaveformPicker({
 
 
 function SnapProposal({
+  stageNumber,
+  videoId,
   proposal,
   onAccept,
   onDismiss,
 }: {
+  stageNumber: number;
+  videoId: string;
   proposal: BeepSnapResult;
   onAccept: () => void;
   onDismiss: () => void;
@@ -847,32 +855,83 @@ function SnapProposal({
   const deltaMs = Math.round(proposal.delta * 1000);
   const sign = deltaMs >= 0 ? "+" : "";
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-2 py-1.5 text-xs">
-      <Sparkles className="size-3" />
-      <span className="font-mono tabular-nums">
-        Suggested: {proposal.snapped_time.toFixed(3)}s
-      </span>
-      <span className="text-muted-foreground">
-        ({sign}
-        {deltaMs} ms)
-      </span>
-      <span
-        className="text-muted-foreground"
-        title={`Silence-preference score: ${proposal.score.toFixed(1)}. Run peak amplitude: ${proposal.peak_amplitude.toFixed(2)}. Run duration: ${Math.round(proposal.duration_ms)} ms.`}
-      >
-        peak {proposal.peak_amplitude.toFixed(2)} &middot;{" "}
-        {Math.round(proposal.duration_ms)} ms
-      </span>
-      <div className="ml-auto flex gap-1">
-        <Button size="sm" variant="default" onClick={onAccept}>
-          <Check />
-          Accept
-        </Button>
-        <Button size="sm" variant="ghost" onClick={onDismiss}>
-          Dismiss
-        </Button>
+    <div className="space-y-2 rounded-md border border-primary/40 bg-primary/5 px-2 py-1.5 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <Sparkles className="size-3" />
+        <span className="font-mono tabular-nums">
+          Suggested: {proposal.snapped_time.toFixed(3)}s
+        </span>
+        <span className="text-muted-foreground">
+          ({sign}
+          {deltaMs} ms)
+        </span>
+        <span
+          className="text-muted-foreground"
+          title={`Silence-preference score: ${proposal.score.toFixed(1)}. Run peak amplitude: ${proposal.peak_amplitude.toFixed(2)}. Run duration: ${Math.round(proposal.duration_ms)} ms.`}
+        >
+          peak {proposal.peak_amplitude.toFixed(2)} &middot;{" "}
+          {Math.round(proposal.duration_ms)} ms
+        </span>
+        <div className="ml-auto flex gap-1">
+          <Button size="sm" variant="default" onClick={onAccept}>
+            <Check />
+            Accept
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </div>
       </div>
+      <ProposalPreview
+        stageNumber={stageNumber}
+        videoId={videoId}
+        time={proposal.snapped_time}
+        ariaLabel={`Preview at suggested ${proposal.snapped_time.toFixed(3)}s`}
+      />
     </div>
+  );
+}
+
+/** A 1-second preview clip centered on a proposed beep time. Reuses the
+ *  same /api/.../beep-preview endpoint as the main BeepPreview, but
+ *  parameterized on an arbitrary time so it works for snap proposals,
+ *  cross-align suggestions, etc. Smaller than BeepPreview so it can sit
+ *  inside a confirmation banner without dominating the row. */
+function ProposalPreview({
+  stageNumber,
+  videoId,
+  time,
+  ariaLabel,
+}: {
+  stageNumber: number;
+  videoId: string;
+  time: number;
+  ariaLabel: string;
+}) {
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [stageNumber, videoId, time]);
+  if (errored) {
+    return (
+      <div className="flex items-center gap-1 rounded-md border border-dashed border-border/60 bg-background/40 px-2 py-1 text-muted-foreground">
+        <Sparkles className="size-3" />
+        Preview unavailable (no cached clip yet)
+      </div>
+    );
+  }
+  return (
+    <video
+      key={`${stageNumber}:${videoId}:${time.toFixed(3)}`}
+      src={api.videoBeepPreviewUrl(stageNumber, videoId, time)}
+      className="h-32 w-56 rounded-md border border-border/60 bg-black object-cover"
+      playsInline
+      controls
+      preload="metadata"
+      aria-label={ariaLabel}
+      title="1s preview around the proposed time -- press play to verify before accepting"
+      onError={() => setErrored(true)}
+    />
   );
 }
 
@@ -1122,6 +1181,8 @@ function BeepPreview({
  *  override -- in-stream has frequency-domain information cross-align
  *  doesn't -- but we offer the user a one-click swap. */
 function AlignmentDisagreement({
+  stageNumber,
+  videoId,
   inStreamTime,
   crossAlignTime,
   deltaMs,
@@ -1129,6 +1190,8 @@ function AlignmentDisagreement({
   onUseCrossAlign,
   busy,
 }: {
+  stageNumber: number;
+  videoId: string;
   inStreamTime: number;
   crossAlignTime: number;
   deltaMs: number;
@@ -1138,34 +1201,53 @@ function AlignmentDisagreement({
 }) {
   const sign = deltaMs >= 0 ? "+" : "";
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1.5 text-xs">
-      <Sparkles className="size-3 text-amber-600 dark:text-amber-400" />
-      <span>
-        In-stream and cross-align disagree by{" "}
-        <span className="font-mono tabular-nums">
-          {sign}
-          {Math.round(deltaMs)} ms
+    <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1.5 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <Sparkles className="size-3 text-amber-600 dark:text-amber-400" />
+        <span>
+          In-stream and cross-align disagree by{" "}
+          <span className="font-mono tabular-nums">
+            {sign}
+            {Math.round(deltaMs)} ms
+          </span>
+          . Could be a steel-strike mistaken for the buzzer.
         </span>
-        . Could be a steel-strike mistaken for the buzzer.
-      </span>
-      <span
-        className="text-muted-foreground"
-        title={`In-stream: ${inStreamTime.toFixed(3)}s. Cross-align: ${crossAlignTime.toFixed(3)}s${
-          confidence != null ? ` (conf ${confidence.toFixed(2)})` : ""
-        }.`}
-      >
-        in-stream <span className="font-mono tabular-nums">{inStreamTime.toFixed(3)}s</span> ·
-        cross-align <span className="font-mono tabular-nums">{crossAlignTime.toFixed(3)}s</span>
-      </span>
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={() => void onUseCrossAlign()}
-        disabled={busy}
-        className="ml-auto"
-      >
-        Use cross-align
-      </Button>
+        <span
+          className="text-muted-foreground"
+          title={`In-stream: ${inStreamTime.toFixed(3)}s. Cross-align: ${crossAlignTime.toFixed(3)}s${
+            confidence != null ? ` (conf ${confidence.toFixed(2)})` : ""
+          }.`}
+        >
+          in-stream <span className="font-mono tabular-nums">{inStreamTime.toFixed(3)}s</span> ·
+          cross-align <span className="font-mono tabular-nums">{crossAlignTime.toFixed(3)}s</span>
+        </span>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void onUseCrossAlign()}
+          disabled={busy}
+          className="ml-auto"
+        >
+          Use cross-align
+        </Button>
+      </div>
+      {/* Side-by-side previews so the user can A/B before swapping. The
+       *  current beep_time preview already lives below this banner via
+       *  BeepPreview; rendering the cross-align candidate here gives the
+       *  user the missing half of the comparison. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[11px] text-muted-foreground">
+            Cross-align preview ({crossAlignTime.toFixed(3)}s)
+          </span>
+          <ProposalPreview
+            stageNumber={stageNumber}
+            videoId={videoId}
+            time={crossAlignTime}
+            ariaLabel={`Cross-align preview at ${crossAlignTime.toFixed(3)}s`}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -83,7 +83,26 @@ export function BeepSection({
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(video.beep_time?.toFixed(3) ?? "");
+  // Brief background highlight on the draft input whenever its value is
+  // changed by a non-typing action (waveform scrub, Snap-to-beep accept,
+  // etc.). The number itself updating is easy to miss when the user's
+  // attention is on a video preview or the Accept button; the flash
+  // makes "we just wrote a new value into the field" obvious. Drives a
+  // tailwind transition-colors fade; see the input className below.
+  const [draftFlashing, setDraftFlashing] = useState(false);
   const [jobStatus, setJobStatus] = useState<Job | null>(null);
+  const flashDraftInput = useCallback(() => {
+    // Drop-then-set across an rAF tick so a second pick in quick
+    // succession re-triggers the fade instead of being a no-op (state
+    // is already true from the previous flash).
+    setDraftFlashing(false);
+    requestAnimationFrame(() => setDraftFlashing(true));
+  }, []);
+  useEffect(() => {
+    if (!draftFlashing) return;
+    const t = setTimeout(() => setDraftFlashing(false), 700);
+    return () => clearTimeout(t);
+  }, [draftFlashing]);
   // Auto-collapse the section once the beep is reviewed so finished cards
   // don't dominate the stage view; the user can click the chevron to
   // re-open. Re-collapses when "Mark reviewed" is clicked mid-session.
@@ -237,7 +256,10 @@ export function BeepSection({
               min="0"
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
-              className="h-8 w-32 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className={cn(
+                "h-8 w-32 rounded-md border border-input px-2 py-1 font-mono text-sm shadow-sm transition-colors duration-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                draftFlashing ? "bg-primary/20" : "bg-background",
+              )}
               disabled={busy}
               aria-label={`Beep time for stage ${stageNumber}`}
               autoFocus
@@ -256,7 +278,10 @@ export function BeepSection({
           videoId={videoId}
           videoBeepTime={video.beep_time}
           draftSourceTime={draftValid ? draftSourceTime : null}
-          onPick={(sourceTime) => setDraft(sourceTime.toFixed(3))}
+          onPick={(sourceTime) => {
+            setDraft(sourceTime.toFixed(3));
+            flashDraftInput();
+          }}
           setError={setError}
         />
       </div>

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -264,6 +264,19 @@ export function BeepSection({
   }
 
   if (!video.beep_time) {
+    // Distinguish "never tried" from "tried both detectors and got nothing".
+    // The latter is the secondary soft-fail (#112): in-stream beep_detect
+    // raised + cross-correlation either errored or fell below the
+    // auto-accept floor. Surfacing it tells the user "automatic alignment
+    // gave up; place the marker yourself" instead of letting them re-click
+    // Detect beep and watch it fail again.
+    const failed = video.beep_auto_detect_failed;
+    const conf = video.beep_alignment_confidence;
+    const failedHint = failed
+      ? conf != null
+        ? `Auto-detect + cross-align failed (conf ${conf.toFixed(2)}). Pick the beep on the waveform.`
+        : "Auto-detect failed and the camera doesn't overlap enough with the primary to align. Pick the beep on the waveform."
+      : null;
     return (
       <div
         className={cn(
@@ -271,26 +284,48 @@ export function BeepSection({
           !bare && "rounded-md border border-border/60 bg-muted/20",
         )}
       >
-        <Badge variant="statusNotStarted" className="gap-1">
-          ○ No beep yet
+        <Badge variant={failed ? "statusWarning" : "statusNotStarted"} className="gap-1">
+          {failed ? "! Auto-detect failed" : "○ No beep yet"}
         </Badge>
         {jobStatus ? (
           <JobProgress job={jobStatus} />
         ) : (
           <span className="text-muted-foreground">
-            {isPrimary
-              ? "Audit screen needs this. Run detection or set manually."
-              : "Needed to sync this camera to the primary timeline."}
+            {failedHint ??
+              (isPrimary
+                ? "Audit screen needs this. Run detection or set manually."
+                : "Needed to sync this camera to the primary timeline.")}
           </span>
         )}
         <div className="ml-auto flex gap-1">
-          <Button size="sm" variant="default" onClick={() => detect(false)} disabled={busy}>
-            <RefreshCw />
-            Detect beep
-          </Button>
-          <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
-            <Pencil />
-            Set manually
+          {failed ? (
+            <Button size="sm" variant="default" onClick={() => setEditing(true)} disabled={busy}>
+              <Pencil />
+              Pick on waveform
+            </Button>
+          ) : (
+            <Button size="sm" variant="default" onClick={() => detect(false)} disabled={busy}>
+              <RefreshCw />
+              Detect beep
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={failed ? () => detect(false) : () => setEditing(true)}
+            disabled={busy}
+          >
+            {failed ? (
+              <>
+                <RefreshCw />
+                Retry detect
+              </>
+            ) : (
+              <>
+                <Pencil />
+                Set manually
+              </>
+            )}
           </Button>
         </div>
       </div>
@@ -298,21 +333,41 @@ export function BeepSection({
   }
 
   const isManual = video.beep_source === "manual";
+  const isAligned = video.beep_source === "aligned";
   const reviewed = video.beep_reviewed;
   // Three-state pill (#71): manual entry counts as reviewed
-  // automatically; auto-detect leaves the user a yellow "review" pill
-  // until they confirm. Pure visual nudge -- pipeline doesn't gate on
-  // it.
+  // automatically; auto-detect and cross-aligned suggestions leave the
+  // user a yellow "review" pill until they confirm. Pure visual nudge --
+  // pipeline doesn't gate on it.
   const pillVariant = reviewed
     ? "statusComplete"
     : isManual
       ? "statusComplete"
       : "statusWarning";
+  const sourceLabel = isManual ? "user" : isAligned ? "aligned" : "auto";
   const pillLabel = reviewed
-    ? `beep · ${isManual ? "user" : "auto"} · reviewed`
+    ? `beep · ${sourceLabel} · reviewed`
     : isManual
       ? "beep · user"
-      : "beep · review";
+      : isAligned
+        ? "beep · aligned · verify"
+        : "beep · review";
+  const conf = video.beep_alignment_confidence;
+  const pillTitle =
+    isAligned && conf != null
+      ? `Cross-correlation alignment to primary (conf ${conf.toFixed(2)}). Verify on the waveform before marking reviewed.`
+      : undefined;
+  // Sanity-check disagreement: in-stream succeeded on a secondary AND
+  // cross-correlation also produced a high-confidence answer that
+  // disagrees with it by more than 250 ms. The most common cause is the
+  // in-stream detector mistaking a steel hit / RO command for the
+  // buzzer. Flagged as a yellow strip with the cross-align suggestion
+  // so the user can compare both candidates on the waveform.
+  const deltaMs = video.beep_alignment_delta_ms;
+  const disagreement =
+    !isManual && deltaMs != null && Math.abs(deltaMs) > 250;
+  const crossAlignSuggestion =
+    disagreement && video.beep_time != null ? video.beep_time - deltaMs / 1000 : null;
 
   const markReviewed = async () => {
     setBusy(true);
@@ -377,7 +432,7 @@ export function BeepSection({
       )}
     >
       <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={pillVariant} className="gap-1">
+        <Badge variant={pillVariant} className="gap-1" title={pillTitle}>
           <Check className="size-3" />
           {pillLabel}
         </Badge>
@@ -441,6 +496,31 @@ export function BeepSection({
           ) : null}
         </div>
       </div>
+      {disagreement && crossAlignSuggestion != null ? (
+        <AlignmentDisagreement
+          inStreamTime={video.beep_time!}
+          crossAlignTime={crossAlignSuggestion}
+          deltaMs={deltaMs!}
+          confidence={conf}
+          onUseCrossAlign={async () => {
+            setBusy(true);
+            try {
+              const updated = await api.overrideBeepForVideo(
+                stageNumber,
+                videoId,
+                crossAlignSuggestion,
+              );
+              onProjectUpdate(updated);
+              setError(null);
+            } catch (e) {
+              setError(e instanceof Error ? e.message : String(e));
+            } finally {
+              setBusy(false);
+            }
+          }}
+          busy={busy}
+        />
+      ) : null}
       <BeepCandidates
         stageNumber={stageNumber}
         videoId={videoId}
@@ -1029,6 +1109,63 @@ function BeepPreview({
           Looks wrong? Refine in audit
         </Link>
       ) : null}
+    </div>
+  );
+}
+
+/** Sanity-check banner: in-stream beep_detect succeeded but cross-correlation
+ *  alignment to the primary lands somewhere different by > 250 ms. The most
+ *  common cause is the in-stream detector locking onto a steel hit or other
+ *  loud transient that tone-matches the buzzer's bandpassed envelope. The
+ *  cross-correlation sees the broader loudness shape (silence -> loud ->
+ *  pause -> shots) and is harder to fool by a single tone. We don't auto-
+ *  override -- in-stream has frequency-domain information cross-align
+ *  doesn't -- but we offer the user a one-click swap. */
+function AlignmentDisagreement({
+  inStreamTime,
+  crossAlignTime,
+  deltaMs,
+  confidence,
+  onUseCrossAlign,
+  busy,
+}: {
+  inStreamTime: number;
+  crossAlignTime: number;
+  deltaMs: number;
+  confidence: number | null;
+  onUseCrossAlign: () => void | Promise<void>;
+  busy: boolean;
+}) {
+  const sign = deltaMs >= 0 ? "+" : "";
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1.5 text-xs">
+      <Sparkles className="size-3 text-amber-600 dark:text-amber-400" />
+      <span>
+        In-stream and cross-align disagree by{" "}
+        <span className="font-mono tabular-nums">
+          {sign}
+          {Math.round(deltaMs)} ms
+        </span>
+        . Could be a steel-strike mistaken for the buzzer.
+      </span>
+      <span
+        className="text-muted-foreground"
+        title={`In-stream: ${inStreamTime.toFixed(3)}s. Cross-align: ${crossAlignTime.toFixed(3)}s${
+          confidence != null ? ` (conf ${confidence.toFixed(2)})` : ""
+        }.`}
+      >
+        in-stream <span className="font-mono tabular-nums">{inStreamTime.toFixed(3)}s</span> ·
+        cross-align <span className="font-mono tabular-nums">{crossAlignTime.toFixed(3)}s</span>
+      </span>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => void onUseCrossAlign()}
+        disabled={busy}
+        className="ml-auto"
+      >
+        Use cross-align
+      </Button>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -7,7 +7,11 @@
  */
 
 export type VideoRole = "primary" | "secondary" | "ignored";
-export type BeepSource = "auto" | "manual";
+/** ``"aligned"`` means the in-stream beep detector failed on a secondary
+ *  and ``cross_align`` projected the primary's beep into the secondary's
+ *  timeline. Treated as a *suggestion* the user must verify on the
+ *  waveform picker before "Mark reviewed". */
+export type BeepSource = "auto" | "manual" | "aligned";
 
 /** One ranked beep candidate emitted by ``detect-beep`` (issue #22).
  *  ``score`` is silence-preference (run_peak / pre-window mean); higher =
@@ -61,6 +65,24 @@ export interface StageVideo {
   /** Ranked alternative candidates from the most recent auto-detection run.
    *  Empty when the project predates issue #22 or after a manual override. */
   beep_candidates: BeepCandidate[];
+  /** True when both in-stream beep detection AND the cross-correlation
+   *  fallback ran on a secondary and neither produced a usable timestamp.
+   *  Distinguishes "tried and failed; pick on waveform" from "not started"
+   *  in the no-beep UI. False on primaries (in-stream failure is fatal
+   *  there). */
+  beep_auto_detect_failed: boolean;
+  /** Peak-to-runner-up confidence ratio from the cross-correlation
+   *  fallback / sanity check. Populated whenever cross-align ran on a
+   *  secondary -- as a promoted suggestion (``beep_source="aligned"``),
+   *  as a below-floor diagnostic (``beep_auto_detect_failed=true``), or
+   *  as a sanity check after in-stream succeeded. Null otherwise. */
+  beep_alignment_confidence: number | null;
+  /** Difference (in-stream minus cross-align) in milliseconds when both
+   *  methods produced a usable timestamp on a secondary. The SPA flags
+   *  large disagreements (> ~250 ms) since they typically mean the
+   *  in-stream detector locked onto a steel-strike or other transient
+   *  rather than the buzzer. Null when only one method ran. */
+  beep_alignment_delta_ms: number | null;
   notes: string;
 }
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3339,7 +3339,9 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     """A cross-align result below the confidence floor must not be promoted
     to ``beep_source='aligned'`` -- the secondary stays in the
     soft-failed state so the user gets the manual-align prompt instead
-    of a wrong auto-set timestamp."""
+    of a wrong auto-set timestamp. The confidence is still saved as a
+    diagnostic so the SPA can render "tried, sub-floor" distinctly from
+    "never tried"."""
     client, _ = _seed_project_with_secondary(tmp_path)
     from splitsmith import beep_detect as bd
     from splitsmith import cross_align as ca
@@ -3361,7 +3363,7 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     def fake_align(*a, **kw):  # type: ignore[no-untyped-def]
         return ca.CrossAlignResult(
             secondary_beep_time=7.250,
-            confidence=1.05,  # below floor 1.5
+            confidence=1.05,  # below floor 1.10
             peak_correlation=0.42,
             lag_seconds=3.25,
         )
@@ -3383,7 +3385,119 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     assert secondary["beep_time"] is None
     assert secondary["beep_source"] == "auto"
     assert secondary["beep_auto_detect_failed"] is True
-    assert secondary["beep_alignment_confidence"] is None
+    # Even on rejection the confidence is preserved -- the SPA needs it to
+    # render "tried, conf 1.05" distinctly from "never tried".
+    assert secondary["beep_alignment_confidence"] == pytest.approx(1.05)
+
+
+def test_secondary_in_stream_success_runs_cross_align_sanity_check(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """When in-stream beep_detect succeeds on a secondary, cross-correlation
+    still runs as a sanity check. When the two methods agree (small delta),
+    the in-stream result wins, ``beep_source`` stays ``"auto"``, but the
+    confidence + delta are surfaced as diagnostics so the SPA can tell
+    "we double-checked" from "we never tried"."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    from splitsmith import beep_detect as bd
+    from splitsmith import cross_align as ca
+    from splitsmith.ui import audio as audio_helpers
+
+    _stub_detect(monkeypatch, beep_time=4.0)
+    primary_id = _video_id_for(client, 1, "primary")
+    _wait_for_job(
+        client,
+        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+    )
+
+    # Secondary in-stream succeeds at 7.250 s; cross-align lands within
+    # 15 ms. The fake_load + Path.exists patches let _try_align run on
+    # synthetic audio without touching real WAVs.
+    _stub_detect(monkeypatch, beep_time=7.250)
+
+    def fake_load(_path):  # type: ignore[no-untyped-def]
+        return np.zeros(48000, dtype=np.float32), 48000
+
+    def fake_align(*a, **kw):  # type: ignore[no-untyped-def]
+        return ca.CrossAlignResult(
+            secondary_beep_time=7.265,
+            confidence=1.30,
+            peak_correlation=0.65,
+            lag_seconds=3.265,
+        )
+
+    monkeypatch.setattr(bd, "load_audio", fake_load)
+    monkeypatch.setattr(ca, "align_secondary_to_primary", fake_align)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    sec_id = _video_id_for(client, 1, "secondary")
+    final = _wait_for_job(
+        client,
+        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+    )
+    assert final["status"] == "succeeded"
+
+    proj = client.get("/api/project").json()
+    secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
+    assert secondary["beep_time"] == pytest.approx(7.250)
+    assert secondary["beep_source"] == "auto"
+    assert secondary["beep_alignment_confidence"] == pytest.approx(1.30)
+    # delta = in_stream - cross_align = 7.250 - 7.265 = -15 ms
+    assert secondary["beep_alignment_delta_ms"] == pytest.approx(-15.0)
+
+
+def test_secondary_in_stream_disagreement_flagged_not_overridden(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """When in-stream and cross-align disagree by hundreds of ms (typical
+    of a steel-strike mistaken for the buzzer), the in-stream result is
+    KEPT as ``beep_time`` -- in-stream has frequency-domain info
+    cross-align doesn't, so we don't auto-override. The delta is
+    surfaced so the SPA can show the user a "use cross-align?" prompt."""
+    client, _ = _seed_project_with_secondary(tmp_path)
+    from splitsmith import beep_detect as bd
+    from splitsmith import cross_align as ca
+    from splitsmith.ui import audio as audio_helpers
+
+    _stub_detect(monkeypatch, beep_time=4.0)
+    primary_id = _video_id_for(client, 1, "primary")
+    _wait_for_job(
+        client,
+        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+    )
+
+    _stub_detect(monkeypatch, beep_time=10.000)
+
+    def fake_load(_path):  # type: ignore[no-untyped-def]
+        return np.zeros(48000, dtype=np.float32), 48000
+
+    def fake_align(*a, **kw):  # type: ignore[no-untyped-def]
+        return ca.CrossAlignResult(
+            secondary_beep_time=7.500,
+            confidence=1.40,
+            peak_correlation=0.70,
+            lag_seconds=3.500,
+        )
+
+    monkeypatch.setattr(bd, "load_audio", fake_load)
+    monkeypatch.setattr(ca, "align_secondary_to_primary", fake_align)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    sec_id = _video_id_for(client, 1, "secondary")
+    final = _wait_for_job(
+        client,
+        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+    )
+    assert final["status"] == "succeeded"
+
+    proj = client.get("/api/project").json()
+    secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
+    # In-stream wins -- not overridden.
+    assert secondary["beep_time"] == pytest.approx(10.000)
+    assert secondary["beep_source"] == "auto"
+    # 2.5 s disagreement, surfaced for the SPA banner.
+    assert secondary["beep_alignment_confidence"] == pytest.approx(1.40)
+    assert secondary["beep_alignment_delta_ms"] == pytest.approx(2500.0)
 
 
 def test_secondary_soft_fail_clears_on_manual_override(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Two related fixes for the secondary-beep flow that was failing silently on `tallmilan-2026` stages 4 and 6.

- **Confidence floor 1.5 -> 1.10.** The 1.5 floor was calibrated on synthetic same-stage pairs and rejected every real-world alignment. On `tallmilan-2026` secondaries where in-stream beep_detect independently succeeded, cross-align lands within 10-16 ms at confidence 1.23-1.34 -- below 1.5 but well above 1.0. New floor calibrated against those validated pairs.
- **Soft-fail UI now visible.** When cross-align falls below the floor, `beep_alignment_confidence` is saved (was wiped) so the SPA can render "Auto-detect failed (conf 1.05)" distinctly from "not started". Failed state offers a "Pick on waveform" button.
- **Always-on sanity check.** When in-stream succeeds on a secondary, cross-align still runs. The delta (`in_stream - cross_align`, ms) is surfaced; large disagreements (> 250 ms) get a yellow banner + one-click "Use cross-align" swap. In-stream is never auto-overridden -- it has frequency-domain info cross-align doesn't.
- **Pill differentiates aligned suggestions.** `beep . aligned . verify` (yellow) for cross-aligned suggestions on the ingest card, with confidence in the tooltip; user must `Mark reviewed` after verifying on the waveform.

End-to-end on tallmilan-2026:

| stage | in-stream | cross-align | delta_ms | conf | verdict |
|------:|----------:|------------:|---------:|-----:|---|
| 2 | 19.330 | 19.320 | +10 | 1.34 | agree (sanity-checked) |
| 4 | -- | 21.170 | -- | 1.31 | promote: aligned (verify) |
| 5 | 1.151 | 1.135 | +16 | 1.23 | agree (sanity-checked) |
| 6 | -- | 10.210 | -- | 1.15 | promote: aligned (verify) |

## Test plan

- [x] `uv run pytest tests/test_ui_server.py` -- 162 passed
- [x] `pnpm run build` -- clean
- [ ] Open `tallmilan-2026` stage 4: secondary shows `beep . aligned . verify` at 21.170 s; scrub waveform, confirm, mark reviewed
- [ ] Same for stage 6 (suggested 10.210 s)
- [ ] Confirm stages 2 and 5 still show `beep . auto` (in-stream wins; sanity-check passed silently)
- [ ] Force a disagreement (manually edit a project to set in-stream != cross-align by > 250 ms) and verify the yellow `AlignmentDisagreement` banner renders + the "Use cross-align" button works

## Notes

- Cross-correlation runs on the Hilbert envelope at 200 Hz, so the per-secondary cost is sub-second on a 60 s clip even with the always-on sanity check.
- The disagreement banner is the answer to "in-stream sometimes locks onto a steel-strike that resembles the buzzer." Cross-align sees the broader silence -> loud -> pause -> shots shape and is harder to fool by a single tone, so disagreement is a useful detector for that failure mode -- without giving up in-stream's tone-specificity when both methods agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)