### PR TITLE
match-export: generate_match_fcpxml core composer (#170)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -407,6 +407,377 @@ def generate_fcpxml(
     _tag_source_application(output_path)
 
 
+@dataclass(frozen=True)
+class StageComposition:
+    """One stage's contribution to a stitched match-export FCPXML (issue #170).
+
+    Each stage is a self-contained piece: trimmed primary + optional secondaries
+    + optional overlay + per-stage shots and beep offset. ``head_pad_seconds`` /
+    ``tail_pad_seconds`` are how much footage to keep before the beep / after the
+    final shot; the composer trims the rest at FCPXML level (no re-encoding).
+    Both pads are clamped to what's actually present in the trimmed clip:
+    head_trim = max(0, beep_offset - head_pad), tail_trim = max(0, available -
+    tail_pad), so the function is safe to call with pads larger than the trim
+    actually contains (the result is "use everything that's there").
+    """
+
+    stage_name: str
+    video_path: Path
+    video: VideoMetadata
+    shots: list[Shot]
+    beep_offset_seconds: float
+    head_pad_seconds: float
+    tail_pad_seconds: float
+    overlay_path: Path | None = None
+    overlay_video: VideoMetadata | None = None
+    secondaries: tuple[SecondaryClip, ...] = ()
+
+
+def generate_match_fcpxml(
+    *,
+    stages: list[StageComposition],
+    output_path: Path,
+    project_name: str,
+    config: OutputConfig,
+) -> None:
+    """Write a stitched FCPXML with N stages back-to-back on the spine.
+
+    Each stage carries its own primary + secondaries + overlay + markers. The
+    composer trims at FCPXML level by adjusting the primary's ``start`` and
+    ``duration`` -- no ffmpeg invocation. Cumulative spine offsets keep the
+    stages contiguous; secondary head-slip math is generalised to handle
+    head-trimmed primaries (every cam's beep stays frame-aligned with the
+    primary's beep regardless of trim).
+
+    Frame-rate mixing across stages is out of scope for v1: all stages must
+    share a frame rate (raises ValueError otherwise).
+    """
+    if not stages:
+        raise ValueError("generate_match_fcpxml requires at least one stage")
+    for stage in stages:
+        if not stage.video_path.exists():
+            raise FileNotFoundError(f"video not found: {stage.video_path}")
+
+    base = stages[0].video
+    for stage in stages[1:]:
+        if (
+            stage.video.frame_rate_num != base.frame_rate_num
+            or stage.video.frame_rate_den != base.frame_rate_den
+        ):
+            raise ValueError(
+                "mixed frame rates across stages are not supported "
+                f"(stage 0: {base.frame_rate_num}/{base.frame_rate_den}, "
+                f"stage with {stage.video_path.name}: "
+                f"{stage.video.frame_rate_num}/{stage.video.frame_rate_den})"
+            )
+
+    frame_duration = Fraction(base.frame_rate_den, base.frame_rate_num)
+    fd_num = base.frame_rate_den
+    fd_den = base.frame_rate_num
+    fd_seconds = float(frame_duration)
+    frame_duration_str = _frame_aligned_str(1, fd_num, fd_den)
+
+    fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
+    resources = ET.SubElement(fcpxml, "resources")
+    format_id = "r1"
+    ET.SubElement(
+        resources,
+        "format",
+        {
+            "id": format_id,
+            "name": _format_name(base),
+            "frameDuration": frame_duration_str,
+            "width": str(base.width),
+            "height": str(base.height),
+            "colorSpace": "1-1-1 (Rec. 709)",
+        },
+    )
+
+    # Per-stage resource + spine plan. Resource IDs are allocated globally in
+    # declaration order: r2 = stage 0 primary, then its secondaries, then its
+    # overlay, then stage 1's primary, etc. Connected-clip lanes reset per
+    # stage (each stage's overlay sits above that stage's secondaries only).
+    resource_counter = 1  # r1 already used by format
+
+    @dataclass
+    class _StagePlan:
+        stage: StageComposition
+        primary_id: str
+        primary_duration_frames: int
+        head_trim_frames: int
+        effective_duration_frames: int
+        # cam, asset_id, sec_dur_in_parent_frames
+        usable_secondaries: list[tuple[SecondaryClip, str, int]]
+        overlay_asset_id: str | None
+        overlay_duration_frames: int  # in parent frame units; 0 when no overlay
+
+    plans: list[_StagePlan] = []
+
+    for stage in stages:
+        stage_frame_duration = Fraction(stage.video.frame_rate_den, stage.video.frame_rate_num)
+        primary_duration_frames = int(
+            round(stage.video.duration_seconds / float(stage_frame_duration))
+        )
+
+        # Determine actual head and tail available in the trimmed file.
+        # head_avail = beep_offset (the trim's pre-buffer; may be < trim_buffer
+        # when the cam beep landed within the pre-buffer of the source).
+        # tail_avail = source_duration - last_shot_clip_local. With no shots,
+        # treat the beep as the last event (degenerate case for action cuts).
+        head_avail = max(0.0, stage.beep_offset_seconds)
+        if stage.shots:
+            last_shot_local = stage.beep_offset_seconds + max(s.time_from_beep for s in stage.shots)
+        else:
+            last_shot_local = stage.beep_offset_seconds
+        tail_avail = max(0.0, stage.video.duration_seconds - last_shot_local)
+
+        head_trim_seconds = max(0.0, head_avail - stage.head_pad_seconds)
+        tail_trim_seconds = max(0.0, tail_avail - stage.tail_pad_seconds)
+        head_trim_frames = int(round(head_trim_seconds / fd_seconds))
+        tail_trim_frames = int(round(tail_trim_seconds / fd_seconds))
+        effective_duration_frames = primary_duration_frames - head_trim_frames - tail_trim_frames
+        if effective_duration_frames <= 0:
+            raise ValueError(
+                f"stage {stage.stage_name!r} would have non-positive effective duration "
+                f"after trim ({effective_duration_frames} frames); reduce head/tail pad "
+                "or check the trimmed clip length"
+            )
+
+        resource_counter += 1
+        primary_id = f"r{resource_counter}"
+
+        usable_secondaries: list[tuple[SecondaryClip, str, int]] = []
+        for sec in stage.secondaries:
+            if not sec.video_path.exists():
+                continue
+            resource_counter += 1
+            sec_id = f"r{resource_counter}"
+            sec_dur_in_parent_frames = int(round(sec.video.duration_seconds / fd_seconds))
+            usable_secondaries.append((sec, sec_id, sec_dur_in_parent_frames))
+
+        overlay_asset_id: str | None = None
+        overlay_duration_frames = 0
+        if stage.overlay_path is not None and stage.overlay_path.exists():
+            resource_counter += 1
+            overlay_asset_id = f"r{resource_counter}"
+            overlay_meta = stage.overlay_video if stage.overlay_video is not None else stage.video
+            overlay_duration_frames = int(round(overlay_meta.duration_seconds / fd_seconds))
+
+        plans.append(
+            _StagePlan(
+                stage=stage,
+                primary_id=primary_id,
+                primary_duration_frames=primary_duration_frames,
+                head_trim_frames=head_trim_frames,
+                effective_duration_frames=effective_duration_frames,
+                usable_secondaries=usable_secondaries,
+                overlay_asset_id=overlay_asset_id,
+                overlay_duration_frames=overlay_duration_frames,
+            )
+        )
+
+    # Emit assets in the same order resource IDs were assigned so the XML
+    # reads top-to-bottom in stage order.
+    for plan in plans:
+        primary_asset = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": plan.primary_id,
+                "name": plan.stage.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(plan.primary_duration_frames, fd_num, fd_den),
+                "hasVideo": "1",
+                "hasAudio": "1",
+                "format": format_id,
+                "videoSources": "1",
+                "audioSources": "1",
+                "audioChannels": "2",
+            },
+        )
+        ET.SubElement(
+            primary_asset,
+            "media-rep",
+            {"kind": "original-media", "src": plan.stage.video_path.resolve().as_uri()},
+        )
+        for sec, sec_id, _sec_dur_in_parent_frames in plan.usable_secondaries:
+            sec_asset = ET.SubElement(
+                resources,
+                "asset",
+                {
+                    "id": sec_id,
+                    "name": sec.video_path.stem,
+                    "start": "0s",
+                    "duration": _frame_aligned_str(
+                        int(
+                            round(
+                                sec.video.duration_seconds
+                                / float(
+                                    Fraction(sec.video.frame_rate_den, sec.video.frame_rate_num)
+                                )
+                            )
+                        ),
+                        sec.video.frame_rate_den,
+                        sec.video.frame_rate_num,
+                    ),
+                    "hasVideo": "1",
+                    "hasAudio": "1",
+                    "format": format_id,
+                    "videoSources": "1",
+                    "audioSources": "1",
+                    "audioChannels": "2",
+                },
+            )
+            ET.SubElement(
+                sec_asset,
+                "media-rep",
+                {"kind": "original-media", "src": sec.video_path.resolve().as_uri()},
+            )
+        if plan.overlay_asset_id is not None and plan.stage.overlay_path is not None:
+            overlay_asset = ET.SubElement(
+                resources,
+                "asset",
+                {
+                    "id": plan.overlay_asset_id,
+                    "name": plan.stage.overlay_path.stem,
+                    "start": "0s",
+                    "duration": _frame_aligned_str(plan.overlay_duration_frames, fd_num, fd_den),
+                    "hasVideo": "1",
+                    "hasAudio": "0",
+                    "format": format_id,
+                    "videoSources": "1",
+                },
+            )
+            ET.SubElement(
+                overlay_asset,
+                "media-rep",
+                {"kind": "original-media", "src": plan.stage.overlay_path.resolve().as_uri()},
+            )
+
+    library = ET.SubElement(fcpxml, "library")
+    event = ET.SubElement(library, "event", {"name": "splitsmith"})
+    project = ET.SubElement(event, "project", {"name": project_name})
+    total_duration_frames = sum(plan.effective_duration_frames for plan in plans)
+    sequence = ET.SubElement(
+        project,
+        "sequence",
+        {
+            "format": format_id,
+            "duration": _frame_aligned_str(total_duration_frames, fd_num, fd_den),
+            "tcStart": "0s",
+            "tcFormat": "NDF",
+            "audioLayout": "stereo",
+            "audioRate": "48k",
+        },
+    )
+    spine = ET.SubElement(sequence, "spine")
+
+    cumulative_offset_frames = 0
+    for plan in plans:
+        stage = plan.stage
+        head_trim_seconds = plan.head_trim_frames * fd_seconds
+        eff_duration_str = _frame_aligned_str(plan.effective_duration_frames, fd_num, fd_den)
+        primary_clip = ET.SubElement(
+            spine,
+            "asset-clip",
+            {
+                "ref": plan.primary_id,
+                "offset": _frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
+                "name": stage.stage_name,
+                "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                "duration": eff_duration_str,
+                "format": format_id,
+            },
+        )
+
+        # Secondary cam connected clips. Lane=1..N (per stage). Beep
+        # alignment generalises the single-stage formula: with the primary's
+        # ``start`` shifted forward by head_trim, the secondary needs to
+        # arrive at the timeline at primary_local_beep = (beep_offset -
+        # head_trim) instead of beep_offset. So delta = (beep_offset -
+        # head_trim) - sec_beep, expressed in frames; a non-negative delta
+        # places the cam later in the parent's local time, a negative delta
+        # skips into the cam's own media.
+        for lane_idx, (sec, sec_id, sec_dur_in_parent_frames) in enumerate(
+            plan.usable_secondaries, start=1
+        ):
+            delta_frames = round(
+                ((stage.beep_offset_seconds - head_trim_seconds) - sec.beep_offset_seconds)
+                / fd_seconds
+            )
+            if delta_frames >= 0:
+                sec_offset_str = _frame_aligned_str(delta_frames, fd_num, fd_den)
+                sec_start_str = "0s"
+            else:
+                sec_offset_str = "0s"
+                sec_start_str = _frame_aligned_str(-delta_frames, fd_num, fd_den)
+            ET.SubElement(
+                primary_clip,
+                "asset-clip",
+                {
+                    "ref": sec_id,
+                    "lane": str(lane_idx),
+                    "offset": sec_offset_str,
+                    "name": sec.label,
+                    "start": sec_start_str,
+                    "duration": _frame_aligned_str(sec_dur_in_parent_frames, fd_num, fd_den),
+                    "format": format_id,
+                },
+            )
+
+        if plan.overlay_asset_id is not None:
+            overlay_lane = len(plan.usable_secondaries) + 1
+            # Overlay was rendered to mirror the primary frame-for-frame, so
+            # to stay in sync after head_trim its ``start`` skips into the
+            # overlay's own media by the same number of frames. ``duration``
+            # matches the primary's effective duration so the overlay covers
+            # the visible window without overhang.
+            ET.SubElement(
+                primary_clip,
+                "asset-clip",
+                {
+                    "ref": plan.overlay_asset_id,
+                    "lane": str(overlay_lane),
+                    "offset": "0s",
+                    "name": "Splitsmith overlay",
+                    "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                    "duration": eff_duration_str,
+                    "format": format_id,
+                },
+            )
+
+        # Markers. Each shot's clip-local source-media time stays the marker
+        # ``start``; FCP only renders markers within [primary.start,
+        # primary.start + duration], so we drop shots outside that window
+        # here for a clean XML.
+        head_trim_seconds_for_window = head_trim_seconds
+        eff_end_seconds = head_trim_seconds_for_window + plan.effective_duration_frames * fd_seconds
+        for shot in stage.shots:
+            clip_local_seconds = stage.beep_offset_seconds + shot.time_from_beep
+            if not head_trim_seconds_for_window <= clip_local_seconds < eff_end_seconds:
+                continue
+            frames = round(clip_local_seconds / fd_seconds)
+            ET.SubElement(
+                primary_clip,
+                "marker",
+                {
+                    "start": _frame_aligned_str(frames, fd_num, fd_den),
+                    "duration": frame_duration_str,
+                    "value": _marker_label(shot, config.split_color_thresholds),
+                },
+            )
+
+        cumulative_offset_frames += plan.effective_duration_frames
+
+    ET.indent(fcpxml, space="    ")
+    tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
+    decl_end = tree_bytes.index(b"?>") + 2
+    output_path.write_bytes(
+        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
+    )
+    _tag_source_application(output_path)
+
+
 def _tag_source_application(path: Path) -> None:
     """Tag the FCPXML file with ``kMDItemCreator`` so FCP's import dialog
     shows ``Splitsmith`` instead of ``application "(null)"`` (issue #41).

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -25,7 +25,9 @@ from splitsmith.config import (
 )
 from splitsmith.fcpxml_gen import (
     FFprobeError,
+    StageComposition,
     generate_fcpxml,
+    generate_match_fcpxml,
     probe_video,
     split_color_band,
 )
@@ -610,6 +612,449 @@ def test_probe_video_raises_on_unparseable(tmp_path: Path) -> None:
 
     with pytest.raises(FFprobeError, match="unparseable"):
         probe_video(video, runner=garbage)
+
+
+# --- generate_match_fcpxml -------------------------------------------------
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def test_match_fcpxml_single_stage_no_shrink_matches_single_export(tmp_path: Path) -> None:
+    """A 1-stage call with pads >= the actual head/tail should leave the
+    timeline structurally identical to ``generate_fcpxml`` for the same
+    inputs. We compare attribute-by-attribute rather than literal bytes
+    because the asset-clip name maps to ``stage_name`` here vs ``project_name``
+    there -- the issue spec calls out "modulo project_name"."""
+    video = _make_video(tmp_path, "stage1.mp4")
+    out_old = tmp_path / "old.fcpxml"
+    out_new = tmp_path / "new.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=1.42, split=1.42),
+        _shot(2, time_from_beep=1.63, split=0.21),
+    ]
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=shots,
+        beep_offset_seconds=5.0,
+        output_path=out_old,
+        project_name="stage1",
+        config=OutputConfig(),
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,  # > beep_offset -> no head trim
+                tail_pad_seconds=20.0,  # > available tail -> no tail trim
+            )
+        ],
+        output_path=out_new,
+        project_name="stage1",
+        config=OutputConfig(),
+    )
+    old = ET.fromstring(out_old.read_bytes())
+    new = ET.fromstring(out_new.read_bytes())
+
+    assert old.attrib == new.attrib
+    # format
+    fmt_old = old.find("./resources/format")
+    fmt_new = new.find("./resources/format")
+    assert fmt_old is not None and fmt_new is not None
+    assert fmt_old.attrib == fmt_new.attrib
+    # asset (just the primary in this single-stage no-overlay case)
+    assets_old = old.findall("./resources/asset")
+    assets_new = new.findall("./resources/asset")
+    assert len(assets_old) == len(assets_new) == 1
+    assert assets_old[0].attrib == assets_new[0].attrib
+    # spine asset-clip
+    clip_old = old.find("./library/event/project/sequence/spine/asset-clip")
+    clip_new = new.find("./library/event/project/sequence/spine/asset-clip")
+    assert clip_old is not None and clip_new is not None
+    for key in ("ref", "offset", "start", "duration", "format"):
+        assert clip_old.attrib[key] == clip_new.attrib[key], key
+    # markers byte-for-byte
+    markers_old = clip_old.findall("marker")
+    markers_new = clip_new.findall("marker")
+    assert len(markers_old) == len(markers_new) == 2
+    for m_old, m_new in zip(markers_old, markers_new, strict=True):
+        assert m_old.attrib == m_new.attrib
+
+
+def test_match_fcpxml_two_stages_back_to_back(tmp_path: Path) -> None:
+    """Two stages with no shrink: spine has two asset-clips, second's offset
+    equals first's effective duration. Sequence duration is the sum."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=2.0, split=2.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    assert spine_clips[0].attrib["offset"] == "0s"
+    assert spine_clips[0].attrib["start"] == "0s"
+    assert spine_clips[0].attrib["duration"] == "600/30s"
+    assert spine_clips[0].attrib["name"] == "stage1"
+    assert spine_clips[1].attrib["offset"] == "600/30s"
+    assert spine_clips[1].attrib["start"] == "0s"
+    assert spine_clips[1].attrib["duration"] == "600/30s"
+    assert spine_clips[1].attrib["name"] == "stage2"
+    seq = root.find("./library/event/project/sequence")
+    assert seq is not None
+    assert seq.attrib["duration"] == "1200/30s"
+    assert root.find("./library/event/project").attrib["name"] == "match"
+
+
+def test_match_fcpxml_action_cut_padding_trims_each_stage(tmp_path: Path) -> None:
+    """head_pad=0.5, tail_pad=1.0 against a 20s synthetic clip with beep at
+    5s and last shot at 1.5s after beep:
+      - head_trim = beep_offset - head_pad = 5.0 - 0.5 = 4.5s = 135 frames
+      - tail_avail = 20 - (5 + 1.5) = 13.5s
+      - tail_trim = 13.5 - 1.0 = 12.5s = 375 frames
+      - eff_duration = 600 - 135 - 375 = 90 frames = 3.0s
+    Stage 1 starts on the spine at 90/30s."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=1.0, split=1.0),
+        _shot(2, time_from_beep=1.5, split=0.5),
+    ]
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name=name,
+                video_path=path,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+            )
+            for name, path in (("stage1", v1), ("stage2", v2))
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert spine_clips[0].attrib["start"] == "135/30s"
+    assert spine_clips[0].attrib["duration"] == "90/30s"
+    assert spine_clips[0].attrib["offset"] == "0s"
+    assert spine_clips[1].attrib["start"] == "135/30s"
+    assert spine_clips[1].attrib["duration"] == "90/30s"
+    assert spine_clips[1].attrib["offset"] == "90/30s"
+    seq = root.find("./library/event/project/sequence")
+    assert seq is not None
+    assert seq.attrib["duration"] == "180/30s"
+
+
+def test_match_fcpxml_drops_markers_outside_trimmed_window(tmp_path: Path) -> None:
+    """Shots whose clip-local time falls outside [head_trim, head_trim +
+    eff_duration] are dropped. With head_pad=0.5, tail_pad=1.0 and a beep at
+    5s the visible window is [4.5s, 7.5s]. The pre-beep shot at -0.6s lands
+    at clip-local 4.4s (dropped); 0.4s past beep -> 5.4s (kept); 1.5s past
+    beep -> 6.5s (kept; this is the latest shot so tail_avail is computed
+    off it)."""
+    video = _make_video(tmp_path, "v.mp4")
+    out = tmp_path / "v.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=-0.6, split=0.0),
+        _shot(2, time_from_beep=0.4, split=1.0),
+        _shot(3, time_from_beep=1.5, split=1.1),
+    ]
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    markers = root.findall(".//spine/asset-clip/marker")
+    assert len(markers) == 2
+    assert "Shot 2" in markers[0].attrib["value"]
+    assert "Shot 3" in markers[1].attrib["value"]
+
+
+def test_match_fcpxml_secondary_alignment_with_head_trim(tmp_path: Path) -> None:
+    """Secondary cam stays beep-aligned even after the primary's head is
+    trimmed. With head_pad=0.5 the primary's beep moves to local 0.5s; the
+    cam (same beep_offset=5.0) needs to skip 4.5s into its own media so its
+    beep also lands at local 0.5s."""
+    primary = _make_video(tmp_path, "primary.mp4")
+    secondary = _make_video(tmp_path, "secondary.mp4")
+    out = tmp_path / "v.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=primary,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=20.0,  # no tail trim (we want a long visible window for the cam)
+                secondaries=(
+                    fcpxml_mod.SecondaryClip(
+                        video_path=secondary,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    ),
+                ),
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    assert cam_clip.attrib["offset"] == "0s"
+    # delta = (5.0 - 4.5) - 5.0 = -4.5s -> sec_start = 4.5s = 135 frames
+    assert cam_clip.attrib["start"] == "135/30s"
+
+
+def test_match_fcpxml_per_stage_overlay_lane_isolation(tmp_path: Path) -> None:
+    """Stage 0 has overlay + secondary, stage 1 has neither. Resource IDs
+    are unique across stages and lanes are isolated per stage (stage 1's
+    primary clip has no nested clips)."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    cam = _make_video(tmp_path, "cam.mp4")
+    overlay = _make_video(tmp_path, "stage1_overlay.mov")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+                overlay_path=overlay,
+                overlay_video=_meta_30fps(),
+                secondaries=(
+                    fcpxml_mod.SecondaryClip(
+                        video_path=cam,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    ),
+                ),
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=2.0, split=2.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    # stage1 primary + cam + overlay + stage2 primary = 4
+    assert len(assets) == 4
+    asset_ids = [a.attrib["id"] for a in assets]
+    assert asset_ids == ["r2", "r3", "r4", "r5"]
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    nested_in_stage1 = spine_clips[0].findall("asset-clip")
+    nested_in_stage2 = spine_clips[1].findall("asset-clip")
+    # stage 1: cam (lane=1) + overlay (lane=2) = 2 nested clips
+    assert {c.attrib["lane"] for c in nested_in_stage1} == {"1", "2"}
+    # stage 2: nothing nested
+    assert nested_in_stage2 == []
+
+
+def test_match_fcpxml_overlay_skips_into_media_when_head_trimmed(tmp_path: Path) -> None:
+    """The overlay was rendered to mirror the primary frame-for-frame, so
+    after head_trim it must skip the same amount into its own media to stay
+    in sync. Its duration also shrinks to match the primary's effective
+    duration."""
+    video = _make_video(tmp_path, "v.mp4")
+    overlay = _make_video(tmp_path, "v_overlay.mov")
+    out = tmp_path / "v.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.5, split=1.5)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+                overlay_path=overlay,
+                overlay_video=_meta_30fps(),
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    overlay_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert overlay_clip is not None
+    # head_trim = 4.5s = 135 frames; eff_duration = 90 frames
+    assert overlay_clip.attrib["start"] == "135/30s"
+    assert overlay_clip.attrib["duration"] == "90/30s"
+    assert overlay_clip.attrib["lane"] == "1"
+
+
+def test_match_fcpxml_raises_on_mixed_frame_rates(tmp_path: Path) -> None:
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(ValueError, match="mixed frame rates"):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="stage1",
+                    video_path=v1,
+                    video=_meta_30fps(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                ),
+                StageComposition(
+                    stage_name="stage2",
+                    video_path=v2,
+                    video=_meta_2997(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                ),
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_on_empty_stages(tmp_path: Path) -> None:
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(ValueError, match="at least one stage"):
+        generate_match_fcpxml(
+            stages=[],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_on_missing_video(tmp_path: Path) -> None:
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(FileNotFoundError):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="stage1",
+                    video_path=tmp_path / "missing.mp4",
+                    video=_meta_30fps(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                )
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_when_pads_collapse_duration(tmp_path: Path) -> None:
+    """If head_pad + tail_pad math leaves nothing visible, the function
+    refuses rather than emitting a zero-duration clip."""
+    video = _make_video(tmp_path, "v.mp4")
+    out = tmp_path / "match.fcpxml"
+    # 20s clip, beep at 0.001s, no shots, head_pad 0, tail_pad 0:
+    # head_trim ~= 0, tail_avail = 20 - 0.001 = ~20, tail_trim ~= 20 ->
+    # effective ~ 0. Use a stage where the shot pushes tail_avail to 0.
+    # Simplest forced collapse: video.duration = 0.001s -> primary_duration
+    # rounds to 0 frames -> negative effective duration.
+    tiny_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=0.001,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    with pytest.raises(ValueError, match="non-positive effective duration"):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="v",
+                    video_path=video,
+                    video=tiny_meta,
+                    shots=[],
+                    beep_offset_seconds=0.0,
+                    head_pad_seconds=0.0,
+                    tail_pad_seconds=0.0,
+                )
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+# --- probe_video -----------------------------------------------------------
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #170. First slice of #169.

## Summary

- Adds `StageComposition` (frozen dataclass) + `generate_match_fcpxml` to `fcpxml_gen.py`.
- Composes a stitched FCPXML from N already-trimmed per-stage clips. No new ffmpeg invocations -- shrinking the head/tail is done at FCPXML level via the primary's `start` and `duration`.
- Cumulative spine offsets keep stages contiguous in stage order.
- Secondary cams stay beep-aligned across head-trim: the existing single-stage formula generalises by subtracting `head_trim` from the alignment delta.
- Overlay was rendered to mirror the primary frame-for-frame, so its `start` skips into its own media by the same amount and its `duration` shrinks to the effective duration.
- Mixed frame rates across stages raise `ValueError` (out of scope for v1).

No UI/endpoint wiring in this PR -- pure composer + tests. #171 wires this into `/api/match/export`.

## Test plan

- [x] `uv run pytest tests/test_fcpxml_gen.py` -- 32 passed (10 new tests covering: single-stage parity with `generate_fcpxml`, two-stage back-to-back, action-cut padding math, marker-window dropping, secondary alignment under head-trim, per-stage lane/ID isolation, overlay `start` skip, mixed-FPS rejection, empty-stages rejection, missing-video rejection, collapsed-duration rejection)
- [x] `uv run pytest -q` -- 686 passed, 1 skipped (no regressions)
- [x] `uv run ruff check` clean on both files
- [x] `uv run black` formatted both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)