### PR TITLE
projects: bulk shot-detect across all eligible stages

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -19,6 +19,7 @@ Endpoints (locked v1 surface):
   POST /api/stages/{n}/beep/select  -- promote one ranked candidate (synchronous)
   POST /api/stages/{n}/trim         -- submit an audit-mode trim job
   POST /api/stages/{n}/shot-detect  -- submit shot detection on the audit clip
+  POST /api/stages/shot-detect      -- bulk shot detection on every eligible stage
   POST /api/stages/{n}/videos/{vid}/detect-beep -- per-video beep detection
   POST /api/stages/{n}/videos/{vid}/beep         -- per-video manual override
   POST /api/stages/{n}/videos/{vid}/beep/select  -- per-video candidate select
@@ -2376,6 +2377,48 @@ def create_app(
             prim_fresh.processed["shot_detect"] = True
             fresh.save(state.project_root)
         handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
+
+    @app.post("/api/stages/shot-detect")
+    def shot_detect_all_endpoint(reset: bool = False) -> JSONResponse:
+        """Submit shot-detection on every eligible stage in the project.
+
+        A stage is eligible when it has a primary video with a confirmed
+        ``beep_time`` and ``time_seconds > 0`` -- i.e. the same gates the
+        per-stage endpoint checks. Stages that don't qualify are silently
+        skipped and reported in ``skipped`` so the SPA can surface them.
+
+        Idempotent dedupe: stages with an already-active shot-detect job
+        adopt the existing job instead of starting a second.
+
+        ``reset=true`` clears each affected stage's ``shots[]`` before
+        running, matching the per-stage endpoint's semantics.
+        """
+        project = state.load()
+        jobs: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        for stage in project.stages:
+            stage_number = stage.stage_number
+            primary = stage.primary()
+            if primary is None:
+                skipped.append({"stage_number": stage_number, "reason": "no_primary"})
+                continue
+            if primary.beep_time is None:
+                skipped.append({"stage_number": stage_number, "reason": "no_beep"})
+                continue
+            if stage.time_seconds <= 0:
+                skipped.append({"stage_number": stage_number, "reason": "no_time_seconds"})
+                continue
+            existing = state.jobs.find_active(kind="shot_detect", stage_number=stage_number)
+            if existing is not None:
+                jobs.append(existing.model_dump(mode="json"))
+                continue
+            job = state.jobs.submit(
+                kind="shot_detect",
+                stage_number=stage_number,
+                fn=lambda h, n=stage_number, r=reset: _run_shot_detect(h, n, reset=r),
+            )
+            jobs.append(job.model_dump(mode="json"))
+        return JSONResponse({"jobs": jobs, "skipped": skipped})
 
     @app.post("/api/stages/{stage_number}/shot-detect")
     def shot_detect_endpoint(stage_number: int, reset: bool = False) -> JSONResponse:

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -934,6 +934,18 @@ export const api = {
     return request<Job>(`/api/stages/${stageNumber}/shot-detect${qs}`, { method: "POST" });
   },
 
+  /** Submit shot detection on every eligible stage. A stage is eligible
+   *  when it has a primary with confirmed beep + non-zero time_seconds.
+   *  Returns the list of submitted (or already-active) jobs plus a
+   *  ``skipped`` array describing why ineligible stages were left alone. */
+  detectShotsAll: (opts: { reset?: boolean } = {}) => {
+    const qs = opts.reset ? "?reset=true" : "";
+    return request<{
+      jobs: Job[];
+      skipped: { stage_number: number; reason: string }[];
+    }>(`/api/stages/shot-detect${qs}`, { method: "POST" });
+  },
+
   /** Server-side feature flags (fetched once on app mount). Today this
    *  surfaces the ``lab`` flag so the SPA can hide the Lab nav entry
    *  unless ``splitsmith ui --lab`` was passed. */

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1949,9 +1949,48 @@ function StagesSection({
     }
   }
 
+  const handleRedetectAll = async () => {
+    if (busy) return;
+    if (
+      !window.confirm(
+        "Re-run shot detection on every eligible stage in this project? Stages with an active job will adopt that job; ineligible stages (no primary, no beep, no time_seconds) are skipped.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const resp = await api.detectShotsAll();
+      if (resp.skipped.length > 0) {
+        setError(
+          `Submitted ${resp.jobs.length} job(s); skipped ${resp.skipped.length}: ` +
+            resp.skipped.map((s) => `stage ${s.stage_number} (${s.reason})`).join(", "),
+        );
+      } else {
+        setError(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={handleRedetectAll}
+          title="Submit shot-detect on every stage with a primary + confirmed beep"
+        >
+          <Crosshair className="size-3.5" />
+          Re-detect all
+        </Button>
+      </div>
       {/* Each stage card now embeds inline thumbnail-as-poster <video>
           players for the primary + each secondary plus role action
           buttons; that needs ~700px of horizontal room before things

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1949,18 +1949,22 @@ function StagesSection({
     }
   }
 
-  const handleRedetectAll = async () => {
+  const handleRedetectAll = async (reset: boolean) => {
     if (busy) return;
+    const verb = reset ? "Re-detect AND reset shots" : "Re-detect (preserve current shots)";
     if (
       !window.confirm(
-        "Re-run shot detection on every eligible stage in this project? Stages with an active job will adopt that job; ineligible stages (no primary, no beep, no time_seconds) are skipped.",
+        `${verb} on every eligible stage?\n\n` +
+          (reset
+            ? "This will discard each stage's current ``shots[]`` (kept / rejected decisions) and re-seed from the new consensus. Ineligible stages (no primary, no beep, no time_seconds) are skipped."
+            : "Existing ``shots[]`` are kept untouched; only the candidate universe is refreshed. Use this when you've already audited shots and only want updated voter signals."),
       )
     ) {
       return;
     }
     setBusy(true);
     try {
-      const resp = await api.detectShotsAll();
+      const resp = await api.detectShotsAll({ reset });
       if (resp.skipped.length > 0) {
         setError(
           `Submitted ${resp.jobs.length} job(s); skipped ${resp.skipped.length}: ` +
@@ -1980,16 +1984,28 @@ function StagesSection({
     <section className="space-y-3">
       <div className="flex items-center justify-between gap-2">
         <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={busy}
-          onClick={handleRedetectAll}
-          title="Submit shot-detect on every stage with a primary + confirmed beep"
-        >
-          <Crosshair className="size-3.5" />
-          Re-detect all
-        </Button>
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={busy}
+            onClick={() => handleRedetectAll(false)}
+            title="Re-run shot detection on every stage. Existing shots[] are kept; only the candidate universe / voter signals are refreshed."
+          >
+            <Crosshair className="size-3.5" />
+            Re-detect all
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={busy}
+            onClick={() => handleRedetectAll(true)}
+            title="Re-run shot detection AND clear each stage's shots[] so consensus reseeds from scratch. Discards prior keep/reject decisions."
+          >
+            <Crosshair className="size-3.5" />
+            Re-detect all + reset
+          </Button>
+        </div>
       </div>
       {/* Each stage card now embeds inline thumbnail-as-poster <video>
           players for the primary + each secondary plus role action

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2174,6 +2174,86 @@ def test_shot_detect_endpoint_passes_default_class_when_mount_missing(
     assert captured.get("camera_class") == "headcam"
 
 
+def test_shot_detect_all_endpoint_submits_per_eligible_stage(tmp_path: Path, monkeypatch) -> None:
+    """``POST /api/stages/shot-detect`` submits a job per eligible stage and
+    reports skipped stages with reasons. Eligible: primary + beep + time_seconds."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.stages[0].time_seconds = 10.0
+
+    src2 = tmp_path / "extra" / "VID_S2.mp4"
+    src2.parent.mkdir(parents=True, exist_ok=True)
+    src2.write_bytes(b"\x00")
+    project.register_video(src2, project_root)
+    src3 = tmp_path / "extra" / "VID_S3.mp4"
+    src3.write_bytes(b"\x00")
+    project.register_video(src3, project_root)
+
+    project.stages.append(
+        StageEntry(stage_number=2, stage_name="B", time_seconds=8.0, scorecard_updated_at=None)
+    )
+    project.stages.append(
+        StageEntry(stage_number=3, stage_name="C", time_seconds=8.0, scorecard_updated_at=None)
+    )
+    project.stages.append(
+        StageEntry(stage_number=4, stage_name="D", time_seconds=0.0, scorecard_updated_at=None)
+    )
+    project.assign_video(Path("raw") / "VID_S2.mp4", to_stage_number=2, role="primary")
+    s2_primary = project.stages[1].primary()
+    assert s2_primary is not None
+    s2_primary.beep_time = 4.0
+    project.assign_video(Path("raw") / "VID_S3.mp4", to_stage_number=3, role="primary")
+
+    project.save(project_root)
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    for n in (1, 2):
+        sf.write(audio_dir / f"stage{n}_audit.wav", np.zeros(48_000, dtype="float32"), 48_000)
+    trimmed_dir = project_root / "trimmed"
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    for n in (1, 2):
+        (trimmed_dir / f"stage{n}_trimmed.mp4").write_bytes(b"\x00")
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        def __init__(self, n: int) -> None:
+            self.audio_path = audio_dir / f"stage{n}_audit.wav"
+            self.beep_in_clip = 5.0 if n == 1 else 4.0
+            self.trimmed = True
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda root, n, *a, **kw: FakeAudit(n))
+    monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
+    monkeypatch.setattr(
+        ensemble_module,
+        "detect_shots_ensemble",
+        lambda *a, **kw: _fake_ensemble_result([]),
+    )
+
+    resp = client.post("/api/stages/shot-detect")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    submitted = sorted(j["stage_number"] for j in body["jobs"])
+    assert submitted == [1, 2]
+    skipped = {s["stage_number"]: s["reason"] for s in body["skipped"]}
+    assert skipped == {3: "no_beep", 4: "no_primary"}
+
+    for j in body["jobs"]:
+        _wait_for_job(client, j["id"])
+
+
 def test_shot_detect_endpoint_writes_stage_rounds_into_audit_json(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Re-running shot detection used to require clicking each stage card individually -- painful on an 8-stage project that just got per-class thresholds (#137) or stage_rounds (#146) wired up.

* ``POST /api/stages/shot-detect`` -- submit a job per eligible stage in one call. Idempotent dedupe (active stage jobs are adopted, not re-queued). Skipped stages come back with structured reasons so the SPA can surface them.
* ``api.detectShotsAll()`` client wrapper in ``lib/api.ts``.
* "Re-detect all" button next to the Stages section header on the Ingest page. Includes a confirm so an accidental click doesn't trash audit-in-progress.

## Test plan

- [x] ``uv run pytest tests/`` -- 601 / 601 (was 600, +1 new).
- [x] ``npx tsc -b`` clean.
- [x] Backend test covers the eligibility gates + skipped-with-reason reporting (eligible: stages 1+2; skipped: stage 3 ``no_beep``, stage 4 ``no_primary``).
- [ ] Manual: hit the new button on blacksmith-2026 and confirm 8 jobs queue, run, and update the audit JSONs with the now-active adaptive Voter C + apriori boost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)