### PR TITLE
coach: shot model + audit-JSON helpers for coaching annotations (#159)

### DIFF
--- a/src/splitsmith/coach.py
+++ b/src/splitsmith/coach.py
@@ -1,0 +1,124 @@
+"""Coaching annotations on audit-JSON shot dicts (issue #158).
+
+The Coach page persists per-shot coaching data into the existing per-stage
+audit JSON. The wire format is a flat extension of each ``shots[i]`` dict:
+
+- ``interval_class``: one of the values in :data:`COACH_INTERVAL_CLASSES`
+  or absent.
+- ``interval_class_source``: ``"auto"`` or ``"manual"`` -- absent iff
+  ``interval_class`` is absent. ``manual`` survives re-classification.
+- ``improvement_flag``: bool, defaults False.
+- ``coaching_note``: free text, absent when not set.
+
+This module is the single source of truth for those field names and the
+shape of a coach-annotated shot dict; the auto-classifier (#160), the
+HTTP layer (#161), and the histogram path (#163) all go through it.
+
+Pure functions only -- no I/O. Callers own the audit JSON read/write.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, get_args
+
+from .config import IntervalClass, IntervalClassSource
+
+COACH_INTERVAL_CLASSES: Final[tuple[str, ...]] = get_args(IntervalClass)
+COACH_INTERVAL_CLASS_SOURCES: Final[tuple[str, ...]] = get_args(IntervalClassSource)
+
+# Public field names. Importers should reference these constants rather
+# than hard-coding strings so a future rename has one place to land.
+FIELD_INTERVAL_CLASS: Final = "interval_class"
+FIELD_INTERVAL_CLASS_SOURCE: Final = "interval_class_source"
+FIELD_IMPROVEMENT_FLAG: Final = "improvement_flag"
+FIELD_COACHING_NOTE: Final = "coaching_note"
+
+COACH_FIELDS: Final[tuple[str, ...]] = (
+    FIELD_INTERVAL_CLASS,
+    FIELD_INTERVAL_CLASS_SOURCE,
+    FIELD_IMPROVEMENT_FLAG,
+    FIELD_COACHING_NOTE,
+)
+
+
+def read_coach_fields(shot: dict[str, Any]) -> dict[str, Any]:
+    """Extract coach annotations from an audit-JSON shot dict.
+
+    Returns a dict containing only the coach fields that are set, with
+    canonical types. Fields that are absent or carry a placeholder value
+    (False ``improvement_flag``, ``None`` note) are omitted from the
+    return so callers can ``len()`` it to ask "is this shot annotated?".
+    """
+    out: dict[str, Any] = {}
+    cls = shot.get(FIELD_INTERVAL_CLASS)
+    src = shot.get(FIELD_INTERVAL_CLASS_SOURCE)
+    if cls is not None:
+        if cls not in COACH_INTERVAL_CLASSES:
+            raise ValueError(f"unknown interval_class: {cls!r}")
+        if src not in COACH_INTERVAL_CLASS_SOURCES:
+            raise ValueError(
+                f"interval_class_source must be one of {COACH_INTERVAL_CLASS_SOURCES} "
+                f"when interval_class is set; got {src!r}"
+            )
+        out[FIELD_INTERVAL_CLASS] = cls
+        out[FIELD_INTERVAL_CLASS_SOURCE] = src
+    elif src is not None:
+        raise ValueError("interval_class_source set without interval_class -- inconsistent state")
+    flag = shot.get(FIELD_IMPROVEMENT_FLAG, False)
+    if flag:
+        out[FIELD_IMPROVEMENT_FLAG] = bool(flag)
+    note = shot.get(FIELD_COACHING_NOTE)
+    if isinstance(note, str) and note != "":
+        out[FIELD_COACHING_NOTE] = note
+    return out
+
+
+def write_coach_fields(
+    shot: dict[str, Any],
+    *,
+    interval_class: str | None = None,
+    interval_class_source: str | None = None,
+    improvement_flag: bool | None = None,
+    coaching_note: str | None = None,
+    clear_class: bool = False,
+    clear_note: bool = False,
+) -> dict[str, Any]:
+    """Patch coach annotations on a shot dict, returning the same dict.
+
+    Each kwarg defaults to ``None`` meaning "leave alone". Use
+    ``clear_class=True`` to drop both class fields (e.g. when reverting a
+    manual override back to auto-classified). Use ``clear_note=True`` to
+    drop the note explicitly. ``improvement_flag`` is set with a literal
+    bool; pass ``False`` to clear it.
+
+    Validates the same invariant as :class:`Shot`: ``interval_class`` and
+    ``interval_class_source`` must be set or unset together.
+    """
+    if clear_class:
+        shot.pop(FIELD_INTERVAL_CLASS, None)
+        shot.pop(FIELD_INTERVAL_CLASS_SOURCE, None)
+    elif interval_class is not None or interval_class_source is not None:
+        if interval_class is None or interval_class_source is None:
+            raise ValueError("interval_class and interval_class_source must be set together")
+        if interval_class not in COACH_INTERVAL_CLASSES:
+            raise ValueError(f"unknown interval_class: {interval_class!r}")
+        if interval_class_source not in COACH_INTERVAL_CLASS_SOURCES:
+            raise ValueError(f"unknown interval_class_source: {interval_class_source!r}")
+        shot[FIELD_INTERVAL_CLASS] = interval_class
+        shot[FIELD_INTERVAL_CLASS_SOURCE] = interval_class_source
+
+    if improvement_flag is not None:
+        if improvement_flag:
+            shot[FIELD_IMPROVEMENT_FLAG] = True
+        else:
+            shot.pop(FIELD_IMPROVEMENT_FLAG, None)
+
+    if clear_note:
+        shot.pop(FIELD_COACHING_NOTE, None)
+    elif coaching_note is not None:
+        if coaching_note == "":
+            shot.pop(FIELD_COACHING_NOTE, None)
+        else:
+            shot[FIELD_COACHING_NOTE] = coaching_note
+
+    return shot

--- a/src/splitsmith/config.py
+++ b/src/splitsmith/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Pipeline data structures
@@ -45,6 +45,18 @@ class StageData(BaseModel):
     stage_rounds: StageRounds | None = None
 
 
+IntervalClass = Literal[
+    "first_shot",
+    "split",
+    "transition",
+    "movement",
+    "reload",
+    "activation",
+]
+
+IntervalClassSource = Literal["auto", "manual"]
+
+
 class Shot(BaseModel):
     shot_number: int
     time_absolute: float
@@ -53,6 +65,24 @@ class Shot(BaseModel):
     peak_amplitude: float
     confidence: float = Field(ge=0.0, le=1.0)
     notes: str = ""
+
+    # Coaching annotations (issue #159). All optional so old audit JSONs
+    # load unchanged; the Coach page populates them on first open via the
+    # auto-classifier (#160). interval_class_source is required whenever
+    # interval_class is set, so we can preserve manual overrides across
+    # re-classification.
+    interval_class: IntervalClass | None = None
+    interval_class_source: IntervalClassSource | None = None
+    improvement_flag: bool = False
+    coaching_note: str | None = None
+
+    @model_validator(mode="after")
+    def _coach_annotations_consistent(self) -> Shot:
+        if self.interval_class is not None and self.interval_class_source is None:
+            raise ValueError("interval_class_source must be set when interval_class is set")
+        if self.interval_class is None and self.interval_class_source is not None:
+            raise ValueError("interval_class_source must be unset when interval_class is unset")
+        return self
 
 
 class StageAnalysis(BaseModel):

--- a/tests/test_coach_schema.py
+++ b/tests/test_coach_schema.py
@@ -1,0 +1,238 @@
+"""Schema-level tests for Coach annotations on Shot + audit-JSON dicts.
+
+Covers issue #159 (sub-issue of #158): the new Pydantic fields and the
+audit-JSON dict helpers in ``splitsmith.coach``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from splitsmith.coach import (
+    COACH_FIELDS,
+    read_coach_fields,
+    write_coach_fields,
+)
+from splitsmith.config import Shot
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _bare_shot(**overrides: Any) -> Shot:
+    base: dict[str, Any] = {
+        "shot_number": 1,
+        "time_absolute": 2.0,
+        "time_from_beep": 1.5,
+        "split": 1.5,
+        "peak_amplitude": 0.5,
+        "confidence": 0.9,
+    }
+    base.update(overrides)
+    return Shot(**base)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Shot model
+# ---------------------------------------------------------------------------
+
+
+def test_shot_defaults_unannotated() -> None:
+    shot = _bare_shot()
+    assert shot.interval_class is None
+    assert shot.interval_class_source is None
+    assert shot.improvement_flag is False
+    assert shot.coaching_note is None
+
+
+def test_shot_round_trip_with_annotations() -> None:
+    shot = _bare_shot(
+        interval_class="split",
+        interval_class_source="manual",
+        improvement_flag=True,
+        coaching_note="too slow on the second A",
+    )
+    dumped = shot.model_dump()
+    reloaded = Shot.model_validate(dumped)
+    assert reloaded == shot
+    assert reloaded.interval_class == "split"
+    assert reloaded.interval_class_source == "manual"
+    assert reloaded.improvement_flag is True
+    assert reloaded.coaching_note == "too slow on the second A"
+
+
+def test_shot_class_without_source_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _bare_shot(interval_class="split")
+
+
+def test_shot_source_without_class_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _bare_shot(interval_class_source="auto")
+
+
+def test_shot_unknown_class_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _bare_shot(interval_class="bogus", interval_class_source="manual")
+
+
+def test_shot_flag_only_is_valid() -> None:
+    # No class, no note -- just a "needs work" flag.
+    shot = _bare_shot(improvement_flag=True)
+    assert shot.improvement_flag is True
+    assert shot.interval_class is None
+
+
+# ---------------------------------------------------------------------------
+# Audit-JSON dict helpers
+# ---------------------------------------------------------------------------
+
+
+def test_read_coach_fields_empty_dict() -> None:
+    assert read_coach_fields({}) == {}
+
+
+def test_read_coach_fields_only_set_returned() -> None:
+    shot = {
+        "shot_number": 1,
+        "time": 2.6,
+        "ms_after_beep": 2137,
+        "improvement_flag": True,
+        "coaching_note": "draw was slow",
+    }
+    assert read_coach_fields(shot) == {
+        "improvement_flag": True,
+        "coaching_note": "draw was slow",
+    }
+
+
+def test_read_coach_fields_class_pair_required() -> None:
+    bad_class = {"interval_class": "split"}
+    with pytest.raises(ValueError):
+        read_coach_fields(bad_class)
+    bad_source = {"interval_class_source": "auto"}
+    with pytest.raises(ValueError):
+        read_coach_fields(bad_source)
+
+
+def test_read_coach_fields_unknown_class_rejected() -> None:
+    with pytest.raises(ValueError):
+        read_coach_fields({"interval_class": "wibble", "interval_class_source": "auto"})
+
+
+def test_write_coach_fields_round_trip() -> None:
+    shot: dict[str, Any] = {"shot_number": 1, "ms_after_beep": 2137}
+    write_coach_fields(
+        shot,
+        interval_class="transition",
+        interval_class_source="manual",
+        improvement_flag=True,
+        coaching_note="late on target B",
+    )
+    assert read_coach_fields(shot) == {
+        "interval_class": "transition",
+        "interval_class_source": "manual",
+        "improvement_flag": True,
+        "coaching_note": "late on target B",
+    }
+
+
+def test_write_coach_fields_preserves_other_keys() -> None:
+    shot: dict[str, Any] = {
+        "shot_number": 1,
+        "time": 2.6,
+        "ms_after_beep": 2137,
+        "candidate_number": 6,
+        "source": "detected",
+    }
+    write_coach_fields(shot, improvement_flag=True)
+    for k in ("shot_number", "time", "ms_after_beep", "candidate_number", "source"):
+        assert k in shot
+
+
+def test_write_coach_fields_clear_class_drops_pair() -> None:
+    shot: dict[str, Any] = {
+        "interval_class": "split",
+        "interval_class_source": "manual",
+        "coaching_note": "keep me",
+    }
+    write_coach_fields(shot, clear_class=True)
+    assert "interval_class" not in shot
+    assert "interval_class_source" not in shot
+    assert shot["coaching_note"] == "keep me"
+
+
+def test_write_coach_fields_clear_note() -> None:
+    shot: dict[str, Any] = {"coaching_note": "obsolete"}
+    write_coach_fields(shot, clear_note=True)
+    assert "coaching_note" not in shot
+
+
+def test_write_coach_fields_class_pair_required_on_write() -> None:
+    shot: dict[str, Any] = {}
+    with pytest.raises(ValueError):
+        write_coach_fields(shot, interval_class="split")
+    with pytest.raises(ValueError):
+        write_coach_fields(shot, interval_class_source="manual")
+
+
+def test_write_coach_fields_flag_false_clears() -> None:
+    shot: dict[str, Any] = {"improvement_flag": True}
+    write_coach_fields(shot, improvement_flag=False)
+    assert "improvement_flag" not in shot
+
+
+def test_write_coach_fields_empty_note_clears() -> None:
+    shot: dict[str, Any] = {"coaching_note": "old"}
+    write_coach_fields(shot, coaching_note="")
+    assert "coaching_note" not in shot
+
+
+# ---------------------------------------------------------------------------
+# Realistic fixture round-trip: a real audit-style JSON survives load,
+# annotation, save-as-JSON, reload.
+# ---------------------------------------------------------------------------
+
+
+def test_real_audit_json_round_trip(tmp_path: Path) -> None:
+    src = FIXTURES / "stage-shots-blacksmith-2026-stage1.json"
+    data = json.loads(src.read_text(encoding="utf-8"))
+    assert isinstance(data.get("shots"), list)
+    assert data["shots"], "fixture must have shots to test against"
+
+    # No coach fields present in the fixture today.
+    for s in data["shots"]:
+        assert read_coach_fields(s) == {}
+
+    # Annotate a real shot the way the Coach UI would.
+    target = data["shots"][0]
+    write_coach_fields(
+        target,
+        interval_class="first_shot",
+        interval_class_source="manual",
+        improvement_flag=True,
+        coaching_note="drew slow on round 1",
+    )
+    annotated = read_coach_fields(target)
+    assert annotated == {
+        "interval_class": "first_shot",
+        "interval_class_source": "manual",
+        "improvement_flag": True,
+        "coaching_note": "drew slow on round 1",
+    }
+
+    # Round-trip through JSON.
+    out = tmp_path / "stage1.json"
+    out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    reloaded = json.loads(out.read_text(encoding="utf-8"))
+    assert read_coach_fields(reloaded["shots"][0]) == annotated
+
+    # Other shots remain untouched, no coach fields injected.
+    for s in reloaded["shots"][1:]:
+        assert read_coach_fields(s) == {}
+        for f in COACH_FIELDS:
+            assert f not in s


### PR DESCRIPTION
## Summary

- Add optional `interval_class`, `interval_class_source`, `improvement_flag`, `coaching_note` to `Shot`.
- New `splitsmith.coach` module owns the audit-JSON shot-dict field names and the read/write helpers.
- Pydantic + dict-level invariants both enforce that `interval_class` and `interval_class_source` are set together.

Foundation for the Coach page (#158). Old audit JSONs load unchanged; downstream pipeline code (CSV/FCPXML/report) is untouched -- coach fields default to None/False when not present.

## Test plan

- [x] `uv run pytest tests/test_coach_schema.py` -- 18 new tests
- [x] Full suite: 622 passed, 1 skipped
- [x] `uv run ruff check` clean on changed files
- [x] `uv run black --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)