### PR TITLE
Add Microsoft BEATs as alternative Voter D backbone (issue #179)

### DIFF
--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -48,6 +48,11 @@ from splitsmith.ensemble.calibration import (
     DEFAULT_CAMERA_CLASS,
     camera_class_from_mount,
 )
+from splitsmith.ensemble.features import (
+    VALID_VOTER_D_BACKENDS,
+    VOTER_D_BACKEND_BEATS,
+    VOTER_D_BACKEND_PANN,
+)
 from splitsmith.ensemble.tta import compute_tta_agreement
 from splitsmith.shot_detect import detect_shots
 
@@ -130,17 +135,62 @@ def _label(cand_t: list[float], truth_shots: list[dict], tol_ms: float) -> list[
     return labels
 
 
+def _voter_d_cache_path(fixture: str, backend: str) -> Path:
+    """Return the per-fixture Voter D probability cache for ``backend``.
+
+    Backends share the cache schema: an .npz with a ``gunshot_prob``
+    column (and any other backend-specific arrays) per detected
+    candidate, in the same order ``detect_shots`` emitted them. Adding a
+    new backend means: (1) sibling cache file via this helper, (2)
+    extractor script that writes the same schema, (3) a branch in
+    ``api.compute_voter_d_probs``.
+    """
+    if backend == VOTER_D_BACKEND_PANN:
+        return CACHE_DIR / f"{fixture}_pann.npz"
+    if backend == VOTER_D_BACKEND_BEATS:
+        return CACHE_DIR / f"{fixture}_beats.npz"
+    raise ValueError(
+        f"unknown voter_d_backend {backend!r}; expected one of {VALID_VOTER_D_BACKENDS}"
+    )
+
+
+def _voter_d_extractor_hint(backend: str) -> str:
+    """User-facing extractor name for the missing-cache error."""
+    if backend == VOTER_D_BACKEND_PANN:
+        return "extract_audio_embeddings.py"
+    if backend == VOTER_D_BACKEND_BEATS:
+        return "extract_beats_embeddings.py"
+    return "<no extractor>"
+
+
+def _voter_d_full_cache_path(fixture: str, backend: str) -> Path:
+    """Wide-window sibling of ``_voter_d_cache_path`` (used by mining)."""
+    if backend == VOTER_D_BACKEND_PANN:
+        return CACHE_DIR / f"{fixture}_pann_full.npz"
+    if backend == VOTER_D_BACKEND_BEATS:
+        return CACHE_DIR / f"{fixture}_beats_full.npz"
+    raise ValueError(
+        f"unknown voter_d_backend {backend!r}; expected one of {VALID_VOTER_D_BACKENDS}"
+    )
+
+
 def _build_universe(
     fixtures: list[str],
     tolerance_ms: float,
     *,
+    voter_d_backend: str = VOTER_D_BACKEND_PANN,
     log: Callable[[str], None] = print,
 ):
-    """Per-fixture: detect at max recall, label, slot CLAP+PANN signals.
+    """Per-fixture: detect at max recall, label, slot CLAP + Voter D signals.
 
     Each universe row carries a ``camera_class`` tag derived from the
     fixture's ``camera.mount`` so the calibrator can stratify per-voter
     thresholds without re-reading the fixture JSONs.
+
+    ``voter_d_backend`` selects which cache file supplies Voter D's
+    per-candidate gunshot probability. PANN reads ``_pann.npz``; BEATs
+    (issue #179) reads ``_beats.npz``. Schema is shared (see
+    ``_voter_d_cache_path``).
     """
     universe = []
     for fix in fixtures:
@@ -150,14 +200,14 @@ def _build_universe(
         truth_path = FIXTURES_DIR / f"{fix}.json"
         wav_path = FIXTURES_DIR / f"{fix}.wav"
         clap_path = CACHE_DIR / f"{fix}_clap.npz"
-        pann_path = CACHE_DIR / f"{fix}_pann.npz"
+        voter_d_path = _voter_d_cache_path(fix, voter_d_backend)
         if not truth_path.exists() or not wav_path.exists():
             log(f"  skip {fix}: missing fixture files")
             continue
-        if not clap_path.exists() or not pann_path.exists():
+        if not clap_path.exists() or not voter_d_path.exists():
             log(
-                f"  skip {fix}: CLAP/PANN cache missing -- run "
-                "extract_clap_features.py + extract_audio_embeddings.py "
+                f"  skip {fix}: CLAP / Voter-D ({voter_d_backend}) cache missing "
+                f"-- run extract_clap_features.py + {_voter_d_extractor_hint(voter_d_backend)} "
                 "for this stem to include it."
             )
             continue
@@ -186,10 +236,13 @@ def _build_universe(
         sims = clap["text_sims"]
         clap_diff = feat.clap_diff_from_similarities(sims)
 
-        pann = np.load(pann_path)
-        if pann["gunshot_prob"].shape[0] != len(shots):
-            raise SystemExit(f"{fix}: PANN cache stale; re-run extract_audio_embeddings.py --force")
-        gunshot_prob = pann["gunshot_prob"]
+        voter_d_cache = np.load(voter_d_path)
+        if voter_d_cache["gunshot_prob"].shape[0] != len(shots):
+            raise SystemExit(
+                f"{fix}: Voter-D ({voter_d_backend}) cache stale; "
+                f"re-run {_voter_d_extractor_hint(voter_d_backend)} --force"
+            )
+        gunshot_prob = voter_d_cache["gunshot_prob"]
 
         times = np.array(cand_t, dtype=np.float64)
         confidences = np.array([s.confidence for s in shots], dtype=np.float64)
@@ -278,6 +331,7 @@ def _load_mined_negatives(
     n_pos_by_fixture: dict[str, int],
     *,
     cap_ratio: float,
+    voter_d_backend: str = VOTER_D_BACKEND_PANN,
     log: Callable[[str], None],
 ) -> tuple[list[dict], dict]:
     """Materialise mined-negative training rows aligned to full-mode caches.
@@ -314,8 +368,8 @@ def _load_mined_negatives(
         sidecar_path = FULL_DIR / f"{fix}_full.json"
         wav_path = FULL_DIR / f"{fix}_full.wav"
         clap_path = CACHE_DIR / f"{fix}_clap_full.npz"
-        pann_path = CACHE_DIR / f"{fix}_pann_full.npz"
-        if not all(p.exists() for p in (sidecar_path, wav_path, clap_path, pann_path)):
+        voter_d_full_path = _voter_d_full_cache_path(fix, voter_d_backend)
+        if not all(p.exists() for p in (sidecar_path, wav_path, clap_path, voter_d_full_path)):
             skipped.append(fix)
             continue
 
@@ -336,13 +390,13 @@ def _load_mined_negatives(
         )
 
         clap = np.load(clap_path, allow_pickle=True)
-        pann = np.load(pann_path)
+        voter_d_full = np.load(voter_d_full_path)
         clap_times = clap["times"].astype(np.float64)
-        if clap_times.shape != pann["gunshot_prob"].shape:
+        if clap_times.shape != voter_d_full["gunshot_prob"].shape:
             raise SystemExit(
-                f"{fix}: full CLAP and PANN caches disagree on candidate count "
-                f"({clap_times.shape[0]} vs {pann['gunshot_prob'].shape[0]}); "
-                "rebuild both with --full --force."
+                f"{fix}: full CLAP and Voter-D ({voter_d_backend}) caches disagree on "
+                f"candidate count ({clap_times.shape[0]} vs "
+                f"{voter_d_full['gunshot_prob'].shape[0]}); rebuild both with --full --force."
             )
         prompts_in_cache = [str(p) for p in clap["prompts"].tolist()]
         if tuple(prompts_in_cache) != feat.CLAP_PROMPTS:
@@ -352,7 +406,7 @@ def _load_mined_negatives(
             )
         sims = clap["text_sims"]
         clap_diffs = feat.clap_diff_from_similarities(sims)
-        gunshot_probs = pann["gunshot_prob"]
+        gunshot_probs = voter_d_full["gunshot_prob"]
 
         # Map mined times -> full-cache row indices. Same WAV + same config in
         # mine_negatives and the --full extractors, so an exact (or sub-ms)
@@ -497,6 +551,7 @@ def build_artifacts(
     mining_cap_ratio: float = DEFAULT_NEG_CAP_RATIO,
     use_mined_negatives: bool = False,
     phone_upweight: float = DEFAULT_PHONE_UPWEIGHT,
+    voter_d_backend: str = VOTER_D_BACKEND_PANN,
     log: Callable[[str], None] = print,
 ) -> dict:
     """Run the calibration build and write artifacts under ``DATA_DIR``.
@@ -504,10 +559,22 @@ def build_artifacts(
     Importable so the production UI's "Rebuild calibration" button can
     drive the same code path as the CLI. Logs progress through ``log``;
     returns the calibration dict that was written.
+
+    ``voter_d_backend`` selects which Voter D backbone the per-voter
+    threshold is calibrated against and which extractor cache is read
+    (``_pann.npz`` vs ``_beats.npz``). Voter C's GBDT does not depend on
+    Voter D's probability, so swapping backends does not invalidate
+    ``voter_c_gbdt.joblib`` and the model file is rewritten with the
+    same training set either way. The artifact records the active
+    backend so ``load_ensemble_runtime`` knows which model to materialise.
     """
+    if voter_d_backend not in VALID_VOTER_D_BACKENDS:
+        raise SystemExit(
+            f"unknown voter_d_backend {voter_d_backend!r}; expected one of {VALID_VOTER_D_BACKENDS}"
+        )
     fixtures = list(fixtures) if fixtures else list(DEFAULT_FIXTURES)
-    log(f"Calibrating ensemble over {len(fixtures)} fixture(s)...")
-    universe = _build_universe(fixtures, tolerance_ms, log=log)
+    log(f"Calibrating ensemble over {len(fixtures)} fixture(s) [Voter D = {voter_d_backend}]...")
+    universe = _build_universe(fixtures, tolerance_ms, voter_d_backend=voter_d_backend, log=log)
     n_total = len(universe)
     n_pos = sum(c["label"] for c in universe)
     log(
@@ -526,7 +593,10 @@ def build_artifacts(
     n_pos_by_fixture = Counter(c["fixture"] for c in universe if c["label"] == 1)
     if use_mined_negatives:
         mined_rows, mining_provenance = _load_mined_negatives(
-            n_pos_by_fixture, cap_ratio=mining_cap_ratio, log=log
+            n_pos_by_fixture,
+            cap_ratio=mining_cap_ratio,
+            voter_d_backend=voter_d_backend,
+            log=log,
         )
     else:
         mined_rows, mining_provenance = [], {
@@ -650,6 +720,7 @@ def build_artifacts(
         "voter_b_threshold": default_thresholds["voter_b_threshold"],
         "voter_c_threshold": default_thresholds["voter_c_threshold"],
         "voter_d_threshold": default_thresholds["voter_d_threshold"],
+        "voter_d_backend": voter_d_backend,
         "voter_c_target_recall": target_recall,
         "tolerance_ms": tolerance_ms,
         "clap_prompts_shot": list(feat.CLAP_PROMPTS_SHOT),
@@ -706,6 +777,18 @@ def main() -> None:
             "threshold drops and FP count rises in threshold-only eval."
         ),
     )
+    p.add_argument(
+        "--voter-d-backend",
+        choices=list(VALID_VOTER_D_BACKENDS),
+        default=VOTER_D_BACKEND_PANN,
+        help=(
+            "Voter D backbone to calibrate against (issue #179). 'pann' "
+            "(default) reads tests/fixtures/.cache/{stem}_pann.npz; "
+            "'beats' reads {stem}_beats.npz. The selection is recorded "
+            "in the shipped calibration JSON so the runtime loader knows "
+            "which model to materialise."
+        ),
+    )
     args = p.parse_args()
     build_artifacts(
         fixtures=args.fixture or None,
@@ -714,6 +797,7 @@ def main() -> None:
         mining_cap_ratio=args.mining_cap_ratio,
         use_mined_negatives=args.with_mining,
         phone_upweight=args.phone_upweight,
+        voter_d_backend=args.voter_d_backend,
     )
 
 

--- a/scripts/compare_voter_d_backends.py
+++ b/scripts/compare_voter_d_backends.py
@@ -1,0 +1,303 @@
+"""Compare PANN vs BEATs as Voter D backbones (issue #179).
+
+Reads the per-fixture caches both extractors produce
+(``tests/fixtures/.cache/{stem}_pann.npz``, ``{stem}_beats.npz``) and
+both pre-built calibration JSONs (``ensemble_calibration_pann_baseline.json``
+and the live ``ensemble_calibration.json``, which is whichever backend
+the most recent ``build_ensemble_artifacts.py`` run produced -- the
+script runs after a BEATs build so the live one is BEATs).
+
+Outputs:
+* Per-voter D separation: ROC-AUC and distribution stats over true-shot
+  vs non-shot candidates.
+* Threshold-only Voter D F1 at the calibrated lowest-positive threshold.
+* B/D correlation (Pearson) -- a high number means BEATs is duplicative
+  with CLAP and adds little ensemble value.
+* Per-camera-class breakdown matching the calibration's stratification.
+
+Reuses ``build_ensemble_artifacts._build_universe`` so the labeling
+greedy-match logic is identical to calibration. Doesn't run the full
+4-voter ensemble: voter A/B/C scoring is the same on both calibrations
+by construction (their thresholds are independent of D's probability),
+so the meaningful delta lives in Voter D itself.
+
+Run after extract_beats_embeddings.py + build_ensemble_artifacts.py:
+    uv run python scripts/compare_voter_d_backends.py
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+from splitsmith.beep_detect import load_audio
+from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble import features as feat
+from splitsmith.ensemble.calibration import camera_class_from_mount
+from splitsmith.shot_detect import detect_shots
+
+DEFAULT_FIXTURES = [
+    "stage-shots-tallmilan-2026-stage3",
+    "stage-shots-blacksmith-2026-stage7",
+    "stage-shots-blacksmith-2026-stage1",
+    "stage-shots-blacksmith-2026-stage2",
+    "stage-shots-blacksmith-2026-stage3",
+    "stage-shots-blacksmith-2026-stage5",
+    "stage-shots-blacksmith-2026-stage6",
+    "stage-shots-blacksmith-2026-stage8",
+    "stage-shots-tallmilan-2026-stage2",
+    "stage-shots-tallmilan-2026-stage7",
+    "stage-shots-tallmilan-2026-stage4",
+    "stage-shots-tallmilan-2026-stage5",
+    "stage-shots-tallmilan-2026-stage6",
+    "stage-shots-tallmilan-2026-stage2-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage5-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage6-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage7-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage1-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage2-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage3-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage5-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage7-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage8-apple-iphone17pro",
+]
+
+FIXTURES_DIR = Path("tests/fixtures")
+CACHE_DIR = FIXTURES_DIR / ".cache"
+DATA_DIR = Path("src/splitsmith/data")
+
+TOLERANCE_MS = 75.0
+
+
+def _label(cand_t: list[float], truth_shots: list[dict], tol_ms: float) -> list[int]:
+    """Greedy nearest-time match (mirrors build_ensemble_artifacts._label)."""
+    labels = [0] * len(cand_t)
+    used: set[int] = set()
+    for s in sorted(truth_shots, key=lambda x: x["time"]):
+        t = s["time"]
+        best_i, best_d = None, None
+        for i, c in enumerate(cand_t):
+            if i in used:
+                continue
+            d = abs(c - t) * 1000.0
+            if d <= tol_ms and (best_d is None or d < best_d):
+                best_i, best_d = i, d
+        if best_i is not None:
+            used.add(best_i)
+            labels[best_i] = 1
+    return labels
+
+
+def _roc_auc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """ROC-AUC for binary labels via the rank-sum formulation."""
+    n_pos = int(labels.sum())
+    n_neg = labels.size - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+    order = np.argsort(scores, kind="stable")
+    ranks = np.empty_like(order, dtype=np.float64)
+    ranks[order] = np.arange(1, scores.size + 1)
+    # Average ranks across ties -- rare in float32 but cheap to handle.
+    _, inverse, counts = np.unique(scores, return_inverse=True, return_counts=True)
+    rank_sum = np.zeros(counts.size, dtype=np.float64)
+    np.add.at(rank_sum, inverse, ranks)
+    avg_rank_per_unique = rank_sum / counts
+    ranks = avg_rank_per_unique[inverse]
+    rank_sum_pos = ranks[labels == 1].sum()
+    return float((rank_sum_pos - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg))
+
+
+def _f1_at_threshold(probs: np.ndarray, labels: np.ndarray, threshold: float) -> dict:
+    keep = probs >= threshold
+    tp = int(((keep) & (labels == 1)).sum())
+    fp = int(((keep) & (labels == 0)).sum())
+    fn = int(((~keep) & (labels == 1)).sum())
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"tp": tp, "fp": fp, "fn": fn, "precision": p, "recall": r, "f1": f1, "threshold": threshold}
+
+
+def _threshold_at_recall(probs: np.ndarray, labels: np.ndarray, target_recall: float) -> float:
+    """Largest threshold whose recall is >= ``target_recall`` (matches calibration logic)."""
+    n_pos = int(labels.sum())
+    if n_pos == 0:
+        return 0.0
+    pairs = sorted(zip(probs.tolist(), labels.tolist(), strict=True), key=lambda x: -x[0])
+    cum = 0
+    threshold = 0.0
+    for prob, lbl in pairs:
+        if lbl == 1:
+            cum += 1
+        if cum / n_pos >= target_recall:
+            threshold = float(prob)
+            break
+    return threshold
+
+
+def _best_f1(probs: np.ndarray, labels: np.ndarray) -> dict:
+    """Sweep thresholds at every positive prob, pick the one with the highest F1."""
+    if labels.sum() == 0:
+        return {"f1": 0.0, "threshold": 0.0, "tp": 0, "fp": 0, "fn": 0, "precision": 0.0, "recall": 0.0}
+    best = _f1_at_threshold(probs, labels, 0.0)
+    for thr in sorted({float(p) for p, l in zip(probs.tolist(), labels.tolist()) if l == 1}):
+        m = _f1_at_threshold(probs, labels, thr)
+        if m["f1"] > best["f1"]:
+            best = m
+    return best
+
+
+def _pearson(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size < 2:
+        return float("nan")
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = float(np.sqrt((a * a).sum() * (b * b).sum()))
+    return float((a * b).sum() / denom) if denom > 0 else float("nan")
+
+
+def _build_paired_universe() -> list[dict]:
+    """Per-fixture: detect at max recall, label, attach PANN + BEATs probs and CLAP diff."""
+    rows: list[dict] = []
+    for fix in DEFAULT_FIXTURES:
+        truth_path = FIXTURES_DIR / f"{fix}.json"
+        wav_path = FIXTURES_DIR / f"{fix}.wav"
+        clap_path = CACHE_DIR / f"{fix}_clap.npz"
+        pann_path = CACHE_DIR / f"{fix}_pann.npz"
+        beats_path = CACHE_DIR / f"{fix}_beats.npz"
+        if not all(p.exists() for p in (truth_path, wav_path, clap_path, pann_path, beats_path)):
+            print(f"  skip {fix}: missing cache(s)")
+            continue
+        truth = json.loads(truth_path.read_text())
+        cam_class = camera_class_from_mount((truth.get("camera") or {}).get("mount"))
+        audio, sr = load_audio(wav_path)
+        cfg = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
+        shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg)
+        if not shots:
+            continue
+        cand_t = [s.time_absolute for s in shots]
+        labels = _label(cand_t, truth.get("shots", []), TOLERANCE_MS)
+        clap = np.load(clap_path, allow_pickle=True)
+        pann = np.load(pann_path)
+        beats = np.load(beats_path)
+        if not (
+            clap["audio_emb"].shape[0]
+            == pann["gunshot_prob"].shape[0]
+            == beats["gunshot_prob"].shape[0]
+            == len(shots)
+        ):
+            print(f"  skip {fix}: cache row counts mismatch")
+            continue
+        clap_diff = feat.clap_diff_from_similarities(clap["text_sims"])
+        for i in range(len(shots)):
+            rows.append(
+                {
+                    "fixture": fix,
+                    "camera_class": cam_class,
+                    "label": labels[i],
+                    "pann": float(pann["gunshot_prob"][i]),
+                    "beats": float(beats["gunshot_prob"][i]),
+                    "clap_diff": float(clap_diff[i]),
+                }
+            )
+    return rows
+
+
+def _print_voter_d_summary(rows: list[dict], pann_thresh: float, beats_thresh: float, label: str) -> None:
+    pann = np.array([r["pann"] for r in rows])
+    beats = np.array([r["beats"] for r in rows])
+    clap_diff = np.array([r["clap_diff"] for r in rows])
+    labels = np.array([r["label"] for r in rows], dtype=np.int64)
+
+    print(f"\n=== {label} (n={len(rows)}, pos={int(labels.sum())}, neg={int((labels == 0).sum())}) ===")
+    for name, scores, thresh in [("PANN", pann, pann_thresh), ("BEATs", beats, beats_thresh)]:
+        pos = scores[labels == 1]
+        neg = scores[labels == 0]
+        auc = _roc_auc(scores, labels)
+        m_calib = _f1_at_threshold(scores, labels, thresh)
+        m_r95 = _f1_at_threshold(scores, labels, _threshold_at_recall(scores, labels, 0.95))
+        m_best = _best_f1(scores, labels)
+        gap_med = float(np.median(pos)) - float(np.median(neg))
+        print(
+            f"  {name:5s}  AUC={auc:.4f}  pos_med={np.median(pos):.4f} neg_med={np.median(neg):.4f}  "
+            f"med_gap={gap_med:+.4f}"
+        )
+        print(
+            f"           calibrated thr={thresh:.4f}  P={m_calib['precision']:.3f} R={m_calib['recall']:.3f} F1={m_calib['f1']:.3f}"
+        )
+        print(
+            f"           R>=0.95   thr={m_r95['threshold']:.4f}  P={m_r95['precision']:.3f} R={m_r95['recall']:.3f} F1={m_r95['f1']:.3f}"
+        )
+        print(
+            f"           best F1   thr={m_best['threshold']:.4f}  P={m_best['precision']:.3f} R={m_best['recall']:.3f} F1={m_best['f1']:.3f}"
+        )
+
+    # B vs D correlation (Pearson on the score vectors).
+    rho_pann = _pearson(clap_diff, pann)
+    rho_beats = _pearson(clap_diff, beats)
+    print(f"  CLAP-diff <-> Voter D Pearson r:  PANN={rho_pann:+.3f}   BEATs={rho_beats:+.3f}")
+
+
+def main() -> None:
+    print("Building paired universe (PANN + BEATs caches)...")
+    rows = _build_paired_universe()
+    print(f"  total: {len(rows)} candidates across {len({r['fixture'] for r in rows})} fixtures")
+
+    pann_cal = json.loads((DATA_DIR / "ensemble_calibration_pann_baseline.json").read_text())
+    beats_cal = json.loads((DATA_DIR / "ensemble_calibration.json").read_text())
+    if beats_cal.get("voter_d_backend") != "beats":
+        raise SystemExit(
+            "Live ensemble_calibration.json is not the BEATs build; rebuild with "
+            "scripts/build_ensemble_artifacts.py --voter-d-backend beats first."
+        )
+
+    # Headcam (default class) thresholds.
+    pann_th_head = pann_cal["thresholds_by_camera_class"]["headcam"]["voter_d_threshold"]
+    beats_th_head = beats_cal["thresholds_by_camera_class"]["headcam"]["voter_d_threshold"]
+    pann_th_hand = pann_cal["thresholds_by_camera_class"]["handheld"]["voter_d_threshold"]
+    beats_th_hand = beats_cal["thresholds_by_camera_class"]["handheld"]["voter_d_threshold"]
+
+    _print_voter_d_summary(rows, pann_th_head, beats_th_head, label="ALL CANDIDATES")
+    _print_voter_d_summary(
+        [r for r in rows if r["camera_class"] == "headcam"],
+        pann_th_head,
+        beats_th_head,
+        label="HEADCAM",
+    )
+    _print_voter_d_summary(
+        [r for r in rows if r["camera_class"] == "handheld"],
+        pann_th_hand,
+        beats_th_hand,
+        label="HANDHELD",
+    )
+
+    # Per-fixture mini-table for headcam, sorted by F1 delta.
+    print("\n=== Per-fixture Voter D F1 (headcam, at calibrated headcam threshold) ===")
+    by_fixture = {}
+    for r in rows:
+        if r["camera_class"] != "headcam":
+            continue
+        by_fixture.setdefault(r["fixture"], []).append(r)
+    summary = []
+    for fix, frows in by_fixture.items():
+        labels = np.array([r["label"] for r in frows])
+        pann = np.array([r["pann"] for r in frows])
+        beats = np.array([r["beats"] for r in frows])
+        if labels.sum() == 0:
+            continue
+        m_p = _f1_at_threshold(pann, labels, pann_th_head)
+        m_b = _f1_at_threshold(beats, labels, beats_th_head)
+        summary.append((fix, m_p, m_b))
+    summary.sort(key=lambda x: x[2]["f1"] - x[1]["f1"])
+    for fix, m_p, m_b in summary:
+        print(
+            f"  {fix:55s}  PANN F1={m_p['f1']:.3f}  BEATs F1={m_b['f1']:.3f}  "
+            f"delta={m_b['f1'] - m_p['f1']:+.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_beats_embeddings.py
+++ b/scripts/extract_beats_embeddings.py
@@ -42,7 +42,6 @@ from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble.features import (
     BEATS_CHECKPOINT_ENV,
-    BEATS_GUNSHOT_CLASS_INDEX,
     BEATS_SR,
     BEATS_WINDOW_S,
     load_beats_runtime,
@@ -153,7 +152,7 @@ def extract_for_fixture(name: str, *, force: bool, beats_runtime, full: bool = F
     batch_t = torch.from_numpy(batch).to(beats_runtime.device)
     probs_t = beats_runtime.model.predict_probs(batch_t)
     clipwise = probs_t.detach().cpu().numpy().astype(np.float32)
-    gunshot_prob = clipwise[:, BEATS_GUNSHOT_CLASS_INDEX]
+    gunshot_prob = clipwise[:, beats_runtime.gunshot_class_index]
 
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     np.savez(

--- a/scripts/extract_beats_embeddings.py
+++ b/scripts/extract_beats_embeddings.py
@@ -1,0 +1,216 @@
+"""Extract BEATs gunshot probabilities for each detector candidate.
+
+Sibling of ``extract_audio_embeddings.py`` (the PANN extractor), used by
+issue #179 to evaluate whether replacing Voter D's PANN backbone with
+Microsoft BEATs improves consensus precision/recall on the audited
+fixture set.
+
+For each audited fixture, runs detect_shots at max recall
+(recall_fallback=cwt, min_confidence=0.0). For each candidate, slices a
+1 s window centred on the candidate, resamples to 16 kHz mono, and
+runs BEATs to produce per-class AudioSet probabilities. The
+``Gunshot, gunfire`` class (index 427) is what Voter D keys on; the
+full clipwise vector is also cached so downstream analysis can compare
+class-level separation between PANN and BEATs.
+
+Cache layout matches the PANN extractor on purpose -- the calibration
+script (``build_ensemble_artifacts.py``) routes between caches via a
+single ``_voter_d_cache_path`` helper that keys on the backend name.
+
+BEATs is dev-only -- not part of the runtime pipeline. It also isn't on
+PyPI; install the official Microsoft codebase locally
+(``pip install -e <microsoft/unilm>/beats``) and either point
+``--checkpoint`` at the .pt file or set the
+``SPLITSMITH_BEATS_CHECKPOINT`` environment variable.
+
+Run:
+    uv run python scripts/extract_beats_embeddings.py --checkpoint /path/to/BEATs_iter3_plus.pt
+    uv run python scripts/extract_beats_embeddings.py --force  # re-extract all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import librosa
+import numpy as np
+
+from splitsmith.beep_detect import load_audio
+from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.features import (
+    BEATS_CHECKPOINT_ENV,
+    BEATS_GUNSHOT_CLASS_INDEX,
+    BEATS_SR,
+    BEATS_WINDOW_S,
+    load_beats_runtime,
+)
+from splitsmith.shot_detect import detect_shots
+
+# Match the PANN extractor's fixture list so calibration sees the same
+# stems regardless of which backend was extracted last. Drift between
+# the two lists silently shrinks the calibration set when switching.
+DEFAULT_FIXTURES = [
+    "stage-shots-tallmilan-2026-stage3",
+    "stage-shots-blacksmith-2026-stage7",
+    "stage-shots-blacksmith-2026-stage1",
+    "stage-shots-blacksmith-2026-stage2",
+    "stage-shots-blacksmith-2026-stage3",
+    "stage-shots-blacksmith-2026-stage5",
+    "stage-shots-blacksmith-2026-stage6",
+    "stage-shots-blacksmith-2026-stage8",
+    "stage-shots-tallmilan-2026-stage2",
+    "stage-shots-tallmilan-2026-stage7",
+    "stage-shots-tallmilan-2026-stage5",
+    "stage-shots-tallmilan-2026-stage6",
+    "stage-shots-tallmilan-2026-stage2-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage4-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage5-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage6-apple-iphone17pro",
+    "stage-shots-tallmilan-2026-stage7-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage1-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage2-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage3-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage5-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage6-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage7-apple-iphone17pro",
+    "stage-shots-blacksmith-2026-stage8-apple-iphone17pro",
+]
+FIXTURES_DIR = Path("tests/fixtures")
+FULL_DIR = FIXTURES_DIR / "full"
+CACHE_DIR = FIXTURES_DIR / ".cache"
+
+
+def _slice_window(audio: np.ndarray, sr: int, t: float, win_s: float) -> np.ndarray:
+    half = int(round(sr * win_s / 2.0))
+    centre = int(round(t * sr))
+    lo = max(0, centre - half)
+    hi = min(audio.size, centre + half)
+    chunk = audio[lo:hi].astype(np.float32)
+    target_len = int(round(sr * win_s))
+    if chunk.size < target_len:
+        pad = target_len - chunk.size
+        left = pad // 2
+        right = pad - left
+        chunk = np.pad(chunk, (left, right), mode="constant")
+    return chunk[:target_len]
+
+
+def _resolve_audio_paths(name: str, *, full: bool) -> tuple[Path, Path, float, float]:
+    """Return ``(wav_path, cache_path, beep_time, stage_time)``.
+
+    Mirrors the PANN extractor's resolver -- ``--full`` reads the
+    wide-window WAV and writes a parallel ``*_beats_full.npz`` so the
+    short-fixture cache is never overwritten.
+    """
+    if full:
+        wav_path = FULL_DIR / f"{name}_full.wav"
+        cache_path = CACHE_DIR / f"{name}_beats_full.npz"
+        from wave import open as wave_open
+
+        with wave_open(str(wav_path), "rb") as w:
+            duration = w.getnframes() / w.getframerate()
+        return wav_path, cache_path, 0.0, duration
+    truth = json.loads((FIXTURES_DIR / f"{name}.json").read_text())
+    return (
+        FIXTURES_DIR / f"{name}.wav",
+        CACHE_DIR / f"{name}_beats.npz",
+        float(truth["beep_time"]),
+        float(truth["stage_time_seconds"]),
+    )
+
+
+def extract_for_fixture(name: str, *, force: bool, beats_runtime, full: bool = False) -> None:
+    wav_path, cache_path, beep_time, stage_time = _resolve_audio_paths(name, full=full)
+    if cache_path.exists() and not force:
+        print(f"  {name}: cached -> {cache_path}")
+        return
+    if not wav_path.exists():
+        print(f"  {name}: WAV missing at {wav_path}, skipping")
+        return
+
+    audio, sr = load_audio(wav_path)
+    config = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
+    shots = detect_shots(audio, sr, beep_time, stage_time, config)
+    if not shots:
+        print(f"  {name}: no candidates, skipping")
+        return
+
+    times = np.array([s.time_absolute for s in shots], dtype=np.float64)
+
+    if sr != BEATS_SR:
+        audio_beats = librosa.resample(audio.astype(np.float32), orig_sr=sr, target_sr=BEATS_SR)
+    else:
+        audio_beats = audio.astype(np.float32)
+    batch = np.stack(
+        [_slice_window(audio_beats, BEATS_SR, float(t), BEATS_WINDOW_S) for t in times], axis=0
+    )
+
+    import torch
+
+    batch_t = torch.from_numpy(batch).to(beats_runtime.device)
+    probs_t = beats_runtime.model.predict_probs(batch_t)
+    clipwise = probs_t.detach().cpu().numpy().astype(np.float32)
+    gunshot_prob = clipwise[:, BEATS_GUNSHOT_CLASS_INDEX]
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        cache_path,
+        times=times,
+        clipwise=clipwise,
+        gunshot_prob=gunshot_prob,
+    )
+    print(
+        f"  {name}: {len(times)} cands  clipwise {clipwise.shape}  "
+        f"gunshot_prob mean={gunshot_prob.mean():.3f} max={gunshot_prob.max():.3f}"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--fixture", action="append")
+    p.add_argument("--force", action="store_true", help="Re-extract even if cache exists")
+    p.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a BEATs .pt checkpoint. Falls back to the "
+            f"{BEATS_CHECKPOINT_ENV} environment variable when omitted."
+        ),
+    )
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help=(
+            "Read tests/fixtures/full/{name}_full.wav (wide-window audio "
+            "from scripts/extract_full_fixture_audio.py) and write a "
+            "parallel *_beats_full.npz cache."
+        ),
+    )
+    args = p.parse_args()
+
+    checkpoint = args.checkpoint or (
+        Path(os.environ[BEATS_CHECKPOINT_ENV]) if BEATS_CHECKPOINT_ENV in os.environ else None
+    )
+    if checkpoint is None:
+        raise SystemExit(
+            "BEATs checkpoint not provided. Pass --checkpoint or set "
+            f"{BEATS_CHECKPOINT_ENV}=<path-to-BEATs.pt>."
+        )
+
+    print(f"Loading BEATs from {checkpoint}...")
+    runtime = load_beats_runtime(checkpoint_path=checkpoint)
+
+    fixtures = args.fixture or DEFAULT_FIXTURES
+    print("Extracting BEATs gunshot probabilities:")
+    for f in fixtures:
+        extract_for_fixture(f, force=args.force, beats_runtime=runtime, full=args.full)
+    suffix = "_beats_full" if args.full else "_beats"
+    print(f"\nDone. Cached to tests/fixtures/.cache/*{suffix}.npz")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/splitsmith/ensemble/api.py
+++ b/src/splitsmith/ensemble/api.py
@@ -96,19 +96,64 @@ class EnsembleResult(BaseModel):
 
 @dataclass
 class EnsembleRuntime:
-    """Loaded heavy state. Build once via ``load_ensemble_runtime``; reuse."""
+    """Loaded heavy state. Build once via ``load_ensemble_runtime``; reuse.
+
+    Voter D's backbone is selected by ``calibration.voter_d_backend``.
+    The runtime carries both ``pann`` and ``beats`` slots so a stub can
+    populate either without re-typing the dataclass; ``compute_voter_d_probs``
+    routes to the matching one. Whichever backend is inactive stays
+    ``None`` to avoid loading both models on startup.
+    """
 
     calibration: EnsembleCalibration
     voter_c_model: Any
     clap: feat.ClapRuntime
-    pann: feat.PannRuntime
+    pann: feat.PannRuntime | None = None
+    beats: feat.BeatsRuntime | None = None
     # Track the prompt list the calibration was built against so we can
     # warn if the on-package CLAP prompt bank ever drifts.
     expected_prompts: tuple[str, ...] = field(default_factory=tuple)
 
 
+def compute_voter_d_probs(
+    audio: np.ndarray,
+    sample_rate: int,
+    candidate_times: np.ndarray,
+    runtime: EnsembleRuntime,
+) -> np.ndarray:
+    """Dispatch Voter D inference to the calibrated backbone.
+
+    Reads ``runtime.calibration.voter_d_backend`` and routes to the
+    matching feature extractor. Raises a clear error when the matching
+    runtime slot wasn't populated (e.g. the artifact says ``beats`` but
+    only ``runtime.pann`` was loaded), so a misconfigured runtime fails
+    loudly rather than silently scoring zeros.
+    """
+    backend = runtime.calibration.voter_d_backend
+    if backend == feat.VOTER_D_BACKEND_PANN:
+        if runtime.pann is None:
+            raise RuntimeError(
+                "calibration says voter_d_backend='pann' but EnsembleRuntime.pann is None"
+            )
+        return feat.compute_pann_gunshot_probs(audio, sample_rate, candidate_times, runtime.pann)
+    if backend == feat.VOTER_D_BACKEND_BEATS:
+        if runtime.beats is None:
+            raise RuntimeError(
+                "calibration says voter_d_backend='beats' but EnsembleRuntime.beats is None"
+            )
+        return feat.compute_beats_gunshot_probs(audio, sample_rate, candidate_times, runtime.beats)
+    raise ValueError(
+        f"unknown voter_d_backend {backend!r}; expected one of {feat.VALID_VOTER_D_BACKENDS}"
+    )
+
+
 def load_ensemble_runtime() -> EnsembleRuntime:
-    """Materialise calibration + heavy models. Slow first-call (model downloads)."""
+    """Materialise calibration + heavy models. Slow first-call (model downloads).
+
+    The Voter D backbone follows ``calibration.voter_d_backend``; only
+    the active backbone is loaded. To switch backbones, rebuild
+    artifacts with ``scripts/build_ensemble_artifacts.py --voter-d-backend ...``.
+    """
     calibration = load_calibration()
     voter_c_model = load_voter_c_model()
     if tuple(calibration.clap_prompts) != feat.CLAP_PROMPTS:
@@ -118,12 +163,23 @@ def load_ensemble_runtime() -> EnsembleRuntime:
             "scripts/build_ensemble_artifacts.py."
         )
     clap = feat.load_clap_runtime()
-    pann = feat.load_pann_runtime()
+    pann: feat.PannRuntime | None = None
+    beats: feat.BeatsRuntime | None = None
+    if calibration.voter_d_backend == feat.VOTER_D_BACKEND_PANN:
+        pann = feat.load_pann_runtime()
+    elif calibration.voter_d_backend == feat.VOTER_D_BACKEND_BEATS:
+        beats = feat.load_beats_runtime()
+    else:
+        raise RuntimeError(
+            f"unknown voter_d_backend {calibration.voter_d_backend!r} in calibration; "
+            f"expected one of {feat.VALID_VOTER_D_BACKENDS}"
+        )
     return EnsembleRuntime(
         calibration=calibration,
         voter_c_model=voter_c_model,
         clap=clap,
         pann=pann,
+        beats=beats,
         expected_prompts=tuple(calibration.clap_prompts),
     )
 
@@ -185,7 +241,7 @@ def detect_shots_ensemble(
     )
     clap_sims = feat.compute_clap_similarities(audio, sample_rate, times, runtime.clap)
     clap_diff = feat.clap_diff_from_similarities(clap_sims)
-    gunshot_prob = feat.compute_pann_gunshot_probs(audio, sample_rate, times, runtime.pann)
+    gunshot_prob = compute_voter_d_probs(audio, sample_rate, times, runtime)
     voter_c_x = feat.voter_c_feature_matrix(hand, clap_sims, clap_diff, camera_classes=camera_class)
     score_c = runtime.voter_c_model.predict_proba(voter_c_x)[:, 1].astype(np.float64)
 

--- a/src/splitsmith/ensemble/calibration.py
+++ b/src/splitsmith/ensemble/calibration.py
@@ -110,8 +110,19 @@ class EnsembleCalibration(BaseModel):
     )
     voter_d_threshold: float = Field(
         description=(
-            "PANN ``Gunshot, gunfire`` class-probability threshold. "
-            "Calibrated to the minimum value across labelled positives."
+            "Gunshot-class probability threshold for Voter D. The "
+            "backend that produced this threshold is named in "
+            "``voter_d_backend``; calibration is to the minimum value "
+            "across labelled positives regardless of backend."
+        ),
+    )
+    voter_d_backend: str = Field(
+        default="pann",
+        description=(
+            "Voter D backbone the threshold was calibrated against. "
+            "``'pann'`` (default, byte-identical to pre-experiment "
+            "behaviour) or ``'beats'`` (issue #179 evaluation). "
+            "Loader uses this to pick which model to materialise."
         ),
     )
     voter_c_target_recall: float = Field(

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -19,6 +19,7 @@ prompt strings were used so loading checks the bank still matches.
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -59,14 +60,22 @@ PANN_SR = 32000  # PANN CNN14 native rate
 PANN_WINDOW_S = 1.0
 PANN_GUNSHOT_CLASS_INDEX = 427  # AudioSet ontology
 
-# BEATs (Microsoft, 2022) -- alternative Voter D backbone. Same AudioSet
-# ontology so the gunshot class index is unchanged; native sample rate is
-# 16 kHz vs PANN's 32 kHz. The checkpoint isn't bundled (Microsoft hosts
-# the .pt directly); point ``SPLITSMITH_BEATS_CHECKPOINT`` at a downloaded
-# checkpoint, or pass ``checkpoint_path=`` explicitly to ``load_beats_runtime``.
+# BEATs (Microsoft, 2022) -- alternative Voter D backbone. Native sample
+# rate is 16 kHz vs PANN's 32 kHz. The checkpoint isn't bundled (Microsoft
+# hosts the .pt directly); point ``SPLITSMITH_BEATS_CHECKPOINT`` at a
+# downloaded checkpoint, or pass ``checkpoint_path=`` explicitly to
+# ``load_beats_runtime``.
+#
+# BEATs uses its OWN class-index ordering (in the checkpoint's
+# ``label_dict``), NOT the canonical AudioSet csv ordering PANN uses.
+# ``Gunshot, gunfire`` is at index 79 in the iter3+ AS2M cpt2 build (not
+# 427 like PANN). The loader resolves the index dynamically from the
+# checkpoint's label_dict by mid; ``BEATS_GUNSHOT_CLASS_INDEX_DEFAULT``
+# is the fallback only used when the lookup fails.
 BEATS_SR = 16000
 BEATS_WINDOW_S = 1.0
-BEATS_GUNSHOT_CLASS_INDEX = 427  # AudioSet ontology, identical to PANN
+BEATS_GUNSHOT_CLASS_INDEX_DEFAULT = 79
+BEATS_GUNSHOT_AUDIOSET_MID = "/m/032s66"  # Gunshot, gunfire
 BEATS_CHECKPOINT_ENV = "SPLITSMITH_BEATS_CHECKPOINT"
 
 VOTER_D_BACKEND_PANN = "pann"
@@ -178,10 +187,18 @@ class BeatsRuntime:
     loader installs as a thin adapter over whichever upstream API the
     installed BEATs build provides). ``device`` is forwarded so callers
     that mock the runtime can skip torch entirely.
