### PR TITLE
audit: promote secondary cameras to fixtures from the audit page

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -84,7 +84,14 @@ from pydantic import BaseModel
 from .. import beep_detect, cross_align, report, user_config, video_probe
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
-from ..fixture_schema import AgcState, AudioSource, Camera, CameraMount, CameraPosition
+from ..fixture_schema import (
+    AgcState,
+    AudioSource,
+    Camera,
+    CameraMount,
+    CameraPosition,
+    probe_camera_metadata,
+)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
 from ..config import BeepDetectConfig, Config
@@ -4314,6 +4321,183 @@ def create_app(
                     status_code=500, detail=f"failed to read report: {exc}"
                 ) from exc
             return JSONResponse(data)
+
+        # ------------------------------------------------------------------
+        # Project-aware secondary promotion (issue #125 follow-up)
+        # ------------------------------------------------------------------
+
+        class PromoteSecondaryBody(BaseModel):
+            mount: str
+            position: str
+            audio_source: str = "internal"
+            agc_state: str = "unknown"
+            snap_window_ms: float = 60.0
+            min_spacing_ms: float = 80.0
+            slug: str | None = None
+            camera_id: str | None = None
+            overwrite: bool = False
+
+        @app.post("/api/stages/{stage_number}/videos/{video_id}/promote-secondary")
+        def promote_secondary(
+            stage_number: int, video_id: str, body: PromoteSecondaryBody
+        ) -> JSONResponse:
+            """Promote a project-mapped secondary video to a derived fixture.
+
+            Resolves the anchor (primary) fixture path, the cached secondary
+            WAV, and probes the source video for camera metadata so the
+            caller only has to supply ``mount`` + ``position``. Anchor
+            fixture must already exist (run the primary promote first).
+            """
+            project, stage, video = _resolve_stage_video(stage_number, video_id)
+            if video.role != "secondary":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"video {video_id!r} is not a secondary on stage {stage_number}",
+                )
+            if video.beep_time is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="secondary has no beep_time; detect or align beep first",
+                )
+
+            primary_slug = (
+                f"stage-shots-{export_helpers._slugify(project.name)}-stage{stage_number}"
+            )
+            fixtures_root = lab_module.core.DEFAULT_FIXTURES_ROOT
+            anchor_path = fixtures_root / f"{primary_slug}.json"
+            if not anchor_path.exists():
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"anchor fixture not found: {anchor_path.name}. "
+                        "Promote the primary stage to a fixture first."
+                    ),
+                )
+            anchor_wav_path = anchor_path.with_suffix(".wav")
+            if not anchor_wav_path.exists():
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"anchor WAV missing: {anchor_wav_path.name}",
+                )
+
+            source = project.resolve_video_path(state.project_root, video.path)
+            _ensure_source_reachable(stage_number, source)
+
+            try:
+                secondary_wav_path = audio_helpers.ensure_video_audio(
+                    state.project_root, stage_number, video, source, project=project
+                )
+            except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+            probe = probe_camera_metadata(source)
+            camera_id = (body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}").strip()
+            if not camera_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="camera_id could not be derived; please supply one",
+                )
+
+            slug = (body.slug or f"{primary_slug}-{camera_id}").strip()
+            target_json = fixtures_root / f"{slug}.json"
+            if target_json.exists() and not body.overwrite:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"fixture already exists: {target_json.name} (set overwrite=true to replace)",
+                )
+
+            try:
+                camera = Camera(
+                    id=camera_id,
+                    mount=CameraMount(body.mount),
+                    position=CameraPosition(body.position),
+                    audio_source=AudioSource(body.audio_source),
+                    agc_state=AgcState(body.agc_state),
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+            secondary_source_desc = str(source)
+
+            def _run(handle: JobHandle) -> None:
+                import shutil as _shutil
+
+                handle.update(progress=0.05, message="loading audio...")
+                primary_audio, primary_sr = beep_detect.load_audio(anchor_wav_path)
+                secondary_audio, secondary_sr = beep_detect.load_audio(secondary_wav_path)
+
+                handle.update(progress=0.10, message="loading ensemble models...")
+                runtime = _get_ensemble_runtime()
+
+                handle.check_cancel()
+                handle.update(progress=0.20, message="aligning + detecting shots...")
+
+                anchor_data = __import__("json").loads(
+                    anchor_path.read_text(encoding="utf-8")
+                )
+                result = lab_module.promote_from_anchor(
+                    lab_module.PromoteFromAnchorRequest(
+                        anchor_data=anchor_data,
+                        primary_audio=primary_audio,
+                        primary_sr=primary_sr,
+                        secondary_audio=secondary_audio,
+                        secondary_sr=secondary_sr,
+                        secondary_source_desc=secondary_source_desc,
+                        camera=camera,
+                        slug=slug,
+                        snap_window_ms=body.snap_window_ms,
+                        min_spacing_ms=body.min_spacing_ms,
+                    ),
+                    runtime=runtime,
+                )
+                for w in result.warnings:
+                    handle.update(message=f"WARNING: {w}")
+
+                handle.check_cancel()
+                handle.update(progress=0.85, message="writing fixture...")
+
+                fixtures_root.mkdir(parents=True, exist_ok=True)
+                tmp = target_json.with_suffix(".json.tmp")
+                tmp.write_text(
+                    __import__("json").dumps(
+                        result.fixture_data, indent=2, ensure_ascii=True
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                tmp.replace(target_json)
+
+                target_wav = fixtures_root / f"{slug}.wav"
+                _shutil.copy2(secondary_wav_path, target_wav)
+
+                report_path = fixtures_root / f"{slug}-promotion-report.json"
+                report_path.write_text(
+                    __import__("json").dumps(
+                        result.promotion_report, indent=2, ensure_ascii=True
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+
+                handle.update(
+                    progress=1.0,
+                    message=(
+                        f"done -- {result.promotion_report['counts']['snapped']}/"
+                        f"{result.promotion_report['counts']['anchor_shots']} snapped"
+                    ),
+                )
+
+            job = state.jobs.submit(kind="promote_from_anchor", fn=_run)
+            return JSONResponse(
+                {
+                    "job": job.model_dump(mode="json"),
+                    "fixture_path": str(target_json),
+                    "anchor_path": str(anchor_path),
+                    "slug": slug,
+                    "camera_id": camera_id,
+                    "anchor_slug": primary_slug,
+                }
+            )
 
     if lab_enabled:
         _setup_lab()

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -84,6 +84,9 @@ from pydantic import BaseModel
 from .. import beep_detect, cross_align, report, user_config, video_probe
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
+from .. import thumbnail as thumbnail_helpers
+from .. import waveform as waveform_helpers
+from ..config import BeepDetectConfig, Config
 from ..fixture_schema import (
     AgcState,
     AudioSource,
@@ -92,9 +95,6 @@ from ..fixture_schema import (
     CameraPosition,
     probe_camera_metadata,
 )
-from .. import thumbnail as thumbnail_helpers
-from .. import waveform as waveform_helpers
-from ..config import BeepDetectConfig, Config
 from . import audio as audio_helpers
 from . import exports as export_helpers
 from .jobs import Job, JobCancelled, JobHandle, JobRegistry
@@ -4188,9 +4188,7 @@ def create_app(
             secondary_wav_path = Path(body.secondary_wav_path).resolve()
 
             if not anchor_path.exists():
-                raise HTTPException(
-                    status_code=404, detail=f"anchor not found: {anchor_path}"
-                )
+                raise HTTPException(status_code=404, detail=f"anchor not found: {anchor_path}")
             if not secondary_wav_path.exists():
                 raise HTTPException(
                     status_code=404,
@@ -4236,9 +4234,7 @@ def create_app(
                 handle.check_cancel()
                 handle.update(progress=0.20, message="aligning + detecting shots...")
 
-                anchor_data = __import__("json").loads(
-                    anchor_path.read_text(encoding="utf-8")
-                )
+                anchor_data = __import__("json").loads(anchor_path.read_text(encoding="utf-8"))
                 result = lab_module.promote_from_anchor(
                     lab_module.PromoteFromAnchorRequest(
                         anchor_data=anchor_data,
@@ -4263,9 +4259,7 @@ def create_app(
                 fixtures_root.mkdir(parents=True, exist_ok=True)
                 tmp = target_json.with_suffix(".json.tmp")
                 tmp.write_text(
-                    __import__("json").dumps(
-                        result.fixture_data, indent=2, ensure_ascii=True
-                    )
+                    __import__("json").dumps(result.fixture_data, indent=2, ensure_ascii=True)
                     + "\n",
                     encoding="utf-8",
                 )
@@ -4276,9 +4270,7 @@ def create_app(
 
                 report_path = fixtures_root / f"{body.slug}-promotion-report.json"
                 report_path.write_text(
-                    __import__("json").dumps(
-                        result.promotion_report, indent=2, ensure_ascii=True
-                    )
+                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True)
                     + "\n",
                     encoding="utf-8",
                 )
@@ -4391,7 +4383,9 @@ def create_app(
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
 
             probe = probe_camera_metadata(source)
-            camera_id = (body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}").strip()
+            camera_id = (
+                body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}"
+            ).strip()
             if not camera_id:
                 raise HTTPException(
                     status_code=400,
@@ -4403,7 +4397,10 @@ def create_app(
             if target_json.exists() and not body.overwrite:
                 raise HTTPException(
                     status_code=409,
-                    detail=f"fixture already exists: {target_json.name} (set overwrite=true to replace)",
+                    detail=(
+                        f"fixture already exists: {target_json.name}"
+                        " (set overwrite=true to replace)"
+                    ),
                 )
 
             try:
@@ -4432,9 +4429,7 @@ def create_app(
                 handle.check_cancel()
                 handle.update(progress=0.20, message="aligning + detecting shots...")
 
-                anchor_data = __import__("json").loads(
-                    anchor_path.read_text(encoding="utf-8")
-                )
+                anchor_data = __import__("json").loads(anchor_path.read_text(encoding="utf-8"))
                 result = lab_module.promote_from_anchor(
                     lab_module.PromoteFromAnchorRequest(
                         anchor_data=anchor_data,
@@ -4459,9 +4454,7 @@ def create_app(
                 fixtures_root.mkdir(parents=True, exist_ok=True)
                 tmp = target_json.with_suffix(".json.tmp")
                 tmp.write_text(
-                    __import__("json").dumps(
-                        result.fixture_data, indent=2, ensure_ascii=True
-                    )
+                    __import__("json").dumps(result.fixture_data, indent=2, ensure_ascii=True)
                     + "\n",
                     encoding="utf-8",
                 )
@@ -4472,9 +4465,7 @@ def create_app(
 
                 report_path = fixtures_root / f"{slug}-promotion-report.json"
                 report_path.write_text(
-                    __import__("json").dumps(
-                        result.promotion_report, indent=2, ensure_ascii=True
-                    )
+                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True)
                     + "\n",
                     encoding="utf-8",
                 )

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1219,6 +1219,32 @@ export const api = {
 
   getPromoteReport: (slug: string) =>
     request<PromoteReport>(`/api/lab/promote-report?slug=${encodeURIComponent(slug)}`),
+
+  promoteSecondary: (
+    stageNumber: number,
+    videoId: string,
+    payload: {
+      mount: string;
+      position: string;
+      audio_source?: string;
+      agc_state?: string;
+      snap_window_ms?: number;
+      slug?: string;
+      camera_id?: string;
+      overwrite?: boolean;
+    },
+  ) =>
+    request<{
+      job: Job;
+      fixture_path: string;
+      anchor_path: string;
+      slug: string;
+      camera_id: string;
+      anchor_slug: string;
+    }>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/promote-secondary`,
+      { method: "POST", json: payload },
+    ),
 };
 
 export interface PromoteSnapResult {

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -35,6 +35,7 @@ import {
   Crosshair,
   FlaskConical,
   HelpCircle,
+  Link2,
   ListChecks,
   Loader2,
   Pause,
@@ -1392,6 +1393,12 @@ export function Audit() {
                       defaultSlug={`stage-shots-${slugify(project?.name ?? "match")}-stage${stageNumber}`}
                     />
                   )}
+                  {stageNumber != null && stage && videos.length > 1 && (
+                    <PromoteSecondaryButton
+                      stageNumber={stageNumber}
+                      secondaries={videos.slice(1)}
+                    />
+                  )}
                   <span className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
                     <span>{detectedCount} detected</span>
                     <span>{rejectedCount} rejected</span>
@@ -2089,6 +2096,193 @@ function PromoteFixtureButton({ stageNumber, defaultSlug }: PromoteFixtureButton
               Close
             </Button>
             <Button size="sm" onClick={submit} disabled={busy || !slug.trim()}>
+              {busy ? <Loader2 className="size-3.5 animate-spin" /> : "Promote"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface PromoteSecondaryButtonProps {
+  stageNumber: number;
+  secondaries: StageVideo[];
+}
+
+function PromoteSecondaryButton({ stageNumber, secondaries }: PromoteSecondaryButtonProps) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const eligible = useMemo(
+    () => secondaries.filter((v) => v.beep_time != null),
+    [secondaries],
+  );
+  const [videoId, setVideoId] = useState(eligible[0]?.video_id ?? "");
+  const [mount, setMount] = useState("tripod");
+  const [position, setPosition] = useState("bay-fixed");
+  const [overwrite, setOverwrite] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [job, setJob] = useState<Job | null>(null);
+  const [paths, setPaths] = useState<{ fixture_path: string; anchor_path: string } | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!eligible.find((v) => v.video_id === videoId)) {
+      setVideoId(eligible[0]?.video_id ?? "");
+    }
+  }, [eligible, videoId]);
+
+  useEffect(() => {
+    if (!job || job.status === "succeeded" || job.status === "failed" || job.status === "cancelled")
+      return;
+    let stopped = false;
+    const tick = async () => {
+      try {
+        const j = await api.getJob(job.id);
+        if (stopped) return;
+        setJob(j);
+        if (j.status === "succeeded" && paths) {
+          setOpen(false);
+          setBusy(false);
+          navigate(
+            `/promote-review?fixture=${encodeURIComponent(paths.fixture_path)}&anchor=${encodeURIComponent(paths.anchor_path)}`,
+          );
+        } else if (j.status === "failed") {
+          setBusy(false);
+          setError(j.error ?? "promotion failed");
+        }
+      } catch (err) {
+        if (!stopped) {
+          setBusy(false);
+          setError(String(err));
+        }
+      }
+    };
+    const id = window.setInterval(tick, 1500);
+    return () => {
+      stopped = true;
+      window.clearInterval(id);
+    };
+  }, [job, paths, navigate]);
+
+  const submit = useCallback(async () => {
+    if (!videoId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const resp = await api.promoteSecondary(stageNumber, videoId, {
+        mount,
+        position,
+        overwrite,
+      });
+      setJob(resp.job);
+      setPaths({ fixture_path: resp.fixture_path, anchor_path: resp.anchor_path });
+    } catch (e) {
+      setBusy(false);
+      setError(String(e));
+    }
+  }, [stageNumber, videoId, mount, position, overwrite]);
+
+  const fieldCls =
+    "w-full rounded border border-border bg-background px-2 py-1 font-mono text-xs";
+
+  return (
+    <div className="relative">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        title="Promote a secondary camera to a derived fixture"
+        disabled={eligible.length === 0}
+      >
+        <Link2 className="size-4" />
+      </Button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 w-80 rounded-md border border-border bg-popover p-3 shadow-md">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Promote secondary
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Cross-aligns to the primary fixture, runs detection, snaps shots
+            into a derived fixture.
+          </p>
+          {eligible.length === 0 ? (
+            <div className="mt-2 rounded bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+              No secondary on this stage has a beep yet.
+            </div>
+          ) : (
+            <>
+              <label className="mt-2 block text-[11px]">
+                <span className="text-muted-foreground">Secondary</span>
+                <select
+                  value={videoId}
+                  onChange={(e) => setVideoId(e.target.value)}
+                  className={`${fieldCls} mt-1`}
+                >
+                  {eligible.map((v) => (
+                    <option key={v.video_id} value={v.video_id}>
+                      {v.path.split("/").pop() ?? v.path}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="mt-2 block text-[11px]">
+                <span className="text-muted-foreground">Mount</span>
+                <select
+                  value={mount}
+                  onChange={(e) => setMount(e.target.value)}
+                  className={`${fieldCls} mt-1`}
+                >
+                  <option value="tripod">tripod</option>
+                  <option value="head">head</option>
+                  <option value="chest">chest</option>
+                  <option value="handheld">handheld</option>
+                  <option value="other">other</option>
+                </select>
+              </label>
+              <label className="mt-2 block text-[11px]">
+                <span className="text-muted-foreground">Position</span>
+                <select
+                  value={position}
+                  onChange={(e) => setPosition(e.target.value)}
+                  className={`${fieldCls} mt-1`}
+                >
+                  <option value="bay-fixed">bay-fixed</option>
+                  <option value="shooter-mounted">shooter-mounted</option>
+                  <option value="other">other</option>
+                </select>
+              </label>
+              <label className="mt-2 flex items-center gap-2 text-[11px]">
+                <input
+                  type="checkbox"
+                  checked={overwrite}
+                  onChange={(e) => setOverwrite(e.target.checked)}
+                />
+                Overwrite if exists
+              </label>
+            </>
+          )}
+          {error && (
+            <div className="mt-2 rounded bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+              {error}
+            </div>
+          )}
+          {job && job.status === "running" && (
+            <div className="mt-2 rounded bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+              {job.message ?? "running..."}
+            </div>
+          )}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button
+              size="sm"
+              onClick={submit}
+              disabled={busy || !videoId || eligible.length === 0}
+            >
               {busy ? <Loader2 className="size-3.5 animate-spin" /> : "Promote"}
             </Button>
           </div>

--- a/tests/test_promote_from_anchor.py
+++ b/tests/test_promote_from_anchor.py
@@ -21,12 +21,10 @@ from splitsmith.fixture_schema import (
 )
 from splitsmith.lab.promote import (
     _build_fixture,
-    _build_report,
     _estimate_drift,
     _slug_from_source,
 )
 from splitsmith.lab.snap_window import SnapResult
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

- Adds a 'Promote secondary' button (Link2 icon) next to the existing primary flask-icon on the Audit page; popover handles multiple secondaries via a dropdown
- New `POST /api/stages/{n}/videos/{video_id}/promote-secondary` endpoint resolves anchor, secondary WAV, and camera metadata from project state -- user only picks mount + position
- Slug auto-derives as `<anchor-slug>-<camera_id>`, with `camera_id` coming from ffprobe make/model (falls back to `cam-<videoId[:8]>`)

## Why

Previous flow required typing absolute WAV paths and filling out the slug + camera_id manually in the Lab popover -- duplicating data the project already knows. The Audit page has the secondary loaded with a detected beep already, so promoting from there is the natural place.

## Test plan

- [ ] On a project with a stage that has both a promoted primary fixture and a secondary with a detected beep, click the Link2 icon on the audit toolbar
- [ ] Verify the dropdown lists only secondaries with `beep_time` set
- [ ] Promote and confirm the redirect to `/promote-review` lands with both waveforms loaded
- [ ] Try promoting before the primary fixture exists -- expect a 409 with a clear message
- [ ] Try promoting on a stage with two secondaries (different camera IDs) -- expect two distinct fixture filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)