### PR TITLE
projects: auto-upgrade first video on a stage to primary

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -1127,6 +1127,12 @@ class MatchProject(BaseModel):
           ``role``.
         - ``to_stage_number=N, role="primary"``: there can be only one primary
           per stage; any existing primary is demoted to ``"secondary"``.
+        - ``to_stage_number=N, role="secondary"`` on a stage with no primary
+          yet: auto-upgrade to ``"primary"``. Matches user expectation that
+          the first video assigned to a stage becomes the primary -- and is
+          the only way to bootstrap a primary in placeholder-mode projects
+          where ``auto_match`` has no scoreboard timestamps to anchor on.
+          Pass ``role="ignored"`` explicitly to opt out of the upgrade.
 
         Returns the moved ``StageVideo``. Raises ``KeyError`` if the video or
         stage doesn't exist.
@@ -1153,11 +1159,17 @@ class MatchProject(BaseModel):
             return video
 
         target = self.stage(to_stage_number)
-        if role == "primary":
+        # Auto-upgrade: a "secondary" assignment to a stage with no primary
+        # yet becomes the primary. Skipped for "ignored" (explicit opt-out)
+        # and a no-op when the caller already passed "primary".
+        effective_role: VideoRole = role
+        if role == "secondary" and not any(v.role == "primary" for v in target.videos):
+            effective_role = "primary"
+        if effective_role == "primary":
             for v in target.videos:
                 if v.role == "primary":
                     v.role = "secondary"
-        video.role = role
+        video.role = effective_role
         target.videos.append(video)
         return video
 

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -737,6 +737,65 @@ def test_assign_video_demotes_existing_primary(tmp_path: Path) -> None:
     assert primaries[0].path == v2.path
 
 
+def test_assign_video_secondary_to_empty_stage_auto_upgrades_to_primary(
+    tmp_path: Path,
+) -> None:
+    """First video onto a stage becomes primary even when role='secondary'.
+
+    Bootstraps placeholder-mode projects (no scoreboard -> ``auto_match``
+    returns nothing) so the user doesn't have to manually promote.
+    """
+    root = tmp_path / "match-auto-primary"
+    project = MatchProject.init(root, name="Auto Primary Match")
+    project.stages = [StageEntry(stage_number=1, stage_name="A", time_seconds=10.0)]
+    src = tmp_path / "VID.mp4"
+    src.write_bytes(b"")
+    v = project.register_video(src, root)
+
+    # Default role from the SPA's drag-drop is "secondary".
+    project.assign_video(v.path, to_stage_number=1, role="secondary")
+
+    assert project.stages[0].videos[0].role == "primary"
+
+
+def test_assign_video_secondary_when_primary_exists_stays_secondary(
+    tmp_path: Path,
+) -> None:
+    """A second 'secondary' assignment does NOT demote the existing primary."""
+    root = tmp_path / "match-no-demote"
+    project = MatchProject.init(root, name="No Demote Match")
+    project.stages = [StageEntry(stage_number=1, stage_name="A", time_seconds=10.0)]
+    src1 = tmp_path / "VID_a.mp4"
+    src2 = tmp_path / "VID_b.mp4"
+    src1.write_bytes(b"")
+    src2.write_bytes(b"")
+    v1 = project.register_video(src1, root)
+    v2 = project.register_video(src2, root)
+    project.assign_video(v1.path, to_stage_number=1, role="primary")
+    project.assign_video(v2.path, to_stage_number=1, role="secondary")
+
+    stage = project.stages[0]
+    primaries = [v for v in stage.videos if v.role == "primary"]
+    secondaries = [v for v in stage.videos if v.role == "secondary"]
+    assert len(primaries) == 1 and primaries[0].path == v1.path
+    assert len(secondaries) == 1 and secondaries[0].path == v2.path
+
+
+def test_assign_video_ignored_does_not_auto_upgrade(tmp_path: Path) -> None:
+    """role='ignored' is the explicit opt-out; never gets upgraded to primary."""
+    root = tmp_path / "match-ignored"
+    project = MatchProject.init(root, name="Ignored Match")
+    project.stages = [StageEntry(stage_number=1, stage_name="A", time_seconds=10.0)]
+    src = tmp_path / "VID.mp4"
+    src.write_bytes(b"")
+    v = project.register_video(src, root)
+
+    project.assign_video(v.path, to_stage_number=1, role="ignored")
+
+    assert project.stages[0].videos[0].role == "ignored"
+    assert project.stages[0].primary() is None
+
+
 def test_assign_video_back_to_unassigned(tmp_path: Path) -> None:
     root = tmp_path / "match-back"
     project = MatchProject.init(root, name="Back Match")


### PR DESCRIPTION
## Summary

Fixes a paper-cut hit while validating phone-cam projects: in placeholder-mode (no scoreboard imported) ``auto_match`` returns ``{}`` because every stage has ``scorecard_updated_at=None``, and the SPA's drag-drop sends ``role=\"secondary\"`` by default. Result: videos land on stages but no primary ever gets set, so shot-detect can't run.

``assign_video`` now upgrades ``role=\"secondary\"`` to ``\"primary\"`` when the target stage has no primary yet. ``role=\"ignored\"`` is the explicit opt-out; ``role=\"primary\"`` keeps its existing semantics (demotes any existing primary).

## Why this approach

- One line in the existing ``assign_video`` helper -> applies uniformly to every entry point (scan auto-assign, drag-drop, programmatic, swap).
- Matches user expectation that the first video on a stage becomes the primary unless told otherwise.
- Does not require placeholder projects to have any scoreboard data.
- Existing explicit ``role=\"primary\"`` callers unchanged. Existing ``role=\"secondary\"`` callers see the new upgrade only on stages that had no primary -- which was a broken state to begin with.

## Test plan

- [x] ``uv run pytest tests/`` -- 596 / 596 (was 593, +3 new).
- [x] First-video-as-secondary -> primary on empty stage.
- [x] Second-video-as-secondary stays secondary, doesn't demote existing primary.
- [x] role=\"ignored\" is preserved (explicit opt-out).

## Related

Surfaced while validating PR #144 / #143 (per-camera-class thresholds in projects) on a phone-cam-only project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)