### PR TITLE
match-export: multi-stage selector + export dialog UI (#172)

### DIFF
--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -122,6 +122,13 @@ class Job(BaseModel):
     # evicting acknowledged failures so the user's dismissed errors roll
     # off faster than the ones they haven't seen yet.
     acknowledged: bool = False
+    # Optional structured result payload set by the worker via
+    # :meth:`JobHandle.set_result`. Reserved for jobs whose successful
+    # output is meaningful to the SPA (e.g. match-export emits the FCPXML
+    # path, total duration, and per-stage anomalies). The schema is per-
+    # kind: the SPA branches on ``Job.kind`` to interpret the dict. Stays
+    # ``None`` for jobs that signal success solely by writing files.
+    result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
     started_at: datetime | None = None
@@ -158,6 +165,15 @@ class JobHandle:
             kwargs["message"] = message
         if kwargs:
             self._registry._patch(self._job_id, **kwargs)
+
+    def set_result(self, payload: dict[str, Any]) -> None:
+        """Stash a structured result on the Job snapshot.
+
+        The SPA reads ``Job.result`` after the job succeeds; the schema is
+        per-kind. Workers that complete by writing files (trim, export,
+        shot-detect) typically don't need this.
+        """
+        self._registry._patch(self._job_id, result=payload)
 
     def is_cancel_requested(self) -> bool:
         """True once the SPA POSTed ``/api/jobs/{id}/cancel`` for this job.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4212,18 +4212,19 @@ def create_app(
 
     @app.post("/api/match/export")
     def export_match(req: MatchExportRequest) -> JSONResponse:
-        """Stitch N stages into one FCPXML (issue #171).
+        """Stitch N stages into one FCPXML (issue #171, #172).
 
-        Synchronous: the work is just XML composition + a few ffprobes, so
-        we don't queue a job. The response carries the output path and the
-        total timeline duration so the SPA can show "exported N stages
-        (M:SS)" without re-stating the file.
+        Job-queued: per-stage trims (and optional overlays) can take
+        minutes for a real match, so the response is a Job snapshot the
+        SPA polls via ``/api/jobs/{id}``. The worker re-runs any missing
+        per-stage exports before invoking the match composer, so the user
+        doesn't have to click Generate on each stage first -- "Export
+        match" is a one-stop button.
 
-        Validation: 400 on stage selection mismatch, missing trim/audit, or
-        out-of-range padding; 404 when no project is bound.
+        Validation up-front (404 on unbound project, 400 on empty
+        selection / unknown stage / missing primary or beep / padding out
+        of range) so the SPA shows a clear error before queueing.
         """
-        from . import exports as exports_mod
-
         project = state.load()
         if not req.stage_numbers:
             raise HTTPException(status_code=400, detail="stage_numbers cannot be empty")
@@ -4251,9 +4252,10 @@ def create_app(
                 ),
             )
 
-        stages_input: list[match_export_helpers.MatchStageInput] = []
-        exports_dir = project.exports_path(state.project_root)
-        audit_dir = project.audit_path(state.project_root)
+        # Pre-flight stage validations. Loaded once here so a bad
+        # selection 400s before we queue a worker. The audit-shots check
+        # happens in the worker (it reads the JSON anyway) so we don't
+        # double-parse.
         for stage_number in req.stage_numbers:
             try:
                 stage = project.stage(stage_number)
@@ -4271,21 +4273,157 @@ def create_app(
                         "finish ingest + audit before match export"
                     ),
                 )
-            base = f"stage{stage_number}_{exports_mod._slugify(stage.stage_name)}"
+            # Source-reachability matters because the worker may have to
+            # produce missing trims via ffmpeg. Surface up-front rather
+            # than letting the worker fail mid-flight.
+            if not project.resolve_video_path(state.project_root, primary.path).exists():
+                _ensure_source_reachable(
+                    stage_number,
+                    project.resolve_video_path(state.project_root, primary.path),
+                )
+
+        existing = state.jobs.find_active(kind="match_export")
+        if existing is not None:
+            return JSONResponse(existing.model_dump(mode="json"))
+        job = state.jobs.submit(
+            kind="match_export",
+            fn=lambda h, r=req: _run_match_export(h, r),
+        )
+        return JSONResponse(job.model_dump(mode="json"))
+
+    def _run_match_export(handle: JobHandle, req: MatchExportRequest) -> None:
+        """Worker for /api/match/export. Re-runs the per-stage exporter for
+        any selected stage missing its lossless trim, then composes the
+        match FCPXML.
+        """
+        from ..config import StageData as EngineStageData
+        from . import exports as exports_mod
+
+        handle.update(progress=0.02, message="Loading project...")
+        proj = state.load()
+        exports_dir = proj.exports_path(state.project_root)
+        audit_dir = proj.audit_path(state.project_root)
+
+        n = len(req.stage_numbers)
+        # Reserve the last 10% for the match compose step; the rest is
+        # split evenly across per-stage trims (the dominant wall time).
+        # Stages that already have a trim skip ahead within their slice
+        # instead of contributing to the wait.
+        per_stage_share = 0.85 / max(1, n)
+
+        for idx, stage_number in enumerate(req.stage_numbers):
+            handle.check_cancel()
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            if prim is None or prim.beep_time is None:
+                raise RuntimeError(f"stage {stage_number}: primary or beep disappeared mid-flight")
+
+            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
+            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+            overlay_target = exports_dir / f"{base}_overlay.mov"
+
+            # Decide what's missing. The match composer needs the
+            # lossless trim + per-cam trims (when include_secondaries) +
+            # optional overlay. Re-run the per-stage exporter for any
+            # stage where any required artefact isn't on disk.
+            wanted_secondary_ids: set[str] = set()
+            if req.include_secondaries:
+                for sv in stg.videos:
+                    if sv.role == "secondary" and sv.beep_time is not None:
+                        wanted_secondary_ids.add(sv.video_id)
+            secondary_trims_present = all(
+                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists()
+                for vid in wanted_secondary_ids
+            )
+            overlay_missing = req.include_overlay and not overlay_target.exists()
+
+            needs_per_stage = (
+                not trimmed_path.exists()
+                or not secondary_trims_present
+                or overlay_missing
+            )
+            if needs_per_stage:
+                handle.update(
+                    progress=0.02 + idx * per_stage_share,
+                    message=(
+                        f"Stage {stage_number} ({idx + 1} of {n}): "
+                        "running per-stage export..."
+                    ),
+                )
+                # Build the secondaries list for the per-stage exporter --
+                # mirrors the single-stage endpoint's logic.
+                secondaries_in: list[export_helpers.SecondaryExport] = []
+                if req.include_secondaries:
+                    for sv in stg.videos:
+                        if sv.role != "secondary" or sv.beep_time is None:
+                            continue
+                        sec_source = proj.resolve_video_path(state.project_root, sv.path)
+                        secondaries_in.append(
+                            export_helpers.SecondaryExport(
+                                video_id=sv.video_id,
+                                source_path=sec_source,
+                                beep_time_in_source=sv.beep_time,
+                                label=f"Cam {sv.video_id}",
+                            )
+                        )
+                source_video = proj.resolve_video_path(state.project_root, prim.path)
+                engine_stage = EngineStageData(
+                    stage_number=stg.stage_number,
+                    stage_name=stg.stage_name,
+                    time_seconds=stg.time_seconds,
+                    scorecard_updated_at=stg.scorecard_updated_at,
+                )
+                try:
+                    export_helpers.export_stage(
+                        request=export_helpers.StageExportRequest(
+                            stage_number=stage_number,
+                            write_trim=True,
+                            write_csv=True,
+                            write_fcpxml=True,
+                            write_report=True,
+                            write_overlay=req.include_overlay,
+                        ),
+                        audit_path=audit_dir / f"stage{stage_number}.json",
+                        exports_dir=exports_dir,
+                        source_video_path=source_video if source_video.exists() else None,
+                        stage_data=engine_stage,
+                        beep_time_in_source=prim.beep_time,
+                        pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                        post_buffer_seconds=proj.trim_post_buffer_seconds,
+                        config=Config(),
+                        secondaries=secondaries_in,
+                    )
+                except export_helpers.StageExportError as exc:
+                    raise RuntimeError(f"stage {stage_number}: {exc}") from exc
+            else:
+                handle.update(
+                    progress=0.02 + idx * per_stage_share,
+                    message=(
+                        f"Stage {stage_number} ({idx + 1} of {n}): "
+                        "trim already present; skipping"
+                    ),
+                )
+
+        handle.check_cancel()
+        handle.update(progress=0.92, message="Stitching match FCPXML...")
+
+        # Re-load the project: the per-stage worker writes processed flags
+        # via project.save() side-effects, so a fresh load picks those up.
+        proj = state.load()
+        stages_input: list[match_export_helpers.MatchStageInput] = []
+        for stage_number in req.stage_numbers:
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            assert prim is not None and prim.beep_time is not None
+            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
             trimmed_path = exports_dir / f"{base}_trimmed.mp4"
             audit_path = audit_dir / f"stage{stage_number}.json"
             overlay_path = exports_dir / f"{base}_overlay.mov"
