### PR TITLE
match-export: /api/match/export endpoint + composition assembly (#171)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -407,6 +407,377 @@ def generate_fcpxml(
     _tag_source_application(output_path)
 
 
+@dataclass(frozen=True)
+class StageComposition:
+    """One stage's contribution to a stitched match-export FCPXML (issue #170).
+
+    Each stage is a self-contained piece: trimmed primary + optional secondaries
+    + optional overlay + per-stage shots and beep offset. ``head_pad_seconds`` /
+    ``tail_pad_seconds`` are how much footage to keep before the beep / after the
+    final shot; the composer trims the rest at FCPXML level (no re-encoding).
+    Both pads are clamped to what's actually present in the trimmed clip:
+    head_trim = max(0, beep_offset - head_pad), tail_trim = max(0, available -
+    tail_pad), so the function is safe to call with pads larger than the trim
+    actually contains (the result is "use everything that's there").
+    """
+
+    stage_name: str
+    video_path: Path
+    video: VideoMetadata
+    shots: list[Shot]
+    beep_offset_seconds: float
+    head_pad_seconds: float
+    tail_pad_seconds: float
+    overlay_path: Path | None = None
+    overlay_video: VideoMetadata | None = None
+    secondaries: tuple[SecondaryClip, ...] = ()
+
+
+def generate_match_fcpxml(
+    *,
+    stages: list[StageComposition],
+    output_path: Path,
+    project_name: str,
+    config: OutputConfig,
+) -> None:
+    """Write a stitched FCPXML with N stages back-to-back on the spine.
+
+    Each stage carries its own primary + secondaries + overlay + markers. The
+    composer trims at FCPXML level by adjusting the primary's ``start`` and
+    ``duration`` -- no ffmpeg invocation. Cumulative spine offsets keep the
+    stages contiguous; secondary head-slip math is generalised to handle
+    head-trimmed primaries (every cam's beep stays frame-aligned with the
+    primary's beep regardless of trim).
+
+    Frame-rate mixing across stages is out of scope for v1: all stages must
+    share a frame rate (raises ValueError otherwise).
+    """
+    if not stages:
+        raise ValueError("generate_match_fcpxml requires at least one stage")
+    for stage in stages:
+        if not stage.video_path.exists():
+            raise FileNotFoundError(f"video not found: {stage.video_path}")
+
+    base = stages[0].video
+    for stage in stages[1:]:
+        if (
+            stage.video.frame_rate_num != base.frame_rate_num
+            or stage.video.frame_rate_den != base.frame_rate_den
+        ):
+            raise ValueError(
+                "mixed frame rates across stages are not supported "
+                f"(stage 0: {base.frame_rate_num}/{base.frame_rate_den}, "
+                f"stage with {stage.video_path.name}: "
+                f"{stage.video.frame_rate_num}/{stage.video.frame_rate_den})"
+            )
+
+    frame_duration = Fraction(base.frame_rate_den, base.frame_rate_num)
+    fd_num = base.frame_rate_den
+    fd_den = base.frame_rate_num
+    fd_seconds = float(frame_duration)
+    frame_duration_str = _frame_aligned_str(1, fd_num, fd_den)
+
+    fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
+    resources = ET.SubElement(fcpxml, "resources")
+    format_id = "r1"
+    ET.SubElement(
+        resources,
+        "format",
+        {
+            "id": format_id,
+            "name": _format_name(base),
+            "frameDuration": frame_duration_str,
+            "width": str(base.width),
+            "height": str(base.height),
+            "colorSpace": "1-1-1 (Rec. 709)",
+        },
+    )
+
+    # Per-stage resource + spine plan. Resource IDs are allocated globally in
+    # declaration order: r2 = stage 0 primary, then its secondaries, then its
+    # overlay, then stage 1's primary, etc. Connected-clip lanes reset per
+    # stage (each stage's overlay sits above that stage's secondaries only).
+    resource_counter = 1  # r1 already used by format
+
+    @dataclass
+    class _StagePlan:
+        stage: StageComposition
+        primary_id: str
+        primary_duration_frames: int
+        head_trim_frames: int
+        effective_duration_frames: int
+        # cam, asset_id, sec_dur_in_parent_frames
+        usable_secondaries: list[tuple[SecondaryClip, str, int]]
+        overlay_asset_id: str | None
+        overlay_duration_frames: int  # in parent frame units; 0 when no overlay
+
+    plans: list[_StagePlan] = []
+
+    for stage in stages:
+        stage_frame_duration = Fraction(stage.video.frame_rate_den, stage.video.frame_rate_num)
+        primary_duration_frames = int(
+            round(stage.video.duration_seconds / float(stage_frame_duration))
+        )
+
+        # Determine actual head and tail available in the trimmed file.
+        # head_avail = beep_offset (the trim's pre-buffer; may be < trim_buffer
+        # when the cam beep landed within the pre-buffer of the source).
+        # tail_avail = source_duration - last_shot_clip_local. With no shots,
+        # treat the beep as the last event (degenerate case for action cuts).
+        head_avail = max(0.0, stage.beep_offset_seconds)
+        if stage.shots:
+            last_shot_local = stage.beep_offset_seconds + max(s.time_from_beep for s in stage.shots)
+        else:
+            last_shot_local = stage.beep_offset_seconds
+        tail_avail = max(0.0, stage.video.duration_seconds - last_shot_local)
+
+        head_trim_seconds = max(0.0, head_avail - stage.head_pad_seconds)
+        tail_trim_seconds = max(0.0, tail_avail - stage.tail_pad_seconds)
+        head_trim_frames = int(round(head_trim_seconds / fd_seconds))
+        tail_trim_frames = int(round(tail_trim_seconds / fd_seconds))
+        effective_duration_frames = primary_duration_frames - head_trim_frames - tail_trim_frames
+        if effective_duration_frames <= 0:
+            raise ValueError(
+                f"stage {stage.stage_name!r} would have non-positive effective duration "
+                f"after trim ({effective_duration_frames} frames); reduce head/tail pad "
+                "or check the trimmed clip length"
+            )
+
+        resource_counter += 1
+        primary_id = f"r{resource_counter}"
+
+        usable_secondaries: list[tuple[SecondaryClip, str, int]] = []
+        for sec in stage.secondaries:
+            if not sec.video_path.exists():
+                continue
+            resource_counter += 1
+            sec_id = f"r{resource_counter}"
+            sec_dur_in_parent_frames = int(round(sec.video.duration_seconds / fd_seconds))
+            usable_secondaries.append((sec, sec_id, sec_dur_in_parent_frames))
+
+        overlay_asset_id: str | None = None
+        overlay_duration_frames = 0
+        if stage.overlay_path is not None and stage.overlay_path.exists():
+            resource_counter += 1
+            overlay_asset_id = f"r{resource_counter}"
+            overlay_meta = stage.overlay_video if stage.overlay_video is not None else stage.video
+            overlay_duration_frames = int(round(overlay_meta.duration_seconds / fd_seconds))
+
+        plans.append(
+            _StagePlan(
+                stage=stage,
+                primary_id=primary_id,
+                primary_duration_frames=primary_duration_frames,
+                head_trim_frames=head_trim_frames,
+                effective_duration_frames=effective_duration_frames,
+                usable_secondaries=usable_secondaries,
+                overlay_asset_id=overlay_asset_id,
+                overlay_duration_frames=overlay_duration_frames,
+            )
+        )
+
+    # Emit assets in the same order resource IDs were assigned so the XML
+    # reads top-to-bottom in stage order.
+    for plan in plans:
+        primary_asset = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": plan.primary_id,
+                "name": plan.stage.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(plan.primary_duration_frames, fd_num, fd_den),
+                "hasVideo": "1",
+                "hasAudio": "1",
+                "format": format_id,
+                "videoSources": "1",
+                "audioSources": "1",
+                "audioChannels": "2",
+            },
+        )
+        ET.SubElement(
+            primary_asset,
+            "media-rep",
+            {"kind": "original-media", "src": plan.stage.video_path.resolve().as_uri()},
+        )
+        for sec, sec_id, _sec_dur_in_parent_frames in plan.usable_secondaries:
+            sec_asset = ET.SubElement(
+                resources,
+                "asset",
+                {
+                    "id": sec_id,
+                    "name": sec.video_path.stem,
+                    "start": "0s",
+                    "duration": _frame_aligned_str(
+                        int(
+                            round(
+                                sec.video.duration_seconds
+                                / float(
+                                    Fraction(sec.video.frame_rate_den, sec.video.frame_rate_num)
+                                )
+                            )
+                        ),
+                        sec.video.frame_rate_den,
+                        sec.video.frame_rate_num,
+                    ),
+                    "hasVideo": "1",
+                    "hasAudio": "1",
+                    "format": format_id,
+                    "videoSources": "1",
+                    "audioSources": "1",
+                    "audioChannels": "2",
+                },
+            )
+            ET.SubElement(
+                sec_asset,
+                "media-rep",
+                {"kind": "original-media", "src": sec.video_path.resolve().as_uri()},
+            )
+        if plan.overlay_asset_id is not None and plan.stage.overlay_path is not None:
+            overlay_asset = ET.SubElement(
+                resources,
+                "asset",
+                {
+                    "id": plan.overlay_asset_id,
+                    "name": plan.stage.overlay_path.stem,
+                    "start": "0s",
+                    "duration": _frame_aligned_str(plan.overlay_duration_frames, fd_num, fd_den),
+                    "hasVideo": "1",
+                    "hasAudio": "0",
+                    "format": format_id,
+                    "videoSources": "1",
+                },
+            )
+            ET.SubElement(
+                overlay_asset,
+                "media-rep",
+                {"kind": "original-media", "src": plan.stage.overlay_path.resolve().as_uri()},
+            )
+
+    library = ET.SubElement(fcpxml, "library")
+    event = ET.SubElement(library, "event", {"name": "splitsmith"})
+    project = ET.SubElement(event, "project", {"name": project_name})
+    total_duration_frames = sum(plan.effective_duration_frames for plan in plans)
+    sequence = ET.SubElement(
+        project,
+        "sequence",
+        {
+            "format": format_id,
+            "duration": _frame_aligned_str(total_duration_frames, fd_num, fd_den),
+            "tcStart": "0s",
+            "tcFormat": "NDF",
+            "audioLayout": "stereo",
+            "audioRate": "48k",
+        },
+    )
+    spine = ET.SubElement(sequence, "spine")
+
+    cumulative_offset_frames = 0
+    for plan in plans:
+        stage = plan.stage
+        head_trim_seconds = plan.head_trim_frames * fd_seconds
+        eff_duration_str = _frame_aligned_str(plan.effective_duration_frames, fd_num, fd_den)
+        primary_clip = ET.SubElement(
+            spine,
+            "asset-clip",
+            {
+                "ref": plan.primary_id,
+                "offset": _frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
+                "name": stage.stage_name,
+                "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                "duration": eff_duration_str,
+                "format": format_id,
+            },
+        )
+
+        # Secondary cam connected clips. Lane=1..N (per stage). Beep
+        # alignment generalises the single-stage formula: with the primary's
+        # ``start`` shifted forward by head_trim, the secondary needs to
+        # arrive at the timeline at primary_local_beep = (beep_offset -
+        # head_trim) instead of beep_offset. So delta = (beep_offset -
+        # head_trim) - sec_beep, expressed in frames; a non-negative delta
+        # places the cam later in the parent's local time, a negative delta
+        # skips into the cam's own media.
+        for lane_idx, (sec, sec_id, sec_dur_in_parent_frames) in enumerate(
+            plan.usable_secondaries, start=1
+        ):
+            delta_frames = round(
+                ((stage.beep_offset_seconds - head_trim_seconds) - sec.beep_offset_seconds)
+                / fd_seconds
+            )
+            if delta_frames >= 0:
+                sec_offset_str = _frame_aligned_str(delta_frames, fd_num, fd_den)
+                sec_start_str = "0s"
+            else:
+                sec_offset_str = "0s"
+                sec_start_str = _frame_aligned_str(-delta_frames, fd_num, fd_den)
+            ET.SubElement(
+                primary_clip,
+                "asset-clip",
+                {
+                    "ref": sec_id,
+                    "lane": str(lane_idx),
+                    "offset": sec_offset_str,
+                    "name": sec.label,
+                    "start": sec_start_str,
+                    "duration": _frame_aligned_str(sec_dur_in_parent_frames, fd_num, fd_den),
+                    "format": format_id,
+                },
+            )
+
+        if plan.overlay_asset_id is not None:
+            overlay_lane = len(plan.usable_secondaries) + 1
+            # Overlay was rendered to mirror the primary frame-for-frame, so
+            # to stay in sync after head_trim its ``start`` skips into the
+            # overlay's own media by the same number of frames. ``duration``
+            # matches the primary's effective duration so the overlay covers
+            # the visible window without overhang.
+            ET.SubElement(
+                primary_clip,
+                "asset-clip",
+                {
+                    "ref": plan.overlay_asset_id,
+                    "lane": str(overlay_lane),
+                    "offset": "0s",
+                    "name": "Splitsmith overlay",
+                    "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                    "duration": eff_duration_str,
+                    "format": format_id,
+                },
+            )
+
+        # Markers. Each shot's clip-local source-media time stays the marker
+        # ``start``; FCP only renders markers within [primary.start,
+        # primary.start + duration], so we drop shots outside that window
+        # here for a clean XML.
+        head_trim_seconds_for_window = head_trim_seconds
+        eff_end_seconds = head_trim_seconds_for_window + plan.effective_duration_frames * fd_seconds
+        for shot in stage.shots:
+            clip_local_seconds = stage.beep_offset_seconds + shot.time_from_beep
+            if not head_trim_seconds_for_window <= clip_local_seconds < eff_end_seconds:
+                continue
+            frames = round(clip_local_seconds / fd_seconds)
+            ET.SubElement(
+                primary_clip,
+                "marker",
+                {
+                    "start": _frame_aligned_str(frames, fd_num, fd_den),
+                    "duration": frame_duration_str,
+                    "value": _marker_label(shot, config.split_color_thresholds),
+                },
+            )
+
+        cumulative_offset_frames += plan.effective_duration_frames
+
+    ET.indent(fcpxml, space="    ")
+    tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
+    decl_end = tree_bytes.index(b"?>") + 2
+    output_path.write_bytes(
+        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
+    )
+    _tag_source_application(output_path)
+
+
 def _tag_source_application(path: Path) -> None:
     """Tag the FCPXML file with ``kMDItemCreator`` so FCP's import dialog
     shows ``Splitsmith`` instead of ``application "(null)"`` (issue #41).

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -1,0 +1,241 @@
+"""Match-level export pipeline: stitch N stages into one FCPXML (issue #171).
+
+Companion to :mod:`splitsmith.ui.exports`. Composes from already-existing
+per-stage trims (lossless ``stage<N>_<slug>_trimmed.mp4`` + per-cam variants
++ optional overlay) by walking
+:func:`splitsmith.fcpxml_gen.generate_match_fcpxml`. Never re-encodes;
+shrinking head/tail pads is done at FCPXML level.
+
+The orchestrator deliberately does not touch ``Project`` state -- the
+endpoint adapter assembles the per-stage bundles from project state and
+hands them in, mirroring the way :func:`exports.export_stage` is wired.
+That keeps the unit tests free of project fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .. import fcpxml_gen
+from ..config import OutputConfig
+from .exports import audit_shots_to_engine_shots
+
+
+@dataclass(frozen=True)
+class MatchSecondaryInput:
+    """One secondary cam ready to ride a stage in the match export."""
+
+    video_id: str
+    trimmed_path: Path
+    beep_offset_seconds: float
+    label: str = "Secondary cam"
+
+
+@dataclass(frozen=True)
+class MatchStageInput:
+    """Inputs the orchestrator needs to build one stage's contribution.
+
+    All paths point at *already-trimmed* artefacts under ``exports/``.
+    ``beep_offset_seconds`` is the clip-local beep time inside the lossless
+    trim (typically equals ``trim_pre_buffer_seconds`` unless the cam beep
+    landed within the pre-buffer of the source).
+    """
+
+    stage_number: int
+    stage_name: str
+    audit_path: Path
+    trimmed_path: Path
+    beep_offset_seconds: float
+    secondaries: tuple[MatchSecondaryInput, ...] = ()
+    overlay_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class MatchExportRequestData:
+    """Container for the validated request body, decoupled from FastAPI.
+
+    The HTTP request model in :mod:`server` populates this; the
+    orchestrator below depends only on this dataclass so unit tests don't
+    need to construct Pydantic models.
+    """
+
+    stage_numbers: tuple[int, ...]
+    head_pad_seconds: float
+    tail_pad_seconds: float
+    include_secondaries: bool
+    include_overlay: bool
+    project_name: str
+
+
+@dataclass(frozen=True)
+class MatchExportResult:
+    fcpxml_path: Path
+    stage_count: int
+    duration_seconds: float
+    anomalies: list[str] = field(default_factory=list)
+
+
+class MatchExportError(RuntimeError):
+    """Raised when one of the selected stages is missing the artefacts the
+    composer needs (no trim, no audit, etc). Endpoints surface as 400."""
+
+
+def export_match(
+    *,
+    stages: list[MatchStageInput],
+    request: MatchExportRequestData,
+    exports_dir: Path,
+    config: OutputConfig,
+    probe: object | None = None,
+) -> MatchExportResult:
+    """Build a stitched FCPXML from N stages' existing trims.
+
+    Probes each trim (and each enabled secondary / overlay), loads the audit
+    JSON for shots, then calls :func:`fcpxml_gen.generate_match_fcpxml`.
+    Returns the output path + stage count + total timeline duration so the
+    caller (HTTP endpoint or CLI) can confirm what was written.
+
+    ``probe`` defaults to :func:`fcpxml_gen.probe_video` resolved at call
+    time so monkeypatching the module attribute (the standard pattern for
+    avoiding ffprobe in tests) works. Pass an explicit callable to override.
+    """
+    if probe is None:
+        probe = fcpxml_gen.probe_video
+    if not stages:
+        raise MatchExportError("at least one stage required")
+
+    compositions: list[fcpxml_gen.StageComposition] = []
+    anomalies: list[str] = []
+    for stage_input in stages:
+        if not stage_input.trimmed_path.exists():
+            raise MatchExportError(
+                f"stage {stage_input.stage_number}: lossless trim missing at "
+                f"{stage_input.trimmed_path} -- run the per-stage export first"
+            )
+        if not stage_input.audit_path.exists():
+            raise MatchExportError(
+                f"stage {stage_input.stage_number}: audit JSON missing at "
+                f"{stage_input.audit_path}"
+            )
+        try:
+            audit_data = json.loads(stage_input.audit_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise MatchExportError(
+                f"stage {stage_input.stage_number}: failed to read audit JSON: {exc}"
+            ) from exc
+        # Convert audit -> engine Shot. We need ``time_absolute`` against the
+        # source, but the FCPXML composer only reads ``time_from_beep``, so
+        # any beep_time_in_source value works here -- we pick 0.0 so the
+        # ``time_absolute`` column stays trivially defined.
+        shots = audit_shots_to_engine_shots(audit_data, beep_time_in_source=0.0)
+        if not shots:
+            raise MatchExportError(f"stage {stage_input.stage_number}: audit JSON has no shots")
+
+        try:
+            primary_meta = probe(stage_input.trimmed_path)  # type: ignore[operator]
+        except fcpxml_gen.FFprobeError as exc:
+            raise MatchExportError(
+                f"stage {stage_input.stage_number}: ffprobe failed on "
+                f"{stage_input.trimmed_path}: {exc}"
+            ) from exc
+
+        secondaries: list[fcpxml_gen.SecondaryClip] = []
+        if request.include_secondaries:
+            for sec in stage_input.secondaries:
+                if not sec.trimmed_path.exists():
+                    anomalies.append(
+                        f"stage {stage_input.stage_number}: cam {sec.video_id} trim "
+                        f"missing at {sec.trimmed_path} -- dropped"
+                    )
+                    continue
+                try:
+                    sec_meta = probe(sec.trimmed_path)  # type: ignore[operator]
+                except fcpxml_gen.FFprobeError as exc:
+                    anomalies.append(
+                        f"stage {stage_input.stage_number}: cam {sec.video_id} dropped: {exc}"
+                    )
+                    continue
+                secondaries.append(
+                    fcpxml_gen.SecondaryClip(
+                        video_path=sec.trimmed_path,
+                        video=sec_meta,
+                        beep_offset_seconds=sec.beep_offset_seconds,
+                        label=sec.label,
+                    )
+                )
+
+        overlay_path: Path | None = None
+        overlay_video = None
+        if request.include_overlay and stage_input.overlay_path is not None:
+            if stage_input.overlay_path.exists():
+                try:
+                    overlay_video = probe(stage_input.overlay_path)  # type: ignore[operator]
+                    overlay_path = stage_input.overlay_path
+                except fcpxml_gen.FFprobeError as exc:
+                    anomalies.append(f"stage {stage_input.stage_number}: overlay dropped: {exc}")
+            else:
+                anomalies.append(
+                    f"stage {stage_input.stage_number}: overlay missing at "
+                    f"{stage_input.overlay_path} -- dropped"
+                )
+
+        compositions.append(
+            fcpxml_gen.StageComposition(
+                stage_name=stage_input.stage_name,
+                video_path=stage_input.trimmed_path,
+                video=primary_meta,
+                shots=shots,
+                beep_offset_seconds=stage_input.beep_offset_seconds,
+                head_pad_seconds=request.head_pad_seconds,
+                tail_pad_seconds=request.tail_pad_seconds,
+                overlay_path=overlay_path,
+                overlay_video=overlay_video,
+                secondaries=tuple(secondaries),
+            )
+        )
+
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    output_path = exports_dir / f"{_slugify(request.project_name)}-match.fcpxml"
+    try:
+        fcpxml_gen.generate_match_fcpxml(
+            stages=compositions,
+            output_path=output_path,
+            project_name=request.project_name,
+            config=config,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        raise MatchExportError(str(exc)) from exc
+
+    # Compute total duration for the response. Mirrors the composer's math
+    # (head_avail / tail_avail per stage, frame-aligned). Cheaper than
+    # re-parsing the FCPXML and good enough for a status line.
+    total_seconds = 0.0
+    for comp in compositions:
+        head_avail = max(0.0, comp.beep_offset_seconds)
+        if comp.shots:
+            last_local = comp.beep_offset_seconds + max(s.time_from_beep for s in comp.shots)
+        else:
+            last_local = comp.beep_offset_seconds
+        tail_avail = max(0.0, comp.video.duration_seconds - last_local)
+        head_trim = max(0.0, head_avail - comp.head_pad_seconds)
+        tail_trim = max(0.0, tail_avail - comp.tail_pad_seconds)
+        total_seconds += max(0.0, comp.video.duration_seconds - head_trim - tail_trim)
+
+    return MatchExportResult(
+        fcpxml_path=output_path,
+        stage_count=len(compositions),
+        duration_seconds=total_seconds,
+        anomalies=anomalies,
+    )
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(name: str) -> str:
+    """Filesystem-friendly slug. Mirrors ``exports._slugify`` so match-export
+    filenames look the same as their per-stage cousins."""
+    return _SLUG_RE.sub("-", name.lower()).strip("-") or "match"

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -106,6 +106,7 @@ from ..fixture_schema import (
 )
 from . import audio as audio_helpers
 from . import exports as export_helpers
+from . import match_exports as match_export_helpers
 from .jobs import Job, JobCancelled, JobHandle, JobRegistry
 from .project import (
     VIDEO_EXTENSIONS,
@@ -879,6 +880,27 @@ class ExportStageRequest(BaseModel):
     # stage). Cams without a beep are still skipped regardless of selection
     # since they can't be sync-aligned.
     secondary_video_ids: list[str] | None = None
+
+
+class MatchExportRequest(BaseModel):
+    """Body for POST /api/match/export (issue #171).
+
+    Stitches the listed stages into one FCPXML, in the order given. Each
+    stage must already have a lossless trim + audit shots (run the per-stage
+    export first); the match export composes from those without re-encoding.
+    ``head_pad_seconds`` / ``tail_pad_seconds`` are the visible padding
+    around the beep / final shot per stage and are clamped server-side to
+    the project's pre/post buffer settings (default 5.0s) -- exceeding the
+    cap returns 400. ``project_name`` defaults to the bound project's name
+    when omitted.
+    """
+
+    stage_numbers: list[int]
+    head_pad_seconds: float = 5.0
+    tail_pad_seconds: float = 5.0
+    include_secondaries: bool = True
+    include_overlay: bool = True
+    project_name: str | None = None
 
 
 class RevealRequest(BaseModel):
@@ -4187,6 +4209,133 @@ def create_app(
             word = "anomaly" if n == 1 else "anomalies"
             summary += f" ({n} {word} -- see report.txt)"
         handle.update(progress=1.0, message=f"Done: {summary}")
+
+    @app.post("/api/match/export")
+    def export_match(req: MatchExportRequest) -> JSONResponse:
+        """Stitch N stages into one FCPXML (issue #171).
+
+        Synchronous: the work is just XML composition + a few ffprobes, so
+        we don't queue a job. The response carries the output path and the
+        total timeline duration so the SPA can show "exported N stages
+        (M:SS)" without re-stating the file.
+
+        Validation: 400 on stage selection mismatch, missing trim/audit, or
+        out-of-range padding; 404 when no project is bound.
+        """
+        from . import exports as exports_mod
+
+        project = state.load()
+        if not req.stage_numbers:
+            raise HTTPException(status_code=400, detail="stage_numbers cannot be empty")
+
+        # Padding cap: clamp at the project's pre/post buffer. Exceeding
+        # the cap is a 400 with a precise message, not a silent clamp --
+        # the user's slider in #172 already enforces the same bound, so a
+        # value above it is a real bug worth surfacing.
+        max_head = project.trim_pre_buffer_seconds
+        max_tail = project.trim_post_buffer_seconds
+        if not 0.0 <= req.head_pad_seconds <= max_head:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"head_pad_seconds={req.head_pad_seconds} out of range; "
+                    f"must be in [0.0, {max_head}] (project trim_pre_buffer)"
+                ),
+            )
+        if not 0.0 <= req.tail_pad_seconds <= max_tail:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"tail_pad_seconds={req.tail_pad_seconds} out of range; "
+                    f"must be in [0.0, {max_tail}] (project trim_post_buffer)"
+                ),
+            )
+
+        stages_input: list[match_export_helpers.MatchStageInput] = []
+        exports_dir = project.exports_path(state.project_root)
+        audit_dir = project.audit_path(state.project_root)
+        for stage_number in req.stage_numbers:
+            try:
+                stage = project.stage(stage_number)
+            except KeyError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"stage {stage_number} not found in project",
+                ) from exc
+            primary = stage.primary()
+            if primary is None or primary.beep_time is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"stage {stage_number} has no primary or no beep yet; "
+                        "finish ingest + audit before match export"
+                    ),
+                )
+            base = f"stage{stage_number}_{exports_mod._slugify(stage.stage_name)}"
+            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+            audit_path = audit_dir / f"stage{stage_number}.json"
+            overlay_path = exports_dir / f"{base}_overlay.mov"
+
+            # Per-cam clip-local beep offset matches the per-stage exporter:
+            # ``min(pre_buffer, beep_time_in_source)`` so short heads (cam beep
+            # within the pre-buffer) align correctly.
+            secondaries: list[match_export_helpers.MatchSecondaryInput] = []
+            for sv in stage.videos:
+                if sv.role != "secondary":
+                    continue
+                if sv.beep_time is None:
+                    continue
+                sec_clip_beep = min(project.trim_pre_buffer_seconds, sv.beep_time)
+                secondaries.append(
+                    match_export_helpers.MatchSecondaryInput(
+                        video_id=sv.video_id,
+                        trimmed_path=exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4",
+                        beep_offset_seconds=sec_clip_beep,
+                        label=f"Cam {sv.video_id}",
+                    )
+                )
+
+            primary_clip_beep = min(project.trim_pre_buffer_seconds, primary.beep_time)
+            stages_input.append(
+                match_export_helpers.MatchStageInput(
+                    stage_number=stage_number,
+                    stage_name=stage.stage_name,
+                    audit_path=audit_path,
+                    trimmed_path=trimmed_path,
+                    beep_offset_seconds=primary_clip_beep,
+                    secondaries=tuple(secondaries),
+                    overlay_path=overlay_path,
+                )
+            )
+
+        project_name = req.project_name or project.name or "match"
+        request_data = match_export_helpers.MatchExportRequestData(
+            stage_numbers=tuple(req.stage_numbers),
+            head_pad_seconds=req.head_pad_seconds,
+            tail_pad_seconds=req.tail_pad_seconds,
+            include_secondaries=req.include_secondaries,
+            include_overlay=req.include_overlay,
+            project_name=project_name,
+        )
+
+        try:
+            result = match_export_helpers.export_match(
+                stages=stages_input,
+                request=request_data,
+                exports_dir=exports_dir,
+                config=Config().output,
+            )
+        except match_export_helpers.MatchExportError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return JSONResponse(
+            {
+                "fcpxml_path": str(result.fcpxml_path),
+                "stage_count": result.stage_count,
+                "duration_seconds": result.duration_seconds,
+                "anomalies": result.anomalies,
+            }
+        )
 
     @app.post("/api/files/reveal")
     def reveal_file(req: RevealRequest) -> JSONResponse:

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -25,7 +25,9 @@ from splitsmith.config import (
 )
 from splitsmith.fcpxml_gen import (
     FFprobeError,
+    StageComposition,
     generate_fcpxml,
+    generate_match_fcpxml,
     probe_video,
     split_color_band,
 )
