### PR TITLE
projects: plumb camera_class through shot-detect (#143)

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -38,6 +38,39 @@ from .. import video_match
 from ..config import BeepCandidate, StageData, VideoMatchConfig
 from ..video_match import match_videos_to_stages
 
+# Camera-make heuristic for the default ``StageVideo.camera_mount``
+# (issue #143). The fixture schema's full ``CameraMount`` enum is much
+# richer; we just need a coarse default that makes the per-camera-class
+# threshold dispatch in #137 do the right thing for the common cases:
+# headcams stay headcam, phones become handheld. Anything we don't
+# recognise stays ``None`` and the user can set it manually.
+_MAKE_TO_MOUNT_HEURISTIC: tuple[tuple[str, str], ...] = (
+    ("apple", "hand"),
+    ("samsung", "hand"),
+    ("google", "hand"),
+    ("oneplus", "hand"),
+    ("xiaomi", "hand"),
+    ("insta360", "head"),
+    ("gopro", "head"),
+)
+
+
+def _heuristic_mount_from_make(make: str | None) -> str | None:
+    """Coarse default mount derived from QuickTime / EXIF make tag.
+
+    Returns ``None`` for unknown vendors so the StageVideo stays
+    explicitly "not classified" rather than silently mis-classified.
+    Callers can override per-video via the API.
+    """
+    if not make:
+        return None
+    needle = make.strip().lower()
+    for token, mount in _MAKE_TO_MOUNT_HEURISTIC:
+        if token in needle:
+            return mount
+    return None
+
+
 VIDEO_EXTENSIONS = {
     ".mp4",
     ".mov",
@@ -137,6 +170,15 @@ class StageVideo(BaseModel):
     # type a timestamp by hand. Cleared on manual override / clear (issue #22).
     beep_candidates: list[BeepCandidate] = Field(default_factory=list)
     notes: str = ""
+    # Camera mount classification (issue #143). Drives per-camera-class
+    # threshold selection in the 4-voter ensemble. Stored as the bare
+    # ``CameraMount`` string ("head", "hand", ...) to keep the project
+    # JSON loose -- avoids a hard import dependency on ``fixture_schema``
+    # and lets old projects upgrade without a migration. ``None`` means
+    # "not yet determined" -- the detector probes the source on first
+    # shot-detect and caches the result here. The user can override via
+    # the project SPA / API at any time.
+    camera_mount: str | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -1046,7 +1088,24 @@ class MatchProject(BaseModel):
             match_ts = video_match.video_timestamp(source, prefer_ctime=True)
         except OSError:
             match_ts = None
-        video = StageVideo(path=stored, match_timestamp=match_ts)
+
+        # Heuristic camera mount stamp (issue #143). Probe is best-effort:
+        # if ffprobe fails or the make is unknown, ``camera_mount`` stays
+        # ``None`` and the detector falls back to the default class. The
+        # user can correct via the videos PATCH endpoint.
+        from ..fixture_schema import probe_camera_metadata
+
+        try:
+            probe = probe_camera_metadata(source)
+            mount_default = _heuristic_mount_from_make(probe.make)
+        except Exception:
+            mount_default = None
+
+        video = StageVideo(
+            path=stored,
+            match_timestamp=match_ts,
+            camera_mount=mount_default,
+        )
         self.unassigned_videos.append(video)
         return video
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -779,6 +779,20 @@ class BeepReviewRequest(BaseModel):
     reviewed: bool
 
 
+class CameraMountRequest(BaseModel):
+    """Body for PATCH /api/stages/{n}/videos/{vid}/camera-mount (#143).
+
+    Override the heuristic ``camera_mount`` stamped at register time.
+    Drives the per-camera-class threshold dispatch in the 4-voter
+    ensemble. ``mount`` accepts any fixture-schema ``CameraMount``
+    string ("head", "chest", "helmet", "belt", "hand", "gimbal",
+    "tripod", "monopod") or ``None`` to clear back to the heuristic
+    default.
+    """
+
+    mount: str | None
+
+
 class BeepSnapRequest(BaseModel):
     """Body for POST /api/stages/{n}/videos/{vid}/beep/snap.
 
@@ -2230,6 +2244,10 @@ def create_app(
 
         handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
         audio_array, sr = beep_detect.load_audio(audit.audio_path)
+        # Camera-class dispatch (issue #143). When the primary's mount
+        # is set, look up handheld vs. headcam thresholds; otherwise
+        # the ensemble falls back to the default class (headcam).
+        cam_class = ensemble_module.camera_class_from_mount(prim.camera_mount)
         result = ensemble_module.detect_shots_ensemble(
             audio_array,
             sr,
@@ -2237,6 +2255,7 @@ def create_app(
             stg.time_seconds,
             runtime,
             expected_rounds=expected_rounds,
+            camera_class=cam_class,
         )
 
         candidates: list[dict[str, Any]] = []
@@ -2734,6 +2753,33 @@ def create_app(
                 fn=lambda h, n=stage_number: _run_shot_detect(h, n),
             )
 
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.patch("/api/stages/{stage_number}/videos/{video_id}/camera-mount")
+    def set_camera_mount(stage_number: int, video_id: str, req: CameraMountRequest) -> JSONResponse:
+        """Override the heuristic ``camera_mount`` (issue #143).
+
+        Validated against the fixture-schema ``CameraMount`` enum so
+        downstream code can trust the stored value. ``None`` clears the
+        override -- the next shot-detect run will use the artifact's
+        default class instead of a per-class threshold.
+        """
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        from ..fixture_schema import CameraMount
+
+        if req.mount is not None:
+            try:
+                CameraMount(req.mount)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"unknown camera mount {req.mount!r}; expected one of "
+                        + ", ".join(m.value for m in CameraMount)
+                    ),
+                ) from exc
+        video.camera_mount = req.mount
+        project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/stages/{stage_number}/beep/select")

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -618,6 +618,63 @@ def test_register_video_symlinks_into_raw(tmp_path: Path) -> None:
     assert len(project.unassigned_videos) == 1
 
 
+def test_register_video_stamps_camera_mount_from_make_heuristic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registering an iPhone clip stamps ``camera_mount='hand'`` (issue #143).
+
+    The probe is monkeypatched so the test doesn't need ffprobe / a
+    real iPhone container; what we're verifying is the wiring + the
+    make-vendor heuristic, not ffprobe.
+    """
+    root = tmp_path / "match-iphone"
+    project = MatchProject.init(root, name="iPhone Match")
+    source = tmp_path / "external" / "IMG_1234.MOV"
+    source.parent.mkdir()
+    source.write_bytes(b"\x00\x00\x00 ftypqt  ")
+
+    from splitsmith import fixture_schema
+
+    monkeypatch.setattr(
+        "splitsmith.ui.project.probe_camera_metadata",
+        lambda _path: fixture_schema.CameraProbeResult(make="Apple", model="iPhone 15 Pro"),
+        raising=False,
+    )
+    # The import in register_video is local; patch the symbol on the
+    # fixture_schema module too so the local ``from .. import`` lookup
+    # picks up the stub.
+    monkeypatch.setattr(
+        fixture_schema,
+        "probe_camera_metadata",
+        lambda _path: fixture_schema.CameraProbeResult(make="Apple", model="iPhone 15 Pro"),
+    )
+
+    video = project.register_video(source, root)
+    assert video.camera_mount == "hand"
+
+
+def test_register_video_unknown_make_leaves_camera_mount_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unrecognised vendor leaves ``camera_mount=None`` -- the user can override."""
+    root = tmp_path / "match-unknown"
+    project = MatchProject.init(root, name="Unknown Cam")
+    source = tmp_path / "external" / "RANDOM.mp4"
+    source.parent.mkdir()
+    source.write_bytes(b"")
+
+    from splitsmith import fixture_schema
+
+    monkeypatch.setattr(
+        fixture_schema,
+        "probe_camera_metadata",
+        lambda _path: fixture_schema.CameraProbeResult(make="ObscureCam Inc.", model="X1"),
+    )
+
+    video = project.register_video(source, root)
+    assert video.camera_mount is None
+
+
 def test_register_video_is_idempotent(tmp_path: Path) -> None:
     root = tmp_path / "match-idem"
     project = MatchProject.init(root, name="Idempotent Match")

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2066,6 +2066,140 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     assert proj_after["stages"][0]["videos"][0]["processed"]["shot_detect"] is True
 
 
+def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Issue #143: ``StageVideo.camera_mount`` flows through ``camera_class_from_mount``
+    into ``detect_shots_ensemble``. Verifies the wiring without exercising
+    the actual ensemble (which is monkeypatched).
+    """
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    primary.camera_mount = "hand"  # iPhone-style; should map to handheld class
+    project.stages[0].time_seconds = 10.0
+    project.save(project_root)
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    wav = audio_dir / "stage1_audit.wav"
+    sf.write(wav, np.zeros(48_000, dtype="float32"), 48_000)
+    trimmed_dir = project_root / "trimmed"
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"\x00")
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        audio_path = wav
+        beep_in_clip = 5.0
+        trimmed = True
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
+
+    captured: dict = {}
+
+    def _fake_detect(audio_array, sr, beep, stage_t, runtime, **kwargs):
+        captured.update(kwargs)
+        return _fake_ensemble_result([])
+
+    monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", _fake_detect)
+
+    resp = client.post("/api/stages/1/shot-detect")
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.json()["id"])
+    assert captured.get("camera_class") == "handheld"
+
+
+def test_shot_detect_endpoint_passes_default_class_when_mount_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``camera_mount=None`` -> default class (``headcam``) reaches the ensemble."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    primary.camera_mount = None
+    project.stages[0].time_seconds = 10.0
+    project.save(project_root)
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    wav = audio_dir / "stage1_audit.wav"
+    sf.write(wav, np.zeros(48_000, dtype="float32"), 48_000)
+    trimmed_dir = project_root / "trimmed"
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"\x00")
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        audio_path = wav
+        beep_in_clip = 5.0
+        trimmed = True
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
+
+    captured: dict = {}
+
+    def _fake_detect(audio_array, sr, beep, stage_t, runtime, **kwargs):
+        captured.update(kwargs)
+        return _fake_ensemble_result([])
+
+    monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", _fake_detect)
+
+    resp = client.post("/api/stages/1/shot-detect")
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.json()["id"])
+    # ``camera_class_from_mount(None)`` -> ``headcam`` (the default class).
+    assert captured.get("camera_class") == "headcam"
+
+
+def test_camera_mount_patch_endpoint_round_trips(tmp_path: Path) -> None:
+    """PATCH /camera-mount validates against the CameraMount enum and persists."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    video_id = primary.video_id
+
+    # Override.
+    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": "hand"})
+    assert resp.status_code == 200, resp.text
+    refreshed = MatchProject.load(project_root)
+    assert refreshed.stages[0].primary().camera_mount == "hand"
+
+    # Bad value rejected.
+    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": "shoulder"})
+    assert resp.status_code == 400, resp.text
+
+    # Clear back to None.
+    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": None})
+    assert resp.status_code == 200
+    refreshed = MatchProject.load(project_root)
+    assert refreshed.stages[0].primary().camera_mount is None
+
+
 def test_shot_detect_endpoint_400_when_no_beep(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     project_root = tmp_path / "match"


### PR DESCRIPTION
## Summary

Closes #143. Makes #137 actually do something for phone-cam projects -- previously the per-class thresholds shipped in the artifact only ran during calibration; now they fire in production based on the primary camera's mount.

- ``StageVideo.camera_mount: str | None`` -- ``None`` means "fall back to the artifact default class" (headcam), preserving byte-identical behaviour for existing projects.
- ``register_video`` stamps a heuristic default from the ffprobe make tag (Apple / Samsung / Google / OnePlus / Xiaomi -> ``hand``; Insta360 / GoPro -> ``head``; otherwise ``None``).
- New ``PATCH /api/stages/{n}/videos/{vid}/camera-mount`` for explicit overrides; validated against the ``CameraMount`` enum.
- ``_run_shot_detect`` reads the primary's mount, derives the class via ``camera_class_from_mount``, passes it into ``detect_shots_ensemble``.

## Why this is the right next step

The umbrella plan in #136 makes #138 (consensus tuning) gated on observing per-class recall holes in production. Without this plumbing those holes are unobservable -- every project runs as headcam regardless. This PR is the prerequisite for the #138 decision gate, and it lands the immediate value of #137 for phone-cam projects.

## Test plan

- [x] ``uv run pytest tests/`` -- 593 / 593 pass.
- [x] Heuristic stamps ``hand`` on iPhone clips, leaves ``None`` on unknown vendors.
- [x] ``camera_class_from_mount('hand') -> 'handheld'`` flows through ``detect_shots_ensemble`` (asserted via captured kwargs).
- [x] ``camera_class_from_mount(None) -> 'headcam'`` for legacy / unknown-vendor projects.
- [x] ``PATCH /camera-mount`` validates against the enum, round-trips through ``project.json``, rejects unknown mounts with 400.
- [ ] Manual: register an iPhone-recorded clip in a project, confirm ``camera_mount=hand`` appears on the registered video, confirm shot-detect picks the handheld thresholds.

## Out of scope

- SPA UI surface for the override (issue #135's editor will cover that more comprehensively).
- Lab-side metadata changes -- this PR only touches the project schema.

## Related

- Umbrella: #136
- Foundation: PR #142 / issue #137
- Lab editor follow-up: #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)