### PR TITLE
ui: camera-mount selector on Ingest + Audit, plus bulk-set toolbar

### DIFF
--- a/src/splitsmith/ui_static/src/components/MountSelect.tsx
+++ b/src/splitsmith/ui_static/src/components/MountSelect.tsx
@@ -1,0 +1,91 @@
+/**
+ * Camera mount selector for a single ``StageVideo`` (issue #143 follow-up).
+ *
+ * Drives the per-camera-class threshold dispatch in the 4-voter ensemble:
+ * ``head|chest|belt|helmet`` -> headcam thresholds; ``hand|tripod|monopod
+ * |gimbal`` -> handheld. The mount is heuristically stamped from camera
+ * make at register time; this control lets the user correct it when the
+ * heuristic guesses wrong (e.g. an iPhone hand-held during the stage).
+ *
+ * "(auto)" clears the override and falls back to the calibration
+ * artifact's default class on the next shot-detect run.
+ */
+
+import {
+  CAMERA_MOUNTS,
+  api,
+  type CameraMount,
+  type MatchProject,
+  type StageVideo,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface MountSelectProps {
+  video: StageVideo;
+  stageNumber: number;
+  disabled?: boolean;
+  /** Optional label in front of the dropdown. Pages with limited horizontal
+   *  space (the Ingest video row) hide it; pages with room (Audit header)
+   *  show "Mount" so the control is self-explanatory. */
+  label?: string;
+  className?: string;
+  setBusy?: (b: boolean) => void;
+  setError?: (msg: string | null) => void;
+  onProjectUpdate: (p: MatchProject) => void;
+}
+
+export function MountSelect({
+  video,
+  stageNumber,
+  disabled = false,
+  label,
+  className,
+  setBusy,
+  setError,
+  onProjectUpdate,
+}: MountSelectProps) {
+  const value = video.camera_mount ?? "";
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      {label ? (
+        <span className="text-[11px] text-muted-foreground">{label}</span>
+      ) : null}
+      <select
+        className="h-7 rounded border border-input bg-background px-1.5 text-[11px] focus:outline-none focus:ring-1 focus:ring-ring"
+        value={value}
+        disabled={disabled}
+        title="Camera mount -- routes this video through the matching ensemble threshold class (handheld vs headcam)"
+        aria-label={`Camera mount for ${
+          video.path.split("/").pop() ?? video.path
+        }`}
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onChange={async (e) => {
+          const next =
+            e.target.value === "" ? null : (e.target.value as CameraMount);
+          setBusy?.(true);
+          setError?.(null);
+          try {
+            const updated = await api.setCameraMount(
+              stageNumber,
+              video.video_id,
+              next,
+            );
+            onProjectUpdate(updated);
+          } catch (err) {
+            setError?.(err instanceof Error ? err.message : String(err));
+          } finally {
+            setBusy?.(false);
+          }
+        }}
+      >
+        <option value="">(auto)</option>
+        {CAMERA_MOUNTS.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -84,7 +84,34 @@ export interface StageVideo {
    *  rather than the buzzer. Null when only one method ran. */
   beep_alignment_delta_ms: number | null;
   notes: string;
+  /** Selects the per-class threshold set used by the ensemble (issue #143):
+   *  ``head|chest|belt|helmet`` -> headcam; ``hand|tripod|monopod|gimbal``
+   *  -> handheld. Stamped heuristically from camera make at register time
+   *  and overridable via PATCH .../camera-mount. ``null`` falls back to
+   *  the artifact's default class. */
+  camera_mount: CameraMount | null;
 }
+
+export type CameraMount =
+  | "head"
+  | "chest"
+  | "belt"
+  | "helmet"
+  | "hand"
+  | "tripod"
+  | "monopod"
+  | "gimbal";
+
+export const CAMERA_MOUNTS: readonly CameraMount[] = [
+  "head",
+  "chest",
+  "belt",
+  "helmet",
+  "hand",
+  "tripod",
+  "monopod",
+  "gimbal",
+] as const;
 
 export interface StageEntry {
   stage_number: number;
@@ -795,6 +822,24 @@ export const api = {
    *  prompt then re-call with ``confirm=true``. On confirm, the existing
    *  audit JSON is renamed to ``.bak`` and detection re-runs on the new
    *  primary's audio. */
+  /** Override the heuristic camera mount on a single video. The mapping
+   *  to ensemble threshold class (handheld vs headcam) happens server-
+   *  side via ``camera_class_from_mount``. Pass ``null`` to clear the
+   *  override and fall back to the artifact's default class on the next
+   *  shot-detect run. */
+  setCameraMount: (
+    stageNumber: number,
+    videoId: string,
+    mount: CameraMount | null,
+  ) =>
+    request<MatchProject>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-mount`,
+      {
+        method: "PATCH",
+        json: { mount },
+      },
+    ),
+
   swapPrimary: (videoPath: string, stageNumber: number, confirm = false) =>
     request<MatchProject>("/api/assignments/swap-primary", {
       method: "POST",

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -57,6 +57,7 @@ import {
 import { HelpOverlay } from "@/components/HelpOverlay";
 import { ListDrawer } from "@/components/ListDrawer";
 import { MarkerLayer, type AuditMarker } from "@/components/MarkerLayer";
+import { MountSelect } from "@/components/MountSelect";
 import { ShotStepper } from "@/components/ShotStepper";
 import { VideoPanel } from "@/components/VideoPanel";
 import { Waveform } from "@/components/Waveform";
@@ -1277,8 +1278,20 @@ export function Audit() {
                 />
               ) : null}
             </CardTitle>
-            <CardDescription>
-              Primary: <code className="text-xs">{primary.path}</code>
+            <CardDescription className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span>
+                {activeVideoIndex === 0 ? "Primary" : `Cam ${activeVideoIndex + 1}`}:{" "}
+                <code className="text-xs">{activeVideo?.path ?? primary.path}</code>
+              </span>
+              {activeVideo && stageNumber != null ? (
+                <MountSelect
+                  video={activeVideo}
+                  stageNumber={stageNumber}
+                  label="Mount"
+                  onProjectUpdate={setProject}
+                  setError={setProjectError}
+                />
+              ) : null}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -36,6 +36,7 @@ import {
 
 import { BeepSection } from "@/components/BeepSection";
 import { FolderPicker } from "@/components/FolderPicker";
+import { MountSelect } from "@/components/MountSelect";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -48,8 +49,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   ApiError,
+  CAMERA_MOUNTS,
   api,
   asScoreboardError,
+  type CameraMount,
   type FsProbeResponse,
   type MatchAnalysis,
   type MatchProject,
@@ -1982,9 +1985,16 @@ function StagesSection({
 
   return (
     <section className="space-y-3">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <h2 className="text-lg font-semibold tracking-tight">Stages</h2>
-        <div className="flex gap-1">
+        <div className="flex flex-wrap gap-1">
+          <BulkMountControl
+            project={project}
+            busy={busy}
+            setBusy={setBusy}
+            setError={setError}
+            onProjectUpdate={onProjectUpdate}
+          />
           <Button
             size="sm"
             variant="outline"
@@ -2034,6 +2044,103 @@ function StagesSection({
         ))}
       </div>
     </section>
+  );
+}
+
+/** Toolbar control: pick a mount, apply it to every stage's primary in one
+ *  shot. Useful for projects shot entirely with one camera type (e.g. all
+ *  iPhone-handheld for tallmilan-2025) where flipping the per-row select
+ *  on every stage would be tedious. The select doesn't fire on change --
+ *  user must click "Apply" -- so a stray click on the dropdown can't mass-
+ *  rewrite metadata. */
+function BulkMountControl({
+  project,
+  busy,
+  setBusy,
+  setError,
+  onProjectUpdate,
+}: {
+  project: MatchProject;
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+  onProjectUpdate: (p: MatchProject) => void;
+}) {
+  const [pending, setPending] = useState<CameraMount | "" | "none">("");
+  const targets = useMemo(
+    () =>
+      project.stages
+        .map((s) => {
+          const primary = s.videos.find((v) => v.role === "primary");
+          return primary ? { stage: s.stage_number, video: primary } : null;
+        })
+        .filter((x): x is { stage: number; video: StageVideo } => x !== null),
+    [project.stages],
+  );
+
+  const apply = async () => {
+    if (busy || pending === "" || targets.length === 0) return;
+    const next: CameraMount | null = pending === "none" ? null : pending;
+    const label = next ?? "auto";
+    if (
+      !window.confirm(
+        `Set primary mount to "${label}" on ${targets.length} stage${
+          targets.length === 1 ? "" : "s"
+        }?\n\nThis only updates metadata; existing shots[] are untouched. ` +
+          "Re-run shot detection afterwards to score with the new threshold class.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    let last: MatchProject | null = null;
+    try {
+      for (const t of targets) {
+        last = await api.setCameraMount(t.stage, t.video.video_id, next);
+      }
+      if (last) onProjectUpdate(last);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (targets.length === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      title={`Set the camera mount on every stage's primary (${targets.length} target${targets.length === 1 ? "" : "s"})`}
+    >
+      <span className="text-[11px] text-muted-foreground">Primary mount:</span>
+      <select
+        className="h-7 rounded border border-input bg-background px-1.5 text-[11px] focus:outline-none focus:ring-1 focus:ring-ring"
+        value={pending}
+        disabled={busy}
+        onChange={(e) => setPending(e.target.value as CameraMount | "" | "none")}
+        aria-label="Bulk-set primary mount"
+      >
+        <option value="" disabled>
+          select...
+        </option>
+        <option value="none">(auto)</option>
+        {CAMERA_MOUNTS.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={busy || pending === ""}
+        onClick={() => void apply()}
+      >
+        Apply to all
+      </Button>
+    </div>
   );
 }
 
@@ -2156,6 +2263,10 @@ function StageCard({
               stage={stage}
               setDragging={setDragging}
               bare
+              busy={busy}
+              setBusy={setBusy}
+              setError={setError}
+              onProjectUpdate={onProjectUpdate}
               badge={
                 <Badge
                   variant={hasConflict ? "statusWarning" : "statusInProgress"}
@@ -2197,6 +2308,10 @@ function StageCard({
               stage={stage}
               setDragging={setDragging}
               bare
+              busy={busy}
+              setBusy={setBusy}
+              setError={setError}
+              onProjectUpdate={onProjectUpdate}
               badge={<Badge variant="secondary">Secondary {idx + 1}</Badge>}
               actions={
                 <RoleActions
@@ -2259,6 +2374,10 @@ function VideoRow({
   actions,
   inlinePlayer = true,
   bare = false,
+  busy = false,
+  setBusy,
+  setError,
+  onProjectUpdate,
 }: {
   video: StageVideo;
   stage: StageEntry | null;
@@ -2271,6 +2390,13 @@ function VideoRow({
   // Drop the row's own border/background when nested inside a video panel
   // so the panel is the single visual frame for "this video + its beep".
   bare?: boolean;
+  // Threaded through so the in-row mount selector can patch the project
+  // without bubbling state changes back up to the page. Optional because
+  // the unassigned-tray version of VideoRow has no stage to target.
+  busy?: boolean;
+  setBusy?: (b: boolean) => void;
+  setError?: (msg: string | null) => void;
+  onProjectUpdate?: (p: MatchProject) => void;
 }) {
   const [meta, setMeta] = useState<FsProbeResponse | null>(null);
 
@@ -2332,6 +2458,16 @@ function VideoRow({
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
+            {stage && setBusy && setError && onProjectUpdate ? (
+              <MountSelect
+                video={video}
+                stageNumber={stage.stage_number}
+                disabled={busy}
+                setBusy={setBusy}
+                setError={setError}
+                onProjectUpdate={onProjectUpdate}
+              />
+            ) : null}
             <Button
               size="sm"
               variant="ghost"


### PR DESCRIPTION
## Summary

The `PATCH /api/stages/{n}/videos/{vid}/camera-mount` endpoint shipped with #143 but had no SPA surface, so projects shot on phone cameras silently ran through the **headcam** threshold class even though the artifact has calibrated handheld thresholds. Reported while evaluating the ensemble against tallmilan-2025 (6 stages, all hand-held iPhone) -- aggregate dropped to recall 88.6 / precision 93.6 because the wrong class was firing.

## Changes

**Types + API**
- `StageVideo.camera_mount: CameraMount | null` added to the TS types
- `CameraMount` union + `CAMERA_MOUNTS` list exported from `lib/api.ts`
- `api.setCameraMount(stageNumber, videoId, mount)` -- thin wrapper around the PATCH endpoint, returns the updated `MatchProject`

**New component**
- `components/MountSelect.tsx` -- reusable compact dropdown (`(auto)` + 8 mount values). Stops drag/click propagation so it doesn't fight `DraggableVideoRow`. Optional `label` so callers control whether to show "Mount" inline.

**Ingest page**
- Per-video selector inside primary + secondary `VideoRow`s (no label -- row is already crowded)
- New `BulkMountControl` toolbar in the Stages section: pick a mount, click "Apply to all", confirm, and the SPA PATCHes every primary sequentially. Hidden when zero primaries; nothing fires until the user clicks "Apply".

**Audit page**
- Selector in the stage card description, next to the active video's path. Targets `activeVideo`, so flipping camera tabs swaps the control to that camera's mount. Updates project state in place; no peaks re-fetch needed since metadata changes don't invalidate trim caches.

## Why three places

- **Ingest** is where the user is already managing video metadata (role, beep). Per-row + bulk = correct affordance for the \"my whole match is one camera type\" common case.
- **Audit** catches the case where the user only notices the wrong class after seeing detection misbehave. They can fix it without leaving the page.
- **Lab** deliberately not touched -- its existing mount control is for fixture metadata during promote-from-anchor; per-video selectors there would conflict.

## Validation

- `npx tsc -b --noEmit` clean
- `npm run build` clean (no new warnings)
- Backend unchanged; existing endpoint tests still cover the PATCH validation + persistence

## Test plan

- [ ] Open Ingest, flip mount on one primary -- project.json picks up the override; subsequent shot-detect runs through the matching class
- [ ] Open Ingest, use \"Primary mount: hand\" + \"Apply to all\" on tallmilan-2025 (6 stages) -- one confirm dialog, six PATCHes, all primaries land at `camera_mount: hand`
- [ ] Open Audit on a multi-cam stage, switch tabs, verify the selector follows the active camera
- [ ] Set a mount, reload the page -- override survives (already covered by backend tests; UI sanity check)

## Related

- Closes the explicit \"out of scope\" item from #143 (\"UI surfaces for editing project camera mount beyond a basic API-level override\")
- Surfaced by an off-repo eval against tallmilan-2025 audits (handheld 9mm minor PF) -- 88.6 / 93.6 recall/precision against ground truth, would have been worse without the per-class thresholds firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)