@@ -610,6 +612,449 @@ def test_probe_video_raises_on_unparseable(tmp_path: Path) -> None:
 
     with pytest.raises(FFprobeError, match="unparseable"):
         probe_video(video, runner=garbage)
+
+
+# --- generate_match_fcpxml -------------------------------------------------
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def test_match_fcpxml_single_stage_no_shrink_matches_single_export(tmp_path: Path) -> None:
+    """A 1-stage call with pads >= the actual head/tail should leave the
+    timeline structurally identical to ``generate_fcpxml`` for the same
+    inputs. We compare attribute-by-attribute rather than literal bytes
+    because the asset-clip name maps to ``stage_name`` here vs ``project_name``
+    there -- the issue spec calls out "modulo project_name"."""
+    video = _make_video(tmp_path, "stage1.mp4")
+    out_old = tmp_path / "old.fcpxml"
+    out_new = tmp_path / "new.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=1.42, split=1.42),
+        _shot(2, time_from_beep=1.63, split=0.21),
+    ]
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=shots,
+        beep_offset_seconds=5.0,
+        output_path=out_old,
+        project_name="stage1",
+        config=OutputConfig(),
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,  # > beep_offset -> no head trim
+                tail_pad_seconds=20.0,  # > available tail -> no tail trim
+            )
+        ],
+        output_path=out_new,
+        project_name="stage1",
+        config=OutputConfig(),
+    )
+    old = ET.fromstring(out_old.read_bytes())
+    new = ET.fromstring(out_new.read_bytes())
+
+    assert old.attrib == new.attrib
+    # format
+    fmt_old = old.find("./resources/format")
+    fmt_new = new.find("./resources/format")
+    assert fmt_old is not None and fmt_new is not None
+    assert fmt_old.attrib == fmt_new.attrib
+    # asset (just the primary in this single-stage no-overlay case)
+    assets_old = old.findall("./resources/asset")
+    assets_new = new.findall("./resources/asset")
+    assert len(assets_old) == len(assets_new) == 1
+    assert assets_old[0].attrib == assets_new[0].attrib
+    # spine asset-clip
+    clip_old = old.find("./library/event/project/sequence/spine/asset-clip")
+    clip_new = new.find("./library/event/project/sequence/spine/asset-clip")
+    assert clip_old is not None and clip_new is not None
+    for key in ("ref", "offset", "start", "duration", "format"):
+        assert clip_old.attrib[key] == clip_new.attrib[key], key
+    # markers byte-for-byte
+    markers_old = clip_old.findall("marker")
+    markers_new = clip_new.findall("marker")
+    assert len(markers_old) == len(markers_new) == 2
+    for m_old, m_new in zip(markers_old, markers_new, strict=True):
+        assert m_old.attrib == m_new.attrib
+
+
+def test_match_fcpxml_two_stages_back_to_back(tmp_path: Path) -> None:
+    """Two stages with no shrink: spine has two asset-clips, second's offset
+    equals first's effective duration. Sequence duration is the sum."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=2.0, split=2.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    assert spine_clips[0].attrib["offset"] == "0s"
+    assert spine_clips[0].attrib["start"] == "0s"
+    assert spine_clips[0].attrib["duration"] == "600/30s"
+    assert spine_clips[0].attrib["name"] == "stage1"
+    assert spine_clips[1].attrib["offset"] == "600/30s"
+    assert spine_clips[1].attrib["start"] == "0s"
+    assert spine_clips[1].attrib["duration"] == "600/30s"
+    assert spine_clips[1].attrib["name"] == "stage2"
+    seq = root.find("./library/event/project/sequence")
+    assert seq is not None
+    assert seq.attrib["duration"] == "1200/30s"
+    assert root.find("./library/event/project").attrib["name"] == "match"
+
+
+def test_match_fcpxml_action_cut_padding_trims_each_stage(tmp_path: Path) -> None:
+    """head_pad=0.5, tail_pad=1.0 against a 20s synthetic clip with beep at
+    5s and last shot at 1.5s after beep:
+      - head_trim = beep_offset - head_pad = 5.0 - 0.5 = 4.5s = 135 frames
+      - tail_avail = 20 - (5 + 1.5) = 13.5s
+      - tail_trim = 13.5 - 1.0 = 12.5s = 375 frames
+      - eff_duration = 600 - 135 - 375 = 90 frames = 3.0s
+    Stage 1 starts on the spine at 90/30s."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=1.0, split=1.0),
+        _shot(2, time_from_beep=1.5, split=0.5),
+    ]
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name=name,
+                video_path=path,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+            )
+            for name, path in (("stage1", v1), ("stage2", v2))
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert spine_clips[0].attrib["start"] == "135/30s"
+    assert spine_clips[0].attrib["duration"] == "90/30s"
+    assert spine_clips[0].attrib["offset"] == "0s"
+    assert spine_clips[1].attrib["start"] == "135/30s"
+    assert spine_clips[1].attrib["duration"] == "90/30s"
+    assert spine_clips[1].attrib["offset"] == "90/30s"
+    seq = root.find("./library/event/project/sequence")
+    assert seq is not None
+    assert seq.attrib["duration"] == "180/30s"
+
+
+def test_match_fcpxml_drops_markers_outside_trimmed_window(tmp_path: Path) -> None:
+    """Shots whose clip-local time falls outside [head_trim, head_trim +
+    eff_duration] are dropped. With head_pad=0.5, tail_pad=1.0 and a beep at
+    5s the visible window is [4.5s, 7.5s]. The pre-beep shot at -0.6s lands
+    at clip-local 4.4s (dropped); 0.4s past beep -> 5.4s (kept); 1.5s past
+    beep -> 6.5s (kept; this is the latest shot so tail_avail is computed
+    off it)."""
+    video = _make_video(tmp_path, "v.mp4")
+    out = tmp_path / "v.fcpxml"
+    shots = [
+        _shot(1, time_from_beep=-0.6, split=0.0),
+        _shot(2, time_from_beep=0.4, split=1.0),
+        _shot(3, time_from_beep=1.5, split=1.1),
+    ]
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=shots,
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    markers = root.findall(".//spine/asset-clip/marker")
+    assert len(markers) == 2
+    assert "Shot 2" in markers[0].attrib["value"]
+    assert "Shot 3" in markers[1].attrib["value"]
+
+
+def test_match_fcpxml_secondary_alignment_with_head_trim(tmp_path: Path) -> None:
+    """Secondary cam stays beep-aligned even after the primary's head is
+    trimmed. With head_pad=0.5 the primary's beep moves to local 0.5s; the
+    cam (same beep_offset=5.0) needs to skip 4.5s into its own media so its
+    beep also lands at local 0.5s."""
+    primary = _make_video(tmp_path, "primary.mp4")
+    secondary = _make_video(tmp_path, "secondary.mp4")
+    out = tmp_path / "v.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=primary,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=20.0,  # no tail trim (we want a long visible window for the cam)
+                secondaries=(
+                    fcpxml_mod.SecondaryClip(
+                        video_path=secondary,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    ),
+                ),
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    assert cam_clip.attrib["offset"] == "0s"
+    # delta = (5.0 - 4.5) - 5.0 = -4.5s -> sec_start = 4.5s = 135 frames
+    assert cam_clip.attrib["start"] == "135/30s"
+
+
+def test_match_fcpxml_per_stage_overlay_lane_isolation(tmp_path: Path) -> None:
+    """Stage 0 has overlay + secondary, stage 1 has neither. Resource IDs
+    are unique across stages and lanes are isolated per stage (stage 1's
+    primary clip has no nested clips)."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    cam = _make_video(tmp_path, "cam.mp4")
+    overlay = _make_video(tmp_path, "stage1_overlay.mov")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+                overlay_path=overlay,
+                overlay_video=_meta_30fps(),
+                secondaries=(
+                    fcpxml_mod.SecondaryClip(
+                        video_path=cam,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    ),
+                ),
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=2.0, split=2.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=10.0,
+                tail_pad_seconds=20.0,
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    assets = root.findall("./resources/asset")
+    # stage1 primary + cam + overlay + stage2 primary = 4
+    assert len(assets) == 4
+    asset_ids = [a.attrib["id"] for a in assets]
+    assert asset_ids == ["r2", "r3", "r4", "r5"]
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    nested_in_stage1 = spine_clips[0].findall("asset-clip")
+    nested_in_stage2 = spine_clips[1].findall("asset-clip")
+    # stage 1: cam (lane=1) + overlay (lane=2) = 2 nested clips
+    assert {c.attrib["lane"] for c in nested_in_stage1} == {"1", "2"}
+    # stage 2: nothing nested
+    assert nested_in_stage2 == []
+
+
+def test_match_fcpxml_overlay_skips_into_media_when_head_trimmed(tmp_path: Path) -> None:
+    """The overlay was rendered to mirror the primary frame-for-frame, so
+    after head_trim it must skip the same amount into its own media to stay
+    in sync. Its duration also shrinks to match the primary's effective
+    duration."""
+    video = _make_video(tmp_path, "v.mp4")
+    overlay = _make_video(tmp_path, "v_overlay.mov")
+    out = tmp_path / "v.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="v",
+                video_path=video,
+                video=_meta_30fps(),
+                shots=[_shot(1, time_from_beep=1.5, split=1.5)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=0.5,
+                tail_pad_seconds=1.0,
+                overlay_path=overlay,
+                overlay_video=_meta_30fps(),
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    overlay_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert overlay_clip is not None
+    # head_trim = 4.5s = 135 frames; eff_duration = 90 frames
+    assert overlay_clip.attrib["start"] == "135/30s"
+    assert overlay_clip.attrib["duration"] == "90/30s"
+    assert overlay_clip.attrib["lane"] == "1"
+
+
+def test_match_fcpxml_raises_on_mixed_frame_rates(tmp_path: Path) -> None:
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(ValueError, match="mixed frame rates"):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="stage1",
+                    video_path=v1,
+                    video=_meta_30fps(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                ),
+                StageComposition(
+                    stage_name="stage2",
+                    video_path=v2,
+                    video=_meta_2997(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                ),
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_on_empty_stages(tmp_path: Path) -> None:
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(ValueError, match="at least one stage"):
+        generate_match_fcpxml(
+            stages=[],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_on_missing_video(tmp_path: Path) -> None:
+    out = tmp_path / "match.fcpxml"
+    with pytest.raises(FileNotFoundError):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="stage1",
+                    video_path=tmp_path / "missing.mp4",
+                    video=_meta_30fps(),
+                    shots=[],
+                    beep_offset_seconds=5.0,
+                    head_pad_seconds=5.0,
+                    tail_pad_seconds=5.0,
+                )
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+def test_match_fcpxml_raises_when_pads_collapse_duration(tmp_path: Path) -> None:
+    """If head_pad + tail_pad math leaves nothing visible, the function
+    refuses rather than emitting a zero-duration clip."""
+    video = _make_video(tmp_path, "v.mp4")
+    out = tmp_path / "match.fcpxml"
+    # 20s clip, beep at 0.001s, no shots, head_pad 0, tail_pad 0:
+    # head_trim ~= 0, tail_avail = 20 - 0.001 = ~20, tail_trim ~= 20 ->
+    # effective ~ 0. Use a stage where the shot pushes tail_avail to 0.
+    # Simplest forced collapse: video.duration = 0.001s -> primary_duration
+    # rounds to 0 frames -> negative effective duration.
+    tiny_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=0.001,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    with pytest.raises(ValueError, match="non-positive effective duration"):
+        generate_match_fcpxml(
+            stages=[
+                StageComposition(
+                    stage_name="v",
+                    video_path=video,
+                    video=tiny_meta,
+                    shots=[],
+                    beep_offset_seconds=0.0,
+                    head_pad_seconds=0.0,
+                    tail_pad_seconds=0.0,
+                )
+            ],
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+        )
+
+
+# --- probe_video -----------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/test_ui_match_exports.py
+++ b/tests/test_ui_match_exports.py
@@ -1,0 +1,402 @@
+"""Tests for the UI match-export orchestrator (issue #171).
+
+Pure orchestration over already-trimmed per-stage artefacts; the FCPXML
+composer itself is exercised in ``test_fcpxml_gen.py``. ffprobe is stubbed
+so the suite doesn't shell out.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from splitsmith.config import OutputConfig, VideoMetadata
+from splitsmith.fcpxml_gen import FFprobeError
+from splitsmith.ui import match_exports as match_exports_mod
+
+
+def _meta_30fps(duration: float = 20.0) -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=duration,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _audit_payload(shots: list[dict]) -> dict:
+    return {
+        "stage_number": 1,
+        "stage_name": "Stage 1",
+        "stage_time_seconds": 8.0,
+        "beep_time": 5.0,
+        "shots": shots,
+        "_candidates_pending_audit": {"candidates": []},
+    }
+
+
+def _make_trim(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def _make_audit(tmp_path: Path, name: str, payload: dict) -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def _stub_probe(_path: Path) -> VideoMetadata:
+    return _meta_30fps()
+
+
+def _make_request(
+    *,
+    head_pad: float = 5.0,
+    tail_pad: float = 5.0,
+    include_secondaries: bool = True,
+    include_overlay: bool = True,
+    project_name: str = "match",
+) -> match_exports_mod.MatchExportRequestData:
+    return match_exports_mod.MatchExportRequestData(
+        stage_numbers=(1, 2),
+        head_pad_seconds=head_pad,
+        tail_pad_seconds=tail_pad,
+        include_secondaries=include_secondaries,
+        include_overlay=include_overlay,
+        project_name=project_name,
+    )
+
+
+def test_export_match_produces_stitched_fcpxml(tmp_path: Path) -> None:
+    audit1 = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    audit2 = _make_audit(
+        tmp_path,
+        "stage2.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 1000}]),
+    )
+    trim1 = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    trim2 = _make_trim(tmp_path, "stage2_trimmed.mp4")
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit1,
+                trimmed_path=trim1,
+                beep_offset_seconds=5.0,
+            ),
+            match_exports_mod.MatchStageInput(
+                stage_number=2,
+                stage_name="Stage 2",
+                audit_path=audit2,
+                trimmed_path=trim2,
+                beep_offset_seconds=5.0,
+            ),
+        ],
+        request=_make_request(head_pad=10.0, tail_pad=20.0),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert result.stage_count == 2
+    assert result.fcpxml_path.exists()
+    assert result.fcpxml_path.name == "match-match.fcpxml"
+    # Two 20s clips with no shrink -> 40s total.
+    assert result.duration_seconds == pytest.approx(40.0)
+    root = ET.fromstring(result.fcpxml_path.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    assert spine_clips[0].attrib["name"] == "Stage 1"
+    assert spine_clips[1].attrib["name"] == "Stage 2"
+
+
+def test_export_match_action_cut_padding_shrinks_total_duration(tmp_path: Path) -> None:
+    """head=0.5, tail=1.0 against a 20s clip with beep at 5s and last shot
+    at 0.5s past beep collapses each stage to ~2.0s on the timeline."""
+    payload = _audit_payload([{"shot_number": 1, "ms_after_beep": 500}])
+    audit = _make_audit(tmp_path, "stage1.json", payload)
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+            )
+        ],
+        request=match_exports_mod.MatchExportRequestData(
+            stage_numbers=(1,),
+            head_pad_seconds=0.5,
+            tail_pad_seconds=1.0,
+            include_secondaries=True,
+            include_overlay=True,
+            project_name="match",
+        ),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    # head_trim = 5.0 - 0.5 = 4.5s; tail_avail = 20 - 5.5 = 14.5; tail_trim
+    # = 14.5 - 1.0 = 13.5s; eff = 20 - 4.5 - 13.5 = 2.0s.
+    assert result.duration_seconds == pytest.approx(2.0)
+
+
+def test_export_match_includes_secondaries_when_flag_set(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    cam_trim = _make_trim(tmp_path, "stage1_cam_abc_trimmed.mp4")
+
+    stage = match_exports_mod.MatchStageInput(
+        stage_number=1,
+        stage_name="Stage 1",
+        audit_path=audit,
+        trimmed_path=trim,
+        beep_offset_seconds=5.0,
+        secondaries=(
+            match_exports_mod.MatchSecondaryInput(
+                video_id="abc",
+                trimmed_path=cam_trim,
+                beep_offset_seconds=5.0,
+                label="Cam abc",
+            ),
+        ),
+    )
+    result = match_exports_mod.export_match(
+        stages=[stage],
+        request=_make_request(head_pad=10.0, tail_pad=20.0, include_secondaries=True),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    root = ET.fromstring(result.fcpxml_path.read_bytes())
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert len(nested) == 1
+    assert nested[0].attrib["name"] == "Cam abc"
+
+
+def test_export_match_drops_secondaries_when_flag_off(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    cam_trim = _make_trim(tmp_path, "stage1_cam_abc_trimmed.mp4")
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+                secondaries=(
+                    match_exports_mod.MatchSecondaryInput(
+                        video_id="abc",
+                        trimmed_path=cam_trim,
+                        beep_offset_seconds=5.0,
+                    ),
+                ),
+            )
+        ],
+        request=_make_request(head_pad=10.0, tail_pad=20.0, include_secondaries=False),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    root = ET.fromstring(result.fcpxml_path.read_bytes())
+    nested = root.findall(".//spine/asset-clip/asset-clip")
+    assert nested == []
+
+
+def test_export_match_records_anomaly_for_missing_secondary(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    # No file at this path -- the orchestrator should warn but not raise.
+    cam_trim = tmp_path / "missing_cam.mp4"
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+                secondaries=(
+                    match_exports_mod.MatchSecondaryInput(
+                        video_id="abc",
+                        trimmed_path=cam_trim,
+                        beep_offset_seconds=5.0,
+                    ),
+                ),
+            )
+        ],
+        request=_make_request(head_pad=10.0, tail_pad=20.0),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert any("cam abc" in a for a in result.anomalies)
+    assert result.fcpxml_path.exists()
+
+
+def test_export_match_raises_on_missing_trim(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    with pytest.raises(match_exports_mod.MatchExportError, match="lossless trim missing"):
+        match_exports_mod.export_match(
+            stages=[
+                match_exports_mod.MatchStageInput(
+                    stage_number=1,
+                    stage_name="Stage 1",
+                    audit_path=audit,
+                    trimmed_path=tmp_path / "missing_trim.mp4",
+                    beep_offset_seconds=5.0,
+                )
+            ],
+            request=_make_request(),
+            exports_dir=tmp_path / "exports",
+            config=OutputConfig(),
+            probe=_stub_probe,
+        )
+
+
+def test_export_match_raises_on_missing_audit(tmp_path: Path) -> None:
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    with pytest.raises(match_exports_mod.MatchExportError, match="audit JSON missing"):
+        match_exports_mod.export_match(
+            stages=[
+                match_exports_mod.MatchStageInput(
+                    stage_number=1,
+                    stage_name="Stage 1",
+                    audit_path=tmp_path / "missing_audit.json",
+                    trimmed_path=trim,
+                    beep_offset_seconds=5.0,
+                )
+            ],
+            request=_make_request(),
+            exports_dir=tmp_path / "exports",
+            config=OutputConfig(),
+            probe=_stub_probe,
+        )
+
+
+def test_export_match_raises_on_audit_with_no_shots(tmp_path: Path) -> None:
+    audit = _make_audit(tmp_path, "stage1.json", _audit_payload([]))
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    with pytest.raises(match_exports_mod.MatchExportError, match="no shots"):
+        match_exports_mod.export_match(
+            stages=[
+                match_exports_mod.MatchStageInput(
+                    stage_number=1,
+                    stage_name="Stage 1",
+                    audit_path=audit,
+                    trimmed_path=trim,
+                    beep_offset_seconds=5.0,
+                )
+            ],
+            request=_make_request(),
+            exports_dir=tmp_path / "exports",
+            config=OutputConfig(),
+            probe=_stub_probe,
+        )
+
+
+def test_export_match_raises_on_empty_stages(tmp_path: Path) -> None:
+    with pytest.raises(match_exports_mod.MatchExportError, match="at least one stage"):
+        match_exports_mod.export_match(
+            stages=[],
+            request=_make_request(),
+            exports_dir=tmp_path / "exports",
+            config=OutputConfig(),
+            probe=_stub_probe,
+        )
+
+
+def test_export_match_wraps_ffprobe_failure(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+
+    def boom(_path: Path) -> VideoMetadata:
+        raise FFprobeError("simulated probe failure")
+
+    with pytest.raises(match_exports_mod.MatchExportError, match="ffprobe failed"):
+        match_exports_mod.export_match(
+            stages=[
+                match_exports_mod.MatchStageInput(
+                    stage_number=1,
+                    stage_name="Stage 1",
+                    audit_path=audit,
+                    trimmed_path=trim,
+                    beep_offset_seconds=5.0,
+                )
+            ],
+            request=_make_request(),
+            exports_dir=tmp_path / "exports",
+            config=OutputConfig(),
+            probe=boom,
+        )
+
+
+def test_export_match_slugifies_project_name_for_filename(tmp_path: Path) -> None:
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+            )
+        ],
+        request=match_exports_mod.MatchExportRequestData(
+            stage_numbers=(1,),
+            head_pad_seconds=10.0,
+            tail_pad_seconds=20.0,
+            include_secondaries=True,
+            include_overlay=True,
+            project_name="Region Cup -- 2026 (May)",
+        ),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert result.fcpxml_path.name == "region-cup-2026-may-match.fcpxml"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4626,3 +4626,136 @@ def test_promote_against_fixture_endpoint_validates_anchor_exists(
     )
     assert resp.status_code == 404
     assert "anchor fixture not found" in resp.json()["detail"]