+
+    ``gunshot_class_index`` is resolved from the checkpoint's
+    ``label_dict`` rather than hardcoded -- BEATs ships its own class
+    ordering (``Gunshot, gunfire`` is index 79 in the iter3+ AS2M cpt2
+    build, not 427 like the canonical AudioSet csv used by PANN). The
+    loader looks up the AudioSet machine-id ``/m/032s66`` and falls
+    back to a sensible default if the field is absent.
     """
 
     model: Any
     device: str = "cpu"
+    gunshot_class_index: int = 79
 
 
 def _slice_window(audio: np.ndarray, sr: int, t: float, win_s: float) -> np.ndarray:
@@ -486,36 +503,67 @@ def load_beats_runtime(
         import torch
 
         # Defer the BEATs import; it lives in microsoft/unilm and isn't
-        # on PyPI. A clear ImportError beats a cryptic KeyError later.
+        # on PyPI. The repo is vendored under ``third_party/beats/`` --
+        # surface that dir on sys.path so ``import beats`` resolves
+        # without the user having to set PYTHONPATH manually.
+        repo_root = Path(__file__).resolve().parents[3]
+        vendor_root = repo_root / "third_party"
+        if vendor_root.is_dir() and str(vendor_root) not in sys.path:
+            sys.path.insert(0, str(vendor_root))
+
         from beats.BEATs import BEATs, BEATsConfig  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover -- only hit when BEATs isn't installed
         raise RuntimeError(
-            "BEATs is not importable. Install the microsoft/unilm BEATs "
-            "package (``pip install -e <unilm>/beats``) and ``torch``, "
-            "then retry."
+            "BEATs is not importable. Vendor microsoft/unilm/beats into "
+            "``third_party/beats/`` (or pip install it) and install "
+            "``torch`` + ``torchaudio``, then retry."
         ) from exc
 
-    state = torch.load(str(ckpt), map_location=device)
+    state = torch.load(str(ckpt), map_location=device, weights_only=False)
     cfg = BEATsConfig(state["cfg"])
     model = BEATs(cfg)
     model.load_state_dict(state["model"])
     model.eval()
     model.to(device)
 
+    # Track whether the loaded checkpoint is a finetuned model. The
+    # finetuned BEATs (e.g. ``BEATs_iter3_plus_AS2M.pt``) already applies
+    # ``sigmoid`` inside ``extract_features`` and returns class
+    # probabilities; the pretraining checkpoints have no predictor head
+    # and return raw encoder features instead. Only the finetuned path
+    # is useful for Voter D, but the wrapper checks anyway so a stray
+    # un-finetuned checkpoint produces a clear error rather than
+    # nonsense gunshot probs.
+    finetuned = bool(getattr(cfg, "finetuned_model", False))
+    if not finetuned:
+        raise RuntimeError(
+            f"BEATs checkpoint at {ckpt} is not a finetuned model "
+            "(no predictor head). Voter D needs an AudioSet-finetuned "
+            "checkpoint such as ``BEATs_iter3_plus_AS2M.pt``."
+        )
+
     @torch.no_grad()
     def _predict_probs(batch: torch.Tensor) -> torch.Tensor:
-        # BEATs returns logits shaped (B, n_classes); upstream releases
-        # vary between calling the predictor ``predict`` and exposing
-        # logits via ``extract_features``. Try both, sigmoid the logits
-        # to match PANN's clipwise probabilities.
-        if hasattr(model, "predict"):
-            logits, _padding_mask = model.predict(batch, padding_mask=None)
-        else:  # pragma: no cover -- exercised by alt BEATs builds
-            logits, _ = model.extract_features(batch, padding_mask=None)
-        return torch.sigmoid(logits)
+        # ``extract_features`` on a finetuned BEATs already applies
+        # sigmoid to the predictor logits and returns shape
+        # ``(B, n_classes)``. Returning the probs directly keeps Voter
+        # D's signal scaled the same way as PANN's clipwise probabilities.
+        probs, _padding_mask = model.extract_features(batch, padding_mask=None)
+        return probs
 
     model.predict_probs = _predict_probs  # type: ignore[attr-defined]
-    return BeatsRuntime(model=model, device=device)
+
+    # Resolve the gunshot class index from the checkpoint's label_dict.
+    # BEATs uses its own class ordering (gunshot is at 79 in iter3+ AS2M
+    # cpt2), not the canonical AudioSet csv ordering PANN uses (427).
+    label_dict = state.get("label_dict")
+    gunshot_idx = BEATS_GUNSHOT_CLASS_INDEX_DEFAULT
+    if isinstance(label_dict, dict):
+        for idx, mid in label_dict.items():
+            if str(mid) == BEATS_GUNSHOT_AUDIOSET_MID:
+                gunshot_idx = int(idx)
+                break
+    return BeatsRuntime(model=model, device=device, gunshot_class_index=gunshot_idx)
 
 
 def compute_beats_gunshot_probs(
@@ -549,7 +597,7 @@ def compute_beats_gunshot_probs(
     batch_t = torch.from_numpy(batch).to(runtime.device)
     probs_t = runtime.model.predict_probs(batch_t)
     probs = probs_t.detach().cpu().numpy().astype(np.float32)
-    return probs[:, BEATS_GUNSHOT_CLASS_INDEX].astype(np.float32)
+    return probs[:, runtime.gunshot_class_index].astype(np.float32)
 
 
 def voter_c_feature_matrix(

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -18,7 +18,9 @@ prompt strings were used so loading checks the bank still matches.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import librosa
@@ -56,6 +58,20 @@ CLAP_WINDOW_S = 1.0  # 1 s window centred on each candidate
 PANN_SR = 32000  # PANN CNN14 native rate
 PANN_WINDOW_S = 1.0
 PANN_GUNSHOT_CLASS_INDEX = 427  # AudioSet ontology
+
+# BEATs (Microsoft, 2022) -- alternative Voter D backbone. Same AudioSet
+# ontology so the gunshot class index is unchanged; native sample rate is
+# 16 kHz vs PANN's 32 kHz. The checkpoint isn't bundled (Microsoft hosts
+# the .pt directly); point ``SPLITSMITH_BEATS_CHECKPOINT`` at a downloaded
+# checkpoint, or pass ``checkpoint_path=`` explicitly to ``load_beats_runtime``.
+BEATS_SR = 16000
+BEATS_WINDOW_S = 1.0
+BEATS_GUNSHOT_CLASS_INDEX = 427  # AudioSet ontology, identical to PANN
+BEATS_CHECKPOINT_ENV = "SPLITSMITH_BEATS_CHECKPOINT"
+
+VOTER_D_BACKEND_PANN = "pann"
+VOTER_D_BACKEND_BEATS = "beats"
+VALID_VOTER_D_BACKENDS: tuple[str, ...] = (VOTER_D_BACKEND_PANN, VOTER_D_BACKEND_BEATS)
 
 _HAND_FEATURE_NAMES: tuple[str, ...] = (
     "peak_amp",
@@ -149,6 +165,23 @@ class PannRuntime:
     """Pre-loaded PANN audio tagger."""
 
     tagger: Any
+
+
+@dataclass
+class BeatsRuntime:
+    """Pre-loaded BEATs audio tagger.
+
+    ``model`` is the loaded ``BEATs`` instance from microsoft/unilm
+    (or any object exposing a compatible ``extract_features`` /
+    ``predict_logits`` surface; ``compute_beats_gunshot_probs`` keys on
+    a callable ``predict_probs(batch_tensor) -> probs_tensor`` that the
+    loader installs as a thin adapter over whichever upstream API the
+    installed BEATs build provides). ``device`` is forwarded so callers
+    that mock the runtime can skip torch entirely.
+    """
+
+    model: Any
+    device: str = "cpu"
 
 
 def _slice_window(audio: np.ndarray, sr: int, t: float, win_s: float) -> np.ndarray:
@@ -412,6 +445,111 @@ def compute_pann_gunshot_probs(
     clipwise, _embedding = runtime.tagger.inference(batch)
     clipwise = np.asarray(clipwise, dtype=np.float32)
     return clipwise[:, PANN_GUNSHOT_CLASS_INDEX].astype(np.float32)
+
+
+def load_beats_runtime(
+    checkpoint_path: Path | str | None = None, device: str = "cpu"
+) -> BeatsRuntime:
+    """Load the Microsoft BEATs audio tagger.
+
+    BEATs is not packaged on PyPI as of this writing; the loader expects
+    the official microsoft/unilm BEATs codebase to be importable as
+    ``beats`` (e.g. ``pip install -e <unilm>/beats``) and a checkpoint
+    ``.pt`` to be on disk. The checkpoint location is resolved in this
+    order:
+
+    1. The ``checkpoint_path`` argument.
+    2. The ``SPLITSMITH_BEATS_CHECKPOINT`` environment variable.
+
+    The loader attaches a ``predict_probs(batch_tensor) -> probs_tensor``
+    adapter that the inference helper keys on, so callers don't need to
+    track the upstream API differences between BEATs releases.
+
+    First call is slow (~360 MB checkpoint); reuse the returned runtime.
+    """
+    resolved = checkpoint_path or os.environ.get(BEATS_CHECKPOINT_ENV)
+    if not resolved:
+        raise RuntimeError(
+            "BEATs checkpoint not provided. Pass ``checkpoint_path=`` to "
+            f"``load_beats_runtime`` or set ``{BEATS_CHECKPOINT_ENV}`` to "
+            "a downloaded BEATs .pt file (see microsoft/unilm/beats)."
+        )
+    ckpt = Path(resolved)
+    if not ckpt.exists():
+        raise FileNotFoundError(
+            f"BEATs checkpoint not found at {ckpt}. Download a checkpoint "
+            "from microsoft/unilm/beats and point ``checkpoint_path`` / "
+            f"``{BEATS_CHECKPOINT_ENV}`` at the .pt file."
+        )
+
+    try:
+        import torch
+
+        # Defer the BEATs import; it lives in microsoft/unilm and isn't
+        # on PyPI. A clear ImportError beats a cryptic KeyError later.
+        from beats.BEATs import BEATs, BEATsConfig  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover -- only hit when BEATs isn't installed
+        raise RuntimeError(
+            "BEATs is not importable. Install the microsoft/unilm BEATs "
+            "package (``pip install -e <unilm>/beats``) and ``torch``, "
+            "then retry."
+        ) from exc
+
+    state = torch.load(str(ckpt), map_location=device)
+    cfg = BEATsConfig(state["cfg"])
+    model = BEATs(cfg)
+    model.load_state_dict(state["model"])
+    model.eval()
+    model.to(device)
+
+    @torch.no_grad()
+    def _predict_probs(batch: torch.Tensor) -> torch.Tensor:
+        # BEATs returns logits shaped (B, n_classes); upstream releases
+        # vary between calling the predictor ``predict`` and exposing
+        # logits via ``extract_features``. Try both, sigmoid the logits
+        # to match PANN's clipwise probabilities.
+        if hasattr(model, "predict"):
+            logits, _padding_mask = model.predict(batch, padding_mask=None)
+        else:  # pragma: no cover -- exercised by alt BEATs builds
+            logits, _ = model.extract_features(batch, padding_mask=None)
+        return torch.sigmoid(logits)
+
+    model.predict_probs = _predict_probs  # type: ignore[attr-defined]
+    return BeatsRuntime(model=model, device=device)
+
+
+def compute_beats_gunshot_probs(
+    audio: np.ndarray,
+    sample_rate: int,
+    candidate_times: np.ndarray,
+    runtime: BeatsRuntime,
+) -> np.ndarray:
+    """Per-candidate ``Gunshot, gunfire`` class probability via BEATs, shape ``(N,)``.
+
+    Mirrors ``compute_pann_gunshot_probs`` so the Voter D dispatcher can
+    route between backends without per-call branching beyond runtime
+    selection. Audio is resampled to ``BEATS_SR``; per-candidate windows
+    are sliced from the resampled stream.
+    """
+    if not len(candidate_times):
+        return np.zeros(0, dtype=np.float32)
+
+    import torch
+
+    if sample_rate != BEATS_SR:
+        beats_audio = librosa.resample(
+            audio.astype(np.float32), orig_sr=sample_rate, target_sr=BEATS_SR
+        )
+    else:
+        beats_audio = audio.astype(np.float32)
+    batch = np.stack(
+        [_slice_window(beats_audio, BEATS_SR, float(t), BEATS_WINDOW_S) for t in candidate_times],
+        axis=0,
+    )
+    batch_t = torch.from_numpy(batch).to(runtime.device)
+    probs_t = runtime.model.predict_probs(batch_t)
+    probs = probs_t.detach().cpu().numpy().astype(np.float32)
+    return probs[:, BEATS_GUNSHOT_CLASS_INDEX].astype(np.float32)
 
 
 def voter_c_feature_matrix(

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -528,6 +528,186 @@ def test_calibration_thresholds_for_legacy_artifact_synthesizes_single_class() -
     assert th.voter_c_threshold == 0.42
 
 
+# ---------------------------------------------------------------------------
+# Voter D backbone selection (issue #179)
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_defaults_voter_d_backend_to_pann() -> None:
+    """Existing artifacts (no ``voter_d_backend`` field) load as PANN."""
+    cal = EnsembleCalibration(
+        voter_a_floor=0.05,
+        voter_b_threshold=0.0,
+        voter_c_threshold=0.5,
+        voter_d_threshold=0.0,
+        voter_c_target_recall=0.95,
+        tolerance_ms=75.0,
+        clap_prompts_shot=list(CLAP_PROMPTS_SHOT),
+        clap_prompts=list(CLAP_PROMPTS),
+        calibration_fixtures=["legacy"],
+        n_calibration_candidates=1,
+        n_calibration_positives=1,
+        voter_c_feature_dim=VOTER_C_FEATURE_DIM,
+        built_at="1970-01-01T00:00:00Z",
+    )
+    assert cal.voter_d_backend == "pann"
+
+
+def test_compute_voter_d_dispatches_to_active_backend(monkeypatch) -> None:
+    """Dispatcher routes to PANN by default; switching the calibration
+    field flips it to BEATs without touching any other field."""
+    from splitsmith.ensemble import api as ensemble_api
+    from splitsmith.ensemble import features as ensemble_features
+
+    runtime = _build_stub_runtime()
+    audio = np.zeros(48_000, dtype=np.float32)
+    times = np.array([0.5, 0.7, 0.9])
+
+    pann_calls: list[int] = []
+    beats_calls: list[int] = []
+
+    def _pann(audio_, sr_, times_, runtime_):
+        pann_calls.append(len(times_))
+        return np.full(len(times_), 0.11, dtype=np.float32)
+
+    def _beats(audio_, sr_, times_, runtime_):
+        beats_calls.append(len(times_))
+        return np.full(len(times_), 0.22, dtype=np.float32)
+
+    monkeypatch.setattr(ensemble_features, "compute_pann_gunshot_probs", _pann)
+    monkeypatch.setattr(ensemble_features, "compute_beats_gunshot_probs", _beats)
+
+    # Default: voter_d_backend='pann' on the stub calibration.
+    out_pann = ensemble_api.compute_voter_d_probs(audio, 48_000, times, runtime)
+    assert pann_calls == [3] and beats_calls == []
+    assert np.allclose(out_pann, 0.11)
+
+    # Flip to BEATs and provide a stub runtime slot. PANN must NOT be
+    # called again; BEATs must.
+    runtime.calibration = runtime.calibration.model_copy(update={"voter_d_backend": "beats"})
+
+    @dataclass
+    class _StubBeatsRuntime:
+        device: str = "cpu"
+
+    runtime.beats = _StubBeatsRuntime()  # type: ignore[assignment]
+    out_beats = ensemble_api.compute_voter_d_probs(audio, 48_000, times, runtime)
+    assert pann_calls == [3] and beats_calls == [3]
+    assert np.allclose(out_beats, 0.22)
+
+
+def test_compute_voter_d_raises_when_active_runtime_slot_missing() -> None:
+    """If calibration says BEATs but ``runtime.beats is None`` the dispatcher
+    fails loudly rather than silently scoring zeros."""
+    from splitsmith.ensemble import api as ensemble_api
+
+    runtime = _build_stub_runtime()
+    runtime.calibration = runtime.calibration.model_copy(update={"voter_d_backend": "beats"})
+    # runtime.beats is left None.
+    with pytest.raises(RuntimeError, match="EnsembleRuntime.beats is None"):
+        ensemble_api.compute_voter_d_probs(
+            np.zeros(48_000, dtype=np.float32), 48_000, np.array([0.5]), runtime
+        )
+
+
+def test_compute_voter_d_rejects_unknown_backend() -> None:
+    from splitsmith.ensemble import api as ensemble_api
+
+    runtime = _build_stub_runtime()
+    runtime.calibration = runtime.calibration.model_copy(update={"voter_d_backend": "wishful"})
+    with pytest.raises(ValueError, match="unknown voter_d_backend 'wishful'"):
+        ensemble_api.compute_voter_d_probs(
+            np.zeros(48_000, dtype=np.float32), 48_000, np.array([0.5]), runtime
+        )
+
+
+def test_detect_shots_ensemble_routes_through_dispatcher_for_beats(monkeypatch) -> None:
+    """End-to-end: ``detect_shots_ensemble`` honours voter_d_backend='beats'.
+
+    Verifies the BEATs path is exercised through the dispatcher and the
+    PANN path stays cold even when ``runtime.pann`` is populated (a
+    misconfigured runtime carrying both should still call the active
+    backend only).
+    """
+    from splitsmith.ensemble import api as ensemble_api
+    from splitsmith.ensemble import features as ensemble_features
+
+    @dataclass
+    class _StubBeatsRuntime:
+        device: str = "cpu"
+
+    runtime = _build_stub_runtime()
+    runtime.calibration = runtime.calibration.model_copy(update={"voter_d_backend": "beats"})
+    runtime.beats = _StubBeatsRuntime()  # type: ignore[assignment]
+
+    pann_calls: list[int] = []
+    beats_calls: list[int] = []
+
+    fake_shots = [
+        Shot(
+            shot_number=i + 1,
+            time_absolute=5.0 + i * 0.3,
+            time_from_beep=i * 0.3,
+            split=0.3 if i > 0 else 5.0,
+            peak_amplitude=0.4,
+            confidence=0.6,
+            notes="",
+        )
+        for i in range(3)
+    ]
+    monkeypatch.setattr(ensemble_api, "detect_shots", lambda *a, **kw: fake_shots)
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_clap_similarities",
+        lambda audio, sr, times, runtime: np.full(
+            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
+        ),
+    )
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_pann_gunshot_probs",
+        lambda audio, sr, times, runtime: (pann_calls.append(len(times)) or np.zeros(len(times))),
+    )
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_beats_gunshot_probs",
+        lambda audio, sr, times, runtime: (
+            beats_calls.append(len(times)) or np.full(len(times), 0.9, dtype=np.float32)
+        ),
+    )
+
+    audio = np.zeros(48_000 * 20, dtype=np.float32)
+    result = detect_shots_ensemble(
+        audio,
+        48_000,
+        beep_time=5.0,
+        stage_time=10.0,
+        runtime=runtime,
+    )
+    assert pann_calls == []
+    assert beats_calls == [3]
+    # All voters pass on the stub; consensus default 3-of-4 keeps everyone.
+    assert all(c.kept for c in result.candidates)
+
+
+def test_load_beats_runtime_errors_clearly_when_checkpoint_missing(tmp_path, monkeypatch) -> None:
+    """Loader gives an actionable error when no checkpoint is provided.
+
+    Sandbox-friendly: doesn't import ``beats`` or ``torch`` until after
+    the checkpoint check, so this passes regardless of whether the
+    optional BEATs install is present.
+    """
+    from splitsmith.ensemble import features as ensemble_features
+
+    monkeypatch.delenv(ensemble_features.BEATS_CHECKPOINT_ENV, raising=False)
+    with pytest.raises(RuntimeError, match="BEATs checkpoint not provided"):
+        ensemble_features.load_beats_runtime()
+
+    missing = tmp_path / "nope.pt"
+    with pytest.raises(FileNotFoundError, match="BEATs checkpoint not found"):
+        ensemble_features.load_beats_runtime(checkpoint_path=missing)
+
+
 def test_detect_shots_ensemble_uses_per_class_thresholds(monkeypatch) -> None:
     """A handheld-class detection picks up the handheld voter A floor.
 

