### PR TITLE
coach: distributions + one-row-per-shot (#163)

### DIFF
--- a/src/splitsmith/coach_distributions.py
+++ b/src/splitsmith/coach_distributions.py
@@ -1,0 +1,350 @@
+"""Distributions over Coach interval classifications (#163).
+
+Pure functions only. Callers feed in audit-style shot dicts (one or many
+stages); we classify any unset intervals in memory using
+:func:`splitsmith.coach.classify_intervals_in_dicts` so an unannotated
+project still produces meaningful histograms.
+
+Histogram bucket sizes are tuned per class so the visual lands on real
+distinctions:
+
+- Splits, transitions: 0.05 s. A shooter who runs 0.20 s splits should
+  see a peak in a different bucket from one who runs 0.25.
+- Movement: 0.25 s. Movement gaps span 1 - 6 s; finer buckets just spray
+  the dots and hide the peak.
+"""
+
+from __future__ import annotations
+
+import statistics
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .coach import (
+    FIELD_INTERVAL_CLASS,
+    FIELD_INTERVAL_CLASS_SOURCE,
+    classify_intervals_in_dicts,
+    read_coach_fields,
+)
+from .config import CoachAutoClassifyConfig, IntervalClass
+
+# Bucket size per class (seconds). Movement gets a coarser bucket.
+DEFAULT_BUCKET_S: dict[IntervalClass, float] = {
+    "first_shot": 0.10,
+    "split": 0.05,
+    "transition": 0.05,
+    "movement": 0.25,
+    "reload": 0.25,
+    "activation": 0.25,
+}
+
+# Histograms only render the four classes the auto-classifier emits plus
+# reload (because manual reload overrides are common). Activation is
+# rare and lives on a different timescale; keep it out of the default
+# panel set so the UI doesn't sprout an empty histogram every match.
+DEFAULT_HISTOGRAM_CLASSES: tuple[IntervalClass, ...] = (
+    "split",
+    "transition",
+    "movement",
+    "reload",
+)
+
+
+class HistogramBucket(BaseModel):
+    """One bin of a histogram. ``lo`` inclusive, ``hi`` exclusive."""
+
+    lo: float
+    hi: float
+    count: int
+
+
+class IntervalDistribution(BaseModel):
+    """Distribution of gap-times for one ``interval_class`` across one
+    stage or one match.
+    """
+
+    interval_class: IntervalClass
+    bucket_size_s: float
+    buckets: list[HistogramBucket] = Field(default_factory=list)
+    count: int = 0
+    mean_s: float | None = None
+    median_s: float | None = None
+    p90_s: float | None = None
+
+
+class TopShotEntry(BaseModel):
+    """One row of "top-N longest <class>" -- aimed at coaching drilling
+    into the slowest moments.
+    """
+
+    stage_number: int
+    stage_name: str
+    shot_number: int
+    interval_class: IntervalClass
+    gap_s: float
+    coaching_note: str | None = None
+    improvement_flag: bool = False
+
+
+class FlaggedShotEntry(BaseModel):
+    """One improvement-flagged shot, surfaced in the match-level panel."""
+
+    stage_number: int
+    stage_name: str
+    shot_number: int
+    interval_class: IntervalClass | None = None
+    gap_s: float | None = None
+    coaching_note: str | None = None
+
+
+class StageDistributionsResponse(BaseModel):
+    stage_number: int
+    stage_name: str
+    distributions: list[IntervalDistribution]
+    first_shot_s: float | None = None
+
+
+class MatchDistributionsResponse(BaseModel):
+    distributions: list[IntervalDistribution]
+    first_shot_seconds: list[float] = Field(default_factory=list)
+    top_splits: list[TopShotEntry] = Field(default_factory=list)
+    top_transitions: list[TopShotEntry] = Field(default_factory=list)
+    flagged_shots: list[FlaggedShotEntry] = Field(default_factory=list)
+    stage_count: int = 0
+    shot_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _gaps_by_class_for_stage(
+    shots: list[dict[str, Any]],
+    config: CoachAutoClassifyConfig,
+) -> tuple[
+    dict[IntervalClass, list[tuple[int, float]]],
+    float | None,
+]:
+    """Compute gaps grouped by ``interval_class``. Returns
+    ``({class: [(shot_number, gap_s), ...]}, first_shot_s)`` where the
+    ``first_shot`` class is excluded from the dict (it's a stage-level
+    scalar, not a distribution).
+    """
+    # Classify any unset intervals in memory; we never persist here.
+    # ``classify_intervals_in_dicts`` mutates in place, so deep-copy the
+    # dicts to avoid leaking auto entries back to the caller's audit
+    # JSON, then re-read the stored class field directly.
+    working = [dict(s) for s in shots if isinstance(s, dict) and "ms_after_beep" in s]
+    classify_intervals_in_dicts(working, config)
+    grouped: dict[IntervalClass, list[tuple[int, float]]] = {}
+    first_shot_s: float | None = None
+    ordered = sorted(working, key=lambda s: float(s.get("ms_after_beep", 0)))
+    prev_ms: float | None = None
+    for s in ordered:
+        ms = float(s["ms_after_beep"])
+        cls_raw = s.get(FIELD_INTERVAL_CLASS)
+        cls: IntervalClass | None = cls_raw if cls_raw is not None else None
+        if cls == "first_shot":
+            first_shot_s = ms / 1000.0
+            prev_ms = ms
+            continue
+        if prev_ms is None:
+            prev_ms = ms
+            continue
+        gap = (ms - prev_ms) / 1000.0
+        prev_ms = ms
+        if cls is None:
+            continue
+        grouped.setdefault(cls, []).append((int(s.get("shot_number", 0)), gap))
+    return grouped, first_shot_s
+
+
+def _bucket_values(values: list[float], bucket_size: float) -> list[HistogramBucket]:
+    """Bin values into fixed-size buckets starting at 0. Buckets with
+    zero count are dropped to keep the wire payload small.
+    """
+    if not values:
+        return []
+    counts: dict[int, int] = {}
+    for v in values:
+        idx = int(v // bucket_size)
+        counts[idx] = counts.get(idx, 0) + 1
+    return [
+        HistogramBucket(
+            lo=idx * bucket_size,
+            hi=(idx + 1) * bucket_size,
+            count=count,
+        )
+        for idx, count in sorted(counts.items())
+    ]
+
+
+def _summarize(values: list[float]) -> tuple[float | None, float | None, float | None]:
+    if not values:
+        return None, None, None
+    mean = statistics.fmean(values)
+    median = statistics.median(values)
+    if len(values) >= 2:
+        # quantiles(n=10) returns 9 cut-points; the 9th == 90th percentile.
+        # Pad with the max for tiny lists where quantiles can't compute.
+        p90 = statistics.quantiles(values, n=10)[8]
+    else:
+        p90 = values[0]
+    return mean, median, p90
+
+
+def _build_distribution(
+    cls: IntervalClass,
+    values: list[float],
+) -> IntervalDistribution:
+    bucket = DEFAULT_BUCKET_S[cls]
+    mean, median, p90 = _summarize(values)
+    return IntervalDistribution(
+        interval_class=cls,
+        bucket_size_s=bucket,
+        buckets=_bucket_values(values, bucket),
+        count=len(values),
+        mean_s=mean,
+        median_s=median,
+        p90_s=p90,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def stage_distributions(
+    *,
+    stage_number: int,
+    stage_name: str,
+    shots: list[dict[str, Any]],
+    config: CoachAutoClassifyConfig,
+    classes: tuple[IntervalClass, ...] = DEFAULT_HISTOGRAM_CLASSES,
+) -> StageDistributionsResponse:
+    grouped, first_shot_s = _gaps_by_class_for_stage(shots, config)
+    distributions = [
+        _build_distribution(cls, [g for _, g in grouped.get(cls, [])]) for cls in classes
+    ]
+    return StageDistributionsResponse(
+        stage_number=stage_number,
+        stage_name=stage_name,
+        distributions=distributions,
+        first_shot_s=first_shot_s,
+    )
+
+
+def match_distributions(
+    *,
+    stages: list[tuple[int, str, list[dict[str, Any]]]],
+    config: CoachAutoClassifyConfig,
+    classes: tuple[IntervalClass, ...] = DEFAULT_HISTOGRAM_CLASSES,
+    top_n: int = 5,
+) -> MatchDistributionsResponse:
+    """Aggregate distributions across an entire match.
+
+    ``stages`` is a list of ``(stage_number, stage_name, shots)`` tuples.
+    Stages with no shots are skipped entirely; they don't contribute
+    empty buckets that misrepresent the shooter's average.
+    """
+    aggregate: dict[IntervalClass, list[float]] = {cls: [] for cls in classes}
+    first_shot_seconds: list[float] = []
+    top_split_pool: list[TopShotEntry] = []
+    top_trans_pool: list[TopShotEntry] = []
+    flagged: list[FlaggedShotEntry] = []
+    shot_count = 0
+    stage_count = 0
+
+    for stage_number, stage_name, shots in stages:
+        if not shots:
+            continue
+        stage_count += 1
+        # Walk shots once: build aggregate distributions, top-N candidates,
+        # flagged list. Re-deriving classes via the same pure helper is
+        # cheaper than threading state out of stage_distributions.
+        grouped, first_shot_s = _gaps_by_class_for_stage(shots, config)
+        if first_shot_s is not None:
+            first_shot_seconds.append(first_shot_s)
+
+        for cls, entries in grouped.items():
+            shot_count += len(entries)
+            if cls in aggregate:
+                aggregate[cls].extend(g for _, g in entries)
+
+        # Top-N pool. Build TopShotEntry against the original shots so
+        # we have the user's notes / flag intact; lookup by shot_number.
+        by_num = {int(s.get("shot_number", -1)): s for s in shots if isinstance(s, dict)}
+        for cls in ("split", "transition"):
+            entries = grouped.get(cls, [])
+            for shot_number, gap in entries:
+                raw = by_num.get(shot_number, {})
+                fields = read_coach_fields(raw)
+                entry = TopShotEntry(
+                    stage_number=stage_number,
+                    stage_name=stage_name,
+                    shot_number=shot_number,
+                    interval_class=cls,
+                    gap_s=gap,
+                    coaching_note=fields.get("coaching_note"),
+                    improvement_flag=bool(fields.get("improvement_flag", False)),
+                )
+                if cls == "split":
+                    top_split_pool.append(entry)
+                else:
+                    top_trans_pool.append(entry)
+
+        # Flagged list -- include every flagged shot regardless of class.
+        # We deliberately skip ``classify_intervals_in_dicts`` here and
+        # read the user's stored fields directly so we don't surface
+        # a class the user explicitly never set.
+        prev_ms: float | None = None
+        ordered = sorted(
+            (s for s in shots if isinstance(s, dict) and "ms_after_beep" in s),
+            key=lambda s: float(s.get("ms_after_beep", 0)),
+        )
+        for s in ordered:
+            ms = float(s["ms_after_beep"])
+            gap_s: float | None
+            if prev_ms is None:
+                gap_s = None
+            else:
+                gap_s = (ms - prev_ms) / 1000.0
+            prev_ms = ms
+            if not s.get("improvement_flag", False):
+                continue
+            stored_class = s.get(FIELD_INTERVAL_CLASS)
+            stored_source = s.get(FIELD_INTERVAL_CLASS_SOURCE)
+            cls_for_entry: IntervalClass | None
+            if stored_class and stored_source is not None:
+                cls_for_entry = stored_class
+            else:
+                cls_for_entry = None
+            flagged.append(
+                FlaggedShotEntry(
+                    stage_number=stage_number,
+                    stage_name=stage_name,
+                    shot_number=int(s.get("shot_number", 0)),
+                    interval_class=cls_for_entry,
+                    gap_s=gap_s,
+                    coaching_note=(
+                        s.get("coaching_note") if isinstance(s.get("coaching_note"), str) else None
+                    ),
+                )
+            )
+
+    distributions = [_build_distribution(cls, aggregate[cls]) for cls in classes]
+    top_splits = sorted(top_split_pool, key=lambda e: e.gap_s, reverse=True)[:top_n]
+    top_transitions = sorted(top_trans_pool, key=lambda e: e.gap_s, reverse=True)[:top_n]
+
+    return MatchDistributionsResponse(
+        distributions=distributions,
+        first_shot_seconds=first_shot_seconds,
+        top_splits=top_splits,
+        top_transitions=top_transitions,
+        flagged_shots=flagged,
+        stage_count=stage_count,
+        shot_count=shot_count,
+    )

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -83,11 +83,18 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .. import beep_detect, cross_align, report, user_config, video_probe
+from .. import coach as coach_module
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
-from ..config import BeepDetectConfig, Config
+from ..config import (
+    BeepDetectConfig,
+    CoachAutoClassifyConfig,
+    Config,
+    IntervalClass,
+    IntervalClassSource,
+)
 from ..fixture_schema import (
     AgcState,
     AudioSource,
@@ -904,6 +911,22 @@ class SkipStageRequest(BaseModel):
     """Body for POST /api/stages/{n}/skip. Toggles ``stage.skipped``."""
 
     skipped: bool
+
+
+class CoachShotPatchRequest(BaseModel):
+    """Body for PATCH /api/stages/{n}/shots/{shot_number}/coach (issue #161).
+
+    Each field is independently optional. Use ``clear_class`` / ``clear_note``
+    to drop a previously-set value. ``interval_class`` and
+    ``interval_class_source`` must be set together when present.
+    """
+
+    interval_class: IntervalClass | None = None
+    interval_class_source: IntervalClassSource | None = None
+    clear_class: bool = False
+    improvement_flag: bool | None = None
+    coaching_note: str | None = None
+    clear_note: bool = False
 
 
 class RemoveVideoRequest(BaseModel):
@@ -3212,6 +3235,193 @@ def create_app(
         )
         anomalies = report.detect_anomalies_structured(shots, beep_time, stg.time_seconds)
         return JSONResponse({"anomalies": [a.model_dump() for a in anomalies]})
+
+    # ----------------------------------------------------------------------
+    # Coach endpoints (#161). Read-only on shot timestamps -- all writes go
+    # to the coaching annotation fields owned by ``splitsmith.coach``.
+    # Storage is the same audit JSON Audit reads/writes. The coach is lazy:
+    # GET surfaces the current rule's verdict + a stale flag without
+    # mutating; reclassify persists auto entries; PATCH writes one shot's
+    # coach fields.
+    # ----------------------------------------------------------------------
+
+    def _load_audit_for_coach(stage_number: int) -> tuple[dict[str, Any], Path, float, Any]:
+        """Shared loader: validates the stage, reads the audit JSON,
+        returns (payload, path, beep_time_in_source, stage).
+        """
+        project = state.load()
+        try:
+            stg = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        audit_file = project.audit_path(state.project_root) / f"stage{stage_number}.json"
+        if not audit_file.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"no audit JSON yet for stage {stage_number}",
+            )
+        try:
+            payload = json.loads(audit_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
+        prim = stg.primary()
+        beep_in_source = prim.beep_time if prim is not None and prim.beep_time is not None else 0.0
+        return payload, audit_file, beep_in_source, stg
+
+    def _coach_atomic_write(audit_file: Path, payload: dict[str, Any]) -> None:
+        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
+        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
+        try:
+            tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            if audit_file.exists():
+                if backup.exists():
+                    backup.unlink()
+                audit_file.replace(backup)
+            tmp.replace(audit_file)
+        except OSError as exc:
+            if tmp.exists():
+                tmp.unlink()
+            raise HTTPException(status_code=500, detail=f"coach write failed: {exc}") from exc
+
+    def _build_coach_response(
+        payload: dict[str, Any],
+        beep_in_source: float,
+        stg: Any,
+        cfg: CoachAutoClassifyConfig,
+    ) -> dict[str, Any]:
+        raw_shots = payload.get("shots") or []
+        ordered = sorted(
+            (s for s in raw_shots if isinstance(s, dict) and "ms_after_beep" in s),
+            key=lambda s: float(s.get("ms_after_beep", 0)),
+        )
+        coach_shots: list[dict[str, Any]] = []
+        prev_ms: float | None = None
+        for s in ordered:
+            ms = float(s["ms_after_beep"])
+            time_from_beep = ms / 1000.0
+            gap_s: float | None
+            if prev_ms is None:
+                gap_s = None
+                split = time_from_beep  # draw
+            else:
+                gap_s = (ms - prev_ms) / 1000.0
+                split = gap_s
+            prev_ms = ms
+            stale = coach_module.is_classification_stale(s, gap_s=gap_s, config=cfg)
+            reload_hint = coach_module.reload_hinted(gap_s, cfg)
+            coach_shots.append(
+                {
+                    "shot_number": int(s.get("shot_number", 0)),
+                    "ms_after_beep": int(ms),
+                    "time_from_beep": time_from_beep,
+                    "time_absolute": beep_in_source + time_from_beep,
+                    "split": split,
+                    "interval_class": s.get("interval_class"),
+                    "interval_class_source": s.get("interval_class_source"),
+                    "improvement_flag": bool(s.get("improvement_flag", False)),
+                    "coaching_note": s.get("coaching_note"),
+                    "stale": stale,
+                    "reload_hint": reload_hint,
+                }
+            )
+        return {
+            "stage_number": stg.stage_number,
+            "stage_name": stg.stage_name,
+            "beep_time": beep_in_source,
+            "shots": coach_shots,
+        }
+
+    @app.get("/api/stages/{stage_number}/coach")
+    def get_stage_coach(stage_number: int) -> JSONResponse:
+        """Return the per-shot coach view for a stage.
+
+        Read-only: the stored ``interval_class`` is surfaced as-is, plus a
+        ``stale`` flag indicating whether the current rule disagrees. The
+        client can call ``POST /coach/reclassify`` to persist the rule's
+        verdict onto unset/auto entries.
+        """
+        payload, _audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        cfg = CoachAutoClassifyConfig()
+        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
+
+    @app.post("/api/stages/{stage_number}/coach/reclassify")
+    def reclassify_stage_coach(stage_number: int) -> JSONResponse:
+        """Force the auto-classifier to (re)write ``interval_class`` for
+        every shot whose source is unset or ``"auto"``. Manual entries are
+        preserved. Idempotent.
+        """
+        payload, audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        cfg = CoachAutoClassifyConfig()
+        shots = payload.get("shots") or []
+        if not isinstance(shots, list):
+            raise HTTPException(status_code=500, detail="audit shots is not a list")
+        coach_module.classify_intervals_in_dicts(shots, cfg)
+        events = list(payload.get("audit_events") or [])
+        events.append(
+            {
+                "ts": _now_iso(),
+                "kind": "coach_reclassify",
+                "payload": {"shot_count": len(shots)},
+            }
+        )
+        payload["audit_events"] = events
+        _coach_atomic_write(audit_file, payload)
+        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
+
+    @app.patch("/api/stages/{stage_number}/shots/{shot_number}/coach")
+    def patch_stage_shot_coach(
+        stage_number: int,
+        shot_number: int,
+        body: CoachShotPatchRequest,
+    ) -> JSONResponse:
+        """Patch the coaching annotation fields on one shot. Returns the
+        updated coach response for the stage so the client can refresh.
+        """
+        payload, audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        cfg = CoachAutoClassifyConfig()
+        shots = payload.get("shots") or []
+        if not isinstance(shots, list):
+            raise HTTPException(status_code=500, detail="audit shots is not a list")
+        target = next(
+            (
+                s
+                for s in shots
+                if isinstance(s, dict) and int(s.get("shot_number", -1)) == shot_number
+            ),
+            None,
+        )
+        if target is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"shot {shot_number} not found in stage {stage_number}",
+            )
+        try:
+            coach_module.write_coach_fields(
+                target,
+                interval_class=body.interval_class,
+                interval_class_source=body.interval_class_source,
+                clear_class=body.clear_class,
+                improvement_flag=body.improvement_flag,
+                coaching_note=body.coaching_note,
+                clear_note=body.clear_note,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        events = list(payload.get("audit_events") or [])
+        events.append(
+            {
+                "ts": _now_iso(),
+                "kind": "coach_patch",
+                "payload": {
+                    "shot_number": shot_number,
+                    "fields": coach_module.read_coach_fields(target),
+                },
+            }
+        )
+        payload["audit_events"] = events
+        _coach_atomic_write(audit_file, payload)
+        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
 
     # ----------------------------------------------------------------------
     # Fixture-review endpoints (closes #19 -- the old splitsmith.review_server

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -84,6 +84,7 @@ from pydantic import BaseModel
 
 from .. import beep_detect, cross_align, report, user_config, video_probe
 from .. import coach as coach_module
+from .. import coach_distributions as coach_distributions_module
 from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
@@ -3245,9 +3246,60 @@ def create_app(
     # coach fields.
     # ----------------------------------------------------------------------
 
-    def _load_audit_for_coach(stage_number: int) -> tuple[dict[str, Any], Path, float, Any]:
+    def _video_beep_in_clip(
+        project: MatchProject,
+        stage_number: int,
+        video: StageVideo,
+    ) -> float | None:
+        """Where the beep falls inside the clip the SPA will receive
+        from ``/api/videos/stream`` for ``video``.
+
+        When a per-video trimmed MP4 exists, the beep sits at
+        ``min(beep_time, trim_pre_buffer_seconds)`` inside it (the trim
+        starts at ``max(0, beep_time - pre_buffer)``). When there's no
+        trim we fall through to the source clip and the beep is at
+        ``beep_time`` directly. Pure check: no ffmpeg, no audio
+        extraction -- the file existence + project config is enough.
+        """
+        if video.beep_time is None:
+            return None
+        trimmed = audio_helpers.trimmed_video_path(
+            state.project_root, stage_number, video, project=project
+        )
+        if trimmed.exists() and trimmed.stat().st_size > 0:
+            return min(video.beep_time, project.trim_pre_buffer_seconds)
+        return video.beep_time
+
+    def _coach_video_entries(project: MatchProject, stg: Any) -> list[dict[str, Any]]:
+        """Per-video metadata the SPA needs to seek every synced camera.
+
+        Order mirrors VideoPanel's expectation: primary first, then
+        secondaries by ``added_at``. ``beep_in_clip`` is the position
+        inside the clip the SPA will actually be playing -- the source
+        clip when no trim exists, the trimmed clip when one does.
+        """
+        primary = stg.primary()
+        secondaries = sorted(
+            (v for v in stg.videos if v.role == "secondary"),
+            key=lambda v: v.added_at,
+        )
+        ordered_videos = ([primary] if primary is not None else []) + secondaries
+        out: list[dict[str, Any]] = []
+        for v in ordered_videos:
+            out.append(
+                {
+                    "path": str(v.path),
+                    "role": v.role,
+                    "beep_in_clip": _video_beep_in_clip(project, stg.stage_number, v),
+                }
+            )
+        return out
+
+    def _load_audit_for_coach(
+        stage_number: int,
+    ) -> tuple[dict[str, Any], Path, float | None, Any, MatchProject]:
         """Shared loader: validates the stage, reads the audit JSON,
-        returns (payload, path, beep_time_in_source, stage).
+        returns (payload, path, primary_beep_in_clip, stage, project).
         """
         project = state.load()
         try:
@@ -3265,8 +3317,10 @@ def create_app(
         except (OSError, json.JSONDecodeError) as exc:
             raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
         prim = stg.primary()
-        beep_in_source = prim.beep_time if prim is not None and prim.beep_time is not None else 0.0
-        return payload, audit_file, beep_in_source, stg
+        primary_beep_in_clip = (
+            _video_beep_in_clip(project, stage_number, prim) if prim is not None else None
+        )
+        return payload, audit_file, primary_beep_in_clip, stg, project
 
     def _coach_atomic_write(audit_file: Path, payload: dict[str, Any]) -> None:
         tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
@@ -3285,10 +3339,18 @@ def create_app(
 
     def _build_coach_response(
         payload: dict[str, Any],
-        beep_in_source: float,
+        primary_beep_in_clip: float | None,
         stg: Any,
+        project: MatchProject,
         cfg: CoachAutoClassifyConfig,
     ) -> dict[str, Any]:
+        # Coach plays the same clip the audit screen serves -- typically
+        # the project-local trimmed MP4 -- so every "absolute" time must
+        # be in the served clip's coordinate system. Anchoring on
+        # ``primary_beep_in_clip`` keeps Coach working when the source
+        # SSD is unplugged. Falls back to 0.0 when the project hasn't
+        # set a beep yet (older / partial audits).
+        clip_anchor = primary_beep_in_clip if primary_beep_in_clip is not None else 0.0
         raw_shots = payload.get("shots") or []
         ordered = sorted(
             (s for s in raw_shots if isinstance(s, dict) and "ms_after_beep" in s),
@@ -3314,7 +3376,9 @@ def create_app(
                     "shot_number": int(s.get("shot_number", 0)),
                     "ms_after_beep": int(ms),
                     "time_from_beep": time_from_beep,
-                    "time_absolute": beep_in_source + time_from_beep,
+                    # In the served clip's coordinate system: where the
+                    # SPA must seek the primary <video> for this shot.
+                    "time_absolute": clip_anchor + time_from_beep,
                     "split": split,
                     "interval_class": s.get("interval_class"),
                     "interval_class_source": s.get("interval_class_source"),
@@ -3327,7 +3391,12 @@ def create_app(
         return {
             "stage_number": stg.stage_number,
             "stage_name": stg.stage_name,
-            "beep_time": beep_in_source,
+            # Where the beep falls in the served primary clip. Used by
+            # the SPA's beep row + as the anchor for offsetting synced
+            # secondaries (each ``videos[i].beep_in_clip`` mirrors this
+            # field for that camera's served clip).
+            "beep_time": clip_anchor,
+            "videos": _coach_video_entries(project, stg),
             "shots": coach_shots,
         }
 
@@ -3340,9 +3409,9 @@ def create_app(
         client can call ``POST /coach/reclassify`` to persist the rule's
         verdict onto unset/auto entries.
         """
-        payload, _audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        payload, _audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
         cfg = CoachAutoClassifyConfig()
-        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
+        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
 
     @app.post("/api/stages/{stage_number}/coach/reclassify")
     def reclassify_stage_coach(stage_number: int) -> JSONResponse:
@@ -3350,7 +3419,7 @@ def create_app(
         every shot whose source is unset or ``"auto"``. Manual entries are
         preserved. Idempotent.
         """
-        payload, audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -3366,7 +3435,7 @@ def create_app(
         )
         payload["audit_events"] = events
         _coach_atomic_write(audit_file, payload)
-        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
+        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
 
     @app.patch("/api/stages/{stage_number}/shots/{shot_number}/coach")
     def patch_stage_shot_coach(
@@ -3377,7 +3446,7 @@ def create_app(
         """Patch the coaching annotation fields on one shot. Returns the
         updated coach response for the stage so the client can refresh.
         """
-        payload, audit_file, beep_in_source, stg = _load_audit_for_coach(stage_number)
+        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -3421,7 +3490,56 @@ def create_app(
         )
         payload["audit_events"] = events
         _coach_atomic_write(audit_file, payload)
-        return JSONResponse(_build_coach_response(payload, beep_in_source, stg, cfg))
+        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
+
+    @app.get("/api/stages/{stage_number}/coach/distributions")
+    def get_stage_coach_distributions(stage_number: int) -> JSONResponse:
+        """Histograms + summary stats for one stage's coach annotations.
+
+        Unset interval classes are computed in memory; nothing persists.
+        Empty classes still appear in the response with count=0 so the
+        UI can render an empty histogram without a special case.
+        """
+        payload, _audit_file, _beep_in_clip, stg, _project = _load_audit_for_coach(stage_number)
+        cfg = CoachAutoClassifyConfig()
+        shots = payload.get("shots") or []
+        if not isinstance(shots, list):
+            raise HTTPException(status_code=500, detail="audit shots is not a list")
+        result = coach_distributions_module.stage_distributions(
+            stage_number=stg.stage_number,
+            stage_name=stg.stage_name,
+            shots=shots,
+            config=cfg,
+        )
+        return JSONResponse(result.model_dump())
+
+    @app.get("/api/coach/distributions")
+    def get_match_coach_distributions() -> JSONResponse:
+        """Match-level distributions across every stage with an audit
+        JSON. Stages without an audit are silently skipped -- they
+        haven't been audited yet so they'd just dilute the average.
+        """
+        project = state.load()
+        cfg = CoachAutoClassifyConfig()
+        audit_dir = project.audit_path(state.project_root)
+        triples: list[tuple[int, str, list[dict[str, Any]]]] = []
+        for stg in project.stages:
+            audit_file = audit_dir / f"stage{stg.stage_number}.json"
+            if not audit_file.exists():
+                continue
+            try:
+                stage_payload = json.loads(audit_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"audit read failed for stage {stg.stage_number}: {exc}",
+                ) from exc
+            shots = stage_payload.get("shots") or []
+            if not isinstance(shots, list):
+                continue
+            triples.append((stg.stage_number, stg.stage_name, shots))
+        result = coach_distributions_module.match_distributions(stages=triples, config=cfg)
+        return JSONResponse(result.model_dump())
 
     # ----------------------------------------------------------------------
     # Fixture-review endpoints (closes #19 -- the old splitsmith.review_server

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { AppShell } from "@/components/AppShell";
 import { ThemeProvider } from "@/lib/theme";
 import { Audit } from "@/pages/Audit";
+import { Coach } from "@/pages/Coach";
 import { Design } from "@/pages/Design";
 import { Export } from "@/pages/Export";
 import { Home } from "@/pages/Home";
@@ -26,6 +27,8 @@ export function App() {
             <Route path="ingest" element={<Ingest />} />
             <Route path="audit" element={<Audit />} />
             <Route path="audit/:stage" element={<Audit />} />
+            <Route path="coach" element={<Coach />} />
+            <Route path="coach/:stage" element={<Coach />} />
             <Route path="export" element={<Export />} />
             <Route path="export/:stage" element={<Export />} />
             <Route path="lab" element={<Lab />} />

--- a/src/splitsmith/ui_static/src/components/AppShell.tsx
+++ b/src/splitsmith/ui_static/src/components/AppShell.tsx
@@ -5,10 +5,12 @@ import {
   FlaskConical,
   FolderInput,
   Home,
+  PanelLeftClose,
+  PanelLeftOpen,
   Palette,
   Repeat,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Navigate, NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { JobsPanel } from "@/components/JobsPanel";
@@ -32,6 +34,8 @@ const BASE_NAV: NavItem[] = [
 ];
 const LAB_NAV: NavItem = { to: "/lab", label: "Lab", icon: FlaskConical };
 
+const SIDEBAR_COLLAPSE_KEY = "splitsmith.appshell.sidebarCollapsed";
+
 export function AppShell() {
   const { pathname } = useLocation();
   // /review is fixture-only: no project context, the project tabs would
@@ -39,6 +43,31 @@ export function AppShell() {
   // Hide the sidebar entirely so the screen reads as a single-purpose
   // tool instead of "audit screen with broken navigation".
   const fixtureMode = pathname.startsWith("/review");
+
+  // Sidebar collapse state. Persisted in localStorage so the user's
+  // choice survives page reloads. Pages that benefit from the extra
+  // horizontal width (Coach grid mode, Audit waveform on a narrow
+  // monitor) collapse once and stay collapsed.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(SIDEBAR_COLLAPSE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(SIDEBAR_COLLAPSE_KEY, next ? "1" : "0");
+      } catch {
+        // localStorage may be unavailable (private mode); preference
+        // stays in-memory for the session, which is fine.
+      }
+      return next;
+    });
+  }, []);
 
   // Server-side feature flags. ``lab`` defaults off and is opt-in via
   // ``splitsmith ui --lab``; if the fetch fails we hide the Lab nav,
@@ -80,10 +109,36 @@ export function AppShell() {
   return (
     <div className="flex min-h-screen bg-background text-foreground">
       {fixtureMode ? null : (
-        <aside className="flex w-60 flex-col border-r border-border bg-card">
-          <div className="flex h-14 items-center gap-2 px-4 font-semibold tracking-tight">
-            <Crosshair className="size-5 text-primary" />
-            splitsmith
+        <aside
+          className={cn(
+            "flex flex-col border-r border-border bg-card transition-[width] duration-150",
+            sidebarCollapsed ? "w-14" : "w-60",
+          )}
+        >
+          <div
+            className={cn(
+              "flex h-14 items-center gap-2 px-3 font-semibold tracking-tight",
+              sidebarCollapsed && "justify-center px-2",
+            )}
+          >
+            <Crosshair className="size-5 shrink-0 text-primary" />
+            {sidebarCollapsed ? null : <span>splitsmith</span>}
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              className={cn(
+                "ml-auto inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+                sidebarCollapsed && "ml-0",
+              )}
+            >
+              {sidebarCollapsed ? (
+                <PanelLeftOpen className="size-4" aria-hidden />
+              ) : (
+                <PanelLeftClose className="size-4" aria-hidden />
+              )}
+            </button>
           </div>
           <nav className="flex flex-1 flex-col gap-0.5 p-2">
             {nav.map(({ to, label, icon: Icon, end }) => (
@@ -91,34 +146,38 @@ export function AppShell() {
                 key={to}
                 to={to}
                 end={end}
+                title={sidebarCollapsed ? label : undefined}
                 className={({ isActive }) =>
                   cn(
                     "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                    sidebarCollapsed && "justify-center px-0",
                     isActive
                       ? "bg-accent text-accent-foreground font-medium"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                   )
                 }
               >
-                <Icon className="size-4" />
-                {label}
+                <Icon className="size-4 shrink-0" />
+                {sidebarCollapsed ? null : <span>{label}</span>}
               </NavLink>
             ))}
           </nav>
           <div className="border-t border-border p-2">
             <NavLink
               to="/_design"
+              title={sidebarCollapsed ? "Design system" : undefined}
               className={({ isActive }) =>
                 cn(
                   "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                  sidebarCollapsed && "justify-center px-0",
                   isActive
                     ? "bg-accent text-accent-foreground font-medium"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                 )
               }
             >
-              <Palette className="size-4" />
-              Design system
+              <Palette className="size-4 shrink-0" />
+              {sidebarCollapsed ? null : <span>Design system</span>}
             </NavLink>
           </div>
         </aside>

--- a/src/splitsmith/ui_static/src/components/AppShell.tsx
+++ b/src/splitsmith/ui_static/src/components/AppShell.tsx
@@ -1,4 +1,5 @@
 import {
+  ClipboardCheck,
   Crosshair,
   FileBarChart,
   FlaskConical,
@@ -26,6 +27,7 @@ const BASE_NAV: NavItem[] = [
   { to: "/", label: "Overview", icon: Home, end: true },
   { to: "/ingest", label: "Ingest", icon: FolderInput },
   { to: "/audit", label: "Audit", icon: Crosshair },
+  { to: "/coach", label: "Coach", icon: ClipboardCheck },
   { to: "/export", label: "Export", icon: FileBarChart },
 ];
 const LAB_NAV: NavItem = { to: "/lab", label: "Lab", icon: FlaskConical };

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -568,10 +568,23 @@ export interface CoachShot {
   reload_hint: boolean;
 }
 
+export interface CoachVideoEntry {
+  path: string;
+  role: VideoRole;
+  /** Where the beep falls in the clip the SPA actually receives from
+   *  /api/videos/stream for this video -- the trimmed clip when one
+   *  exists, the source otherwise. ``null`` for cameras without a beep
+   *  yet; those are unsyncable and the SPA leaves them disabled. */
+  beep_in_clip: number | null;
+}
+
 export interface CoachStageResponse {
   stage_number: number;
   stage_name: string;
+  /** Where the beep falls in the served primary clip; same coordinate
+   *  system as ``shots[i].time_absolute``. */
   beep_time: number;
+  videos: CoachVideoEntry[];
   shots: CoachShot[];
 }
 

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -530,6 +530,60 @@ export interface AuditEvent {
   payload: Record<string, unknown>;
 }
 
+/** Coaching annotation set on a single shot (issue #159).
+ *
+ * - ``interval_class`` and ``interval_class_source`` are set together or
+ *   both null. ``manual`` survives reclassification; ``auto`` is rewritten
+ *   on every reclassify call.
+ * - ``stale=true`` means the stored class disagrees with what the rule
+ *   would assign now (typical after an Audit timestamp edit). The Coach
+ *   page surfaces a "stale" badge with click-to-accept.
+ * - ``reload_hint`` is purely UI: gap exceeds the reload-hint threshold,
+ *   prompting the user to reclassify as ``reload`` if appropriate.
+ */
+export type CoachIntervalClass =
+  | "first_shot"
+  | "split"
+  | "transition"
+  | "movement"
+  | "reload"
+  | "activation";
+export type CoachIntervalClassSource = "auto" | "manual";
+
+export interface CoachShot {
+  shot_number: number;
+  ms_after_beep: number;
+  /** Seconds from the beep. */
+  time_from_beep: number;
+  /** Seconds in the source timeline -- the value the SPA seeks the
+   *  primary video to when the user clicks this row. */
+  time_absolute: number;
+  /** Seconds since previous shot, or the draw for the first shot. */
+  split: number;
+  interval_class: CoachIntervalClass | null;
+  interval_class_source: CoachIntervalClassSource | null;
+  improvement_flag: boolean;
+  coaching_note: string | null;
+  stale: boolean;
+  reload_hint: boolean;
+}
+
+export interface CoachStageResponse {
+  stage_number: number;
+  stage_name: string;
+  beep_time: number;
+  shots: CoachShot[];
+}
+
+export interface CoachShotPatch {
+  interval_class?: CoachIntervalClass | null;
+  interval_class_source?: CoachIntervalClassSource | null;
+  clear_class?: boolean;
+  improvement_flag?: boolean | null;
+  coaching_note?: string | null;
+  clear_note?: boolean;
+}
+
 export interface StageAudit {
   stage_number: number;
   stage_name: string;
@@ -1124,6 +1178,33 @@ export const api = {
       method: "PUT",
       json: payload,
     }),
+
+  /** Coach view: per-shot interval class + flags + notes (#161). The
+   *  GET is read-only; ``stale=true`` means the rule disagrees with the
+   *  stored class and the user can accept the recompute via reclassify. */
+  getStageCoach: async (stageNumber: number): Promise<CoachStageResponse | null> => {
+    try {
+      return await request<CoachStageResponse>(`/api/stages/${stageNumber}/coach`);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) return null;
+      throw err;
+    }
+  },
+
+  reclassifyStageCoach: (stageNumber: number) =>
+    request<CoachStageResponse>(`/api/stages/${stageNumber}/coach/reclassify`, {
+      method: "POST",
+    }),
+
+  patchStageShotCoach: (
+    stageNumber: number,
+    shotNumber: number,
+    patch: CoachShotPatch,
+  ) =>
+    request<CoachStageResponse>(
+      `/api/stages/${stageNumber}/shots/${shotNumber}/coach`,
+      { method: "PATCH", json: patch },
+    ),
 
   /** Structured anomalies for the *saved* audit JSON (issue #42).
    *

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -588,6 +588,63 @@ export interface CoachStageResponse {
   shots: CoachShot[];
 }
 
+/** One bin of a Coach histogram (#163). ``lo`` inclusive, ``hi`` exclusive. */
+export interface CoachHistogramBucket {
+  lo: number;
+  hi: number;
+  count: number;
+}
+
+/** Distribution of gap-times for one ``interval_class`` across one stage
+ *  or one match. ``buckets`` only contains non-empty bins to keep the
+ *  payload small; ``count``/``mean_s``/etc. are computed over the full
+ *  set of values. */
+export interface CoachIntervalDistribution {
+  interval_class: CoachIntervalClass;
+  bucket_size_s: number;
+  buckets: CoachHistogramBucket[];
+  count: number;
+  mean_s: number | null;
+  median_s: number | null;
+  p90_s: number | null;
+}
+
+export interface CoachTopShotEntry {
+  stage_number: number;
+  stage_name: string;
+  shot_number: number;
+  interval_class: CoachIntervalClass;
+  gap_s: number;
+  coaching_note: string | null;
+  improvement_flag: boolean;
+}
+
+export interface CoachFlaggedShotEntry {
+  stage_number: number;
+  stage_name: string;
+  shot_number: number;
+  interval_class: CoachIntervalClass | null;
+  gap_s: number | null;
+  coaching_note: string | null;
+}
+
+export interface CoachStageDistributions {
+  stage_number: number;
+  stage_name: string;
+  distributions: CoachIntervalDistribution[];
+  first_shot_s: number | null;
+}
+
+export interface CoachMatchDistributions {
+  distributions: CoachIntervalDistribution[];
+  first_shot_seconds: number[];
+  top_splits: CoachTopShotEntry[];
+  top_transitions: CoachTopShotEntry[];
+  flagged_shots: CoachFlaggedShotEntry[];
+  stage_count: number;
+  shot_count: number;
+}
+
 export interface CoachShotPatch {
   interval_class?: CoachIntervalClass | null;
   interval_class_source?: CoachIntervalClassSource | null;
@@ -1218,6 +1275,19 @@ export const api = {
       `/api/stages/${stageNumber}/shots/${shotNumber}/coach`,
       { method: "PATCH", json: patch },
     ),
+
+  /** Per-stage histograms + summary stats for the Coach distributions
+   *  panel (#163). Empty classes still appear with count=0 so the UI
+   *  can render an empty histogram without a special case. */
+  getStageCoachDistributions: (stageNumber: number) =>
+    request<CoachStageDistributions>(
+      `/api/stages/${stageNumber}/coach/distributions`,
+    ),
+
+  /** Match-level histograms aggregated across every stage with an audit
+   *  JSON. Stages without an audit are silently skipped server-side. */
+  getMatchCoachDistributions: () =>
+    request<CoachMatchDistributions>("/api/coach/distributions"),
 
   /** Structured anomalies for the *saved* audit JSON (issue #42).
    *

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -19,8 +19,17 @@
  * shots appear at the same scrub position across every camera.
  */
 
-import { ClipboardCheck, Flag, Pause, Play, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChevronRight,
+  ClipboardCheck,
+  Flag,
+  Layers,
+  Pause,
+  Play,
+  Radio,
+  RefreshCw,
+} from "lucide-react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { VideoPanel } from "@/components/VideoPanel";
@@ -378,8 +387,23 @@ export function Coach() {
 
           <ShotTable
             shots={coach.shots}
+            beepTime={coach.beep_time}
             activeShotNumber={activeShotNumber}
             onRowClick={seekTo}
+            onSeekToBeep={() => {
+              setActiveShotNumber(0);
+              const v = videoRef.current;
+              if (v) v.currentTime = coach.beep_time;
+              for (const [path, sv] of secondaryRefs.current) {
+                const off = secondaryOffsets.current.get(path);
+                if (off == null) continue;
+                const expected = coach.beep_time + off;
+                const dur = Number.isFinite(sv.duration) ? sv.duration : null;
+                if (expected < 0) continue;
+                if (dur != null && expected > dur) continue;
+                sv.currentTime = expected;
+              }
+            }}
             onPatch={patchShot}
           />
         </div>
@@ -432,30 +456,99 @@ function StagePicker({
   );
 }
 
+// Group consecutive shots that share a class so a long "array on one
+// target" doesn't fill the table with 6 visually identical split rows.
+// First-shot is always its own group. We only collapse groups of >= 2;
+// a singleton transition stays on its own row.
+interface ShotGroup {
+  key: string;
+  cls: CoachIntervalClass | null;
+  shots: CoachShot[];
+}
+
+function groupShots(shots: CoachShot[]): ShotGroup[] {
+  const groups: ShotGroup[] = [];
+  for (const s of shots) {
+    const last = groups[groups.length - 1];
+    if (
+      last &&
+      last.cls === s.interval_class &&
+      // Never merge across first_shot -- it's a stage-level event, not
+      // a coachable interval to be grouped.
+      s.interval_class !== "first_shot"
+    ) {
+      last.shots.push(s);
+    } else {
+      groups.push({
+        key: `${s.interval_class ?? "_"}-${s.shot_number}`,
+        cls: s.interval_class,
+        shots: [s],
+      });
+    }
+  }
+  return groups;
+}
+
 function ShotTable({
   shots,
+  beepTime,
   activeShotNumber,
   onRowClick,
+  onSeekToBeep,
   onPatch,
 }: {
   shots: CoachShot[];
+  beepTime: number;
   activeShotNumber: number | null;
   onRowClick: (s: CoachShot) => void;
+  onSeekToBeep: () => void;
   onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
 }) {
+  const [compact, setCompact] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const groups = useMemo(() => groupShots(shots), [shots]);
+
+  const toggleGroup = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Shots ({shots.length})</CardTitle>
-        <CardDescription>
-          Class chips are inline-editable. Manual stays sticky across reclassify.
-        </CardDescription>
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <CardTitle>Shots ({shots.length})</CardTitle>
+            <CardDescription>
+              Class chips are inline-editable. Manual stays sticky across reclassify.
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant={compact ? "default" : "outline"}
+            size="sm"
+            onClick={() => setCompact((c) => !c)}
+            title={
+              compact
+                ? "Show every shot individually"
+                : "Collapse runs of same-class shots (e.g. arrays of splits)"
+            }
+          >
+            <Layers className="size-4" />
+            {compact ? "Compact" : "Detail"}
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="p-0">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
               <tr>
+                <th className="w-6 px-2 py-2"></th>
                 <th className="px-3 py-2 text-left">#</th>
                 <th className="px-3 py-2 text-right">T</th>
                 <th className="px-3 py-2 text-right">Split</th>
@@ -465,15 +558,58 @@ function ShotTable({
               </tr>
             </thead>
             <tbody>
-              {shots.map((s) => (
-                <ShotRow
-                  key={s.shot_number}
-                  shot={s}
-                  active={s.shot_number === activeShotNumber}
-                  onRowClick={onRowClick}
-                  onPatch={onPatch}
-                />
-              ))}
+              <BeepRow
+                beepTime={beepTime}
+                active={activeShotNumber === 0}
+                onClick={onSeekToBeep}
+              />
+              {compact
+                ? groups.map((g) => {
+                    const isOpen = expanded.has(g.key);
+                    if (g.shots.length < 2) {
+                      return (
+                        <ShotRow
+                          key={g.key}
+                          shot={g.shots[0]}
+                          active={g.shots[0].shot_number === activeShotNumber}
+                          onRowClick={onRowClick}
+                          onPatch={onPatch}
+                        />
+                      );
+                    }
+                    return (
+                      <Fragment key={g.key}>
+                        <GroupRow
+                          group={g}
+                          expanded={isOpen}
+                          activeShotNumber={activeShotNumber}
+                          onToggle={() => toggleGroup(g.key)}
+                          onRowClick={onRowClick}
+                        />
+                        {isOpen
+                          ? g.shots.map((s) => (
+                              <ShotRow
+                                key={s.shot_number}
+                                shot={s}
+                                indented
+                                active={s.shot_number === activeShotNumber}
+                                onRowClick={onRowClick}
+                                onPatch={onPatch}
+                              />
+                            ))
+                          : null}
+                      </Fragment>
+                    );
+                  })
+                : shots.map((s) => (
+                    <ShotRow
+                      key={s.shot_number}
+                      shot={s}
+                      active={s.shot_number === activeShotNumber}
+                      onRowClick={onRowClick}
+                      onPatch={onPatch}
+                    />
+                  ))}
             </tbody>
           </table>
         </div>
@@ -482,14 +618,128 @@ function ShotTable({
   );
 }
 
+function BeepRow({
+  beepTime,
+  active,
+  onClick,
+}: {
+  beepTime: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <tr
+      className={cn(
+        "cursor-pointer border-b border-border/50 bg-muted/20 transition-colors hover:bg-accent/40",
+        active && "bg-accent",
+      )}
+      onClick={onClick}
+      title="Seek to the start signal"
+    >
+      <td className="w-6 px-2 py-2"></td>
+      <td className="px-3 py-2 font-mono text-xs">
+        <Radio className="inline size-3.5 text-primary" aria-hidden /> beep
+      </td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums text-muted-foreground">
+        0.000
+      </td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums text-muted-foreground/60">
+        --
+      </td>
+      <td className="px-3 py-2 text-xs uppercase tracking-wide text-muted-foreground">
+        start signal
+      </td>
+      <td className="px-3 py-2"></td>
+      <td className="px-3 py-2 text-xs text-muted-foreground/70 italic">
+        source t = {beepTime.toFixed(3)} s
+      </td>
+    </tr>
+  );
+}
+
+function GroupRow({
+  group,
+  expanded,
+  activeShotNumber,
+  onToggle,
+  onRowClick,
+}: {
+  group: ShotGroup;
+  expanded: boolean;
+  activeShotNumber: number | null;
+  onToggle: () => void;
+  onRowClick: (s: CoachShot) => void;
+}) {
+  const first = group.shots[0];
+  const last = group.shots[group.shots.length - 1];
+  const totalSplit = group.shots.reduce((acc, s) => acc + s.split, 0);
+  const containsActive = group.shots.some((s) => s.shot_number === activeShotNumber);
+  const label = group.cls ? CLASS_LABELS[group.cls] : "unset";
+  return (
+    <tr
+      className={cn(
+        "cursor-pointer border-b border-border/50 transition-colors hover:bg-accent/40",
+        containsActive && !expanded && "bg-accent/60",
+      )}
+      onClick={() => onRowClick(first)}
+      title="Click to seek to the first shot in the group"
+    >
+      <td className="w-6 px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground hover:bg-accent"
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse group" : "Expand group"}
+        >
+          <ChevronRight
+            className={cn("size-4 transition-transform", expanded && "rotate-90")}
+          />
+        </button>
+      </td>
+      <td className="px-3 py-2 font-mono text-xs">
+        {first.shot_number}-{last.shot_number}
+      </td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums">
+        {first.time_from_beep.toFixed(3)}
+      </td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums">
+        {totalSplit.toFixed(3)}
+      </td>
+      <td className="px-3 py-2">
+        <Badge variant={group.cls ? CLASS_VARIANT[group.cls] : "outline"}>
+          {label} x{group.shots.length}
+        </Badge>
+      </td>
+      <td className="px-3 py-2"></td>
+      <td className="px-3 py-2 text-xs text-muted-foreground italic">
+        click to seek -- expand to edit individual shots
+      </td>
+    </tr>
+  );
+}
+
+const CLASS_LABELS: Record<CoachIntervalClass, string> = {
+  first_shot: "First shot",
+  split: "Splits",
+  transition: "Transitions",
+  movement: "Movements",
+  reload: "Reloads",
+  activation: "Activations",
+};
+
 function ShotRow({
   shot,
   active,
+  indented = false,
   onRowClick,
   onPatch,
 }: {
   shot: CoachShot;
   active: boolean;
+  /** True when rendered as a child of an expanded group; renders with a
+   *  faint left rail so the visual hierarchy reads at a glance. */
+  indented?: boolean;
   onRowClick: (s: CoachShot) => void;
   onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
 }) {
@@ -531,9 +781,16 @@ function ShotRow({
       className={cn(
         "cursor-pointer border-b border-border/50 transition-colors hover:bg-accent/40",
         active && "bg-accent",
+        indented && "bg-muted/10",
       )}
       onClick={() => onRowClick(shot)}
     >
+      <td
+        className={cn(
+          "w-6 px-2 py-2",
+          indented && "border-l-2 border-border/40",
+        )}
+      ></td>
       <td className="px-3 py-2 font-mono text-xs">{shot.shot_number}</td>
       <td className="px-3 py-2 text-right font-mono tabular-nums">
         {shot.time_from_beep.toFixed(3)}

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -8,18 +8,22 @@
  * audit JSON so Audit and Coach see each other's writes.
  *
  * Click any shot row -> the primary video seeks to that shot's source
- * time. Stale badges surface auto-classifications whose stored class
- * disagrees with the current rule (typical after an Audit timestamp
- * edit); click to accept the recompute.
+ * time and every synced secondary follows. Stale badges surface
+ * auto-classifications whose stored class disagrees with the current
+ * rule (typical after an Audit timestamp edit); click to accept the
+ * recompute.
  *
- * Video grid + secondaries are deferred to a follow-up; this v1 plays
- * the primary only.
+ * Multi-camera: VideoPanel handles the tab/grid layout. Coach owns the
+ * single playback source (primary) and offsets each secondary by
+ * ``(secondary.beep_time - primary.beep_time)`` so the beep aligns and
+ * shots appear at the same scrub position across every camera.
  */
 
-import { ClipboardCheck, Flag, RefreshCw } from "lucide-react";
+import { ClipboardCheck, Flag, Pause, Play, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { VideoPanel } from "@/components/VideoPanel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -70,6 +74,17 @@ export function Coach() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [activeShotNumber, setActiveShotNumber] = useState<number | null>(null);
 
+  // Multi-camera state. VideoPanel renders both modes; Coach owns the
+  // single playback source (the primary) and the secondary refs/offsets
+  // so click-to-scrub seeks every synced camera in lockstep.
+  const [activeVideoIndex, setActiveVideoIndex] = useState(0);
+  const [gridMode, setGridMode] = useState(false);
+  const secondaryRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
+  // path -> (secondary.beep_time - primary.beep_time). When the primary
+  // sits at sourceTime T, the synced secondary should be at T + offset
+  // so the beep aligns. Recomputed whenever the videos array changes.
+  const secondaryOffsets = useRef<Map<string, number>>(new Map());
+
   const stageNumber = useMemo(() => {
     if (!stageParam) return null;
     const n = Number.parseInt(stageParam, 10);
@@ -109,12 +124,102 @@ export function Coach() {
     return project.stages.find((s) => s.stage_number === stageNumber) ?? null;
   }, [project, stageNumber]);
 
-  const primaryVideo = useMemo<StageVideo | null>(() => {
-    if (!stage) return null;
-    return stage.videos.find((v) => v.role === "primary") ?? null;
+  // VideoPanel expects [primary, ...secondaries]. Sort secondaries by
+  // added_at to match Audit's tab order so the user's mental model of
+  // "Cam 2 / Cam 3" stays stable across pages.
+  const videos = useMemo<StageVideo[]>(() => {
+    if (!stage) return [];
+    const primary = stage.videos.find((v) => v.role === "primary");
+    const secondaries = stage.videos
+      .filter((v) => v.role === "secondary")
+      .slice()
+      .sort((a, b) => a.added_at.localeCompare(b.added_at));
+    return primary ? [primary, ...secondaries] : [...secondaries];
   }, [stage]);
 
-  const videoSrc = primaryVideo ? api.videoStreamUrl(primaryVideo.path) : "";
+  const primaryVideo = videos[0] ?? null;
+  const activeVideo = videos[activeVideoIndex] ?? primaryVideo;
+  const videoSrc = activeVideo ? api.videoStreamUrl(activeVideo.path) : "";
+
+  // Offsets: secondaries with a beep_time can be synced; the rest stay
+  // disabled in VideoPanel's tab list. Rebuild on every videos change so
+  // a stage swap doesn't leave stale entries from the previous stage.
+  useEffect(() => {
+    const next = new Map<string, number>();
+    const primaryBeep = primaryVideo?.beep_time ?? null;
+    if (primaryBeep != null) {
+      for (const v of videos.slice(1)) {
+        if (v.beep_time != null) {
+          next.set(v.path, v.beep_time - primaryBeep);
+        }
+      }
+    }
+    secondaryOffsets.current = next;
+  }, [videos, primaryVideo]);
+
+  // Reset active tab to primary on stage swap so the user lands on the
+  // headcam by default; grid stays sticky across stages because that's
+  // usually the workflow ("compare these two angles for every shot").
+  useEffect(() => {
+    setActiveVideoIndex(0);
+  }, [stageNumber]);
+
+  const handleSecondaryRef = useCallback(
+    (path: string, el: HTMLVideoElement | null) => {
+      if (el) {
+        secondaryRefs.current.set(path, el);
+        const off = secondaryOffsets.current.get(path);
+        const v = videoRef.current;
+        if (off != null && v != null) {
+          const target = v.currentTime + off;
+          if (el.readyState >= 1) {
+            el.currentTime = target;
+          } else {
+            el.addEventListener(
+              "loadedmetadata",
+              () => {
+                el.currentTime = target;
+              },
+              { once: true },
+            );
+          }
+        }
+      } else {
+        secondaryRefs.current.delete(path);
+      }
+    },
+    [],
+  );
+
+  // Coach is paused-by-default review; we don't need the play/pause loop
+  // logic Audit uses. timeupdate just keeps secondaries glued to the
+  // primary if the user hits the native controls. Clamp to each
+  // secondary's content range so we don't seek past a shorter clip.
+  const handlePrimaryTimeUpdate = useCallback(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    for (const [path, sv] of secondaryRefs.current) {
+      const off = secondaryOffsets.current.get(path);
+      if (off == null) continue;
+      const expected = v.currentTime + off;
+      const dur = Number.isFinite(sv.duration) ? sv.duration : null;
+      if (expected < 0) continue;
+      if (dur != null && expected > dur) continue;
+      // Only re-seek when drift exceeds ~80 ms; cheap timeupdate firings
+      // would otherwise cause continuous re-seeks during native playback.
+      if (Math.abs(sv.currentTime - expected) > 0.08) {
+        sv.currentTime = expected;
+      }
+    }
+  }, []);
+
+  const handleSecondaryBuffering = useCallback(
+    (_path: string, _buffering: boolean) => {
+      // Coach doesn't surface a panel-level buffering state -- the
+      // SecondarySlot's own overlay is enough for review.
+    },
+    [],
+  );
 
   // Load coach payload whenever the stage changes; on first hit we
   // auto-reclassify if any shot is unclassified, so the user always
@@ -172,6 +277,15 @@ export function Coach() {
     if (v) {
       v.currentTime = shot.time_absolute;
     }
+    for (const [path, sv] of secondaryRefs.current) {
+      const off = secondaryOffsets.current.get(path);
+      if (off == null) continue;
+      const expected = shot.time_absolute + off;
+      const dur = Number.isFinite(sv.duration) ? sv.duration : null;
+      if (expected < 0) continue;
+      if (dur != null && expected > dur) continue;
+      sv.currentTime = expected;
+    }
   }, []);
 
   const patchShot = useCallback(
@@ -222,29 +336,42 @@ export function Coach() {
       ) : null}
 
       {coach && (
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+        <div className="space-y-6">
           <Card>
             <CardHeader>
               <CardTitle>
                 Stage {coach.stage_number} -- {coach.stage_name}
               </CardTitle>
               <CardDescription>
-                Click a shot to seek the video. Beep is at {coach.beep_time.toFixed(2)} s in source.
+                Click a shot to seek every synced camera. Beep is at {coach.beep_time.toFixed(2)} s
+                in source.
               </CardDescription>
             </CardHeader>
             <CardContent>
-              {videoSrc ? (
-                <video
-                  ref={videoRef}
-                  src={videoSrc}
-                  controls
-                  preload="metadata"
-                  className="aspect-video w-full rounded-md bg-black"
-                />
-              ) : (
+              {videos.length === 0 ? (
                 <div className="rounded-md border border-dashed border-border p-6 text-sm text-muted-foreground">
                   No primary video bound to this stage.
                 </div>
+              ) : (
+                <>
+                  <VideoPanel
+                    ref={videoRef}
+                    videos={videos}
+                    primaryBeepTime={primaryVideo?.beep_time ?? null}
+                    activeIndex={activeVideoIndex}
+                    onActiveIndexChange={setActiveVideoIndex}
+                    videoSrc={videoSrc}
+                    gridMode={gridMode}
+                    onGridModeToggle={() => setGridMode((g) => !g)}
+                    onSecondaryRef={handleSecondaryRef}
+                    onSecondaryBuffering={handleSecondaryBuffering}
+                    onPrimaryTimeUpdate={handlePrimaryTimeUpdate}
+                  />
+                  <PlaybackBar
+                    videoRef={videoRef}
+                    secondaryRefs={secondaryRefs}
+                  />
+                </>
               )}
             </CardContent>
           </Card>
@@ -509,4 +636,96 @@ function ShotRow({
       </td>
     </tr>
   );
+}
+
+// Minimal playback control: play/pause + a current-time display. The
+// shot table is the primary scrub UX; this just lets the user roll the
+// video forward to watch a sequence between two clicks. Seeking via the
+// shot rows already pauses-via-implicit by setting currentTime.
+function PlaybackBar({
+  videoRef,
+  secondaryRefs,
+}: {
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  secondaryRefs: React.RefObject<Map<string, HTMLVideoElement>>;
+}) {
+  const [playing, setPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState<number | null>(null);
+
+  // Subscribe to playback state on the primary so the toggle button
+  // reflects what the user sees. Re-binds on ref churn (stage switch).
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    const onPlay = () => setPlaying(true);
+    const onPause = () => setPlaying(false);
+    const onTime = () => setCurrentTime(v.currentTime);
+    const onMeta = () => {
+      setDuration(Number.isFinite(v.duration) ? v.duration : null);
+      setCurrentTime(v.currentTime);
+    };
+    v.addEventListener("play", onPlay);
+    v.addEventListener("pause", onPause);
+    v.addEventListener("timeupdate", onTime);
+    v.addEventListener("loadedmetadata", onMeta);
+    if (v.readyState >= 1) onMeta();
+    return () => {
+      v.removeEventListener("play", onPlay);
+      v.removeEventListener("pause", onPause);
+      v.removeEventListener("timeupdate", onTime);
+      v.removeEventListener("loadedmetadata", onMeta);
+    };
+    // The ref identity is stable but the underlying element swaps on
+    // tab change; tying the effect to `videoRef.current` keeps the
+    // listeners pointed at the live element. Reading `.current` inside
+    // the effect deliberately on each run.
+  }, [videoRef, videoRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const togglePlay = useCallback(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (v.paused) {
+      void v.play().catch(() => {});
+      // Start synced secondaries too. Each one was offset by the
+      // primary timeupdate handler; just call .play() so they roll.
+      const refs = secondaryRefs.current;
+      if (refs) {
+        for (const sv of refs.values()) {
+          if (sv.paused) void sv.play().catch(() => {});
+        }
+      }
+    } else {
+      v.pause();
+      const refs = secondaryRefs.current;
+      if (refs) {
+        for (const sv of refs.values()) sv.pause();
+      }
+    }
+  }, [videoRef, secondaryRefs]);
+
+  return (
+    <div className="mt-3 flex items-center gap-3">
+      <Button type="button" variant="outline" size="sm" onClick={togglePlay}>
+        {playing ? <Pause className="size-4" /> : <Play className="size-4" />}
+        {playing ? "Pause" : "Play"}
+      </Button>
+      <div className="font-mono text-xs tabular-nums text-muted-foreground">
+        {formatTime(currentTime)}
+        {duration != null ? ` / ${formatTime(duration)}` : ""}
+      </div>
+    </div>
+  );
+}
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "00:00.000";
+  const mins = Math.floor(seconds / 60);
+  const rest = seconds - mins * 60;
+  const wholeSec = Math.floor(rest);
+  const ms = Math.round((rest - wholeSec) * 1000);
+  const mm = String(mins).padStart(2, "0");
+  const ss = String(wholeSec).padStart(2, "0");
+  const mmm = String(ms).padStart(3, "0");
+  return `${mm}:${ss}.${mmm}`;
 }

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -1,0 +1,512 @@
+/**
+ * Coach screen (#161).
+ *
+ * Read-only on shot timing -- the user can't drag markers here. The page
+ * is built around the Coach API (#161): it fetches the per-stage coach
+ * payload, lets the user override classifications, flag improvement
+ * shots, and leave coaching notes. All edits round-trip through the
+ * audit JSON so Audit and Coach see each other's writes.
+ *
+ * Click any shot row -> the primary video seeks to that shot's source
+ * time. Stale badges surface auto-classifications whose stored class
+ * disagrees with the current rule (typical after an Audit timestamp
+ * edit); click to accept the recompute.
+ *
+ * Video grid + secondaries are deferred to a follow-up; this v1 plays
+ * the primary only.
+ */
+
+import { ClipboardCheck, Flag, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  api,
+  type CoachIntervalClass,
+  type CoachShot,
+  type CoachShotPatch,
+  type CoachStageResponse,
+  type MatchProject,
+  type StageVideo,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const CLASS_OPTIONS: { value: CoachIntervalClass; label: string }[] = [
+  { value: "first_shot", label: "First shot" },
+  { value: "split", label: "Split" },
+  { value: "transition", label: "Transition" },
+  { value: "movement", label: "Movement" },
+  { value: "reload", label: "Reload" },
+  { value: "activation", label: "Activation" },
+];
+
+const CLASS_VARIANT: Record<CoachIntervalClass, "default" | "secondary" | "outline"> = {
+  first_shot: "outline",
+  split: "default",
+  transition: "secondary",
+  movement: "outline",
+  reload: "outline",
+  activation: "outline",
+};
+
+export function Coach() {
+  const { stage: stageParam } = useParams();
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState<MatchProject | null>(null);
+  const [coach, setCoach] = useState<CoachStageResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [reclassifying, setReclassifying] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [activeShotNumber, setActiveShotNumber] = useState<number | null>(null);
+
+  const stageNumber = useMemo(() => {
+    if (!stageParam) return null;
+    const n = Number.parseInt(stageParam, 10);
+    return Number.isFinite(n) ? n : null;
+  }, [stageParam]);
+
+  // Project (stage list).
+  useEffect(() => {
+    let alive = true;
+    api
+      .getProject()
+      .then((p) => {
+        if (alive) setProject(p);
+      })
+      .catch((err) => {
+        if (alive) setLoadError(String(err));
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const auditedStages = useMemo(() => {
+    if (!project) return [];
+    return project.stages.filter((s) => s.videos.some((v) => v.role === "primary"));
+  }, [project]);
+
+  // Auto-pick first stage if URL has no stage.
+  useEffect(() => {
+    if (stageNumber != null) return;
+    if (auditedStages.length === 0) return;
+    navigate(`/coach/${auditedStages[0].stage_number}`, { replace: true });
+  }, [stageNumber, auditedStages, navigate]);
+
+  const stage = useMemo(() => {
+    if (!project || stageNumber == null) return null;
+    return project.stages.find((s) => s.stage_number === stageNumber) ?? null;
+  }, [project, stageNumber]);
+
+  const primaryVideo = useMemo<StageVideo | null>(() => {
+    if (!stage) return null;
+    return stage.videos.find((v) => v.role === "primary") ?? null;
+  }, [stage]);
+
+  const videoSrc = primaryVideo ? api.videoStreamUrl(primaryVideo.path) : "";
+
+  // Load coach payload whenever the stage changes; on first hit we
+  // auto-reclassify if any shot is unclassified, so the user always
+  // lands on a populated table.
+  useEffect(() => {
+    if (stageNumber == null) return;
+    let alive = true;
+    setLoading(true);
+    setLoadError(null);
+    setActiveShotNumber(null);
+    (async () => {
+      try {
+        const initial = await api.getStageCoach(stageNumber);
+        if (!alive) return;
+        if (!initial) {
+          setCoach(null);
+          setLoadError("This stage has no audit JSON yet -- audit it first.");
+          return;
+        }
+        const needsAuto = initial.shots.some((s) => s.interval_class === null);
+        if (needsAuto) {
+          const populated = await api.reclassifyStageCoach(stageNumber);
+          if (!alive) return;
+          setCoach(populated);
+        } else {
+          setCoach(initial);
+        }
+      } catch (err) {
+        if (alive) setLoadError(String(err));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [stageNumber]);
+
+  const onReclassify = useCallback(async () => {
+    if (stageNumber == null) return;
+    setReclassifying(true);
+    try {
+      const updated = await api.reclassifyStageCoach(stageNumber);
+      setCoach(updated);
+    } catch (err) {
+      setLoadError(String(err));
+    } finally {
+      setReclassifying(false);
+    }
+  }, [stageNumber]);
+
+  const seekTo = useCallback((shot: CoachShot) => {
+    setActiveShotNumber(shot.shot_number);
+    const v = videoRef.current;
+    if (v) {
+      v.currentTime = shot.time_absolute;
+    }
+  }, []);
+
+  const patchShot = useCallback(
+    async (shotNumber: number, patch: CoachShotPatch) => {
+      if (stageNumber == null) return;
+      try {
+        const updated = await api.patchStageShotCoach(stageNumber, shotNumber, patch);
+        setCoach(updated);
+      } catch (err) {
+        setLoadError(String(err));
+      }
+    },
+    [stageNumber],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <ClipboardCheck className="size-6 text-primary" />
+            Coach
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Review shots, classify intervals, flag improvements. Marker timing is read-only here -- edit in Audit.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onReclassify}
+          disabled={reclassifying || stageNumber == null}
+        >
+          <RefreshCw className={cn("size-4", reclassifying && "animate-spin")} />
+          Reclassify
+        </Button>
+      </div>
+
+      <StagePicker stages={auditedStages} active={stageNumber} />
+
+      {loadError ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Can't load coach view</CardTitle>
+            <CardDescription>{loadError}</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {coach && (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Stage {coach.stage_number} -- {coach.stage_name}
+              </CardTitle>
+              <CardDescription>
+                Click a shot to seek the video. Beep is at {coach.beep_time.toFixed(2)} s in source.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {videoSrc ? (
+                <video
+                  ref={videoRef}
+                  src={videoSrc}
+                  controls
+                  preload="metadata"
+                  className="aspect-video w-full rounded-md bg-black"
+                />
+              ) : (
+                <div className="rounded-md border border-dashed border-border p-6 text-sm text-muted-foreground">
+                  No primary video bound to this stage.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <ShotTable
+            shots={coach.shots}
+            activeShotNumber={activeShotNumber}
+            onRowClick={seekTo}
+            onPatch={patchShot}
+          />
+        </div>
+      )}
+
+      {loading && !coach ? (
+        <Card>
+          <CardHeader>
+            <CardDescription>Loading coach view...</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+    </div>
+  );
+}
+
+function StagePicker({
+  stages,
+  active,
+}: {
+  stages: { stage_number: number; stage_name: string }[];
+  active: number | null;
+}) {
+  const navigate = useNavigate();
+  if (stages.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {stages.map((s) => {
+        const isActive = s.stage_number === active;
+        return (
+          <button
+            key={s.stage_number}
+            type="button"
+            onClick={() => navigate(`/coach/${s.stage_number}`)}
+            className={cn(
+              "rounded-md border px-3 py-1.5 text-sm transition-colors",
+              isActive
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-card text-foreground hover:bg-accent",
+            )}
+          >
+            <span className="font-mono text-xs text-muted-foreground/70 mr-2">
+              #{s.stage_number}
+            </span>
+            {s.stage_name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ShotTable({
+  shots,
+  activeShotNumber,
+  onRowClick,
+  onPatch,
+}: {
+  shots: CoachShot[];
+  activeShotNumber: number | null;
+  onRowClick: (s: CoachShot) => void;
+  onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Shots ({shots.length})</CardTitle>
+        <CardDescription>
+          Class chips are inline-editable. Manual stays sticky across reclassify.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">#</th>
+                <th className="px-3 py-2 text-right">T</th>
+                <th className="px-3 py-2 text-right">Split</th>
+                <th className="px-3 py-2 text-left">Class</th>
+                <th className="px-3 py-2 text-center">Flag</th>
+                <th className="px-3 py-2 text-left">Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shots.map((s) => (
+                <ShotRow
+                  key={s.shot_number}
+                  shot={s}
+                  active={s.shot_number === activeShotNumber}
+                  onRowClick={onRowClick}
+                  onPatch={onPatch}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ShotRow({
+  shot,
+  active,
+  onRowClick,
+  onPatch,
+}: {
+  shot: CoachShot;
+  active: boolean;
+  onRowClick: (s: CoachShot) => void;
+  onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
+}) {
+  const [editingNote, setEditingNote] = useState(false);
+  const [noteDraft, setNoteDraft] = useState(shot.coaching_note ?? "");
+  useEffect(() => {
+    if (!editingNote) setNoteDraft(shot.coaching_note ?? "");
+  }, [shot.coaching_note, editingNote]);
+
+  const saveNote = () => {
+    setEditingNote(false);
+    const trimmed = noteDraft.trim();
+    if (trimmed === (shot.coaching_note ?? "")) return;
+    if (trimmed === "") {
+      onPatch(shot.shot_number, { clear_note: true });
+    } else {
+      onPatch(shot.shot_number, { coaching_note: trimmed });
+    }
+  };
+
+  const onClassChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    if (val === "_auto") {
+      onPatch(shot.shot_number, { clear_class: true });
+      return;
+    }
+    onPatch(shot.shot_number, {
+      interval_class: val as CoachIntervalClass,
+      interval_class_source: "manual",
+    });
+  };
+
+  const onAcceptStale = () => {
+    onPatch(shot.shot_number, { clear_class: true });
+  };
+
+  return (
+    <tr
+      className={cn(
+        "cursor-pointer border-b border-border/50 transition-colors hover:bg-accent/40",
+        active && "bg-accent",
+      )}
+      onClick={() => onRowClick(shot)}
+    >
+      <td className="px-3 py-2 font-mono text-xs">{shot.shot_number}</td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums">
+        {shot.time_from_beep.toFixed(3)}
+      </td>
+      <td className="px-3 py-2 text-right font-mono tabular-nums">
+        {shot.split.toFixed(3)}
+      </td>
+      <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-1.5">
+          <select
+            className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+            value={shot.interval_class ?? ""}
+            onChange={onClassChange}
+          >
+            <option value="" disabled>
+              -- unset --
+            </option>
+            {CLASS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+            {shot.interval_class_source === "manual" ? (
+              <option value="_auto">Reset to auto</option>
+            ) : null}
+          </select>
+          {shot.interval_class && shot.interval_class_source === "auto" ? (
+            <Badge variant={CLASS_VARIANT[shot.interval_class]} className="text-[10px]">
+              auto
+            </Badge>
+          ) : null}
+          {shot.interval_class && shot.interval_class_source === "manual" ? (
+            <Badge variant="default" className="text-[10px]">
+              manual
+            </Badge>
+          ) : null}
+          {shot.stale ? (
+            <button
+              type="button"
+              onClick={onAcceptStale}
+              className="rounded-md border border-amber-500/60 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 hover:bg-amber-500/20 dark:text-amber-400"
+              title="The rule disagrees with the stored class. Click to accept the recompute."
+            >
+              stale
+            </button>
+          ) : null}
+          {shot.reload_hint && shot.interval_class !== "reload" ? (
+            <span
+              className="text-[10px] text-muted-foreground"
+              title="Gap is large enough that this might be a reload"
+            >
+              reload?
+            </span>
+          ) : null}
+        </div>
+      </td>
+      <td className="px-3 py-2 text-center" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          onClick={() => onPatch(shot.shot_number, { improvement_flag: !shot.improvement_flag })}
+          className={cn(
+            "inline-flex size-7 items-center justify-center rounded-md border transition-colors",
+            shot.improvement_flag
+              ? "border-amber-500/60 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+              : "border-transparent text-muted-foreground hover:bg-accent",
+          )}
+          title={shot.improvement_flag ? "Unflag" : "Flag for improvement"}
+        >
+          <Flag className="size-4" />
+        </button>
+      </td>
+      <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+        {editingNote ? (
+          <input
+            autoFocus
+            className="w-full rounded-md border border-border bg-background px-2 py-1 text-xs"
+            value={noteDraft}
+            onChange={(e) => setNoteDraft(e.target.value)}
+            onBlur={saveNote}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") saveNote();
+              if (e.key === "Escape") {
+                setNoteDraft(shot.coaching_note ?? "");
+                setEditingNote(false);
+              }
+            }}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setEditingNote(true)}
+            className="block w-full truncate rounded-md px-1 py-1 text-left text-xs text-muted-foreground hover:bg-accent"
+            title={shot.coaching_note ?? "Add a note"}
+          >
+            {shot.coaching_note || (
+              <span className="italic text-muted-foreground/60">add note...</span>
+            )}
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -85,13 +85,17 @@ export function Coach() {
 
   // Multi-camera state. VideoPanel renders both modes; Coach owns the
   // single playback source (the primary) and the secondary refs/offsets
-  // so click-to-scrub seeks every synced camera in lockstep.
+  // so click-to-scrub seeks every synced camera in lockstep. Grid is
+  // the default because side-by-side comparison is the entire point of
+  // the Coach view.
   const [activeVideoIndex, setActiveVideoIndex] = useState(0);
-  const [gridMode, setGridMode] = useState(false);
+  const [gridMode, setGridMode] = useState(true);
   const secondaryRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
-  // path -> (secondary.beep_time - primary.beep_time). When the primary
-  // sits at sourceTime T, the synced secondary should be at T + offset
-  // so the beep aligns. Recomputed whenever the videos array changes.
+  // path -> (secondary.beep_in_clip - primary.beep_in_clip). When the
+  // primary sits at clipTime T, the synced secondary should be at
+  // T + offset so both cameras show the same real-world instant.
+  // Computed in clip coords so the page works off the project-local
+  // trimmed cache; source files don't need to be reachable.
   const secondaryOffsets = useRef<Map<string, number>>(new Map());
 
   const stageNumber = useMemo(() => {
@@ -150,21 +154,27 @@ export function Coach() {
   const activeVideo = videos[activeVideoIndex] ?? primaryVideo;
   const videoSrc = activeVideo ? api.videoStreamUrl(activeVideo.path) : "";
 
-  // Offsets: secondaries with a beep_time can be synced; the rest stay
-  // disabled in VideoPanel's tab list. Rebuild on every videos change so
-  // a stage swap doesn't leave stale entries from the previous stage.
+  // Offsets: derive from the Coach API's per-video ``beep_in_clip``
+  // values. Each camera's served clip has its own coordinate system
+  // (trimmed clips are cut around their own beep), so the offset that
+  // keeps two clips visually aligned is
+  //   secondary.beep_in_clip - primary.beep_in_clip.
+  // Only secondaries with a beep are synced; cameras without one stay
+  // disabled in VideoPanel's tab list.
   useEffect(() => {
     const next = new Map<string, number>();
-    const primaryBeep = primaryVideo?.beep_time ?? null;
-    if (primaryBeep != null) {
-      for (const v of videos.slice(1)) {
-        if (v.beep_time != null) {
-          next.set(v.path, v.beep_time - primaryBeep);
-        }
+    const coachVideos = coach?.videos ?? [];
+    const primaryEntry = coachVideos.find((v) => v.role === "primary");
+    const primaryClipBeep = primaryEntry?.beep_in_clip ?? null;
+    if (primaryClipBeep != null) {
+      for (const v of coachVideos) {
+        if (v.role === "primary") continue;
+        if (v.beep_in_clip == null) continue;
+        next.set(v.path, v.beep_in_clip - primaryClipBeep);
       }
     }
     secondaryOffsets.current = next;
-  }, [videos, primaryVideo]);
+  }, [coach]);
 
   // Reset active tab to primary on stage swap so the user lands on the
   // headcam by default; grid stays sticky across stages because that's
@@ -204,6 +214,16 @@ export function Coach() {
   // logic Audit uses. timeupdate just keeps secondaries glued to the
   // primary if the user hits the native controls. Clamp to each
   // secondary's content range so we don't seek past a shorter clip.
+  // Also track which shot the playhead is currently inside so the table
+  // highlights and auto-scrolls along with the video -- the user expects
+  // the rows to follow as the recording plays out.
+  const coachShotsRef = useRef<CoachShot[]>([]);
+  const beepTimeRef = useRef<number>(0);
+  useEffect(() => {
+    coachShotsRef.current = coach?.shots ?? [];
+    beepTimeRef.current = coach?.beep_time ?? 0;
+  }, [coach]);
+
   const handlePrimaryTimeUpdate = useCallback(() => {
     const v = videoRef.current;
     if (!v) return;
@@ -220,6 +240,21 @@ export function Coach() {
         sv.currentTime = expected;
       }
     }
+
+    // Active-shot tracking: the row whose time_absolute most recently
+    // passed under the playhead. ``shot 0`` (beep) covers the lead-in
+    // before shot 1 fires.
+    const shots = coachShotsRef.current;
+    const t = v.currentTime;
+    let nextActive: number | null = t >= beepTimeRef.current ? 0 : null;
+    for (const s of shots) {
+      if (s.time_absolute <= t + 0.01) {
+        nextActive = s.shot_number;
+      } else {
+        break;
+      }
+    }
+    setActiveShotNumber((prev) => (prev === nextActive ? prev : nextActive));
   }, []);
 
   const handleSecondaryBuffering = useCallback(
@@ -507,6 +542,7 @@ function ShotTable({
   const [compact, setCompact] = useState(true);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const groups = useMemo(() => groupShots(shots), [shots]);
+  const tableRef = useRef<HTMLDivElement | null>(null);
 
   const toggleGroup = useCallback((key: string) => {
     setExpanded((prev) => {
@@ -516,6 +552,21 @@ function ShotTable({
       return next;
     });
   }, []);
+
+  // Scroll the active row into view as playback advances. ``block: "nearest"``
+  // avoids yanking the page when the active row is already visible -- the
+  // row only moves when it would otherwise scroll out of the table.
+  useEffect(() => {
+    if (activeShotNumber == null) return;
+    const container = tableRef.current;
+    if (!container) return;
+    const row = container.querySelector<HTMLElement>(
+      `[data-active-shot="${activeShotNumber}"]`,
+    );
+    if (row) {
+      row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [activeShotNumber]);
 
   return (
     <Card>
@@ -544,7 +595,7 @@ function ShotTable({
         </div>
       </CardHeader>
       <CardContent className="p-0">
-        <div className="overflow-x-auto">
+        <div ref={tableRef} className="max-h-[60vh] overflow-auto">
           <table className="w-full text-sm">
             <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
               <tr>
@@ -634,6 +685,7 @@ function BeepRow({
         active && "bg-accent",
       )}
       onClick={onClick}
+      data-active-shot={0}
       title="Seek to the start signal"
     >
       <td className="w-6 px-2 py-2"></td>
@@ -682,6 +734,7 @@ function GroupRow({
         containsActive && !expanded && "bg-accent/60",
       )}
       onClick={() => onRowClick(first)}
+      data-active-shot={containsActive && !expanded ? activeShotNumber ?? undefined : undefined}
       title="Click to seek to the first shot in the group"
     >
       <td className="w-6 px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
@@ -784,6 +837,7 @@ function ShotRow({
         indented && "bg-muted/10",
       )}
       onClick={() => onRowClick(shot)}
+      data-active-shot={active ? shot.shot_number : undefined}
     >
       <td
         className={cn(

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -20,16 +20,14 @@
  */
 
 import {
-  ChevronRight,
   ClipboardCheck,
   Flag,
-  Layers,
   Pause,
   Play,
   Radio,
   RefreshCw,
 } from "lucide-react";
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { VideoPanel } from "@/components/VideoPanel";
@@ -45,8 +43,10 @@ import {
 import {
   api,
   type CoachIntervalClass,
+  type CoachIntervalDistribution,
   type CoachShot,
   type CoachShotPatch,
+  type CoachStageDistributions,
   type CoachStageResponse,
   type MatchProject,
   type StageVideo,
@@ -441,6 +441,8 @@ export function Coach() {
             }}
             onPatch={patchShot}
           />
+
+          {stageNumber != null ? <DistributionsPanel stageNumber={stageNumber} /> : null}
         </div>
       )}
 
@@ -491,39 +493,6 @@ function StagePicker({
   );
 }
 
-// Group consecutive shots that share a class so a long "array on one
-// target" doesn't fill the table with 6 visually identical split rows.
-// First-shot is always its own group. We only collapse groups of >= 2;
-// a singleton transition stays on its own row.
-interface ShotGroup {
-  key: string;
-  cls: CoachIntervalClass | null;
-  shots: CoachShot[];
-}
-
-function groupShots(shots: CoachShot[]): ShotGroup[] {
-  const groups: ShotGroup[] = [];
-  for (const s of shots) {
-    const last = groups[groups.length - 1];
-    if (
-      last &&
-      last.cls === s.interval_class &&
-      // Never merge across first_shot -- it's a stage-level event, not
-      // a coachable interval to be grouped.
-      s.interval_class !== "first_shot"
-    ) {
-      last.shots.push(s);
-    } else {
-      groups.push({
-        key: `${s.interval_class ?? "_"}-${s.shot_number}`,
-        cls: s.interval_class,
-        shots: [s],
-      });
-    }
-  }
-  return groups;
-}
-
 function ShotTable({
   shots,
   beepTime,
@@ -539,19 +508,7 @@ function ShotTable({
   onSeekToBeep: () => void;
   onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
 }) {
-  const [compact, setCompact] = useState(true);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const groups = useMemo(() => groupShots(shots), [shots]);
   const tableRef = useRef<HTMLDivElement | null>(null);
-
-  const toggleGroup = useCallback((key: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
 
   // Scroll the active row into view as playback advances. ``block: "nearest"``
   // avoids yanking the page when the active row is already visible -- the
@@ -571,28 +528,11 @@ function ShotTable({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between gap-2">
-          <div>
-            <CardTitle>Shots ({shots.length})</CardTitle>
-            <CardDescription>
-              Class chips are inline-editable. Manual stays sticky across reclassify.
-            </CardDescription>
-          </div>
-          <Button
-            type="button"
-            variant={compact ? "default" : "outline"}
-            size="sm"
-            onClick={() => setCompact((c) => !c)}
-            title={
-              compact
-                ? "Show every shot individually"
-                : "Collapse runs of same-class shots (e.g. arrays of splits)"
-            }
-          >
-            <Layers className="size-4" />
-            {compact ? "Compact" : "Detail"}
-          </Button>
-        </div>
+        <CardTitle>Shots ({shots.length})</CardTitle>
+        <CardDescription>
+          Every shot is its own row. Class chips are inline-editable; manual
+          overrides survive reclassify.
+        </CardDescription>
       </CardHeader>
       <CardContent className="p-0">
         <div ref={tableRef} className="max-h-[60vh] overflow-auto">
@@ -614,53 +554,15 @@ function ShotTable({
                 active={activeShotNumber === 0}
                 onClick={onSeekToBeep}
               />
-              {compact
-                ? groups.map((g) => {
-                    const isOpen = expanded.has(g.key);
-                    if (g.shots.length < 2) {
-                      return (
-                        <ShotRow
-                          key={g.key}
-                          shot={g.shots[0]}
-                          active={g.shots[0].shot_number === activeShotNumber}
-                          onRowClick={onRowClick}
-                          onPatch={onPatch}
-                        />
-                      );
-                    }
-                    return (
-                      <Fragment key={g.key}>
-                        <GroupRow
-                          group={g}
-                          expanded={isOpen}
-                          activeShotNumber={activeShotNumber}
-                          onToggle={() => toggleGroup(g.key)}
-                          onRowClick={onRowClick}
-                        />
-                        {isOpen
-                          ? g.shots.map((s) => (
-                              <ShotRow
-                                key={s.shot_number}
-                                shot={s}
-                                indented
-                                active={s.shot_number === activeShotNumber}
-                                onRowClick={onRowClick}
-                                onPatch={onPatch}
-                              />
-                            ))
-                          : null}
-                      </Fragment>
-                    );
-                  })
-                : shots.map((s) => (
-                    <ShotRow
-                      key={s.shot_number}
-                      shot={s}
-                      active={s.shot_number === activeShotNumber}
-                      onRowClick={onRowClick}
-                      onPatch={onPatch}
-                    />
-                  ))}
+              {shots.map((s) => (
+                <ShotRow
+                  key={s.shot_number}
+                  shot={s}
+                  active={s.shot_number === activeShotNumber}
+                  onRowClick={onRowClick}
+                  onPatch={onPatch}
+                />
+              ))}
             </tbody>
           </table>
         </div>
@@ -709,90 +611,14 @@ function BeepRow({
   );
 }
 
-function GroupRow({
-  group,
-  expanded,
-  activeShotNumber,
-  onToggle,
-  onRowClick,
-}: {
-  group: ShotGroup;
-  expanded: boolean;
-  activeShotNumber: number | null;
-  onToggle: () => void;
-  onRowClick: (s: CoachShot) => void;
-}) {
-  const first = group.shots[0];
-  const last = group.shots[group.shots.length - 1];
-  const totalSplit = group.shots.reduce((acc, s) => acc + s.split, 0);
-  const containsActive = group.shots.some((s) => s.shot_number === activeShotNumber);
-  const label = group.cls ? CLASS_LABELS[group.cls] : "unset";
-  return (
-    <tr
-      className={cn(
-        "cursor-pointer border-b border-border/50 transition-colors hover:bg-accent/40",
-        containsActive && !expanded && "bg-accent/60",
-      )}
-      onClick={() => onRowClick(first)}
-      data-active-shot={containsActive && !expanded ? activeShotNumber ?? undefined : undefined}
-      title="Click to seek to the first shot in the group"
-    >
-      <td className="w-6 px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
-        <button
-          type="button"
-          onClick={onToggle}
-          className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground hover:bg-accent"
-          aria-expanded={expanded}
-          aria-label={expanded ? "Collapse group" : "Expand group"}
-        >
-          <ChevronRight
-            className={cn("size-4 transition-transform", expanded && "rotate-90")}
-          />
-        </button>
-      </td>
-      <td className="px-3 py-2 font-mono text-xs">
-        {first.shot_number}-{last.shot_number}
-      </td>
-      <td className="px-3 py-2 text-right font-mono tabular-nums">
-        {first.time_from_beep.toFixed(3)}
-      </td>
-      <td className="px-3 py-2 text-right font-mono tabular-nums">
-        {totalSplit.toFixed(3)}
-      </td>
-      <td className="px-3 py-2">
-        <Badge variant={group.cls ? CLASS_VARIANT[group.cls] : "outline"}>
-          {label} x{group.shots.length}
-        </Badge>
-      </td>
-      <td className="px-3 py-2"></td>
-      <td className="px-3 py-2 text-xs text-muted-foreground italic">
-        click to seek -- expand to edit individual shots
-      </td>
-    </tr>
-  );
-}
-
-const CLASS_LABELS: Record<CoachIntervalClass, string> = {
-  first_shot: "First shot",
-  split: "Splits",
-  transition: "Transitions",
-  movement: "Movements",
-  reload: "Reloads",
-  activation: "Activations",
-};
-
 function ShotRow({
   shot,
   active,
-  indented = false,
   onRowClick,
   onPatch,
 }: {
   shot: CoachShot;
   active: boolean;
-  /** True when rendered as a child of an expanded group; renders with a
-   *  faint left rail so the visual hierarchy reads at a glance. */
-  indented?: boolean;
   onRowClick: (s: CoachShot) => void;
   onPatch: (shotNumber: number, patch: CoachShotPatch) => void;
 }) {
@@ -834,17 +660,11 @@ function ShotRow({
       className={cn(
         "cursor-pointer border-b border-border/50 transition-colors hover:bg-accent/40",
         active && "bg-accent",
-        indented && "bg-muted/10",
       )}
       onClick={() => onRowClick(shot)}
       data-active-shot={active ? shot.shot_number : undefined}
     >
-      <td
-        className={cn(
-          "w-6 px-2 py-2",
-          indented && "border-l-2 border-border/40",
-        )}
-      ></td>
+      <td className="w-6 px-2 py-2"></td>
       <td className="px-3 py-2 font-mono text-xs">{shot.shot_number}</td>
       <td className="px-3 py-2 text-right font-mono tabular-nums">
         {shot.time_from_beep.toFixed(3)}
@@ -1039,4 +859,119 @@ function formatTime(seconds: number): string {
   const ss = String(wholeSec).padStart(2, "0");
   const mmm = String(ms).padStart(3, "0");
   return `${mm}:${ss}.${mmm}`;
+}
+
+// ---------------------------------------------------------------------------
+// Distributions panel (#163)
+// ---------------------------------------------------------------------------
+
+function DistributionsPanel({ stageNumber }: { stageNumber: number }) {
+  const [data, setData] = useState<CoachStageDistributions | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setError(null);
+    api
+      .getStageCoachDistributions(stageNumber)
+      .then((d) => {
+        if (alive) setData(d);
+      })
+      .catch((err) => {
+        if (alive) setError(String(err));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [stageNumber]);
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Distributions</CardTitle>
+          <CardDescription>{error}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  if (!data) return null;
+  // Splits + transitions are the coachable bread-and-butter; movement
+  // and reload distributions usually have a handful of values per stage
+  // and read better at the match level. Show the top two here, defer
+  // the rest to the (future) match view (#162 / #163 follow-up).
+  const focus = data.distributions.filter(
+    (d) => d.interval_class === "split" || d.interval_class === "transition",
+  );
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Distributions</CardTitle>
+        <CardDescription>
+          {data.first_shot_s != null
+            ? `Draw: ${data.first_shot_s.toFixed(3)} s. Histograms below cover splits + transitions for this stage.`
+            : "Histograms cover splits + transitions for this stage."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-2">
+        {focus.map((d) => (
+          <Histogram key={d.interval_class} dist={d} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Histogram({ dist }: { dist: CoachIntervalDistribution }) {
+  const maxCount = Math.max(0, ...dist.buckets.map((b) => b.count));
+  const label =
+    dist.interval_class === "split"
+      ? "Splits"
+      : dist.interval_class === "transition"
+        ? "Transitions"
+        : dist.interval_class === "movement"
+          ? "Movements"
+          : dist.interval_class === "reload"
+            ? "Reloads"
+            : dist.interval_class;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="font-mono text-xs text-muted-foreground">
+          n={dist.count}
+          {dist.mean_s != null ? ` · mean ${dist.mean_s.toFixed(3)} s` : ""}
+          {dist.median_s != null ? ` · med ${dist.median_s.toFixed(3)} s` : ""}
+          {dist.p90_s != null ? ` · p90 ${dist.p90_s.toFixed(3)} s` : ""}
+        </span>
+      </div>
+      {dist.count === 0 ? (
+        <div className="rounded-md border border-dashed border-border p-4 text-xs text-muted-foreground">
+          No values on this stage.
+        </div>
+      ) : (
+        <div className="space-y-1 font-mono text-[11px]">
+          {dist.buckets.map((b) => {
+            const w = maxCount > 0 ? (b.count / maxCount) * 100 : 0;
+            return (
+              <div key={`${b.lo}-${b.hi}`} className="flex items-center gap-2">
+                <span className="w-20 shrink-0 text-right tabular-nums text-muted-foreground">
+                  {b.lo.toFixed(2)}-{b.hi.toFixed(2)} s
+                </span>
+                <div className="flex-1">
+                  <div
+                    className="h-3 rounded-sm bg-primary/70"
+                    style={{ width: `${w}%` }}
+                  />
+                </div>
+                <span className="w-6 text-right tabular-nums text-muted-foreground">
+                  {b.count}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -92,6 +92,71 @@ def test_get_coach_returns_shots_with_stale_when_unset(tmp_path: Path) -> None:
     assert body["shots"][3]["reload_hint"] is True
 
 
+def test_get_coach_returns_videos_with_beep_in_clip(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.get("/api/stages/1/coach")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "videos" in body
+    assert len(body["videos"]) == 1
+    primary_entry = body["videos"][0]
+    assert primary_entry["role"] == "primary"
+    # No trimmed clip on disk in the bootstrap; beep_in_clip == beep in
+    # source so clip coords match source coords for this fixture.
+    assert primary_entry["beep_in_clip"] == pytest.approx(5.0)
+
+
+def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> None:
+    """Beep at 8 s in source + a trimmed clip on disk -> the SPA must
+    seek inside the trimmed clip, where the beep sits at min(8, 5)=5 s.
+    All shot ``time_absolute`` values follow the same anchor.
+    """
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="Trimmed Match")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="K-vallen",
+            time_seconds=30.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=8.0)],
+        )
+    ]
+    project.save(root)
+
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    (audit_dir / "stage1.json").write_text(
+        json.dumps(
+            {
+                "stage_number": 1,
+                "stage_name": "K-vallen",
+                "shots": [
+                    {"shot_number": 1, "ms_after_beep": 1500, "source": "detected"},
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Place a non-empty file at the trimmed-clip path so the helper
+    # detects "trim exists" without running ffmpeg.
+    trimmed_dir = project.trimmed_path(root)
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"not really a video, but non-empty")
+
+    app = create_app(project_root=root, project_name="Trimmed Match")
+    client = TestClient(app)
+    resp = client.get("/api/stages/1/coach")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Default trim_pre_buffer_seconds is 5.0; beep clamps to that.
+    assert body["beep_time"] == pytest.approx(5.0)
+    assert body["videos"][0]["beep_in_clip"] == pytest.approx(5.0)
+    assert body["shots"][0]["time_absolute"] == pytest.approx(5.0 + 1.5)
+
+
 def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
     root = tmp_path / "match"
     project = MatchProject.init(root, name="Empty")

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -157,6 +157,34 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
     assert body["shots"][0]["time_absolute"] == pytest.approx(5.0 + 1.5)
 
 
+def test_get_stage_distributions(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.get("/api/stages/1/coach/distributions")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stage_number"] == 1
+    classes = {d["interval_class"] for d in body["distributions"]}
+    assert classes == {"split", "transition", "movement", "reload"}
+    by_class = {d["interval_class"]: d for d in body["distributions"]}
+    assert by_class["split"]["count"] == 1
+    assert by_class["transition"]["count"] == 1
+    assert by_class["movement"]["count"] == 1
+    assert by_class["reload"]["count"] == 0
+    assert body["first_shot_s"] == pytest.approx(1.5)
+
+
+def test_get_match_distributions_aggregates(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.get("/api/coach/distributions")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stage_count"] == 1
+    by_class = {d["interval_class"]: d for d in body["distributions"]}
+    assert by_class["split"]["count"] == 1
+    assert by_class["transition"]["count"] == 1
+    assert body["first_shot_seconds"] == pytest.approx([1.5])
+
+
 def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
     root = tmp_path / "match"
     project = MatchProject.init(root, name="Empty")

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -1,0 +1,268 @@
+"""End-to-end tests for the Coach HTTP endpoints (issue #161).
+
+Bootstraps a minimal project + an audit JSON, then exercises GET /coach,
+POST /coach/reclassify, and PATCH /shots/{n}/coach. Mirrors the test
+style in ``test_ui_server.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+from splitsmith.ui.server import create_app
+
+
+@pytest.fixture(autouse=True)
+def _disable_auto_beep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPLITSMITH_AUTO_BEEP_DISABLED", "1")
+
+
+def _bootstrap(tmp_path: Path) -> tuple[TestClient, Path]:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="Coach Match")
+    project.competitor_name = "Tester"
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="K-vallen",
+            time_seconds=30.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=5.0)],
+        )
+    ]
+    project.save(root)
+
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_file = audit_dir / "stage1.json"
+    payload = {
+        "stage_number": 1,
+        "stage_name": "K-vallen",
+        "beep_time": 5.0,
+        "shots": [
+            {"shot_number": 1, "ms_after_beep": 1500, "source": "detected"},
+            {"shot_number": 2, "ms_after_beep": 1800, "source": "detected"},  # 0.30 -> split
+            {"shot_number": 3, "ms_after_beep": 2700, "source": "detected"},  # 0.90 -> transition
+            {"shot_number": 4, "ms_after_beep": 5300, "source": "detected"},  # 2.60 -> movement
+        ],
+    }
+    audit_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    app = create_app(project_root=root, project_name="Coach Match")
+    return TestClient(app), audit_file
+
+
+def _read(audit_file: Path) -> dict[str, Any]:
+    return json.loads(audit_file.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# GET
+# ---------------------------------------------------------------------------
+
+
+def test_get_coach_returns_shots_with_stale_when_unset(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.get("/api/stages/1/coach")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stage_number"] == 1
+    assert body["beep_time"] == 5.0
+    assert len(body["shots"]) == 4
+
+    # Nothing classified yet -> stored class is None and stale=False per
+    # the spec (unannotated shots aren't stale).
+    for s in body["shots"]:
+        assert s["interval_class"] is None
+        assert s["interval_class_source"] is None
+        assert s["stale"] is False
+        assert s["improvement_flag"] is False
+
+    # time_absolute = beep_time + ms/1000 so the SPA can seek videos.
+    assert body["shots"][0]["time_absolute"] == pytest.approx(5.0 + 1.5)
+    # First shot's "split" is the draw.
+    assert body["shots"][0]["split"] == pytest.approx(1.5)
+    assert body["shots"][1]["split"] == pytest.approx(0.3)
+    # Reload-hint flag fires on the long gap.
+    assert body["shots"][3]["reload_hint"] is True
+
+
+def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="Empty")
+    project.stages = [StageEntry(stage_number=1, stage_name="x", time_seconds=10.0, videos=[])]
+    project.save(root)
+    app = create_app(project_root=root, project_name="Empty")
+    client = TestClient(app)
+    resp = client.get("/api/stages/1/coach")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reclassify
+# ---------------------------------------------------------------------------
+
+
+def test_reclassify_persists_auto_classes(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+
+    resp = client.post("/api/stages/1/coach/reclassify")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    classes = [s["interval_class"] for s in body["shots"]]
+    assert classes == ["first_shot", "split", "transition", "movement"]
+    assert all(s["interval_class_source"] == "auto" for s in body["shots"])
+    assert all(s["stale"] is False for s in body["shots"])
+
+    # Persisted on disk.
+    saved = _read(audit_file)
+    persisted = [s["interval_class"] for s in saved["shots"]]
+    assert persisted == ["first_shot", "split", "transition", "movement"]
+    # audit_events appended.
+    events = saved.get("audit_events", [])
+    assert any(e.get("kind") == "coach_reclassify" for e in events)
+
+
+def test_reclassify_preserves_manual(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+
+    # Set a manual override on shot 4 first.
+    resp = client.patch(
+        "/api/stages/1/shots/4/coach",
+        json={"interval_class": "reload", "interval_class_source": "manual"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Reclassify -- should leave shot 4 alone.
+    resp = client.post("/api/stages/1/coach/reclassify")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["shots"][3]["interval_class"] == "reload"
+    assert body["shots"][3]["interval_class_source"] == "manual"
+    # Auto would say "movement" -> stale flag fires on the manual entry.
+    assert body["shots"][3]["stale"] is True
+
+
+# ---------------------------------------------------------------------------
+# PATCH
+# ---------------------------------------------------------------------------
+
+
+def test_patch_set_class_and_note_and_flag(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+
+    resp = client.patch(
+        "/api/stages/1/shots/2/coach",
+        json={
+            "interval_class": "split",
+            "interval_class_source": "manual",
+            "improvement_flag": True,
+            "coaching_note": "second A was slow",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    s = body["shots"][1]
+    assert s["interval_class"] == "split"
+    assert s["interval_class_source"] == "manual"
+    assert s["improvement_flag"] is True
+    assert s["coaching_note"] == "second A was slow"
+
+    saved = _read(audit_file)
+    target = next(x for x in saved["shots"] if x["shot_number"] == 2)
+    assert target["interval_class"] == "split"
+    assert target["coaching_note"] == "second A was slow"
+
+
+def test_patch_clear_class_drops_pair(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+    client.patch(
+        "/api/stages/1/shots/2/coach",
+        json={"interval_class": "reload", "interval_class_source": "manual"},
+    )
+    resp = client.patch("/api/stages/1/shots/2/coach", json={"clear_class": True})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["shots"][1]["interval_class"] is None
+    assert body["shots"][1]["interval_class_source"] is None
+
+
+def test_patch_class_without_source_rejected(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.patch(
+        "/api/stages/1/shots/2/coach",
+        json={"interval_class": "split"},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_unknown_shot_404(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    resp = client.patch(
+        "/api/stages/1/shots/999/coach",
+        json={"improvement_flag": True},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_clear_note(tmp_path: Path) -> None:
+    client, _audit = _bootstrap(tmp_path)
+    client.patch(
+        "/api/stages/1/shots/2/coach",
+        json={"coaching_note": "old note"},
+    )
+    resp = client.patch("/api/stages/1/shots/2/coach", json={"clear_note": True})
+    assert resp.status_code == 200
+    assert resp.json()["shots"][1]["coaching_note"] is None
+
+
+def test_patch_emits_audit_event(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+    client.patch(
+        "/api/stages/1/shots/2/coach",
+        json={"improvement_flag": True, "coaching_note": "fix me"},
+    )
+    saved = _read(audit_file)
+    events = saved.get("audit_events", [])
+    coach_events = [e for e in events if e.get("kind") == "coach_patch"]
+    assert len(coach_events) == 1
+    assert coach_events[0]["payload"]["shot_number"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Stale recompute on Audit-style timestamp drift
+# ---------------------------------------------------------------------------
+
+
+def test_stale_after_audit_edit(tmp_path: Path) -> None:
+    client, audit_file = _bootstrap(tmp_path)
+    # First persist auto classes.
+    client.post("/api/stages/1/coach/reclassify")
+
+    # Simulate an Audit-side timestamp move: shot 2 drifts from 0.30 -> 0.70 s gap.
+    saved = _read(audit_file)
+    for s in saved["shots"]:
+        if s["shot_number"] == 2:
+            s["ms_after_beep"] = 2200  # 1500 + 700 ms
+    audit_file.write_text(json.dumps(saved, indent=2) + "\n", encoding="utf-8")
+
+    # GET surfaces stale=True; the stored class is "split" but the rule
+    # would now say "transition".
+    resp = client.get("/api/stages/1/coach")
+    assert resp.status_code == 200
+    body = resp.json()
+    moved = body["shots"][1]
+    assert moved["interval_class"] == "split"
+    assert moved["stale"] is True
+
+    # Reclassify clears stale.
+    resp = client.post("/api/stages/1/coach/reclassify")
+    body = resp.json()
+    moved = body["shots"][1]
+    assert moved["interval_class"] == "transition"
+    assert moved["stale"] is False

--- a/tests/test_coach_distributions.py
+++ b/tests/test_coach_distributions.py
@@ -1,0 +1,175 @@
+"""Tests for the Coach distributions module (#163)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from splitsmith.coach_distributions import (
+    DEFAULT_BUCKET_S,
+    DEFAULT_HISTOGRAM_CLASSES,
+    match_distributions,
+    stage_distributions,
+)
+from splitsmith.config import CoachAutoClassifyConfig
+
+
+@pytest.fixture
+def cfg() -> CoachAutoClassifyConfig:
+    return CoachAutoClassifyConfig()
+
+
+def _shot(n: int, ms: int, **extra: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"shot_number": n, "ms_after_beep": ms}
+    base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Per-stage distributions
+# ---------------------------------------------------------------------------
+
+
+def test_stage_distribution_classifies_unset_in_memory(cfg: CoachAutoClassifyConfig) -> None:
+    # Three splits + a transition + a movement, all unset; the helper
+    # classifies them in memory without persisting anything.
+    shots = [
+        _shot(1, 1500),
+        _shot(2, 1700),  # 0.20 split
+        _shot(3, 1900),  # 0.20 split
+        _shot(4, 2100),  # 0.20 split
+        _shot(5, 2900),  # 0.80 transition
+        _shot(6, 4500),  # 1.60 movement
+    ]
+    out = stage_distributions(
+        stage_number=1,
+        stage_name="K-vallen",
+        shots=shots,
+        config=cfg,
+    )
+    assert out.first_shot_s == pytest.approx(1.5)
+    by_class = {d.interval_class: d for d in out.distributions}
+    assert by_class["split"].count == 3
+    assert by_class["transition"].count == 1
+    assert by_class["movement"].count == 1
+    # No persistence: the input dicts are untouched.
+    assert all("interval_class" not in s for s in shots)
+
+
+def test_stage_distribution_buckets_seeded_from_class(cfg: CoachAutoClassifyConfig) -> None:
+    # All splits hit the same 0.05 s bucket (0.20-0.25).
+    shots = [_shot(1, 1500), _shot(2, 1700), _shot(3, 1900), _shot(4, 2100)]
+    out = stage_distributions(stage_number=1, stage_name="x", shots=shots, config=cfg)
+    splits = next(d for d in out.distributions if d.interval_class == "split")
+    assert splits.bucket_size_s == DEFAULT_BUCKET_S["split"]
+    assert len(splits.buckets) == 1
+    assert splits.buckets[0].lo == pytest.approx(0.20)
+    assert splits.buckets[0].count == 3
+
+
+def test_stage_distribution_summary_stats(cfg: CoachAutoClassifyConfig) -> None:
+    # Splits at 0.20, 0.30, 0.40 -> mean 0.30, median 0.30. p90 with
+    # statistics.quantiles' default "exclusive" method extrapolates
+    # beyond the max for small samples; we just assert it lands above
+    # the median, since the user-facing value is "rough p90 hint".
+    shots = [_shot(1, 1500), _shot(2, 1700), _shot(3, 2000), _shot(4, 2400)]
+    out = stage_distributions(stage_number=1, stage_name="x", shots=shots, config=cfg)
+    splits = next(d for d in out.distributions if d.interval_class == "split")
+    assert splits.count == 3
+    assert splits.mean_s == pytest.approx(0.30, abs=1e-9)
+    assert splits.median_s == pytest.approx(0.30, abs=1e-9)
+    assert splits.p90_s is not None and splits.p90_s > splits.median_s
+
+
+def test_stage_distribution_empty_class_has_zero_count(cfg: CoachAutoClassifyConfig) -> None:
+    # Just three splits -- transition and movement should still appear in
+    # the response with count=0 so the UI can render an empty histogram.
+    shots = [_shot(1, 1500), _shot(2, 1700), _shot(3, 1900), _shot(4, 2100)]
+    out = stage_distributions(stage_number=1, stage_name="x", shots=shots, config=cfg)
+    classes = {d.interval_class for d in out.distributions}
+    assert classes == set(DEFAULT_HISTOGRAM_CLASSES)
+    transitions = next(d for d in out.distributions if d.interval_class == "transition")
+    assert transitions.count == 0
+    assert transitions.buckets == []
+    assert transitions.mean_s is None
+
+
+def test_stage_distribution_preserves_manual_class(cfg: CoachAutoClassifyConfig) -> None:
+    # Manual reload override on a long gap -- the auto rule would call
+    # this "movement"; manual sticks and the gap is counted under reload.
+    shots = [
+        _shot(1, 1500),
+        _shot(
+            2,
+            5000,
+            interval_class="reload",
+            interval_class_source="manual",
+        ),
+    ]
+    out = stage_distributions(stage_number=1, stage_name="x", shots=shots, config=cfg)
+    by_class = {d.interval_class: d for d in out.distributions}
+    assert by_class["reload"].count == 1
+    assert by_class["movement"].count == 0
+
+
+# ---------------------------------------------------------------------------
+# Match-level aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_match_distribution_aggregates_across_stages(cfg: CoachAutoClassifyConfig) -> None:
+    stage_a = [_shot(1, 1500), _shot(2, 1700), _shot(3, 1900)]  # 2 splits
+    stage_b = [_shot(1, 2000), _shot(2, 2300), _shot(3, 2600)]  # 2 splits
+    out = match_distributions(
+        stages=[(1, "A", stage_a), (2, "B", stage_b)],
+        config=cfg,
+    )
+    by_class = {d.interval_class: d for d in out.distributions}
+    assert by_class["split"].count == 4
+    assert out.stage_count == 2
+    assert out.first_shot_seconds == pytest.approx([1.5, 2.0])
+
+
+def test_match_top_shots_sorted_desc(cfg: CoachAutoClassifyConfig) -> None:
+    # Build a stage with three transitions of increasing length so we
+    # can verify top-N ordering.
+    shots = [
+        _shot(1, 1500),
+        _shot(2, 2200),  # 0.70 transition
+        _shot(3, 3000),  # 0.80 transition
+        _shot(4, 3950),  # 0.95 transition
+    ]
+    out = match_distributions(
+        stages=[(1, "A", shots)],
+        config=cfg,
+        top_n=3,
+    )
+    assert [e.gap_s for e in out.top_transitions] == pytest.approx([0.95, 0.80, 0.70])
+    assert all(e.interval_class == "transition" for e in out.top_transitions)
+
+
+def test_match_flagged_list_filters_by_flag(cfg: CoachAutoClassifyConfig) -> None:
+    shots = [
+        _shot(1, 1500, improvement_flag=True, coaching_note="slow draw"),
+        _shot(2, 1800),
+        _shot(3, 2100, improvement_flag=True),
+    ]
+    out = match_distributions(stages=[(1, "A", shots)], config=cfg)
+    assert {e.shot_number for e in out.flagged_shots} == {1, 3}
+    n1 = next(e for e in out.flagged_shots if e.shot_number == 1)
+    assert n1.coaching_note == "slow draw"
+    # Shot 1 is the first shot -> gap is None on the flagged entry.
+    assert n1.gap_s is None
+    n3 = next(e for e in out.flagged_shots if e.shot_number == 3)
+    assert n3.gap_s == pytest.approx(0.30)
+
+
+def test_match_skips_empty_stage(cfg: CoachAutoClassifyConfig) -> None:
+    # A stage with no shots shouldn't contribute -- it's not an audited
+    # stage yet, so it would just dilute the average.
+    out = match_distributions(
+        stages=[(1, "A", [_shot(1, 1500), _shot(2, 1700)]), (2, "B", [])],
+        config=cfg,
+    )
+    assert out.stage_count == 1


### PR DESCRIPTION
## Summary

### #163 distributions

- New \`splitsmith.coach_distributions\` module: pure functions that compute per-stage and match-level histograms over coach annotations. Unset classes are auto-classified in memory; nothing persists.
- Per-class buckets: 0.05 s for splits / transitions, 0.25 s for movement / reload.
- \`GET /api/stages/{n}/coach/distributions\` -- per-stage.
- \`GET /api/coach/distributions\` -- match-level aggregate.
- SPA: \`DistributionsPanel\` below the shot table renders splits + transitions histograms with mean / median / p90.

### #161 follow-up: one-row-per-shot

Per review feedback "shots shall never be collapsed in the list, only non-shot events". Drops the per-class shot grouping from #166: arrays of splits stay individual rows. Compact toggle, \`GroupRow\`, and \`groupShots()\` removed. Future "non-shot event" rows (#162 follow-up) can introduce collapsibility for inter-shot events without ever merging shots.

Stacks on #166 (#161). Match-level distributions view will land with #162.

## Test plan

- [x] \`uv run pytest tests/test_coach_distributions.py\` -- 9 unit tests (rule table, buckets, summary stats, manual stickiness, match aggregation, top-N ordering, flagged filter)
- [x] \`uv run pytest tests/test_coach_api.py\` -- 15 e2e tests (the two new distribution endpoints, plus the existing #161 coverage)
- [x] Full backend suite: 666 passed, 1 skipped
- [x] \`uv run ruff check\` clean
- [x] \`uv run black --check\` clean
- [x] SPA \`pnpm typecheck\` clean
- [x] SPA \`pnpm build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)