-
-            # Per-cam clip-local beep offset matches the per-stage exporter:
-            # ``min(pre_buffer, beep_time_in_source)`` so short heads (cam beep
-            # within the pre-buffer) align correctly.
             secondaries: list[match_export_helpers.MatchSecondaryInput] = []
-            for sv in stage.videos:
-                if sv.role != "secondary":
+            for sv in stg.videos:
+                if sv.role != "secondary" or sv.beep_time is None:
                     continue
-                if sv.beep_time is None:
-                    continue
-                sec_clip_beep = min(project.trim_pre_buffer_seconds, sv.beep_time)
+                sec_clip_beep = min(proj.trim_pre_buffer_seconds, sv.beep_time)
                 secondaries.append(
                     match_export_helpers.MatchSecondaryInput(
                         video_id=sv.video_id,
@@ -4294,12 +4432,11 @@ def create_app(
                         label=f"Cam {sv.video_id}",
                     )
                 )
-
-            primary_clip_beep = min(project.trim_pre_buffer_seconds, primary.beep_time)
+            primary_clip_beep = min(proj.trim_pre_buffer_seconds, prim.beep_time)
             stages_input.append(
                 match_export_helpers.MatchStageInput(
                     stage_number=stage_number,
-                    stage_name=stage.stage_name,
+                    stage_name=stg.stage_name,
                     audit_path=audit_path,
                     trimmed_path=trimmed_path,
                     beep_offset_seconds=primary_clip_beep,
@@ -4308,7 +4445,7 @@ def create_app(
                 )
             )
 
-        project_name = req.project_name or project.name or "match"
+        project_name = req.project_name or proj.name or "match"
         request_data = match_export_helpers.MatchExportRequestData(
             stage_numbers=tuple(req.stage_numbers),
             head_pad_seconds=req.head_pad_seconds,
@@ -4317,7 +4454,6 @@ def create_app(
             include_overlay=req.include_overlay,
             project_name=project_name,
         )
-
         try:
             result = match_export_helpers.export_match(
                 stages=stages_input,
@@ -4326,15 +4462,26 @@ def create_app(
                 config=Config().output,
             )
         except match_export_helpers.MatchExportError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise RuntimeError(str(exc)) from exc
 
-        return JSONResponse(
+        handle.set_result(
             {
                 "fcpxml_path": str(result.fcpxml_path),
                 "stage_count": result.stage_count,
                 "duration_seconds": result.duration_seconds,
                 "anomalies": result.anomalies,
             }
+        )
+        anom_word = "anomaly" if len(result.anomalies) == 1 else "anomalies"
+        anom_suffix = (
+            f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
+        )
+        handle.update(
+            progress=1.0,
+            message=(
+                f"Done: {result.stage_count} stages, "
+                f"{result.duration_seconds:.1f}s{anom_suffix}"
+            ),
         )
 
     @app.post("/api/files/reveal")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4338,16 +4338,13 @@ def create_app(
             overlay_missing = req.include_overlay and not overlay_target.exists()
 
             needs_per_stage = (
-                not trimmed_path.exists()
-                or not secondary_trims_present
-                or overlay_missing
+                not trimmed_path.exists() or not secondary_trims_present or overlay_missing
             )
             if needs_per_stage:
                 handle.update(
                     progress=0.02 + idx * per_stage_share,
                     message=(
-                        f"Stage {stage_number} ({idx + 1} of {n}): "
-                        "running per-stage export..."
+                        f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."
                     ),
                 )
                 # Build the secondaries list for the per-stage exporter --
@@ -4473,9 +4470,7 @@ def create_app(
             }
         )
         anom_word = "anomaly" if len(result.anomalies) == 1 else "anomalies"
-        anom_suffix = (
-            f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
-        )
+        anom_suffix = f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
         handle.update(
             progress=1.0,
             message=(

--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -45,6 +45,8 @@ const KIND_LABEL: Record<string, string> = {
   detect_beep: "Detect beep",
   trim: "Trim audit clip",
   shot_detect: "Detect shots",
+  export: "Export stage",
+  match_export: "Match export",
 };
 
 function formatKind(kind: string): string {

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -453,6 +453,34 @@ export interface ExportStageResult {
   anomalies: string[];
 }
 
+/** Match-level stitched-FCPXML export (issue #171). The selected stages
+ *  must already have a lossless trim + audit shots; the match export
+ *  composes from those without re-encoding. */
+export interface MatchExportRequestPayload {
+  stage_numbers: number[];
+  /** Seconds of footage kept before the beep in each stage. Clamped
+   *  server-side to the project's pre-buffer (default 5.0). */
+  head_pad_seconds?: number;
+  /** Seconds of footage kept after the final shot in each stage.
+   *  Clamped server-side to the project's post-buffer. */
+  tail_pad_seconds?: number;
+  include_secondaries?: boolean;
+  include_overlay?: boolean;
+  /** Defaults to the bound project's name. Slugified for the output
+   *  filename: ``<slug>-match.fcpxml``. */
+  project_name?: string | null;
+}
+
+export interface MatchExportResult {
+  fcpxml_path: string;
+  stage_count: number;
+  duration_seconds: number;
+  /** Soft-failure messages (missing cam trim, ffprobe drop on a cam,
+   *  missing overlay). The export still wrote the FCPXML; these are
+   *  surfaced so the SPA can show "exported with warnings". */
+  anomalies: string[];
+}
+
 export interface RemovalPlan {
   video_path: string;
   raw_link_path: string;
@@ -1323,6 +1351,26 @@ export const api = {
         // caller can explicitly exclude all secondaries.
         ...(opts.secondary_video_ids !== undefined
           ? { secondary_video_ids: opts.secondary_video_ids }
+          : {}),
+      },
+    }),
+
+  /** Stitch N stages into one FCPXML (issue #171). Synchronous: the
+   *  composer runs in-process (just XML + a few ffprobes) and the response
+   *  carries the output path + total duration directly -- no JobHandle
+   *  poll. Stages must be pre-exported (lossless trim + audit shots);
+   *  400s otherwise with a per-stage message. */
+  exportMatch: (payload: MatchExportRequestPayload) =>
+    request<MatchExportResult>("/api/match/export", {
+      method: "POST",
+      json: {
+        stage_numbers: payload.stage_numbers,
+        head_pad_seconds: payload.head_pad_seconds ?? 5.0,
+        tail_pad_seconds: payload.tail_pad_seconds ?? 5.0,
+        include_secondaries: payload.include_secondaries ?? true,
+        include_overlay: payload.include_overlay ?? true,
+        ...(payload.project_name !== undefined
+          ? { project_name: payload.project_name }
           : {}),
       },
     }),

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -723,6 +723,13 @@ export interface Job {
    *  and the registry rolls acknowledged failures off faster than
    *  unacknowledged ones. */
   acknowledged: boolean;
+  /** Optional structured result payload set by the worker. Present on
+   *  successful jobs whose output is meaningful to the SPA -- e.g.
+   *  match-export emits ``{ fcpxml_path, stage_count, duration_seconds,
+   *  anomalies }``. The schema is per-kind: branch on ``Job.kind`` to
+   *  interpret. ``null`` for jobs that signal success only by writing
+   *  files. */
+  result: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
   started_at: string | null;
@@ -1355,13 +1362,14 @@ export const api = {
       },
     }),
 
-  /** Stitch N stages into one FCPXML (issue #171). Synchronous: the
-   *  composer runs in-process (just XML + a few ffprobes) and the response
-   *  carries the output path + total duration directly -- no JobHandle
-   *  poll. Stages must be pre-exported (lossless trim + audit shots);
-   *  400s otherwise with a per-stage message. */
+  /** Stitch N stages into one FCPXML (issue #171, #172). Job-queued: the
+   *  worker re-runs any missing per-stage exports (trim + optional
+   *  overlay) before stitching, so a fresh project goes from "audit done"
+   *  to "match FCPXML on disk" in one click. Returns a Job snapshot;
+   *  poll via {@link api.pollJob} until terminal, then read the
+   *  {@link MatchExportResult} from ``Job.result``. */
   exportMatch: (payload: MatchExportRequestPayload) =>
-    request<MatchExportResult>("/api/match/export", {
+    request<Job>("/api/match/export", {
       method: "POST",
       json: {
         stage_numbers: payload.stage_numbers,

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
+  Film,
   FileBarChart,
   FileText,
   FolderOpen,
@@ -45,6 +46,7 @@ import {
   asSourceUnreachable,
   type ExportOverview,
   type Job,
+  type MatchExportResult,
   type MatchProject,
   type SecondaryExportStatus,
   type StageAudit,
@@ -52,10 +54,45 @@ import {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
+type PaddingPreset = "full" | "action" | "highlight" | "custom";
+
+const PADDING_PRESETS: Record<
+  Exclude<PaddingPreset, "custom">,
+  { label: string; head: number; tail: number; help: string }
+> = {
+  full: {
+    label: "Full",
+    head: 5.0,
+    tail: 5.0,
+    help: "Matches the per-stage export defaults (5s before beep, 5s after final shot).",
+  },
+  action: {
+    label: "Action cut",
+    head: 0.5,
+    tail: 1.0,
+    help: "Tight: 0.5s before beep, 1s after final shot. Best for a fast-moving match reel.",
+  },
+  highlight: {
+    label: "Highlight",
+    head: 1.5,
+    tail: 2.0,
+    help: "Mid: 1.5s before beep, 2s after final shot. Room to read the body before the draw.",
+  },
+};
+
 export function Export() {
   const [project, setProject] = useState<MatchProject | null>(null);
   const [overview, setOverview] = useState<ExportOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Match-export multi-select. A stage qualifies for inclusion only when
+  // it's already exported (lossless trim + audit shots present); otherwise
+  // the match-export endpoint would 400. The dialog reads ``selectedForMatch``
+  // and the trim-buffer caps from the project settings.
+  const [selectedForMatch, setSelectedForMatch] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const [matchDialogOpen, setMatchDialogOpen] = useState(false);
+  const [matchResult, setMatchResult] = useState<MatchExportResult | null>(null);
 
   const reload = useCallback(async () => {
     try {
@@ -91,6 +128,57 @@ export function Export() {
   const exported = (overview?.stages ?? []).filter(
     (s) => !s.skipped && s.has_exports,
   ).length;
+
+  // A stage is eligible for the match export when the per-stage exporter
+  // already produced its lossless trim + the audit has shots. We use the
+  // overview's ``has_exports`` proxy for that since it lights up only after
+  // a successful Generate.
+  const matchEligibleStageNumbers = useMemo(
+    () =>
+      (overview?.stages ?? [])
+        .filter((s) => !s.skipped && s.has_exports && s.ready_to_export)
+        .map((s) => s.stage_number),
+    [overview],
+  );
+  const eligibleSet = useMemo(
+    () => new Set(matchEligibleStageNumbers),
+    [matchEligibleStageNumbers],
+  );
+  // Drop any selections whose stage stopped being eligible (re-run cleared
+  // exports, stage skipped, etc) so the banner count and dialog stay
+  // truthful.
+  useEffect(() => {
+    setSelectedForMatch((prev) => {
+      const next = new Set<number>();
+      for (const n of prev) {
+        if (eligibleSet.has(n)) next.add(n);
+      }
+      return next.size === prev.size ? prev : next;
+    });
+  }, [eligibleSet]);
+
+  const toggleSelection = useCallback(
+    (stageNumber: number, checked: boolean) => {
+      setSelectedForMatch((prev) => {
+        const next = new Set(prev);
+        if (checked) next.add(stageNumber);
+        else next.delete(stageNumber);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const orderedSelection = useMemo(
+    () =>
+      (overview?.stages ?? [])
+        .map((s) => s.stage_number)
+        .filter((n) => selectedForMatch.has(n)),
+    [overview, selectedForMatch],
+  );
+
+  const headPadCap = project?.trim_pre_buffer_seconds ?? 5.0;
+  const tailPadCap = project?.trim_post_buffer_seconds ?? 5.0;
 
   return (
     <div className="space-y-6">
@@ -138,6 +226,91 @@ export function Export() {
         </CardHeader>
       </Card>
 
+      {selectedForMatch.size > 0 ? (
+        <div className="sticky top-0 z-10 -mx-4 border-b border-border/60 bg-background/95 px-4 py-2 backdrop-blur">
+          <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+            <div>
+              <strong>{selectedForMatch.size}</strong> stage
+              {selectedForMatch.size === 1 ? "" : "s"} selected for match export
+              {selectedForMatch.size === 1
+                ? " -- pick at least one more to enable Export match."
+                : ""}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setSelectedForMatch(new Set())}
+              >
+                Clear
+              </Button>
+              <Button
+                size="sm"
+                disabled={selectedForMatch.size < 2}
+                onClick={() => setMatchDialogOpen(true)}
+                title={
+                  selectedForMatch.size >= 2
+                    ? "Stitch the selected stages into one FCPXML"
+                    : "Select 2+ exported stages to enable"
+                }
+              >
+                <Film className="size-4" />
+                Export match...
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {matchResult ? (
+        <Card>
+          <CardContent className="pt-6 text-sm">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 font-medium">
+                  <CheckCircle2 className="size-4 text-status-complete" />
+                  Match export written ({matchResult.stage_count} stages,{" "}
+                  {matchResult.duration_seconds.toFixed(1)}s)
+                </div>
+                <div className="font-mono text-xs text-muted-foreground">
+                  {matchResult.fcpxml_path}
+                </div>
+                {matchResult.anomalies.length > 0 ? (
+                  <ul className="ml-4 list-disc text-xs text-status-warning">
+                    {matchResult.anomalies.map((a, i) => (
+                      <li key={i}>{a}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    void api
+                      .revealFile(matchResult.fcpxml_path)
+                      .catch((e) =>
+                        setError(e instanceof Error ? e.message : String(e)),
+                      );
+                  }}
+                >
+                  <FolderOpen className="size-4" />
+                  Reveal in Finder
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setMatchResult(null)}
+                >
+                  Dismiss
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <div className="space-y-3">
         {(overview?.stages ?? []).map((row) => (
           <StageRow
@@ -145,9 +318,28 @@ export function Export() {
             row={row}
             onChanged={reload}
             onError={setError}
+            matchEligible={eligibleSet.has(row.stage_number)}
+            matchSelected={selectedForMatch.has(row.stage_number)}
+            onToggleMatchSelection={toggleSelection}
           />
         ))}
       </div>
+
+      {matchDialogOpen ? (
+        <MatchExportDialog
+          stageNumbers={orderedSelection}
+          headPadCap={headPadCap}
+          tailPadCap={tailPadCap}
+          defaultProjectName={project?.name ?? "match"}
+          stages={overview?.stages ?? []}
+          onCancel={() => setMatchDialogOpen(false)}
+          onSuccess={(result) => {
+            setMatchDialogOpen(false);
+            setMatchResult(result);
+          }}
+          onError={setError}
+        />
+      ) : null}
     </div>
   );
 }
@@ -156,10 +348,16 @@ function StageRow({
   row,
   onChanged,
   onError,
+  matchEligible,
+  matchSelected,
+  onToggleMatchSelection,
 }: {
   row: StageExportStatus;
   onChanged: () => Promise<void>;
   onError: (msg: string | null) => void;
+  matchEligible: boolean;
+  matchSelected: boolean;
+  onToggleMatchSelection: (stageNumber: number, checked: boolean) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   return (
@@ -170,6 +368,21 @@ function StageRow({
       >
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              className="mt-1 size-4 accent-primary"
+              checked={matchSelected}
+              disabled={!matchEligible}
+              title={
+                matchEligible
+                  ? "Include this stage in a match export"
+                  : "Run the per-stage export first to enable match selection"
+              }
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) =>
+                onToggleMatchSelection(row.stage_number, e.target.checked)
+              }
+            />
             {expanded ? (
               <ChevronDown className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
             ) : (
@@ -807,6 +1020,268 @@ function StageShotTable({
         <ExternalLink className="size-3" />
         Notes save on blur or Enter; flow into the next CSV regen.
       </p>
+    </div>
+  );
+}
+
+function MatchExportDialog({
+  stageNumbers,
+  headPadCap,
+  tailPadCap,
+  defaultProjectName,
+  stages,
+  onCancel,
+  onSuccess,
+  onError,
+}: {
+  stageNumbers: number[];
+  headPadCap: number;
+  tailPadCap: number;
+  defaultProjectName: string;
+  stages: StageExportStatus[];
+  onCancel: () => void;
+  onSuccess: (result: MatchExportResult) => void;
+  onError: (msg: string | null) => void;
+}) {
+  // Default to "Full" -- mirrors the per-stage export's defaults so the
+  // user has to opt in to a tighter cut.
+  const [preset, setPreset] = useState<PaddingPreset>("full");
+  const [headPad, setHeadPad] = useState<number>(PADDING_PRESETS.full.head);
+  const [tailPad, setTailPad] = useState<number>(PADDING_PRESETS.full.tail);
+  const [includeSecondaries, setIncludeSecondaries] = useState(true);
+  const [includeOverlay, setIncludeOverlay] = useState(true);
+  const [projectName, setProjectName] = useState(defaultProjectName);
+  const [busy, setBusy] = useState(false);
+
+  const choosePreset = (next: PaddingPreset) => {
+    setPreset(next);
+    if (next !== "custom") {
+      const cfg = PADDING_PRESETS[next];
+      // Cap presets at the project's pre/post buffer in case it was
+      // configured below the preset's nominal value.
+      setHeadPad(Math.min(cfg.head, headPadCap));
+      setTailPad(Math.min(cfg.tail, tailPadCap));
+    }
+  };
+
+  // Any flag that has at least one stage in the selection covers it. If
+  // none of the selected stages have e.g. a secondary, the toggle is
+  // disabled (the matching backend would silently ignore an empty list,
+  // but it reads better to grey it out).
+  const anySelectedStageHasSecondaries = stages
+    .filter((s) => stageNumbers.includes(s.stage_number))
+    .some((s) => s.secondaries.length > 0);
+
+  const submit = async () => {
+    onError(null);
+    setBusy(true);
+    try {
+      const result = await api.exportMatch({
+        stage_numbers: stageNumbers,
+        head_pad_seconds: headPad,
+        tail_pad_seconds: tailPad,
+        include_secondaries: includeSecondaries,
+        include_overlay: includeOverlay,
+        project_name: projectName,
+      });
+      onSuccess(result);
+    } catch (e) {
+      onError(
+        e instanceof ApiError
+          ? `Match export failed: ${e.detail}`
+          : e instanceof Error
+            ? e.message
+            : String(e),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="match-export-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-4"
+      onClick={onCancel}
+    >
+      <Card
+        className="w-full max-w-xl shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle id="match-export-title" className="flex items-center gap-2">
+            <Film className="size-5" />
+            Export match
+          </CardTitle>
+          <CardDescription>
+            Stitches {stageNumbers.length} stage
+            {stageNumbers.length === 1 ? "" : "s"} into one FCPXML in stage
+            order. Composes from existing trims; no re-encoding.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <section className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Padding
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(Object.keys(PADDING_PRESETS) as Array<keyof typeof PADDING_PRESETS>).map(
+                (key) => (
+                  <label
+                    key={key}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
+                      preset === key && "border-primary bg-primary/10",
+                    )}
+                    title={PADDING_PRESETS[key].help}
+                  >
+                    <input
+                      type="radio"
+                      name="match-export-preset"
+                      checked={preset === key}
+                      onChange={() => choosePreset(key)}
+                      className="accent-primary"
+                    />
+                    {PADDING_PRESETS[key].label}
+                    <span className="text-muted-foreground">
+                      ({PADDING_PRESETS[key].head}s / {PADDING_PRESETS[key].tail}s)
+                    </span>
+                  </label>
+                ),
+              )}
+              <label
+                className={cn(
+                  "flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
+                  preset === "custom" && "border-primary bg-primary/10",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="match-export-preset"
+                  checked={preset === "custom"}
+                  onChange={() => choosePreset("custom")}
+                  className="accent-primary"
+                />
+                Custom
+              </label>
+            </div>
+            <div
+              className={cn(
+                "grid grid-cols-2 gap-3 pt-1",
+                preset !== "custom" && "opacity-60",
+              )}
+            >
+              <label className="space-y-1 text-xs">
+                <div className="flex items-center justify-between">
+                  <span>Head (before beep)</span>
+                  <span className="font-mono tabular-nums">
+                    {headPad.toFixed(2)}s
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={headPadCap}
+                  step={0.1}
+                  value={headPad}
+                  disabled={preset !== "custom" || busy}
+                  onChange={(e) => setHeadPad(parseFloat(e.target.value))}
+                  className="w-full accent-primary"
+                />
+              </label>
+              <label className="space-y-1 text-xs">
+                <div className="flex items-center justify-between">
+                  <span>Tail (after final shot)</span>
+                  <span className="font-mono tabular-nums">
+                    {tailPad.toFixed(2)}s
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={tailPadCap}
+                  step={0.1}
+                  value={tailPad}
+                  disabled={preset !== "custom" || busy}
+                  onChange={(e) => setTailPad(parseFloat(e.target.value))}
+                  className="w-full accent-primary"
+                />
+              </label>
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Tracks
+            </div>
+            <div className="flex flex-wrap gap-3 text-xs">
+              <label
+                className={cn(
+                  "flex items-center gap-1.5",
+                  !anySelectedStageHasSecondaries && "opacity-60",
+                )}
+                title={
+                  anySelectedStageHasSecondaries
+                    ? "Attach each stage's per-cam trims as connected clips"
+                    : "None of the selected stages have secondary cams"
+                }
+              >
+                <input
+                  type="checkbox"
+                  className="size-4 accent-primary"
+                  checked={includeSecondaries && anySelectedStageHasSecondaries}
+                  disabled={!anySelectedStageHasSecondaries || busy}
+                  onChange={(e) => setIncludeSecondaries(e.target.checked)}
+                />
+                Include secondary cams
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  className="size-4 accent-primary"
+                  checked={includeOverlay}
+                  disabled={busy}
+                  onChange={(e) => setIncludeOverlay(e.target.checked)}
+                />
+                Include overlay (when present)
+              </label>
+            </div>
+          </section>
+
+          <section className="space-y-1">
+            <label className="text-xs">
+              Project name
+              <input
+                type="text"
+                value={projectName}
+                disabled={busy}
+                onChange={(e) => setProjectName(e.target.value)}
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-1 font-mono text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </label>
+            <p className="text-[11px] text-muted-foreground">
+              Output file: <code>exports/&lt;slug&gt;-match.fcpxml</code>.
+              Re-running overwrites.
+            </p>
+          </section>
+
+          <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+            <Button variant="ghost" disabled={busy} onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={submit} disabled={busy || !projectName.trim()}>
+              {busy ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Film className="size-4" />
+              )}
+              Export match
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -113,9 +113,11 @@ export function Export() {
   }, [reload]);
 
   // A stage is eligible for the match export once its audit is complete
-  // (primary + beep + shots). The match-export endpoint queues a job that
-  // re-runs any missing per-stage trim before stitching, so we don't need
-  // ``has_exports`` here -- "ready" is enough.
+  // (primary + beep + shots) AND its source video is reachable -- the
+  // worker may need to (re-)trim, which requires the source on disk.
+  // We exclude unreachable stages here rather than letting the endpoint
+  // 424 on submit; the row's StatusBadge already flags "Source missing"
+  // so the user can see why a stage is greyed out.
   //
   // All match-export hooks live ABOVE the early-return below so the hook
   // order is stable across the loading -> loaded transition (React rules
@@ -123,7 +125,12 @@ export function Export() {
   const matchEligibleStageNumbers = useMemo(
     () =>
       (overview?.stages ?? [])
-        .filter((s) => !s.skipped && s.ready_to_export)
+        .filter(
+          (s) =>
+            !s.skipped &&
+            s.ready_to_export &&
+            s.source_reachable !== false,
+        )
         .map((s) => s.stage_number),
     [overview],
   );
@@ -354,7 +361,6 @@ export function Export() {
             setMatchDialogOpen(false);
             setMatchResult(result);
           }}
-          onError={setError}
         />
       ) : null}
     </div>
@@ -393,7 +399,9 @@ function StageRow({
               title={
                 matchEligible
                   ? "Include this stage in a match export (any missing trim is produced automatically)"
-                  : "Finish the audit first -- shot detection must produce at least one shot"
+                  : row.source_reachable === false
+                    ? "Source video is not reachable -- reconnect external storage or re-link on Ingest"
+                    : "Finish the audit first -- shot detection must produce at least one shot"
               }
               onClick={(e) => e.stopPropagation()}
               onChange={(e) =>
@@ -1049,7 +1057,6 @@ function MatchExportDialog({
   stages,
   onCancel,
   onSuccess,
-  onError,
 }: {
   stageNumbers: number[];
   headPadCap: number;
@@ -1058,7 +1065,6 @@ function MatchExportDialog({
   stages: StageExportStatus[];
   onCancel: () => void;
   onSuccess: (result: MatchExportResult) => void;
-  onError: (msg: string | null) => void;
 }) {
   // Default to "Full" -- mirrors the per-stage export's defaults so the
   // user has to opt in to a tighter cut.
@@ -1072,6 +1078,7 @@ function MatchExportDialog({
   const [includeOverlay, setIncludeOverlay] = useState(false);
   const [projectName, setProjectName] = useState(defaultProjectName);
   const [job, setJob] = useState<Job | null>(null);
+  const [dialogError, setDialogError] = useState<string | null>(null);
   const busy = job?.status === "pending" || job?.status === "running";
 
   const choosePreset = (next: PaddingPreset) => {
@@ -1094,7 +1101,11 @@ function MatchExportDialog({
     .some((s) => s.secondaries.length > 0);
 
   const submit = async () => {
-    onError(null);
+    // Errors during submit live inline in the dialog so the user sees
+    // them in context. Page-level ``onError`` is reserved for failures
+    // that occur after the dialog has closed (or that the user explicitly
+    // dismisses by closing the dialog).
+    setDialogError(null);
     try {
       const submitted = await api.exportMatch({
         stage_numbers: stageNumbers,
@@ -1107,11 +1118,11 @@ function MatchExportDialog({
       setJob(submitted);
       const final = await api.pollJob(submitted.id, setJob);
       if (final.status === "failed") {
-        onError(final.error ?? "Match export failed");
+        setDialogError(final.error ?? "Match export failed");
         return;
       }
       if (final.status === "cancelled") {
-        onError("Match export cancelled");
+        setDialogError("Match export cancelled");
         return;
       }
       const result = final.result as
@@ -1123,18 +1134,16 @@ function MatchExportDialog({
           }
         | null;
       if (!result) {
-        onError("Match export finished without a result payload");
+        setDialogError("Match export finished without a result payload");
         return;
       }
       onSuccess(result);
     } catch (e) {
-      // Source-unreachable comes back as a structured 424 from the
-      // pre-flight check; surface its message verbatim.
       const unreachable = asSourceUnreachable(e);
       if (unreachable) {
-        onError(unreachable.message);
+        setDialogError(unreachable.message);
       } else {
-        onError(
+        setDialogError(
           e instanceof ApiError
             ? `Match export failed: ${e.detail}`
             : e instanceof Error
@@ -1314,7 +1323,7 @@ function MatchExportDialog({
             </p>
           </section>
 
-          {job ? (
+          {job && !dialogError ? (
             <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs">
               <div className="flex items-center gap-2 font-medium">
                 {busy ? (
@@ -1330,6 +1339,16 @@ function MatchExportDialog({
                   />
                 </div>
               ) : null}
+            </div>
+          ) : null}
+
+          {dialogError ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
+              <div className="mb-1 flex items-center gap-1 font-medium text-destructive">
+                <AlertCircle className="size-3.5" />
+                Match export failed
+              </div>
+              <p className="text-muted-foreground">{dialogError}</p>
             </div>
           ) : null}
 

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -112,27 +112,14 @@ export function Export() {
     void reload();
   }, [reload]);
 
-  if (!project && !error) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-7 w-1/3" />
-        <Skeleton className="h-32" />
-      </div>
-    );
-  }
-
-  const total = (overview?.stages ?? []).filter((s) => !s.skipped).length;
-  const ready = (overview?.stages ?? []).filter(
-    (s) => !s.skipped && s.ready_to_export,
-  ).length;
-  const exported = (overview?.stages ?? []).filter(
-    (s) => !s.skipped && s.has_exports,
-  ).length;
-
   // A stage is eligible for the match export when the per-stage exporter
   // already produced its lossless trim + the audit has shots. We use the
   // overview's ``has_exports`` proxy for that since it lights up only after
   // a successful Generate.
+  //
+  // All match-export hooks live ABOVE the early-return below so the hook
+  // order is stable across the loading -> loaded transition (React rules
+  // of hooks: every render must call the same hooks in the same order).
   const matchEligibleStageNumbers = useMemo(
     () =>
       (overview?.stages ?? [])
@@ -176,6 +163,23 @@ export function Export() {
         .filter((n) => selectedForMatch.has(n)),
     [overview, selectedForMatch],
   );
+
+  if (!project && !error) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-7 w-1/3" />
+        <Skeleton className="h-32" />
+      </div>
+    );
+  }
+
+  const total = (overview?.stages ?? []).filter((s) => !s.skipped).length;
+  const ready = (overview?.stages ?? []).filter(
+    (s) => !s.skipped && s.ready_to_export,
+  ).length;
+  const exported = (overview?.stages ?? []).filter(
+    (s) => !s.skipped && s.has_exports,
+  ).length;
 
   const headPadCap = project?.trim_pre_buffer_seconds ?? 5.0;
   const tailPadCap = project?.trim_post_buffer_seconds ?? 5.0;

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -112,10 +112,10 @@ export function Export() {
     void reload();
   }, [reload]);
 
-  // A stage is eligible for the match export when the per-stage exporter
-  // already produced its lossless trim + the audit has shots. We use the
-  // overview's ``has_exports`` proxy for that since it lights up only after
-  // a successful Generate.
+  // A stage is eligible for the match export once its audit is complete
+  // (primary + beep + shots). The match-export endpoint queues a job that
+  // re-runs any missing per-stage trim before stitching, so we don't need
+  // ``has_exports`` here -- "ready" is enough.
   //
   // All match-export hooks live ABOVE the early-return below so the hook
   // order is stable across the loading -> loaded transition (React rules
@@ -123,7 +123,7 @@ export function Export() {
   const matchEligibleStageNumbers = useMemo(
     () =>
       (overview?.stages ?? [])
-        .filter((s) => !s.skipped && s.has_exports && s.ready_to_export)
+        .filter((s) => !s.skipped && s.ready_to_export)
         .map((s) => s.stage_number),
     [overview],
   );
@@ -230,20 +230,33 @@ export function Export() {
         </CardHeader>
       </Card>
 
-      {selectedForMatch.size > 0 ? (
+      {matchEligibleStageNumbers.length > 0 ? (
         <div className="sticky top-0 z-10 -mx-4 border-b border-border/60 bg-background/95 px-4 py-2 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
             <div>
-              <strong>{selectedForMatch.size}</strong> stage
-              {selectedForMatch.size === 1 ? "" : "s"} selected for match export
-              {selectedForMatch.size === 1
-                ? " -- pick at least one more to enable Export match."
-                : ""}
+              <strong>{selectedForMatch.size}</strong> of{" "}
+              {matchEligibleStageNumbers.length} eligible stage
+              {matchEligibleStageNumbers.length === 1 ? "" : "s"} selected
+              {selectedForMatch.size === 0 ? " -- pick stages to stitch" : ""}
             </div>
             <div className="flex items-center gap-2">
               <Button
                 size="sm"
+                variant="outline"
+                disabled={
+                  selectedForMatch.size === matchEligibleStageNumbers.length
+                }
+                onClick={() =>
+                  setSelectedForMatch(new Set(matchEligibleStageNumbers))
+                }
+                title="Select every audited stage"
+              >
+                Select all
+              </Button>
+              <Button
+                size="sm"
                 variant="ghost"
+                disabled={selectedForMatch.size === 0}
                 onClick={() => setSelectedForMatch(new Set())}
               >
                 Clear
@@ -254,8 +267,8 @@ export function Export() {
                 onClick={() => setMatchDialogOpen(true)}
                 title={
                   selectedForMatch.size >= 2
-                    ? "Stitch the selected stages into one FCPXML"
-                    : "Select 2+ exported stages to enable"
+                    ? "Stitch the selected stages into one FCPXML (auto-runs missing per-stage trims)"
+                    : "Select 2+ stages to enable"
                 }
               >
                 <Film className="size-4" />
@@ -379,8 +392,8 @@ function StageRow({
               disabled={!matchEligible}
               title={
                 matchEligible
-                  ? "Include this stage in a match export"
-                  : "Run the per-stage export first to enable match selection"
+                  ? "Include this stage in a match export (any missing trim is produced automatically)"
+                  : "Finish the audit first -- shot detection must produce at least one shot"
               }
               onClick={(e) => e.stopPropagation()}
               onChange={(e) =>
@@ -1053,9 +1066,13 @@ function MatchExportDialog({
   const [headPad, setHeadPad] = useState<number>(PADDING_PRESETS.full.head);
   const [tailPad, setTailPad] = useState<number>(PADDING_PRESETS.full.tail);
   const [includeSecondaries, setIncludeSecondaries] = useState(true);
-  const [includeOverlay, setIncludeOverlay] = useState(true);
+  // Overlay defaults off because the per-frame PIL + ffmpeg ProRes 4444
+  // render is the slowest writer; opt in per export. Mirrors the per-
+  // stage Generate's default.
+  const [includeOverlay, setIncludeOverlay] = useState(false);
   const [projectName, setProjectName] = useState(defaultProjectName);
-  const [busy, setBusy] = useState(false);
+  const [job, setJob] = useState<Job | null>(null);
+  const busy = job?.status === "pending" || job?.status === "running";
 
   const choosePreset = (next: PaddingPreset) => {
     setPreset(next);
@@ -1078,9 +1095,8 @@ function MatchExportDialog({
 
   const submit = async () => {
     onError(null);
-    setBusy(true);
     try {
-      const result = await api.exportMatch({
+      const submitted = await api.exportMatch({
         stage_numbers: stageNumbers,
         head_pad_seconds: headPad,
         tail_pad_seconds: tailPad,
@@ -1088,17 +1104,44 @@ function MatchExportDialog({
         include_overlay: includeOverlay,
         project_name: projectName,
       });
+      setJob(submitted);
+      const final = await api.pollJob(submitted.id, setJob);
+      if (final.status === "failed") {
+        onError(final.error ?? "Match export failed");
+        return;
+      }
+      if (final.status === "cancelled") {
+        onError("Match export cancelled");
+        return;
+      }
+      const result = final.result as
+        | {
+            fcpxml_path: string;
+            stage_count: number;
+            duration_seconds: number;
+            anomalies: string[];
+          }
+        | null;
+      if (!result) {
+        onError("Match export finished without a result payload");
+        return;
+      }
       onSuccess(result);
     } catch (e) {
-      onError(
-        e instanceof ApiError
-          ? `Match export failed: ${e.detail}`
-          : e instanceof Error
-            ? e.message
-            : String(e),
-      );
-    } finally {
-      setBusy(false);
+      // Source-unreachable comes back as a structured 424 from the
+      // pre-flight check; surface its message verbatim.
+      const unreachable = asSourceUnreachable(e);
+      if (unreachable) {
+        onError(unreachable.message);
+      } else {
+        onError(
+          e instanceof ApiError
+            ? `Match export failed: ${e.detail}`
+            : e instanceof Error
+              ? e.message
+              : String(e),
+        );
+      }
     }
   };
 
@@ -1270,6 +1313,25 @@ function MatchExportDialog({
               Re-running overwrites.
             </p>
           </section>
+
+          {job ? (
+            <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs">
+              <div className="flex items-center gap-2 font-medium">
+                {busy ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : null}
+                {job.message ?? "Running..."}
+              </div>
+              {job.progress != null ? (
+                <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-primary transition-[width]"
+                    style={{ width: `${Math.round(job.progress * 100)}%` }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
             <Button variant="ghost" disabled={busy} onClick={onCancel}>

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4778,6 +4778,4 @@ def test_match_export_endpoint_job_fails_when_trim_unrecoverable(
     assert resp.status_code == 424
     detail = resp.json()["detail"]
     # _ensure_source_reachable returns structured detail with a code.
-    assert (
-        detail.get("code") == "source_unreachable" if isinstance(detail, dict) else False
-    ), detail
+    assert detail.get("code") == "source_unreachable" if isinstance(detail, dict) else False, detail

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -4700,7 +4700,7 @@ def _stub_match_export_probe(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_match_export_endpoint_writes_fcpxml(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    client, project_root = _seed_match_export_project(tmp_path)
+    client, _ = _seed_match_export_project(tmp_path)
     _stub_match_export_probe(monkeypatch)
 
     resp = client.post(
@@ -4710,18 +4710,26 @@ def test_match_export_endpoint_writes_fcpxml(
             "head_pad_seconds": 0.5,
             "tail_pad_seconds": 1.0,
             "include_secondaries": True,
-            "include_overlay": True,
+            # Trims are pre-staged but no overlay, so disable to keep the
+            # worker on the "skip per-stage exporter" branch (otherwise it
+            # would try to render an overlay via ffmpeg).
+            "include_overlay": False,
         },
     )
     assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["stage_count"] == 2
-    assert Path(body["fcpxml_path"]).exists()
-    assert Path(body["fcpxml_path"]).name.endswith("-match.fcpxml")
+    job = resp.json()
+    assert job["kind"] == "match_export"
+    final = _wait_for_job(client, job["id"])
+    assert final["status"] == "succeeded", final
+    result = final["result"]
+    assert result is not None
+    assert result["stage_count"] == 2
+    assert Path(result["fcpxml_path"]).exists()
+    assert Path(result["fcpxml_path"]).name.endswith("-match.fcpxml")
     # Per stage: 20s clip, beep@5s, last shot at 0.5s past beep -> head_trim
     # = 5.0 - 0.5 = 4.5s; tail_trim = (20 - 5.5) - 1.0 = 13.5s; eff = 2.0s.
     # Two stages -> 4.0s total.
-    assert body["duration_seconds"] == pytest.approx(4.0, abs=0.1)
+    assert result["duration_seconds"] == pytest.approx(4.0, abs=0.1)
 
 
 def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> None:
@@ -4748,14 +4756,28 @@ def test_match_export_endpoint_400_on_unknown_stage(tmp_path: Path) -> None:
     assert "stage 99 not found" in resp.json()["detail"]
 
 
-def test_match_export_endpoint_400_when_trim_missing(
+def test_match_export_endpoint_job_fails_when_trim_unrecoverable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Source video missing AND no pre-staged trim -> the job fails (not
+    the endpoint). Pre-flight catches reachability up-front: the source is
+    ``project_root/raw/VID1.mp4`` which the seed helper writes, so to
+    simulate a missing source we delete it after seeding and remove the
+    pre-staged trim. The endpoint's source-reachability check then 424s."""
     client, project_root = _seed_match_export_project(tmp_path, stage_count=1)
     _stub_match_export_probe(monkeypatch)
-    # Remove the trim that the seed helper wrote.
     (project_root / "exports" / "stage1_stage-1_trimmed.mp4").unlink()
-
-    resp = client.post("/api/match/export", json={"stage_numbers": [1]})
-    assert resp.status_code == 400
-    assert "lossless trim missing" in resp.json()["detail"]
+    # Make the source unreachable by removing the underlying file (the
+    # symlink in raw/ stays). The endpoint pre-flight surfaces this as a
+    # structured 424.
+    (project_root / "raw" / "VID1.mp4").unlink()
+    resp = client.post(
+        "/api/match/export",
+        json={"stage_numbers": [1], "include_overlay": False},
+    )
+    assert resp.status_code == 424
+    detail = resp.json()["detail"]
+    # _ensure_source_reachable returns structured detail with a code.
+    assert (
+        detail.get("code") == "source_unreachable" if isinstance(detail, dict) else False
+    ), detail


### PR DESCRIPTION
Closes #172. Stacked on #176 (#171). Final slice of #169 minus intro/outro (#173) and ffmpeg render (#174).

## Summary

- Each \`StageRow\` on the Export page gets a leading checkbox. It's enabled only when the row already has \`has_exports\` + \`ready_to_export\` true (the match-export endpoint would 400 on stages missing a trim or audit shots).
- A sticky banner appears at the top of the page once 1+ stages are selected:
  - Shows the count and a Clear button.
  - The Export match button is disabled until 2+ stages are selected (single-stage match export would be a degenerate \`generate_match_fcpxml\` call -- wire that to the existing single-stage flow if anyone needs it).
- \`MatchExportDialog\` (native modal, mirrors the existing \`RemoveVideoDialog\` style) with:
  - **Padding presets**: Full (5/5), Action cut (0.5/1), Highlight (1.5/2), Custom (sliders 0..pre/post buffer cap, 0.1s steps).
  - **Tracks**: Include secondaries (auto-disabled when no selected stage has secondaries), include overlay.
  - **Project name** input (defaults to the bound project's name; slugified server-side for the output filename).
- Successful submit dismisses the dialog, surfaces a result card with the output path, anomalies, a Reveal in Finder button, and a Dismiss button.
- Stale selections clear automatically when a stage stops being eligible (e.g. exports got nuked) so the banner stays truthful.

## Test plan

- [x] \`pnpm build\` clean (TypeScript + Vite).
- [x] \`uv run pytest -q\` -- 702 passed, 1 skipped (Python suite still green).
- [x] Manual: launched \`splitsmith ui --project ...\` and confirmed the SPA loads + assets serve correctly.
- [ ] Manual: select 2+ exported stages, run Action Cut, verify the FCPXML imports into Final Cut with stages back-to-back.

## Notes

- No new dependencies; uses the existing card / button / lucide-icon stack.
- The dialog has no internal validation beyond the project-name being non-empty -- the endpoint owns padding bounds (clamp to project's pre/post buffer) and stage eligibility (audit + trim must exist).
- Intro/outro pickers and an ffmpeg render-to-MP4 button are deliberately deferred to #173 / #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)