### PR TITLE
match-export: bias connected-clip offset by head_trim

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -690,14 +690,15 @@ def generate_match_fcpxml(
             },
         )
 
-        # Secondary cam connected clips. Lane=1..N (per stage). Beep
-        # alignment generalises the single-stage formula: with the primary's
-        # ``start`` shifted forward by head_trim, the secondary needs to
-        # arrive at the timeline at primary_local_beep = (beep_offset -
-        # head_trim) instead of beep_offset. So delta = (beep_offset -
-        # head_trim) - sec_beep, expressed in frames; a non-negative delta
-        # places the cam later in the parent's local time, a negative delta
-        # skips into the cam's own media.
+        # Secondary cam connected clips. Lane=1..N (per stage). The parent's
+        # ``offset`` on a connected clip is in the parent's source-time
+        # coordinates -- offset=0s would land at parent_source=0, which is
+        # ``head_trim`` seconds *before* the parent's visible spine start.
+        # So every connected-clip offset is biased by ``head_trim_frames``
+        # to anchor at the parent's visible start. Beep alignment then
+        # follows from delta = (beep_offset - head_trim) - sec_beep in
+        # frames; a non-negative delta places the cam later in the parent's
+        # local time, a negative delta skips into the cam's own media.
         for lane_idx, (sec, sec_id, sec_dur_in_parent_frames) in enumerate(
             plan.usable_secondaries, start=1
         ):
@@ -706,20 +707,20 @@ def generate_match_fcpxml(
                 / fd_seconds
             )
             if delta_frames >= 0:
-                sec_offset_str = _frame_aligned_str(delta_frames, fd_num, fd_den)
-                sec_start_str = "0s"
+                sec_offset_frames = plan.head_trim_frames + delta_frames
+                sec_start_frames = 0
             else:
-                sec_offset_str = "0s"
-                sec_start_str = _frame_aligned_str(-delta_frames, fd_num, fd_den)
+                sec_offset_frames = plan.head_trim_frames
+                sec_start_frames = -delta_frames
             ET.SubElement(
                 primary_clip,
                 "asset-clip",
                 {
                     "ref": sec_id,
                     "lane": str(lane_idx),
-                    "offset": sec_offset_str,
+                    "offset": _frame_aligned_str(sec_offset_frames, fd_num, fd_den),
                     "name": sec.label,
-                    "start": sec_start_str,
+                    "start": _frame_aligned_str(sec_start_frames, fd_num, fd_den),
                     "duration": _frame_aligned_str(sec_dur_in_parent_frames, fd_num, fd_den),
                     "format": format_id,
                 },
@@ -728,19 +729,20 @@ def generate_match_fcpxml(
         if plan.overlay_asset_id is not None:
             overlay_lane = len(plan.usable_secondaries) + 1
             # Overlay was rendered to mirror the primary frame-for-frame, so
-            # to stay in sync after head_trim its ``start`` skips into the
-            # overlay's own media by the same number of frames. ``duration``
-            # matches the primary's effective duration so the overlay covers
-            # the visible window without overhang.
+            # ``start`` skips into the overlay's own media by head_trim to
+            # stay in sync. ``offset`` is also head_trim (parent-source-time
+            # of the parent's visible start) so the overlay anchors at the
+            # primary's visible start instead of head_trim seconds earlier.
+            head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
             ET.SubElement(
                 primary_clip,
                 "asset-clip",
                 {
                     "ref": plan.overlay_asset_id,
                     "lane": str(overlay_lane),
-                    "offset": "0s",
+                    "offset": head_trim_str,
                     "name": "Splitsmith overlay",
-                    "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                    "start": head_trim_str,
                     "duration": eff_duration_str,
                     "format": format_id,
                 },

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -854,8 +854,10 @@ def test_match_fcpxml_secondary_alignment_with_head_trim(tmp_path: Path) -> None
     root = ET.fromstring(out.read_bytes())
     cam_clip = root.find(".//spine/asset-clip/asset-clip")
     assert cam_clip is not None
-    assert cam_clip.attrib["offset"] == "0s"
-    # delta = (5.0 - 4.5) - 5.0 = -4.5s -> sec_start = 4.5s = 135 frames
+    # Connected-clip offset is in the parent's source-time, so it must be
+    # bumped by head_trim (135 frames) to anchor at the parent's visible
+    # start. delta = (5.0 - 4.5) - 5.0 = -4.5s -> sec_start = 4.5s = 135.
+    assert cam_clip.attrib["offset"] == "135/30s"
     assert cam_clip.attrib["start"] == "135/30s"
 
 
@@ -948,7 +950,10 @@ def test_match_fcpxml_overlay_skips_into_media_when_head_trimmed(tmp_path: Path)
     root = ET.fromstring(out.read_bytes())
     overlay_clip = root.find(".//spine/asset-clip/asset-clip")
     assert overlay_clip is not None
-    # head_trim = 4.5s = 135 frames; eff_duration = 90 frames
+    # head_trim = 4.5s = 135 frames; eff_duration = 90 frames. ``offset``
+    # is in the parent's source-time, so it matches ``start`` (head_trim)
+    # to anchor the overlay at the parent's visible spine start.
+    assert overlay_clip.attrib["offset"] == "135/30s"
     assert overlay_clip.attrib["start"] == "135/30s"
     assert overlay_clip.attrib["duration"] == "90/30s"
     assert overlay_clip.attrib["lane"] == "1"


### PR DESCRIPTION
## Summary
- Overlay (and secondary-cam) connected clips in match-export FCPXMLs were anchored at the parent's source-time 0 instead of the parent's visible spine start.
- With ``start=head_trim_frames`` on the primary, the connected ``offset="0s"`` placed the overlay ``head_trim`` seconds *before* the primary on the spine, so every stage that used the Action / Highlight presets showed the overlay leaking left of the stage clip in FCP.
- Both connected-clip offsets now add ``head_trim_frames`` so they anchor at the parent's visible start. ``start`` still skips the same amount into the connected media to keep beep/frame sync.

## Test plan
- [x] ``uv run pytest tests/test_fcpxml_gen.py`` (32 passed)
- [x] ``uv run pytest -k match`` (88 passed)
- [x] Regenerated a 3-stage match export and re-opened in FCP -- overlays now align with each stage's primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)