--- a/third_party/beats/BEATs.py
+++ b/third_party/beats/BEATs.py
@@ -1,0 +1,179 @@
+# --------------------------------------------------------
+# BEATs: Audio Pre-Training with Acoustic Tokenizers (https://arxiv.org/abs/2212.09058)
+# Github source: https://github.com/microsoft/unilm/tree/master/beats
+# Copyright (c) 2022 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Based on fairseq code bases
+# https://github.com/pytorch/fairseq
+# --------------------------------------------------------
+
+
+import torch
+import torch.nn as nn
+from torch.nn import LayerNorm
+import torchaudio.compliance.kaldi as ta_kaldi
+
+from .backbone import (
+    TransformerEncoder,
+)
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BEATsConfig:
+    def __init__(self, cfg=None):
+        self.input_patch_size: int = -1  # path size of patch embedding
+        self.embed_dim: int = 512  # patch embedding dimension
+        self.conv_bias: bool = False  # include bias in conv encoder
+
+        self.encoder_layers: int = 12  # num encoder layers in the transformer
+        self.encoder_embed_dim: int = 768  # encoder embedding dimension
+        self.encoder_ffn_embed_dim: int = 3072  # encoder embedding dimension for FFN
+        self.encoder_attention_heads: int = 12  # num encoder attention heads
+        self.activation_fn: str = "gelu"  # activation function to use
+
+        self.layer_wise_gradient_decay_ratio: float = 1.0  # ratio for layer-wise gradient decay
+        self.layer_norm_first: bool = False  # apply layernorm first in the transformer
+        self.deep_norm: bool = False  # apply deep_norm first in the transformer
+
+        # dropouts
+        self.dropout: float = 0.1  # dropout probability for the transformer
+        self.attention_dropout: float = 0.1  # dropout probability for attention weights
+        self.activation_dropout: float = 0.0  # dropout probability after activation in FFN
+        self.encoder_layerdrop: float = 0.0  # probability of dropping a tarnsformer layer
+        self.dropout_input: float = 0.0  # dropout to apply to the input (after feat extr)
+
+        # positional embeddings
+        self.conv_pos: int = 128  # number of filters for convolutional positional embeddings
+        self.conv_pos_groups: int = 16  # number of groups for convolutional positional embedding
+
+        # relative position embedding
+        self.relative_position_embedding: bool = False  # apply relative position embedding
+        self.num_buckets: int = 320  # number of buckets for relative position embedding
+        self.max_distance: int = 1280  # maximum distance for relative position embedding
+        self.gru_rel_pos: bool = False  # apply gated relative position embedding
+
+        # label predictor
+        self.finetuned_model: bool = False  # whether the model is a fine-tuned model.
+        self.predictor_dropout: float = 0.1  # dropout probability for the predictor
+        self.predictor_class: int = 527  # target class number for the predictor
+
+        if cfg is not None:
+            self.update(cfg)
+
+    def update(self, cfg: dict):
+        self.__dict__.update(cfg)
+
+
+class BEATs(nn.Module):
+    def __init__(
+            self,
+            cfg: BEATsConfig,
+    ) -> None:
+        super().__init__()
+        logger.info(f"BEATs Config: {cfg.__dict__}")
+
+        self.cfg = cfg
+
+        self.embed = cfg.embed_dim
+        self.post_extract_proj = (
+            nn.Linear(self.embed, cfg.encoder_embed_dim)
+            if self.embed != cfg.encoder_embed_dim
+            else None
+        )
+
+        self.input_patch_size = cfg.input_patch_size
+        self.patch_embedding = nn.Conv2d(1, self.embed, kernel_size=self.input_patch_size, stride=self.input_patch_size,
+                                         bias=cfg.conv_bias)
+
+        self.dropout_input = nn.Dropout(cfg.dropout_input)
+
+        assert not cfg.deep_norm or not cfg.layer_norm_first
+        self.encoder = TransformerEncoder(cfg)
+        self.layer_norm = LayerNorm(self.embed)
+
+        if cfg.finetuned_model:
+            self.predictor_dropout = nn.Dropout(cfg.predictor_dropout)
+            self.predictor = nn.Linear(cfg.encoder_embed_dim, cfg.predictor_class)
+        else:
+            self.predictor = None
+
+    def forward_padding_mask(
+            self,
+            features: torch.Tensor,
+            padding_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        extra = padding_mask.size(1) % features.size(1)
+        if extra > 0:
+            padding_mask = padding_mask[:, :-extra]
+        padding_mask = padding_mask.view(
+            padding_mask.size(0), features.size(1), -1
+        )
+        padding_mask = padding_mask.all(-1)
+        return padding_mask
+
+    def preprocess(
+            self,
+            source: torch.Tensor,
+            fbank_mean: float = 15.41663,
+            fbank_std: float = 6.55582,
+    ) -> torch.Tensor:
+        fbanks = []
+        for waveform in source:
+            waveform = waveform.unsqueeze(0) * 2 ** 15
+            fbank = ta_kaldi.fbank(waveform, num_mel_bins=128, sample_frequency=16000, frame_length=25, frame_shift=10)
+            fbanks.append(fbank)
+        fbank = torch.stack(fbanks, dim=0)
+        fbank = (fbank - fbank_mean) / (2 * fbank_std)
+        return fbank
+
+    def extract_features(
+            self,
+            source: torch.Tensor,
+            padding_mask: Optional[torch.Tensor] = None,
+            fbank_mean: float = 15.41663,
+            fbank_std: float = 6.55582,
+    ):
+        fbank = self.preprocess(source, fbank_mean=fbank_mean, fbank_std=fbank_std)
+
+        if padding_mask is not None:
+            padding_mask = self.forward_padding_mask(fbank, padding_mask)
+
+        fbank = fbank.unsqueeze(1)
+        features = self.patch_embedding(fbank)
+        features = features.reshape(features.shape[0], features.shape[1], -1)
+        features = features.transpose(1, 2)
+        features = self.layer_norm(features)
+
+        if padding_mask is not None:
+            padding_mask = self.forward_padding_mask(features, padding_mask)
+
+        if self.post_extract_proj is not None:
+            features = self.post_extract_proj(features)
+
+        x = self.dropout_input(features)
+
+        x, layer_results = self.encoder(
+            x,
+            padding_mask=padding_mask,
+        )
+
+        if self.predictor is not None:
+            x = self.predictor_dropout(x)
+            logits = self.predictor(x)
+
+            if padding_mask is not None and padding_mask.any():
+                logits[padding_mask] = 0
+                logits = logits.sum(dim=1)
+                logits = logits / (~padding_mask).sum(dim=1).unsqueeze(-1).expand_as(logits)
+            else:
+                logits = logits.mean(dim=1)
+
+            lprobs = torch.sigmoid(logits)
+
+            return lprobs, padding_mask
+        else:
+            return x, padding_mask

--- a/third_party/beats/LICENSE.microsoft-unilm
+++ b/third_party/beats/LICENSE.microsoft-unilm
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/beats/README.md
+++ b/third_party/beats/README.md
@@ -1,0 +1,17 @@
+# Vendored BEATs source
+
+Files vendored from [microsoft/unilm/beats](https://github.com/microsoft/unilm/tree/master/beats)
+@ master, MIT licensed (see `LICENSE.microsoft-unilm`). Used by
+`splitsmith.ensemble.features.load_beats_runtime` and the issue #179
+comparison experiment.
+
+Local modifications:
+- Sibling-module imports converted to relative (`from backbone import ...`
+  -> `from .backbone import ...`) so the directory works as a Python
+  package when surfaced on `sys.path`.
+
+To use, point `SPLITSMITH_BEATS_CHECKPOINT` at a fine-tuned BEATs `.pt`
+checkpoint (e.g. `BEATs_iter3_plus_AS2M_finetuned_on_AS2M_cpt2.pt` from
+`huggingface.co/camenduru/beats`) and call
+`load_beats_runtime()`. Only finetuned checkpoints work; pretraining
+checkpoints have no predictor head.

--- a/third_party/beats/Tokenizers.py
+++ b/third_party/beats/Tokenizers.py
@@ -1,0 +1,173 @@
+# --------------------------------------------------------
+# BEATs: Audio Pre-Training with Acoustic Tokenizers (https://arxiv.org/abs/2212.09058)
+# Github source: https://github.com/microsoft/unilm/tree/master/beats
+# Copyright (c) 2022 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Based on fairseq code bases
+# https://github.com/pytorch/fairseq
+# --------------------------------------------------------
+
+
+import torch
+import torch.nn as nn
+from torch.nn import LayerNorm
+import torchaudio.compliance.kaldi as ta_kaldi
+
+from .backbone import (
+    TransformerEncoder,
+)
+from .quantizer import (
+    NormEMAVectorQuantizer,
+)
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizersConfig:
+    def __init__(self, cfg=None):
+        self.input_patch_size: int = -1  # path size of patch embedding
+        self.embed_dim: int = 512  # patch embedding dimension
+        self.conv_bias: bool = False  # include bias in conv encoder
+
+        self.encoder_layers: int = 12  # num encoder layers in the transformer
+        self.encoder_embed_dim: int = 768  # encoder embedding dimension
+        self.encoder_ffn_embed_dim: int = 3072  # encoder embedding dimension for FFN
+        self.encoder_attention_heads: int = 12  # num encoder attention heads
+        self.activation_fn: str = "gelu"  # activation function to use
+
+        self.layer_norm_first: bool = False  # apply layernorm first in the transformer
+        self.deep_norm: bool = False  # apply deep_norm first in the transformer
+
+        # dropouts
+        self.dropout: float = 0.1  # dropout probability for the transformer
+        self.attention_dropout: float = 0.1  # dropout probability for attention weights
+        self.activation_dropout: float = 0.0  # dropout probability after activation in FFN
+        self.encoder_layerdrop: float = 0.0  # probability of dropping a tarnsformer layer
+        self.dropout_input: float = 0.0  # dropout to apply to the input (after feat extr)
+
+        # positional embeddings
+        self.conv_pos: int = 128  # number of filters for convolutional positional embeddings
+        self.conv_pos_groups: int = 16  # number of groups for convolutional positional embedding
+
+        # relative position embedding
+        self.relative_position_embedding: bool = False  # apply relative position embedding
+        self.num_buckets: int = 320  # number of buckets for relative position embedding
+        self.max_distance: int = 1280  # maximum distance for relative position embedding
+        self.gru_rel_pos: bool = False  # apply gated relative position embedding
+
+        # quantizer
+        self.quant_n: int = 1024 # codebook number in quantizer
+        self.quant_dim: int = 256    # codebook dimension in quantizer
+
+        if cfg is not None:
+            self.update(cfg)
+
+    def update(self, cfg: dict):
+        self.__dict__.update(cfg)
+
+
+class Tokenizers(nn.Module):
+    def __init__(
+            self,
+            cfg: TokenizersConfig,
+    ) -> None:
+        super().__init__()
+        logger.info(f"Tokenizers Config: {cfg.__dict__}")
+
+        self.cfg = cfg
+
+        self.embed = cfg.embed_dim
+        self.post_extract_proj = (
+            nn.Linear(self.embed, cfg.encoder_embed_dim)
+            if self.embed != cfg.encoder_embed_dim
+            else None
+        )
+
+        self.input_patch_size = cfg.input_patch_size
+        self.patch_embedding = nn.Conv2d(1, self.embed, kernel_size=self.input_patch_size, stride=self.input_patch_size,
+                                         bias=cfg.conv_bias)
+
+        self.dropout_input = nn.Dropout(cfg.dropout_input)
+
+        assert not cfg.deep_norm or not cfg.layer_norm_first
+        self.encoder = TransformerEncoder(cfg)
+        self.layer_norm = LayerNorm(self.embed)
+
+        self.quantize = NormEMAVectorQuantizer(
+            n_embed=cfg.quant_n, embedding_dim=cfg.quant_dim, beta=1.0, kmeans_init=True, decay=0.99,
+        )
+        self.quant_n = cfg.quant_n
+        self.quantize_layer = nn.Sequential(
+            nn.Linear(cfg.encoder_embed_dim, cfg.encoder_embed_dim),
+            nn.Tanh(),
+            nn.Linear(cfg.encoder_embed_dim, cfg.quant_dim)  # for quantize
+        )
+
+    def forward_padding_mask(
+            self,
+            features: torch.Tensor,
+            padding_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        extra = padding_mask.size(1) % features.size(1)
+        if extra > 0:
+            padding_mask = padding_mask[:, :-extra]
+        padding_mask = padding_mask.view(
+            padding_mask.size(0), features.size(1), -1
+        )
+        padding_mask = padding_mask.all(-1)
+        return padding_mask
+
+    def preprocess(
+            self,
+            source: torch.Tensor,
+            fbank_mean: float = 15.41663,
+            fbank_std: float = 6.55582,
+    ) -> torch.Tensor:
+        fbanks = []
+        for waveform in source:
+            waveform = waveform.unsqueeze(0) * 2 ** 15
+            fbank = ta_kaldi.fbank(waveform, num_mel_bins=128, sample_frequency=16000, frame_length=25, frame_shift=10)
+            fbanks.append(fbank)
+        fbank = torch.stack(fbanks, dim=0)
+        fbank = (fbank - fbank_mean) / (2 * fbank_std)
+        return fbank
+
+    def extract_labels(
+            self,
+            source: torch.Tensor,
+            padding_mask: Optional[torch.Tensor] = None,
+            fbank_mean: float = 15.41663,
+            fbank_std: float = 6.55582,
+    ):
+        fbank = self.preprocess(source, fbank_mean=fbank_mean, fbank_std=fbank_std)
+
+        if padding_mask is not None:
+            padding_mask = self.forward_padding_mask(fbank, padding_mask)
+
+        fbank = fbank.unsqueeze(1)
+        features = self.patch_embedding(fbank)
+        features = features.reshape(features.shape[0], features.shape[1], -1)
+        features = features.transpose(1, 2)
+        features = self.layer_norm(features)
+
+        if padding_mask is not None:
+            padding_mask = self.forward_padding_mask(features, padding_mask)
+
+        if self.post_extract_proj is not None:
+            features = self.post_extract_proj(features)
+
+        x = self.dropout_input(features)
+
+        x, layer_results = self.encoder(
+            x,
+            padding_mask=padding_mask,
+        )
+
+        quantize_input = self.quantize_layer(x)
+        quantize_feature, embed_loss, embed_ind = self.quantize(quantize_input)
+
+        return embed_ind
+

--- a/third_party/beats/backbone.py
+++ b/third_party/beats/backbone.py
@@ -1,0 +1,783 @@
+# --------------------------------------------------------
+# BEATs: Audio Pre-Training with Acoustic Tokenizers (https://arxiv.org/abs/2212.09058)
+# Github source: https://github.com/microsoft/unilm/tree/master/beats
+# Copyright (c) 2022 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Based on fairseq code bases
+# https://github.com/pytorch/fairseq
+# --------------------------------------------------------
+
+import math
+import numpy as np
+from typing import Dict, Optional, Tuple
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+from torch.nn import LayerNorm, Parameter
+from .modules import (
+    GradMultiply,
+    SamePad,
+    get_activation_fn,
+    GLU_Linear,
+    quant_noise,
+)
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.dropout = args.dropout
+        self.embedding_dim = args.encoder_embed_dim
+
+        self.pos_conv = nn.Conv1d(
+            self.embedding_dim,
+            self.embedding_dim,
+            kernel_size=args.conv_pos,
+            padding=args.conv_pos // 2,
+            groups=args.conv_pos_groups,
+        )
+        dropout = 0
+        std = math.sqrt((4 * (1.0 - dropout)) / (args.conv_pos * self.embedding_dim))
+        nn.init.normal_(self.pos_conv.weight, mean=0, std=std)
+        nn.init.constant_(self.pos_conv.bias, 0)
+
+        self.pos_conv = nn.utils.weight_norm(self.pos_conv, name="weight", dim=2)
+        self.pos_conv = nn.Sequential(self.pos_conv, SamePad(args.conv_pos), nn.GELU())
+
+        if hasattr(args, "relative_position_embedding"):
+            self.relative_position_embedding = args.relative_position_embedding
+            self.num_buckets = args.num_buckets
+            self.max_distance = args.max_distance
+        else:
+            self.relative_position_embedding = False
+            self.num_buckets = 0
+            self.max_distance = 0
+
+        self.layers = nn.ModuleList(
+            [
+                TransformerSentenceEncoderLayer(
+                    embedding_dim=self.embedding_dim,
+                    ffn_embedding_dim=args.encoder_ffn_embed_dim,
+                    num_attention_heads=args.encoder_attention_heads,
+                    dropout=self.dropout,
+                    attention_dropout=args.attention_dropout,
+                    activation_dropout=args.activation_dropout,
+                    activation_fn=args.activation_fn,
+                    layer_norm_first=args.layer_norm_first,
+                    deep_norm=args.deep_norm,
+                    has_relative_attention_bias=self.relative_position_embedding,
+                    num_buckets=self.num_buckets,
+                    max_distance=self.max_distance,
+                    gru_rel_pos=args.gru_rel_pos,
+                    encoder_layers=args.encoder_layers,
+                )
+                for i in range(args.encoder_layers)
+            ]
+        )
+        if self.relative_position_embedding:
+            for i in range(1, args.encoder_layers):
+                del self.layers[i].self_attn.relative_attention_bias
+                self.layers[i].self_attn.relative_attention_bias = self.layers[0].self_attn.relative_attention_bias
+
+        self.layer_norm_first = args.layer_norm_first
+        self.layer_norm = LayerNorm(self.embedding_dim)
+        self.layerdrop = args.encoder_layerdrop
+
+        self.apply(init_bert_params)
+
+        if args.deep_norm:
+            deep_norm_beta = math.pow(8 * args.encoder_layers, -1 / 4)
+            for i in range(args.encoder_layers):
+                nn.init.xavier_normal_(self.layers[i].self_attn.k_proj.weight, gain=1)
+                nn.init.xavier_normal_(self.layers[i].self_attn.v_proj.weight, gain=deep_norm_beta)
+                nn.init.xavier_normal_(self.layers[i].self_attn.q_proj.weight, gain=1)
+                nn.init.xavier_normal_(self.layers[i].self_attn.out_proj.weight, gain=deep_norm_beta)
+                nn.init.xavier_normal_(self.layers[i].fc1.weight, gain=deep_norm_beta)
+                nn.init.xavier_normal_(self.layers[i].fc2.weight, gain=deep_norm_beta)
+
+        self.layer_wise_gradient_decay_ratio = getattr(args, "layer_wise_gradient_decay_ratio", 1)
+
+    def forward(self, x, padding_mask=None, layer=None):
+        x, layer_results = self.extract_features(x, padding_mask, layer)
+
+        if self.layer_norm_first and layer is None:
+            x = self.layer_norm(x)
+
+        return x, layer_results
+
+    def extract_features(self, x, padding_mask=None, tgt_layer=None):
+
+        if padding_mask is not None:
+            x[padding_mask] = 0
+
+        x_conv = self.pos_conv(x.transpose(1, 2))
+        x_conv = x_conv.transpose(1, 2)
+        x = x + x_conv
+
+        if not self.layer_norm_first:
+            x = self.layer_norm(x)
+
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        # B x T x C -> T x B x C
+        x = x.transpose(0, 1)
+
+        layer_results = []
+        z = None
+        if tgt_layer is not None:
+            layer_results.append((x, z))
+        r = None
+        pos_bias = None
+        for i, layer in enumerate(self.layers):
+            if self.layer_wise_gradient_decay_ratio != 1.0:
+                x = GradMultiply.apply(x, self.layer_wise_gradient_decay_ratio)
+            dropout_probability = np.random.random()
+            if not self.training or (dropout_probability > self.layerdrop):
+                x, z, pos_bias = layer(x, self_attn_padding_mask=padding_mask, need_weights=False, pos_bias=pos_bias)
+            if tgt_layer is not None:
+                layer_results.append((x, z))
+            if i == tgt_layer:
+                r = x
+                break
+
+        if r is not None:
+            x = r
+
+        # T x B x C -> B x T x C
+        x = x.transpose(0, 1)
+
+        return x, layer_results
+
+
+class TransformerSentenceEncoderLayer(nn.Module):
+    def __init__(
+            self,
+            embedding_dim: float = 768,
+            ffn_embedding_dim: float = 3072,
+            num_attention_heads: float = 8,
+            dropout: float = 0.1,
+            attention_dropout: float = 0.1,
+            activation_dropout: float = 0.1,
+            activation_fn: str = "relu",
+            layer_norm_first: bool = False,
+            deep_norm: bool = False,
+            has_relative_attention_bias: bool = False,
+            num_buckets: int = 0,
+            max_distance: int = 0,
+            rescale_init: bool = False,
+            gru_rel_pos: bool = False,
+            encoder_layers: int = 0,
+    ) -> None:
+
+        super().__init__()
+        self.embedding_dim = embedding_dim
+        self.dropout = dropout
+        self.activation_dropout = activation_dropout
+
+        self.activation_name = activation_fn
+        self.activation_fn = get_activation_fn(activation_fn)
+        self.self_attn = MultiheadAttention(
+            self.embedding_dim,
+            num_attention_heads,
+            dropout=attention_dropout,
+            self_attention=True,
+            has_relative_attention_bias=has_relative_attention_bias,
+            num_buckets=num_buckets,
+            max_distance=max_distance,
+            rescale_init=rescale_init,
+            gru_rel_pos=gru_rel_pos,
+        )
+
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(self.activation_dropout)
+        self.dropout3 = nn.Dropout(dropout)
+
+        self.layer_norm_first = layer_norm_first
+
+        self.self_attn_layer_norm = LayerNorm(self.embedding_dim)
+
+        if self.activation_name == "glu":
+            self.fc1 = GLU_Linear(self.embedding_dim, ffn_embedding_dim, "swish")
+        else:
+            self.fc1 = nn.Linear(self.embedding_dim, ffn_embedding_dim)
+        self.fc2 = nn.Linear(ffn_embedding_dim, self.embedding_dim)
+
+        self.final_layer_norm = LayerNorm(self.embedding_dim)
+
+        self.deep_norm = deep_norm
+        if self.deep_norm:
+            self.deep_norm_alpha = math.pow(2 * encoder_layers, 1 / 4)
+        else:
+            self.deep_norm_alpha = 1
+
+    def forward(
+            self,
+            x: torch.Tensor,
+            self_attn_mask: torch.Tensor = None,
+            self_attn_padding_mask: torch.Tensor = None,
+            need_weights: bool = False,
+            pos_bias=None
+    ):
+        residual = x
+
+        if self.layer_norm_first:
+            x = self.self_attn_layer_norm(x)
+            x, attn, pos_bias = self.self_attn(
+                query=x,
+                key=x,
+                value=x,
+                key_padding_mask=self_attn_padding_mask,
+                need_weights=False,
+                attn_mask=self_attn_mask,
+                position_bias=pos_bias
+            )
+            x = self.dropout1(x)
+            x = residual + x
+
+            residual = x
+            x = self.final_layer_norm(x)
+            if self.activation_name == "glu":
+                x = self.fc1(x)
+            else:
+                x = self.activation_fn(self.fc1(x))
+            x = self.dropout2(x)
+            x = self.fc2(x)
+            x = self.dropout3(x)
+            x = residual + x
+        else:
+            x, attn, pos_bias = self.self_attn(
+                query=x,
+                key=x,
+                value=x,
+                key_padding_mask=self_attn_padding_mask,
+                need_weights=need_weights,
+                attn_mask=self_attn_mask,
+                position_bias=pos_bias
+            )
+
+            x = self.dropout1(x)
+            x = residual * self.deep_norm_alpha + x
+
+            x = self.self_attn_layer_norm(x)
+
+            residual = x
+            if self.activation_name == "glu":
+                x = self.fc1(x)
+            else:
+                x = self.activation_fn(self.fc1(x))
+            x = self.dropout2(x)
+            x = self.fc2(x)
+            x = self.dropout3(x)
+            x = residual * self.deep_norm_alpha + x
+            x = self.final_layer_norm(x)
+
+        return x, attn, pos_bias
+
+
+class MultiheadAttention(nn.Module):
+    """Multi-headed attention.
+
+    See "Attention Is All You Need" for more details.
+    """
+
+    def __init__(
+            self,
+            embed_dim,
+            num_heads,
+            kdim=None,
+            vdim=None,
+            dropout=0.0,
+            bias=True,
+            add_bias_kv=False,
+            add_zero_attn=False,
+            self_attention=False,
+            encoder_decoder_attention=False,
+            q_noise=0.0,
+            qn_block_size=8,
+            has_relative_attention_bias=False,
+            num_buckets=32,
+            max_distance=128,
+            gru_rel_pos=False,
+            rescale_init=False,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.kdim = kdim if kdim is not None else embed_dim
+        self.vdim = vdim if vdim is not None else embed_dim
+        self.qkv_same_dim = self.kdim == embed_dim and self.vdim == embed_dim
+
+        self.num_heads = num_heads
+        self.dropout_module = nn.Dropout(dropout)
+
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.num_buckets = num_buckets
+        self.max_distance = max_distance
+        if self.has_relative_attention_bias:
+            self.relative_attention_bias = nn.Embedding(num_buckets, num_heads)
+
+        self.head_dim = embed_dim // num_heads
+        self.q_head_dim = self.head_dim
+        self.k_head_dim = self.head_dim
+        assert (
+                self.head_dim * num_heads == self.embed_dim
+        ), "embed_dim must be divisible by num_heads"
+        self.scaling = self.head_dim ** -0.5
+
+        self.self_attention = self_attention
+        self.encoder_decoder_attention = encoder_decoder_attention
+
+        assert not self.self_attention or self.qkv_same_dim, (
+            "Self-attention requires query, key and " "value to be of the same size"
+        )
+
+        k_bias = True
+        if rescale_init:
+            k_bias = False
+
+        k_embed_dim = embed_dim
+        q_embed_dim = embed_dim
+
+        self.k_proj = quant_noise(
+            nn.Linear(self.kdim, k_embed_dim, bias=k_bias), q_noise, qn_block_size
+        )
+        self.v_proj = quant_noise(
+            nn.Linear(self.vdim, embed_dim, bias=bias), q_noise, qn_block_size
+        )
+        self.q_proj = quant_noise(
+            nn.Linear(embed_dim, q_embed_dim, bias=bias), q_noise, qn_block_size
+        )
+
+        self.out_proj = quant_noise(
+            nn.Linear(embed_dim, embed_dim, bias=bias), q_noise, qn_block_size
+        )
+
+        if add_bias_kv:
+            self.bias_k = Parameter(torch.Tensor(1, 1, embed_dim))
+            self.bias_v = Parameter(torch.Tensor(1, 1, embed_dim))
+        else:
+            self.bias_k = self.bias_v = None
+
+        self.add_zero_attn = add_zero_attn
+
+        self.gru_rel_pos = gru_rel_pos
+        if self.gru_rel_pos:
+            self.grep_linear = nn.Linear(self.q_head_dim, 8)
+            self.grep_a = nn.Parameter(torch.ones(1, num_heads, 1, 1))
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.qkv_same_dim:
+            # Empirically observed the convergence to be much better with
+            # the scaled initialization
+            nn.init.xavier_uniform_(self.k_proj.weight, gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(self.v_proj.weight, gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(self.q_proj.weight, gain=1 / math.sqrt(2))
+        else:
+            nn.init.xavier_uniform_(self.k_proj.weight)
+            nn.init.xavier_uniform_(self.v_proj.weight)
+            nn.init.xavier_uniform_(self.q_proj.weight)
+
+        nn.init.xavier_uniform_(self.out_proj.weight)
+        if self.out_proj.bias is not None:
+            nn.init.constant_(self.out_proj.bias, 0.0)
+        if self.bias_k is not None:
+            nn.init.xavier_normal_(self.bias_k)
+        if self.bias_v is not None:
+            nn.init.xavier_normal_(self.bias_v)
+        if self.has_relative_attention_bias:
+            nn.init.xavier_normal_(self.relative_attention_bias.weight)
+
+    def _relative_positions_bucket(self, relative_positions, bidirectional=True):
+        num_buckets = self.num_buckets
+        max_distance = self.max_distance
+        relative_buckets = 0
+
+        if bidirectional:
+            num_buckets = num_buckets // 2
+            relative_buckets += (relative_positions > 0).to(torch.long) * num_buckets
+            relative_positions = torch.abs(relative_positions)
+        else:
+            relative_positions = -torch.min(relative_positions, torch.zeros_like(relative_positions))
+
+        max_exact = num_buckets // 2
+        is_small = relative_positions < max_exact
+
+        relative_postion_if_large = max_exact + (
+                torch.log(relative_positions.float() / max_exact)
+                / math.log(max_distance / max_exact)
+                * (num_buckets - max_exact)
+        ).to(torch.long)
+        relative_postion_if_large = torch.min(
+            relative_postion_if_large, torch.full_like(relative_postion_if_large, num_buckets - 1)
+        )
+
+        relative_buckets += torch.where(is_small, relative_positions, relative_postion_if_large)
+        return relative_buckets
+
+    def compute_bias(self, query_length, key_length):
+        context_position = torch.arange(query_length, dtype=torch.long)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long)[None, :]
+        relative_position = memory_position - context_position
+        relative_position_bucket = self._relative_positions_bucket(
+            relative_position,
+            bidirectional=True
+        )
+        relative_position_bucket = relative_position_bucket.to(self.relative_attention_bias.weight.device)
+        values = self.relative_attention_bias(relative_position_bucket)
+        values = values.permute([2, 0, 1])
+        return values
+
+    def forward(
+            self,
+            query,
+            key: Optional[Tensor],
+            value: Optional[Tensor],
+            key_padding_mask: Optional[Tensor] = None,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+            need_weights: bool = True,
+            static_kv: bool = False,
+            attn_mask: Optional[Tensor] = None,
+            before_softmax: bool = False,
+            need_head_weights: bool = False,
+            position_bias: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
+        """Input shape: Time x Batch x Channel
+
+        Args:
+            key_padding_mask (ByteTensor, optional): mask to exclude
+                keys that are pads, of shape `(batch, src_len)`, where
+                padding elements are indicated by 1s.
+            need_weights (bool, optional): return the attention weights,
+                averaged over heads (default: False).
+            attn_mask (ByteTensor, optional): typically used to
+                implement causal attention, where the mask prevents the
+                attention from looking forward in time (default: None).
+            before_softmax (bool, optional): return the raw attention
+                weights and values before the attention softmax.
+            need_head_weights (bool, optional): return the attention
+                weights for each head. Implies *need_weights*. Default:
+                return the average attention weights over all heads.
+        """
+        if need_head_weights:
+            need_weights = True
+
+        is_tpu = query.device.type == "xla"
+
+        tgt_len, bsz, embed_dim = query.size()
+        src_len = tgt_len
+        assert embed_dim == self.embed_dim
+        assert list(query.size()) == [tgt_len, bsz, embed_dim]
+        if key is not None:
+            src_len, key_bsz, _ = key.size()
+            if not torch.jit.is_scripting():
+                assert key_bsz == bsz
+                assert value is not None
+                assert src_len, bsz == value.shape[:2]
+
+        if self.has_relative_attention_bias and position_bias is None:
+            position_bias = self.compute_bias(tgt_len, src_len)
+            position_bias = position_bias.unsqueeze(0).repeat(bsz, 1, 1, 1).view(bsz * self.num_heads, tgt_len, src_len)
+
+        if incremental_state is not None:
+            saved_state = self._get_input_buffer(incremental_state)
+            if saved_state is not None and "prev_key" in saved_state:
+                # previous time steps are cached - no need to recompute
+                # key and value if they are static
+                if static_kv:
+                    assert self.encoder_decoder_attention and not self.self_attention
+                    key = value = None
+        else:
+            saved_state = None
+
+        if self.self_attention:
+            q = self.q_proj(query)
+            k = self.k_proj(query)
+            v = self.v_proj(query)
+        elif self.encoder_decoder_attention:
+            # encoder-decoder attention
+            q = self.q_proj(query)
+            if key is None:
+                assert value is None
+                k = v = None
+            else:
+                k = self.k_proj(key)
+                v = self.v_proj(key)
+
+        else:
+            assert key is not None and value is not None
+            q = self.q_proj(query)
+            k = self.k_proj(key)
+            v = self.v_proj(value)
+        q *= self.scaling
+        alpha = 32
+        q *= 1 / alpha
+
+        if self.bias_k is not None:
+            assert self.bias_v is not None
+            k = torch.cat([k, self.bias_k.repeat(1, bsz, 1)])
+            v = torch.cat([v, self.bias_v.repeat(1, bsz, 1)])
+            if attn_mask is not None:
+                attn_mask = torch.cat(
+                    [attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1
+                )
+            if key_padding_mask is not None:
+                key_padding_mask = torch.cat(
+                    [
+                        key_padding_mask,
+                        key_padding_mask.new_zeros(key_padding_mask.size(0), 1),
+                    ],
+                    dim=1,
+                )
+
+        q = (
+            q.contiguous()
+                .view(tgt_len, bsz * self.num_heads, self.q_head_dim)
+                .transpose(0, 1)
+        )
+        if k is not None:
+            k = (
+                k.contiguous()
+                    .view(-1, bsz * self.num_heads, self.k_head_dim)
+                    .transpose(0, 1)
+            )
+        if v is not None:
+            v = (
+                v.contiguous()
+                    .view(-1, bsz * self.num_heads, self.head_dim)
+                    .transpose(0, 1)
+            )
+
+        if saved_state is not None:
+            # saved states are stored with shape (bsz, num_heads, seq_len, head_dim)
+            if "prev_key" in saved_state:
+                _prev_key = saved_state["prev_key"]
+                assert _prev_key is not None
+                prev_key = _prev_key.view(bsz * self.num_heads, -1, self.head_dim)
+                if static_kv:
+                    k = prev_key
+                else:
+                    assert k is not None
+                    k = torch.cat([prev_key, k], dim=1)
+                src_len = k.size(1)
+            if "prev_value" in saved_state:
+                _prev_value = saved_state["prev_value"]
+                assert _prev_value is not None
+                prev_value = _prev_value.view(bsz * self.num_heads, -1, self.head_dim)
+                if static_kv:
+                    v = prev_value
+                else:
+                    assert v is not None
+                    v = torch.cat([prev_value, v], dim=1)
+            prev_key_padding_mask: Optional[Tensor] = None
+            if "prev_key_padding_mask" in saved_state:
+                prev_key_padding_mask = saved_state["prev_key_padding_mask"]
+            assert k is not None and v is not None
+            key_padding_mask = MultiheadAttention._append_prev_key_padding_mask(
+                key_padding_mask=key_padding_mask,
+                prev_key_padding_mask=prev_key_padding_mask,
+                batch_size=bsz,
+                src_len=k.size(1),
+                static_kv=static_kv,
+            )
+
+            saved_state["prev_key"] = k.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_key_padding_mask"] = key_padding_mask
+            # In this branch incremental_state is never None
+            assert incremental_state is not None
+            incremental_state = self._set_input_buffer(incremental_state, saved_state)
+        assert k is not None
+        assert k.size(1) == src_len
+
+        # This is part of a workaround to get around fork/join parallelism
+        # not supporting Optional types.
+        if key_padding_mask is not None and key_padding_mask.dim() == 0:
+            key_padding_mask = None
+
+        if key_padding_mask is not None:
+            assert key_padding_mask.size(0) == bsz
+            assert key_padding_mask.size(1) == src_len
+
+        if self.add_zero_attn:
+            assert v is not None
+            src_len += 1
+            k = torch.cat([k, k.new_zeros((k.size(0), 1) + k.size()[2:])], dim=1)
+            v = torch.cat([v, v.new_zeros((v.size(0), 1) + v.size()[2:])], dim=1)
+            if attn_mask is not None:
+                attn_mask = torch.cat(
+                    [attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1
+                )
+            if key_padding_mask is not None:
+                key_padding_mask = torch.cat(
+                    [
+                        key_padding_mask,
+                        torch.zeros(key_padding_mask.size(0), 1).type_as(
+                            key_padding_mask
+                        ),
+                    ],
+                    dim=1,
+                )
+
+        attn_weights = torch.bmm(q, k.transpose(1, 2))
+        attn_weights = (attn_weights - attn_weights.max(dim=-1, keepdim=True)[0]) * alpha
+        attn_weights = self.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
+
+        assert list(attn_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]
+
+        if attn_mask is not None:
+            attn_mask = attn_mask.unsqueeze(0)
+            attn_weights += attn_mask
+
+        if key_padding_mask is not None:
+            # don't attend to padding symbols
+            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
+            if not is_tpu:
+                attn_weights = attn_weights.masked_fill(
+                    key_padding_mask.unsqueeze(1).unsqueeze(2).to(torch.bool),
+                    float("-inf"),
+                )
+            else:
+                attn_weights = attn_weights.transpose(0, 2)
+                attn_weights = attn_weights.masked_fill(key_padding_mask, float("-inf"))
+                attn_weights = attn_weights.transpose(0, 2)
+            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
+
+        if before_softmax:
+            return attn_weights, v, position_bias
+
+        if position_bias is not None:
+            attn_mask_rel_pos = position_bias
+            if self.gru_rel_pos == 1:
+                query_layer = q.view(bsz, self.num_heads, tgt_len, self.q_head_dim) * alpha / self.scaling
+                _B, _H, _L, __ = query_layer.size()
+                gate_a, gate_b = torch.sigmoid(self.grep_linear(query_layer).view(
+                    _B, _H, _L, 2, 4).sum(-1, keepdim=False)).chunk(2, dim=-1)
+                gate_a_1 = gate_a * (gate_b * self.grep_a - 1.0) + 2.0
+                attn_mask_rel_pos = gate_a_1.view(bsz * self.num_heads, tgt_len, 1) * position_bias
+
+            attn_mask_rel_pos = attn_mask_rel_pos.view(attn_weights.size())
+
+            attn_weights = attn_weights + attn_mask_rel_pos
+
+        attn_weights_float = F.softmax(
+            attn_weights, dim=-1
+        )
+        attn_weights = attn_weights_float.type_as(attn_weights)
+        attn_probs = self.dropout_module(attn_weights)
+
+        assert v is not None
+        attn = torch.bmm(attn_probs, v)
+        assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
+        attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
+        attn = self.out_proj(attn)
+        attn_weights: Optional[Tensor] = None
+        if need_weights:
+            attn_weights = attn_weights_float.view(
+                bsz, self.num_heads, tgt_len, src_len
+            ).transpose(1, 0)
+            if not need_head_weights:
+                # average attention weights over heads
+                attn_weights = attn_weights.mean(dim=0)
+
+        return attn, attn_weights, position_bias
+
+    @staticmethod
+    def _append_prev_key_padding_mask(
+            key_padding_mask: Optional[Tensor],
+            prev_key_padding_mask: Optional[Tensor],
+            batch_size: int,
+            src_len: int,
+            static_kv: bool,
+    ) -> Optional[Tensor]:
+        # saved key padding masks have shape (bsz, seq_len)
+        if prev_key_padding_mask is not None and static_kv:
+            new_key_padding_mask = prev_key_padding_mask
+        elif prev_key_padding_mask is not None and key_padding_mask is not None:
+            new_key_padding_mask = torch.cat(
+                [prev_key_padding_mask.float(), key_padding_mask.float()], dim=1
+            )
+        # During incremental decoding, as the padding token enters and
+        # leaves the frame, there will be a time when prev or current
+        # is None
+        elif prev_key_padding_mask is not None:
+            if src_len > prev_key_padding_mask.size(1):
+                filler = torch.zeros(
+                    (batch_size, src_len - prev_key_padding_mask.size(1)),
+                    device=prev_key_padding_mask.device,
+                )
+                new_key_padding_mask = torch.cat(
+                    [prev_key_padding_mask.float(), filler.float()], dim=1
+                )
+            else:
+                new_key_padding_mask = prev_key_padding_mask.float()
+        elif key_padding_mask is not None:
+            if src_len > key_padding_mask.size(1):
+                filler = torch.zeros(
+                    (batch_size, src_len - key_padding_mask.size(1)),
+                    device=key_padding_mask.device,
+                )
+                new_key_padding_mask = torch.cat(
+                    [filler.float(), key_padding_mask.float()], dim=1
+                )
+            else:
+                new_key_padding_mask = key_padding_mask.float()
+        else:
+            new_key_padding_mask = prev_key_padding_mask
+        return new_key_padding_mask
+
+    def _get_input_buffer(
+            self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]
+    ) -> Dict[str, Optional[Tensor]]:
+        result = self.get_incremental_state(incremental_state, "attn_state")
+        if result is not None:
+            return result
+        else:
+            empty_result: Dict[str, Optional[Tensor]] = {}
+            return empty_result
+
+    def _set_input_buffer(
+            self,
+            incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+            buffer: Dict[str, Optional[Tensor]],
+    ):
+        return self.set_incremental_state(incremental_state, "attn_state", buffer)
+
+    def apply_sparse_mask(self, attn_weights, tgt_len: int, src_len: int, bsz: int):
+        return attn_weights
+
+
+def init_bert_params(module):
+    """
+    Initialize the weights specific to the BERT Model.
+    This overrides the default initializations depending on the specified arguments.
+        1. If normal_init_linear_weights is set then weights of linear
+           layer will be initialized using the normal distribution and
+           bais will be set to the specified value.
+        2. If normal_init_embed_weights is set then weights of embedding
+           layer will be initialized using the normal distribution.
+        3. If normal_init_proj_weights is set then weights of
+           in_project_weight for MultiHeadAttention initialized using
+           the normal distribution (to be validated).
+    """
+
+    def normal_(data):
+        # with FSDP, module params will be on CUDA, so we cast them back to CPU
+        # so that the RNG is consistent with and without FSDP
+        data.copy_(
+            data.cpu().normal_(mean=0.0, std=0.02).to(data.device)
+        )
+
+    if isinstance(module, nn.Linear):
+        normal_(module.weight.data)
+        if module.bias is not None:
+            module.bias.data.zero_()
+    if isinstance(module, nn.Embedding):
+        normal_(module.weight.data)
+        if module.padding_idx is not None:
+            module.weight.data[module.padding_idx].zero_()
+    if isinstance(module, MultiheadAttention):
+        normal_(module.q_proj.weight.data)
+        normal_(module.k_proj.weight.data)
+        normal_(module.v_proj.weight.data)

--- a/third_party/beats/modules.py
+++ b/third_party/beats/modules.py
@@ -1,0 +1,219 @@
+# --------------------------------------------------------
+# BEATs: Audio Pre-Training with Acoustic Tokenizers (https://arxiv.org/abs/2212.09058)
+# Github source: https://github.com/microsoft/unilm/tree/master/beats
+# Copyright (c) 2022 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Based on fairseq code bases
+# https://github.com/pytorch/fairseq
+# --------------------------------------------------------
+
+import math
+import warnings
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+
+
+class GradMultiply(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, scale):
+        ctx.scale = scale
+        res = x.new(x)
+        return res
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad * ctx.scale, None
+
+
+class SamePad(nn.Module):
+    def __init__(self, kernel_size, causal=False):
+        super().__init__()
+        if causal:
+            self.remove = kernel_size - 1
+        else:
+            self.remove = 1 if kernel_size % 2 == 0 else 0
+
+    def forward(self, x):
+        if self.remove > 0:
+            x = x[:, :, : -self.remove]
+        return x
+
+
+class Swish(nn.Module):
+    def __init__(self):
+        super(Swish, self).__init__()
+        self.act = torch.nn.Sigmoid()
+
+    def forward(self, x):
+        return x * self.act(x)
+
+
+class GLU_Linear(nn.Module):
+    def __init__(self, input_dim, output_dim, glu_type="sigmoid", bias_in_glu=True):
+        super(GLU_Linear, self).__init__()
+
+        self.glu_type = glu_type
+        self.output_dim = output_dim
+
+        if glu_type == "sigmoid":
+            self.glu_act = torch.nn.Sigmoid()
+        elif glu_type == "swish":
+            self.glu_act = Swish()
+        elif glu_type == "relu":
+            self.glu_act = torch.nn.ReLU()
+        elif glu_type == "gelu":
+            self.glu_act = torch.nn.GELU()
+
+        if bias_in_glu:
+            self.linear = nn.Linear(input_dim, output_dim * 2, True)
+        else:
+            self.linear = nn.Linear(input_dim, output_dim * 2, False)
+
+    def forward(self, x):
+        # to be consistent with GLU_Linear, we assume the input always has the #channel (#dim) in the last dimension of the tensor, so need to switch the dimension first for 1D-Conv case
+        x = self.linear(x)
+
+        if self.glu_type == "bilinear":
+            x = (x[:, :, 0:self.output_dim] * x[:, :, self.output_dim:self.output_dim * 2])
+        else:
+            x = (x[:, :, 0:self.output_dim] * self.glu_act(x[:, :, self.output_dim:self.output_dim * 2]))
+
+        return x
+
+
+def gelu_accurate(x):
+    if not hasattr(gelu_accurate, "_a"):
+        gelu_accurate._a = math.sqrt(2 / math.pi)
+    return (
+        0.5 * x * (1 + torch.tanh(gelu_accurate._a * (x + 0.044715 * torch.pow(x, 3))))
+    )
+
+
+def gelu(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.gelu(x.float()).type_as(x)
+
+
+def get_activation_fn(activation: str):
+    """Returns the activation function corresponding to `activation`"""
+
+    if activation == "relu":
+        return F.relu
+    elif activation == "gelu":
+        return gelu
+    elif activation == "gelu_fast":
+        warnings.warn(
+            "--activation-fn=gelu_fast has been renamed to gelu_accurate"
+        )
+        return gelu_accurate
+    elif activation == "gelu_accurate":
+        return gelu_accurate
+    elif activation == "tanh":
+        return torch.tanh
+    elif activation == "linear":
+        return lambda x: x
+    elif activation == "glu":
+        return lambda x: x
+    else:
+        raise RuntimeError("--activation-fn {} not supported".format(activation))
+
+
+def quant_noise(module, p, block_size):
+    """
+    Wraps modules and applies quantization noise to the weights for
+    subsequent quantization with Iterative Product Quantization as
+    described in "Training with Quantization Noise for Extreme Model Compression"
+
+    Args:
+        - module: nn.Module
+        - p: amount of Quantization Noise
+        - block_size: size of the blocks for subsequent quantization with iPQ
+
+    Remarks:
+        - Module weights must have the right sizes wrt the block size
+        - Only Linear, Embedding and Conv2d modules are supported for the moment
+        - For more detail on how to quantize by blocks with convolutional weights,
+          see "And the Bit Goes Down: Revisiting the Quantization of Neural Networks"
+        - We implement the simplest form of noise here as stated in the paper
+          which consists in randomly dropping blocks
+    """
+
+    # if no quantization noise, don't register hook
+    if p <= 0:
+        return module
+
+    # supported modules
+    assert isinstance(module, (nn.Linear, nn.Embedding, nn.Conv2d))
+
+    # test whether module.weight has the right sizes wrt block_size
+    is_conv = module.weight.ndim == 4
+
+    # 2D matrix
+    if not is_conv:
+        assert (
+            module.weight.size(1) % block_size == 0
+        ), "Input features must be a multiple of block sizes"
+
+    # 4D matrix
+    else:
+        # 1x1 convolutions
+        if module.kernel_size == (1, 1):
+            assert (
+                module.in_channels % block_size == 0
+            ), "Input channels must be a multiple of block sizes"
+        # regular convolutions
+        else:
+            k = module.kernel_size[0] * module.kernel_size[1]
+            assert k % block_size == 0, "Kernel size must be a multiple of block size"
+
+    def _forward_pre_hook(mod, input):
+        # no noise for evaluation
+        if mod.training:
+            if not is_conv:
+                # gather weight and sizes
+                weight = mod.weight
+                in_features = weight.size(1)
+                out_features = weight.size(0)
+
+                # split weight matrix into blocks and randomly drop selected blocks
+                mask = torch.zeros(
+                    in_features // block_size * out_features, device=weight.device
+                )
+                mask.bernoulli_(p)
+                mask = mask.repeat_interleave(block_size, -1).view(-1, in_features)
+
+            else:
+                # gather weight and sizes
+                weight = mod.weight
+                in_channels = mod.in_channels
+                out_channels = mod.out_channels
+
+                # split weight matrix into blocks and randomly drop selected blocks
+                if mod.kernel_size == (1, 1):
+                    mask = torch.zeros(
+                        int(in_channels // block_size * out_channels),
+                        device=weight.device,
+                    )
+                    mask.bernoulli_(p)
+                    mask = mask.repeat_interleave(block_size, -1).view(-1, in_channels)
+                else:
+                    mask = torch.zeros(
+                        weight.size(0), weight.size(1), device=weight.device
+                    )
+                    mask.bernoulli_(p)
+                    mask = (
+                        mask.unsqueeze(2)
+                        .unsqueeze(3)
+                        .repeat(1, 1, mod.kernel_size[0], mod.kernel_size[1])
+                    )
+
+            # scale weights and apply mask
+            mask = mask.to(
+                torch.bool
+            )  # x.bool() is not currently supported in TorchScript
+            s = 1 / (1 - p)
+            mod.weight.data = s * weight.masked_fill(mask, 0)
+
+    module.register_forward_pre_hook(_forward_pre_hook)
+    return module
+

--- a/third_party/beats/quantizer.py
+++ b/third_party/beats/quantizer.py
@@ -1,0 +1,215 @@
+# --------------------------------------------------------
+# BEATs: Audio Pre-Training with Acoustic Tokenizers (https://arxiv.org/abs/2212.09058)
+# Github source: https://github.com/microsoft/unilm/tree/master/beats
+# Copyright (c) 2022 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Based on VQGAN code bases
+# https://github.com/CompVis/taming-transformers
+# --------------------------------------------------------'
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.distributed as distributed
+
+try:
+    from einops import rearrange, repeat
+except ImportError:
+    pass
+
+
+def l2norm(t):
+    return F.normalize(t, p=2, dim=-1)
+
+
+def ema_inplace(moving_avg, new, decay):
+    moving_avg.data.mul_(decay).add_(new, alpha=(1 - decay))
+
+
+def sample_vectors(samples, num):
+    num_samples, device = samples.shape[0], samples.device
+
+    if num_samples >= num:
+        indices = torch.randperm(num_samples, device=device)[:num]
+    else:
+        indices = torch.randint(0, num_samples, (num,), device=device)
+
+    return samples[indices]
+
+
+def kmeans(samples, num_clusters, num_iters=10, use_cosine_sim=False):
+    dim, dtype, device = samples.shape[-1], samples.dtype, samples.device
+
+    means = sample_vectors(samples, num_clusters)
+
+    for _ in range(num_iters):
+        if use_cosine_sim:
+            dists = samples @ means.t()
+        else:
+            diffs = rearrange(samples, 'n d -> n () d') \
+                    - rearrange(means, 'c d -> () c d')
+            dists = -(diffs ** 2).sum(dim=-1)
+
+        buckets = dists.max(dim=-1).indices
+        bins = torch.bincount(buckets, minlength=num_clusters)
+        zero_mask = bins == 0
+        bins_min_clamped = bins.masked_fill(zero_mask, 1)
+
+        new_means = buckets.new_zeros(num_clusters, dim, dtype=dtype)
+        new_means.scatter_add_(0, repeat(buckets, 'n -> n d', d=dim), samples)
+        new_means = new_means / bins_min_clamped[..., None]
+
+        if use_cosine_sim:
+            new_means = l2norm(new_means)
+
+        means = torch.where(zero_mask[..., None], means, new_means)
+
+    return means, bins
+
+
+class EmbeddingEMA(nn.Module):
+    def __init__(self, num_tokens, codebook_dim, decay=0.99, eps=1e-5, kmeans_init=True, codebook_init_path=''):
+        super().__init__()
+        self.num_tokens = num_tokens
+        self.codebook_dim = codebook_dim
+        self.decay = decay
+        self.eps = eps
+        if codebook_init_path == '':
+            if not kmeans_init:
+                weight = torch.randn(num_tokens, codebook_dim)
+                weight = l2norm(weight)
+            else:
+                weight = torch.zeros(num_tokens, codebook_dim)
+            self.register_buffer('initted', torch.Tensor([not kmeans_init]))
+        else:
+            print(f"load init codebook weight from {codebook_init_path}")
+            codebook_ckpt_weight = torch.load(codebook_init_path, map_location='cpu')
+            weight = codebook_ckpt_weight.clone()
+            self.register_buffer('initted', torch.Tensor([True]))
+
+        self.weight = nn.Parameter(weight, requires_grad=False)
+        self.cluster_size = nn.Parameter(torch.zeros(num_tokens), requires_grad=False)
+        self.embed_avg = nn.Parameter(weight.clone(), requires_grad=False)
+        # self.register_buffer('initted', torch.Tensor([not kmeans_init]))
+        self.update = True
+
+    @torch.jit.ignore
+    def init_embed_(self, data):
+        if self.initted:
+            return
+        print("Performing Kemans init for codebook")
+        embed, cluster_size = kmeans(data, self.num_tokens, 10, use_cosine_sim=True)
+        self.weight.data.copy_(embed)
+        self.cluster_size.data.copy_(cluster_size)
+        self.initted.data.copy_(torch.Tensor([True]))
+
+    def forward(self, embed_id):
+        return F.embedding(embed_id, self.weight)
+
+    def cluster_size_ema_update(self, new_cluster_size):
+        self.cluster_size.data.mul_(self.decay).add_(new_cluster_size, alpha=1 - self.decay)
+
+    def embed_avg_ema_update(self, new_embed_avg):
+        self.embed_avg.data.mul_(self.decay).add_(new_embed_avg, alpha=1 - self.decay)
+
+    def weight_update(self, num_tokens):
+        n = self.cluster_size.sum()
+        smoothed_cluster_size = (
+                (self.cluster_size + self.eps) / (n + num_tokens * self.eps) * n
+        )
+        # normalize embedding average with smoothed cluster size
+        embed_normalized = self.embed_avg / smoothed_cluster_size.unsqueeze(1)
+        # embed_normalized = l2norm(self.embed_avg / smoothed_cluster_size.unsqueeze(1))
+        self.weight.data.copy_(embed_normalized)
+
+
+def norm_ema_inplace(moving_avg, new, decay):
+    moving_avg.data.mul_(decay).add_(new, alpha=(1 - decay))
+    moving_avg.data.copy_(l2norm(moving_avg.data))
+
+
+class NormEMAVectorQuantizer(nn.Module):
+    def __init__(self, n_embed, embedding_dim, beta, decay=0.99, eps=1e-5,
+                 statistic_code_usage=True, kmeans_init=False, codebook_init_path=''):
+        super().__init__()
+        self.codebook_dim = embedding_dim
+        self.num_tokens = n_embed
+        self.beta = beta
+        self.decay = decay
+
+        # learnable = True if orthogonal_reg_weight > 0 else False
+        self.embedding = EmbeddingEMA(self.num_tokens, self.codebook_dim, decay, eps, kmeans_init, codebook_init_path)
+
+        self.statistic_code_usage = statistic_code_usage
+        if statistic_code_usage:
+            self.register_buffer('cluster_size', torch.zeros(n_embed))
+        if distributed.is_available() and distributed.is_initialized():
+            print("ddp is enable, so use ddp_reduce to sync the statistic_code_usage for each gpu!")
+            self.all_reduce_fn = distributed.all_reduce
+        else:
+            self.all_reduce_fn = nn.Identity()
+
+    def reset_cluster_size(self, device):
+        if self.statistic_code_usage:
+            self.register_buffer('cluster_size', torch.zeros(self.num_tokens))
+            self.cluster_size = self.cluster_size.to(device)
+
+    def forward(self, z):
+        # reshape z -> (batch, height, width, channel) and flatten
+        # z, 'b c h w -> b h w c'
+        # z = rearrange(z, 'b c h w -> b h w c')
+        # z = z.transpose(1, 2)
+        z = l2norm(z)
+        z_flattened = z.reshape(-1, self.codebook_dim)
+
+        self.embedding.init_embed_(z_flattened)
+
+        d = z_flattened.pow(2).sum(dim=1, keepdim=True) + \
+            self.embedding.weight.pow(2).sum(dim=1) - 2 * \
+            torch.einsum('bd,nd->bn', z_flattened, self.embedding.weight)  # 'n d -> d n'
+
+        encoding_indices = torch.argmin(d, dim=1)
+
+        z_q = self.embedding(encoding_indices).view(z.shape)
+
+        encodings = F.one_hot(encoding_indices, self.num_tokens).type(z.dtype)
+
+        if not self.training:
+            with torch.no_grad():
+                cluster_size = encodings.sum(0)
+                self.all_reduce_fn(cluster_size)
+                ema_inplace(self.cluster_size, cluster_size, self.decay)
+
+        if self.training and self.embedding.update:
+            # EMA cluster size
+
+            bins = encodings.sum(0)
+            self.all_reduce_fn(bins)
+
+            # self.embedding.cluster_size_ema_update(bins)
+            ema_inplace(self.cluster_size, bins, self.decay)
+
+            zero_mask = (bins == 0)
+            bins = bins.masked_fill(zero_mask, 1.)
+
+            embed_sum = z_flattened.t() @ encodings
+            self.all_reduce_fn(embed_sum)
+
+            embed_normalized = (embed_sum / bins.unsqueeze(0)).t()
+            embed_normalized = l2norm(embed_normalized)
+
+            embed_normalized = torch.where(zero_mask[..., None], self.embedding.weight,
+                                           embed_normalized)
+            norm_ema_inplace(self.embedding.weight, embed_normalized, self.decay)
+
+        # compute loss for embedding
+        loss = self.beta * F.mse_loss(z_q.detach(), z)
+
+        # preserve gradients
+        z_q = z + (z_q - z).detach()
+
+        # reshape back to match original input shape
+        # z_q, 'b h w c -> b c h w'
+        # z_q = rearrange(z_q, 'b h w c -> b c h w')
+        # z_q = z_q.transpose(1, 2)
+        return z_q, loss, encoding_indices


### PR DESCRIPTION
## Summary

Implements support for Microsoft BEATs as an alternative audio classification backbone for Voter D, alongside the existing PANN implementation. This enables evaluation of whether BEATs improves consensus precision/recall on audited fixture sets.

## Key Changes

- **New BEATs extractor script** (`scripts/extract_beats_embeddings.py`): Mirrors the PANN extractor to generate per-candidate gunshot probabilities from BEATs checkpoints. Supports both short-fixture and wide-window (`--full`) modes with the same cache schema as PANN.

- **BEATs runtime loading** (`ensemble/features.py`):
  - Added `BeatsRuntime` dataclass to hold loaded BEATs model and device
  - Implemented `load_beats_runtime()` to load Microsoft BEATs checkpoints with clear error messages when checkpoint is missing or not found
  - Implemented `compute_beats_gunshot_probs()` to compute per-candidate gunshot probabilities, mirroring PANN's interface
  - Added constants for BEATs sample rate (16 kHz), window size (1 s), and gunshot class index (427, same as PANN)

- **Voter D backend selection** (`ensemble/calibration.py`, `ensemble/api.py`):
  - Added `voter_d_backend` field to `EnsembleCalibration` (defaults to `"pann"` for backward compatibility)
  - Modified `EnsembleRuntime` to carry both `pann` and `beats` slots; only the active backend is loaded
  - Implemented `compute_voter_d_probs()` dispatcher that routes inference to the calibrated backbone with validation that the matching runtime slot is populated

- **Calibration builder updates** (`scripts/build_ensemble_artifacts.py`):
  - Added `--voter-d-backend` CLI argument to select which backend to calibrate against
  - Refactored cache path resolution into `_voter_d_cache_path()` and `_voter_d_full_cache_path()` helpers to support both backends
  - Updated `_build_universe()` and `_load_mined_negatives()` to read from the selected backend's cache
  - Artifact now records the active backend so `load_ensemble_runtime()` knows which model to materialize

- **Comprehensive test coverage** (`tests/test_ensemble.py`):
  - Tests for backward compatibility (existing artifacts default to PANN)
  - Tests for dispatcher routing between backends
  - Tests for error handling when runtime slot is missing or backend is unknown
  - End-to-end test verifying BEATs path through the full ensemble pipeline
  - Tests for checkpoint loading error messages

## Implementation Details

- **Cache schema compatibility**: Both PANN and BEATs extractors write `.npz` files with `times`, `gunshot_prob`, and backend-specific arrays (e.g., `clipwise` for both). The calibration builder routes between caches via a single helper that keys on backend name.

- **Backward compatibility**: Existing artifacts without a `voter_d_backend` field load as PANN. The default is explicitly set to maintain byte-identical behavior.

- **Optional dependency**: BEATs is dev-only and not part of the runtime pipeline. The loader defers imports and provides actionable errors if the optional install is missing.

- **Device handling**: Both runtimes track device (CPU/GPU) so mocked runtimes in tests can skip torch entirely.

https://claude.ai/code/session_01W3h8RMiB9S9tn5xByZr7To