+
+
+# --- /api/match/export (issue #171) ---------------------------------------
+
+
+def _seed_match_export_project(tmp_path: Path, *, stage_count: int = 2) -> tuple[TestClient, Path]:
+    """Seed a project with N stages, each having a primary + beep_time +
+    audit JSON + lossless trim ready for match export.
+    """
+    import json as _json
+
+    from splitsmith.ui.project import MatchProject, StageEntry
+
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="Match Export Test")
+    client = TestClient(app)
+    project = MatchProject.load(project_root)
+    project.stages = []
+    for n in range(1, stage_count + 1):
+        project.stages.append(
+            StageEntry(stage_number=n, stage_name=f"Stage {n}", time_seconds=10.0)
+        )
+        src = project_root / "raw" / f"VID{n}.mp4"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_bytes(b"\x00")
+        video = project.register_video(src, project_root)
+        project.assign_video(video.path, to_stage_number=n, role="primary")
+        primary = project.stages[n - 1].primary()
+        assert primary is not None
+        primary.beep_time = 5.0
+    project.save(project_root)
+
+    audit_dir = project_root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    exports_dir = project_root / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    for n in range(1, stage_count + 1):
+        (audit_dir / f"stage{n}.json").write_text(
+            _json.dumps(
+                {
+                    "stage_number": n,
+                    "stage_name": f"Stage {n}",
+                    "stage_time_seconds": 10.0,
+                    "beep_time": 5.0,
+                    "shots": [{"shot_number": 1, "ms_after_beep": 500}],
+                    "_candidates_pending_audit": {"candidates": []},
+                }
+            ),
+            encoding="utf-8",
+        )
+        slug = f"stage{n}_stage-{n}"
+        (exports_dir / f"{slug}_trimmed.mp4").write_bytes(b"")
+    return client, project_root
+
+
+def _stub_match_export_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    from splitsmith import fcpxml_gen as fcpxml_mod
+    from splitsmith.config import VideoMetadata
+
+    def fake(_path: Path) -> VideoMetadata:
+        return VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=20.0,
+            frame_rate_num=30,
+            frame_rate_den=1,
+        )
+
+    monkeypatch.setattr(fcpxml_mod, "probe_video", fake)
+
+
+def test_match_export_endpoint_writes_fcpxml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, project_root = _seed_match_export_project(tmp_path)
+    _stub_match_export_probe(monkeypatch)
+
+    resp = client.post(
+        "/api/match/export",
+        json={
+            "stage_numbers": [1, 2],
+            "head_pad_seconds": 0.5,
+            "tail_pad_seconds": 1.0,
+            "include_secondaries": True,
+            "include_overlay": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stage_count"] == 2
+    assert Path(body["fcpxml_path"]).exists()
+    assert Path(body["fcpxml_path"]).name.endswith("-match.fcpxml")
+    # Per stage: 20s clip, beep@5s, last shot at 0.5s past beep -> head_trim
+    # = 5.0 - 0.5 = 4.5s; tail_trim = (20 - 5.5) - 1.0 = 13.5s; eff = 2.0s.
+    # Two stages -> 4.0s total.
+    assert body["duration_seconds"] == pytest.approx(4.0, abs=0.1)
+
+
+def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> None:
+    client, _ = _seed_match_export_project(tmp_path, stage_count=1)
+    resp = client.post("/api/match/export", json={"stage_numbers": []})
+    assert resp.status_code == 400
+    assert "stage_numbers cannot be empty" in resp.json()["detail"]
+
+
+def test_match_export_endpoint_400_on_padding_above_buffer(tmp_path: Path) -> None:
+    client, _ = _seed_match_export_project(tmp_path, stage_count=1)
+    resp = client.post(
+        "/api/match/export",
+        json={"stage_numbers": [1], "head_pad_seconds": 99.0},
+    )
+    assert resp.status_code == 400
+    assert "head_pad_seconds" in resp.json()["detail"]
+
+
+def test_match_export_endpoint_400_on_unknown_stage(tmp_path: Path) -> None:
+    client, _ = _seed_match_export_project(tmp_path, stage_count=1)
+    resp = client.post("/api/match/export", json={"stage_numbers": [99]})
+    assert resp.status_code == 400
+    assert "stage 99 not found" in resp.json()["detail"]
+
+
+def test_match_export_endpoint_400_when_trim_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, project_root = _seed_match_export_project(tmp_path, stage_count=1)
+    _stub_match_export_probe(monkeypatch)
+    # Remove the trim that the seed helper wrote.
+    (project_root / "exports" / "stage1_stage-1_trimmed.mp4").unlink()
+
+    resp = client.post("/api/match/export", json={"stage_numbers": [1]})
+    assert resp.status_code == 400
+    assert "lossless trim missing" in resp.json()["detail"]


### PR DESCRIPTION
Closes #171. Stacked on #175 (#170). Second slice of #169.

## Summary

- New module \`src/splitsmith/ui/match_exports.py\` with \`MatchStageInput\` / \`MatchSecondaryInput\` / \`MatchExportRequestData\` / \`MatchExportResult\` and an \`export_match\` orchestrator that walks already-trimmed per-stage artefacts (lossless trim + audit JSON + secondary trims + overlay) into one stitched FCPXML.
- New endpoint \`POST /api/match/export\` in \`server.py\` that:
  - 400s on empty \`stage_numbers\`, padding above the project's pre/post buffer, unknown stage, stage missing primary or beep, or missing trim/audit.
  - Builds \`MatchStageInput\`s from project state (mirrors single-stage export's path conventions: \`stage<N>_<slug>_trimmed.mp4\` etc).
  - Returns \`{ fcpxml_path, stage_count, duration_seconds, anomalies }\`.
- The orchestrator stays decoupled from \`MatchProject\` state -- the endpoint adapts; tests construct \`MatchStageInput\`s directly without a project fixture.
- Soft-failure anomalies (missing secondary cam trim, ffprobe drop on a cam, missing overlay) ride the response so the SPA can surface them without dropping the whole export.

## Test plan

- [x] \`uv run pytest tests/test_ui_match_exports.py\` -- 11 tests covering: happy path, action-cut padding math, secondary inclusion/exclusion, missing-secondary anomaly, missing-trim/audit/no-shots/empty-stages errors, ffprobe-failure wrapping, slugified output filename.
- [x] \`uv run pytest tests/test_ui_server.py -k match_export\` -- 5 endpoint tests: 200 happy path, 400 empty stage_numbers, 400 padding above buffer, 400 unknown stage, 400 missing trim.
- [x] \`uv run pytest -q\` -- 702 passed, 1 skipped (no regressions).
- [x] \`uv run ruff check\` clean. \`uv run black\` formatted.

## Notes

- Padding bound is the project's \`trim_pre_buffer_seconds\` / \`trim_post_buffer_seconds\` (default 5.0), not a hardcoded 5.0. Customised projects get the right cap.
- \`probe\` is resolved at call time so monkeypatching \`fcpxml_gen.probe_video\` works in tests; explicit \`probe\` kwarg still supported.
- Output filename: \`<slug(project_name)>-match.fcpxml\` under the project's exports dir. Re-runs overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)