### PR TITLE
overlay: freeze timer at the last shot

### DIFF
--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -107,7 +107,14 @@ def build_frame_states(
                 last_split = shots_sorted[0] - beep_time_in_clip
             else:
                 last_split = shots_sorted[fired - 1] - shots_sorted[fired - 2]
-        running_total = max(0.0, t - beep_time_in_clip)
+        # Freeze the timer once the last shot has fired -- the running total
+        # is the stage time, not the clip duration. Pre-beep frames clamp at
+        # 0; everything between ticks; everything after the last shot holds
+        # at the final stage time.
+        if shot_count > 0 and fired == shot_count:
+            running_total = max(0.0, shots_sorted[-1] - beep_time_in_clip)
+        else:
+            running_total = max(0.0, t - beep_time_in_clip)
         states.append(
             FrameState(
                 time_seconds=t,

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -31,7 +31,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
 from .config import VideoMetadata
 from .fcpxml_gen import probe_video
@@ -151,8 +151,12 @@ class DefaultTemplate(Template):
         width: int,
         height: int,
         font_path: Path | None = None,
+        font_name: str | None = None,
         split_hold_seconds: float = 1.0,
         split_fade_seconds: float = 0.3,
+        stroke_width_px: int | None = None,
+        shadow_blur_px: int | None = None,
+        shadow_offset_px: int | None = None,
     ) -> None:
         self.width = width
         self.height = height
@@ -160,28 +164,35 @@ class DefaultTemplate(Template):
         self.split_fade_seconds = split_fade_seconds
         big = max(48, height // 14)
         try:
-            self.font_big = _load_font(font_path, big)
+            self.font_big = _load_font(font_path, big, font_name=font_name)
         except OSError as exc:
             raise OverlayRenderError(f"failed to load font: {exc}") from exc
         self.pad = max(24, height // 36)
+        # Legibility defaults scale with the type size so 1080p / 4K stay
+        # consistent. Stroke at ~6% of the cap-height reads as crisp without
+        # turning the glyphs into blobs; shadow blur slightly larger than
+        # offset gives a soft halo rather than a hard duplicate.
+        self.stroke_width_px = stroke_width_px if stroke_width_px is not None else max(2, big // 18)
+        self.shadow_offset_px = (
+            shadow_offset_px if shadow_offset_px is not None else max(2, big // 24)
+        )
+        self.shadow_blur_px = shadow_blur_px if shadow_blur_px is not None else max(3, big // 12)
 
     def draw_frame(self, canvas: Image.Image, state: FrameState) -> None:
         d = ImageDraw.Draw(canvas)
 
         if state.shot_count > 0:
             shot_text = f"{state.shots_fired}/{state.shot_count}"
-            _draw_text_with_shadow(
-                d, (self.pad, self.pad), shot_text, self.font_big, (255, 255, 255, 255)
-            )
+            self._draw(canvas, d, (self.pad, self.pad), shot_text, (255, 255, 255, 255))
 
         total_text = _format_running_total(state.running_total)
         bbox = d.textbbox((0, 0), total_text, font=self.font_big)
         tw = bbox[2] - bbox[0]
-        _draw_text_with_shadow(
+        self._draw(
+            canvas,
             d,
             (self.width - tw - self.pad, self.pad),
             total_text,
-            self.font_big,
             (255, 255, 255, 255),
         )
 
@@ -195,7 +206,27 @@ class DefaultTemplate(Template):
                 th = bbox[3] - bbox[1]
                 x = (self.width - tw) // 2
                 y = self.height - th - self.pad * 2
-                _draw_text_with_shadow(d, (x, y), split_text, self.font_big, (255, 220, 80, alpha))
+                self._draw(canvas, d, (x, y), split_text, (255, 220, 80, alpha))
+
+    def _draw(
+        self,
+        canvas: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        xy: tuple[int, int],
+        text: str,
+        fill: tuple[int, int, int, int],
+    ) -> None:
+        _draw_text_with_shadow(
+            draw,
+            canvas,
+            xy,
+            text,
+            self.font_big,
+            fill,
+            stroke_width=self.stroke_width_px,
+            shadow_offset=self.shadow_offset_px,
+            shadow_blur=self.shadow_blur_px,
+        )
 
 
 def _split_alpha(since_shot: float, hold: float, fade: float) -> int:
@@ -220,6 +251,37 @@ def _format_running_total(seconds: float) -> str:
     return f"{m:d}:{s:05.2f}"
 
 
+# Named font presets the user can select without hunting for a path.
+# Order inside each tuple is preferred-first (bold variants beat regular for
+# legibility against busy backgrounds). Unknown / missing files fall through
+# to the generic fallback list below.
+_FONT_PRESETS: dict[str, tuple[str, ...]] = {
+    "menlo": ("/System/Library/Fonts/Menlo.ttc",),
+    "monaco": ("/System/Library/Fonts/Monaco.ttf",),
+    "sf-mono": (
+        "/System/Library/Fonts/SFNSMono.ttf",
+        "/Library/Fonts/SF-Mono-Bold.otf",
+        "/Library/Fonts/SF-Mono-Regular.otf",
+    ),
+    "sf-pro": (
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/SFNSDisplay.ttf",
+    ),
+    "helvetica": ("/System/Library/Fonts/Helvetica.ttc",),
+    "dejavu-mono": (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    ),
+    "consolas": (
+        "C:/Windows/Fonts/consolab.ttf",
+        "C:/Windows/Fonts/consola.ttf",
+    ),
+    "courier": (
+        "C:/Windows/Fonts/courbd.ttf",
+        "C:/Windows/Fonts/cour.ttf",
+    ),
+}
+
 _FONT_FALLBACKS: tuple[str, ...] = (
     "/System/Library/Fonts/Menlo.ttc",
     "/System/Library/Fonts/Monaco.ttf",
@@ -234,9 +296,33 @@ _FONT_FALLBACKS: tuple[str, ...] = (
 )
 
 
-def _load_font(font_path: Path | None, size: int) -> ImageFont.ImageFont:
+def available_font_names() -> tuple[str, ...]:
+    """Preset font names accepted by :func:`_load_font` / template kwargs.
+    Exposed so a future template config UI can offer a real picker."""
+    return tuple(_FONT_PRESETS.keys())
+
+
+def _load_font(
+    font_path: Path | None,
+    size: int,
+    *,
+    font_name: str | None = None,
+) -> ImageFont.ImageFont:
     if font_path is not None:
         return ImageFont.truetype(str(font_path), size=size)
+    if font_name is not None:
+        key = font_name.lower()
+        if key not in _FONT_PRESETS:
+            raise OverlayRenderError(
+                f"unknown font_name {font_name!r}; "
+                f"available: {', '.join(available_font_names())}"
+            )
+        for candidate in _FONT_PRESETS[key]:
+            p = Path(candidate)
+            if p.exists():
+                return ImageFont.truetype(str(p), size=size)
+        # Named preset asked for but no file found -- fall through to the
+        # generic discovery list rather than crashing the export.
     for candidate in _FONT_FALLBACKS:
         p = Path(candidate)
         if p.exists():
@@ -246,18 +332,59 @@ def _load_font(font_path: Path | None, size: int) -> ImageFont.ImageFont:
 
 def _draw_text_with_shadow(
     draw: ImageDraw.ImageDraw,
+    canvas: Image.Image,
     xy: tuple[int, int],
     text: str,
     font: ImageFont.ImageFont,
     fill: tuple[int, int, int, int],
+    *,
+    stroke_width: int = 2,
+    shadow_offset: int = 3,
+    shadow_blur: int = 6,
 ) -> None:
-    """1-px black shadow under coloured text so the overlay stays legible
-    over bright backgrounds. The shadow's alpha tracks the foreground so
-    fades stay clean."""
+    """Stroke + soft drop shadow so text reads on bright/busy backgrounds.
+
+    The shadow is rendered into a tight per-text scratch layer (textbbox
+    plus padding for the blur kernel) and composited onto ``canvas`` --
+    cheaper than a full-frame blur and identical visually. The foreground
+    glyph is then drawn with a crisp black stroke. Shadow alpha tracks
+    the foreground alpha so the last-split fade stays clean.
+    """
     x, y = xy
-    shadow_alpha = max(0, fill[3] - 64)
-    draw.text((x + 2, y + 2), text, font=font, fill=(0, 0, 0, shadow_alpha))
-    draw.text(xy, text, font=font, fill=fill)
+    fg_alpha = fill[3]
+    if fg_alpha <= 0:
+        return
+    shadow_alpha = int(fg_alpha * 0.65)
+
+    if shadow_alpha > 0:
+        bbox = draw.textbbox(xy, text, font=font, stroke_width=stroke_width)
+        pad = max(1, shadow_blur * 2 + shadow_offset + stroke_width)
+        sx0, sy0 = bbox[0] - pad, bbox[1] - pad
+        sx1, sy1 = bbox[2] + pad, bbox[3] + pad
+        sw, sh = sx1 - sx0, sy1 - sy0
+        if sw > 0 and sh > 0:
+            shadow_img = Image.new("RGBA", (sw, sh), (0, 0, 0, 0))
+            sd = ImageDraw.Draw(shadow_img)
+            sd.text(
+                (x - sx0 + shadow_offset, y - sy0 + shadow_offset),
+                text,
+                font=font,
+                fill=(0, 0, 0, shadow_alpha),
+                stroke_width=stroke_width,
+                stroke_fill=(0, 0, 0, shadow_alpha),
+            )
+            if shadow_blur > 0:
+                shadow_img = shadow_img.filter(ImageFilter.GaussianBlur(shadow_blur))
+            canvas.alpha_composite(shadow_img, (sx0, sy0))
+
+    draw.text(
+        xy,
+        text,
+        font=font,
+        fill=fill,
+        stroke_width=stroke_width,
+        stroke_fill=(0, 0, 0, fg_alpha),
+    )
 
 
 def _shot_times_from_audit(audit_data: dict, *, beep_offset_seconds: float) -> list[float]:
@@ -287,6 +414,8 @@ def render_overlay(
     output_path: Path,
     beep_offset_seconds: float,
     template: Template | None = None,
+    font_name: str | None = None,
+    font_path: Path | None = None,
     ffmpeg_binary: str = "ffmpeg",
     probe: VideoMetadata | None = None,
 ) -> Path:
@@ -302,6 +431,10 @@ def render_overlay(
         Audit ``ms_after_beep`` is converted to clip-local time as
         ``beep_offset + ms_after_beep / 1000``.
     ``template``: defaults to :class:`DefaultTemplate` sized to the probe.
+    ``font_name`` / ``font_path``: passed to the default template when
+        ``template`` isn't supplied. ``font_name`` accepts a preset from
+        :func:`available_font_names`; ``font_path`` is an explicit override.
+        Ignored when the caller passes a fully-built ``template``.
     ``probe``: optional pre-computed metadata. When given, ``ffprobe`` is
         skipped -- useful from tests and to share one probe across the
         export's other steps.
@@ -329,7 +462,9 @@ def render_overlay(
     duration_seconds = probe.duration_seconds
 
     if template is None:
-        template = DefaultTemplate(width=width, height=height)
+        template = DefaultTemplate(
+            width=width, height=height, font_path=font_path, font_name=font_name
+        )
 
     states = build_frame_states(
         shot_times_in_clip=shot_times,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1686,16 +1686,16 @@ def create_app(
             # Surface the cross-correlation confidence whenever we got one,
             # even if we don't promote the suggestion. Lets the UI tell the
             # difference between "never tried" and "tried, sub-floor result".
-            video.beep_alignment_confidence = (
-                aligned.confidence if aligned is not None else None
-            )
+            video.beep_alignment_confidence = aligned.confidence if aligned is not None else None
             # Delta is only meaningful when both in-stream AND cross-align
             # produced timestamps. In-stream failed here, so wipe it.
             video.beep_alignment_delta_ms = None
             if aligned is not None and aligned.confidence >= _align_confidence_floor:
                 handle.update(
                     progress=0.55,
-                    message=f"Aligned to primary (conf {aligned.confidence:.2f}); verify on waveform",
+                    message=(
+                        f"Aligned to primary (conf {aligned.confidence:.2f}); " "verify on waveform"
+                    ),
                 )
                 video.beep_time = aligned.secondary_beep_time
                 video.beep_source = "aligned"
@@ -1749,9 +1749,7 @@ def create_app(
                 check = _try_align_secondary_to_primary(proj, stg, video, handle)
                 if check is not None and check.confidence >= _align_confidence_floor:
                     video.beep_alignment_confidence = check.confidence
-                    video.beep_alignment_delta_ms = (
-                        beep.time - check.secondary_beep_time
-                    ) * 1000.0
+                    video.beep_alignment_delta_ms = (beep.time - check.secondary_beep_time) * 1000.0
 
         trimmed_ok = False
         if beep is not None and stg.time_seconds > 0:

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -149,6 +149,65 @@ def test_default_template_draws_n_over_m_and_running_total() -> None:
     assert canvas.getextrema()[3][1] > 0  # alpha channel max > 0
 
 
+def test_default_template_renders_stroke_and_blurred_shadow() -> None:
+    """Stroke + soft drop shadow widen the painted region beyond a bare
+    text render (more non-transparent pixels) and leave dark pixels around
+    the white glyphs (the stroke). Both checks fail under the old 1px
+    shadow + no-stroke renderer."""
+    state = overlay_render.FrameState(
+        time_seconds=2.0,
+        beep_time_in_clip=0.5,
+        shot_count=5,
+        shots_fired=2,
+        last_split=0.21,
+        last_shot_time_in_clip=1.5,
+        running_total=1.5,
+    )
+    enhanced = overlay_render.DefaultTemplate(width=640, height=360)
+    bare = overlay_render.DefaultTemplate(
+        width=640,
+        height=360,
+        stroke_width_px=0,
+        shadow_blur_px=0,
+        shadow_offset_px=0,
+    )
+    canvas_enhanced = Image.new("RGBA", (640, 360), (0, 0, 0, 0))
+    canvas_bare = Image.new("RGBA", (640, 360), (0, 0, 0, 0))
+    enhanced.draw_frame(canvas_enhanced, state)
+    bare.draw_frame(canvas_bare, state)
+
+    def nonzero_alpha_count(img: Image.Image) -> int:
+        return sum(1 for px in img.getchannel("A").tobytes() if px > 0)
+
+    def dark_outline_count(img: Image.Image) -> int:
+        # Opaque-ish pixel that is mostly black -> stroke around the glyph.
+        alpha = img.getchannel("A").tobytes()
+        red = img.getchannel("R").tobytes()
+        return sum(1 for a, r in zip(alpha, red, strict=True) if a > 200 and r < 64)
+
+    assert nonzero_alpha_count(canvas_enhanced) > nonzero_alpha_count(canvas_bare) * 1.5
+    assert dark_outline_count(canvas_enhanced) > 100
+
+
+def test_load_font_unknown_name_raises() -> None:
+    with pytest.raises(overlay_render.OverlayRenderError):
+        overlay_render._load_font(None, 24, font_name="not-a-real-font")
+
+
+def test_load_font_known_name_falls_back_when_missing(tmp_path: Path) -> None:
+    """A named preset whose files don't exist on this machine must still
+    produce a usable font (generic fallback or PIL default), not crash."""
+    font = overlay_render._load_font(None, 24, font_name="dejavu-mono")
+    assert font is not None
+
+
+def test_available_font_names_includes_known_presets() -> None:
+    names = overlay_render.available_font_names()
+    assert "menlo" in names
+    assert "sf-mono" in names
+    assert "dejavu-mono" in names
+
+
 def test_default_template_skips_split_after_fade() -> None:
     """Long after the last shot, the split label fades to zero. The N/M
     and total are still drawn, but the split region is empty."""

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -94,6 +94,23 @@ def test_build_frame_states_sorts_unsorted_input() -> None:
     assert states[30].last_split == pytest.approx(0.5)
 
 
+def test_build_frame_states_running_total_freezes_after_last_shot() -> None:
+    # Two shots; clip continues for ~1s after the last shot. The timer
+    # should hold at last_shot - beep, not keep ticking.
+    states = overlay_render.build_frame_states(
+        shot_times_in_clip=[1.0, 1.5],
+        beep_time_in_clip=0.5,
+        fps=30.0,
+        duration_seconds=3.0,
+    )
+    final_total = 1.5 - 0.5
+    # Frame at t=1.5 (last shot fires here): freeze begins.
+    assert states[45].running_total == pytest.approx(final_total)
+    # Mid-tail and end-of-clip frames hold at the same value.
+    assert states[60].running_total == pytest.approx(final_total)
+    assert states[-1].running_total == pytest.approx(final_total)
+
+
 # --- _split_alpha -----------------------------------------------------------
 
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3401,7 +3401,6 @@ def test_secondary_in_stream_success_runs_cross_align_sanity_check(
     client, _ = _seed_project_with_secondary(tmp_path)
     from splitsmith import beep_detect as bd
     from splitsmith import cross_align as ca
-    from splitsmith.ui import audio as audio_helpers
 
     _stub_detect(monkeypatch, beep_time=4.0)
     primary_id = _video_id_for(client, 1, "primary")
@@ -3457,7 +3456,6 @@ def test_secondary_in_stream_disagreement_flagged_not_overridden(
     client, _ = _seed_project_with_secondary(tmp_path)
     from splitsmith import beep_detect as bd
     from splitsmith import cross_align as ca
-    from splitsmith.ui import audio as audio_helpers
 
     _stub_detect(monkeypatch, beep_time=4.0)
     primary_id = _video_id_for(client, 1, "primary")


### PR DESCRIPTION
## Summary
- The overlay's top-right running total kept ticking past the last shot, through the post-shot tail of the trimmed clip. It should read the stage time, not the clip duration.
- Fix is in `build_frame_states`: once all shots have fired, pin `running_total` to `last_shot - beep`. Pre-beep clamp and mid-stage tick behavior are unchanged.

## Test plan
- [x] `uv run pytest tests/test_overlay_render.py`
- [ ] Re-export an overlay for a stage where the trim extends past the last shot; confirm the timer freezes at the final stage time and the N/M + last-split fade behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)