### PR TITLE
overlay: configurable codec / resolution / fps cap (CLI + UI)

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -25,6 +25,7 @@ from . import (
     beep_detect,
     csv_gen,
     fcpxml_gen,
+    overlay_render,
     report,
     shot_detect,
     shot_refine,
@@ -694,6 +695,64 @@ def fcpxml(
         output_path=output,
         project_name=project_name or video.stem,
         config=config.output,
+    )
+    console.print(f"[green]Wrote[/] {output}")
+
+
+@app.command()
+def overlay(
+    audit_path: Path = typer.Option(
+        ..., "--audit", help="Audited stage JSON (e.g. <project>/audit/stage<N>.json)."
+    ),
+    video: Path = typer.Option(
+        ..., "--video", help="Trimmed video the overlay must mirror frame-for-frame."
+    ),
+    output: Path = typer.Option(..., "--output", help="Output overlay MOV (alpha)."),
+    beep_offset: float = typer.Option(
+        5.0, "--beep-offset", help="Seconds from start of trimmed video to the beep."
+    ),
+    codec: str = typer.Option(
+        "auto",
+        "--codec",
+        help=(
+            "Encoder: 'auto' (HEVC w/ alpha on macOS, ProRes 4444 elsewhere), "
+            "'hevc-alpha' (smallest, macOS only), or 'prores-4444' (largest, "
+            "cross-platform / archival)."
+        ),
+    ),
+    max_height: int | None = typer.Option(
+        None,
+        "--max-height",
+        help=(
+            "Cap output height (aspect preserved). FCPXML emits a separate "
+            "format so FCP scales it back up."
+        ),
+    ),
+    max_fps: float | None = typer.Option(
+        None, "--max-fps", help="Cap output frame rate. Source rate kept when below cap."
+    ),
+    font_name: str | None = typer.Option(
+        None, "--font", help=f"Preset font: {', '.join(overlay_render.available_font_names())}."
+    ),
+) -> None:
+    """Render an alpha overlay MOV for an audited stage.
+
+    The overlay drops onto V2 in FCP as a connected clip; the renderer
+    mirrors the trimmed clip's resolution / fps / duration unless capped.
+    """
+    if codec not in overlay_render.OVERLAY_CODECS:
+        raise typer.BadParameter(
+            f"--codec must be one of {overlay_render.OVERLAY_CODECS}, got {codec!r}"
+        )
+    overlay_render.render_overlay(
+        audit_path=audit_path,
+        trimmed_video_path=video,
+        output_path=output,
+        beep_offset_seconds=beep_offset,
+        codec=codec,  # type: ignore[arg-type]
+        max_height=max_height,
+        max_fps=max_fps,
+        font_name=font_name,
     )
     console.print(f"[green]Wrote[/] {output}")
 

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -171,11 +171,21 @@ def generate_fcpxml(
     asset_id = "r2"
     format_id = "r1"
     # Resource IDs after the primary asset are allocated in this order:
-    # secondary cams first, then overlay last so the overlay always lives on
-    # the highest lane (V2/V3/... below it) regardless of cam count.
+    # secondary cams first, then (optionally) a dedicated overlay format,
+    # then the overlay asset last so the overlay always lives on the highest
+    # lane (V2/V3/... below it) regardless of cam count.
     usable_secondaries = [s for s in (secondaries or []) if s.video_path.exists()]
-    overlay_asset_id = f"r{3 + len(usable_secondaries)}"
     use_overlay = overlay_path is not None and overlay_path.exists()
+    overlay_meta_for_format = overlay_video if overlay_video is not None else video
+    overlay_uses_own_format = use_overlay and _overlay_format_differs(
+        video, overlay_meta_for_format
+    )
+    next_id = 3 + len(usable_secondaries)
+    overlay_format_id: str | None = None
+    if overlay_uses_own_format:
+        overlay_format_id = f"r{next_id}"
+        next_id += 1
+    overlay_asset_id = f"r{next_id}"
 
     fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
 
@@ -274,6 +284,29 @@ def generate_fcpxml(
         assert overlay_path is not None  # narrowed by use_overlay
         overlay_duration_frames = int(round(overlay_meta.duration_seconds / float(frame_duration)))
         overlay_duration_str = _frame_aligned_str(overlay_duration_frames, fd_num, fd_den)
+        # Dedicated format when geometry / fps differs so FCP scales the
+        # overlay over the timeline at default ``spatialConform="fit"``.
+        # When dims & fps match the primary, reusing format_id keeps the
+        # XML byte-comparable with the pre-#45 output.
+        if overlay_uses_own_format:
+            assert overlay_format_id is not None
+            overlay_fd_num = overlay_meta.frame_rate_den
+            overlay_fd_den = overlay_meta.frame_rate_num
+            ET.SubElement(
+                resources,
+                "format",
+                {
+                    "id": overlay_format_id,
+                    "name": _format_name(overlay_meta),
+                    "frameDuration": _frame_aligned_str(1, overlay_fd_num, overlay_fd_den),
+                    "width": str(overlay_meta.width),
+                    "height": str(overlay_meta.height),
+                    "colorSpace": "1-1-1 (Rec. 709)",
+                },
+            )
+            asset_format_ref = overlay_format_id
+        else:
+            asset_format_ref = format_id
         overlay_asset = ET.SubElement(
             resources,
             "asset",
@@ -284,7 +317,7 @@ def generate_fcpxml(
                 "duration": overlay_duration_str,
                 "hasVideo": "1",
                 "hasAudio": "0",
-                "format": format_id,
+                "format": asset_format_ref,
                 "videoSources": "1",
             },
         )
@@ -509,6 +542,7 @@ def generate_match_fcpxml(
         # cam, asset_id, sec_dur_in_parent_frames
         usable_secondaries: list[tuple[SecondaryClip, str, int]]
         overlay_asset_id: str | None
+        overlay_format_id: str | None  # None when overlay reuses the timeline format
         overlay_duration_frames: int  # in parent frame units; 0 when no overlay
 
     plans: list[_StagePlan] = []
@@ -556,11 +590,15 @@ def generate_match_fcpxml(
             usable_secondaries.append((sec, sec_id, sec_dur_in_parent_frames))
 
         overlay_asset_id: str | None = None
+        overlay_format_id: str | None = None
         overlay_duration_frames = 0
         if stage.overlay_path is not None and stage.overlay_path.exists():
+            overlay_meta = stage.overlay_video if stage.overlay_video is not None else stage.video
+            if _overlay_format_differs(stage.video, overlay_meta):
+                resource_counter += 1
+                overlay_format_id = f"r{resource_counter}"
             resource_counter += 1
             overlay_asset_id = f"r{resource_counter}"
-            overlay_meta = stage.overlay_video if stage.overlay_video is not None else stage.video
             overlay_duration_frames = int(round(overlay_meta.duration_seconds / fd_seconds))
 
         plans.append(
@@ -572,6 +610,7 @@ def generate_match_fcpxml(
                 effective_duration_frames=effective_duration_frames,
                 usable_secondaries=usable_secondaries,
                 overlay_asset_id=overlay_asset_id,
+                overlay_format_id=overlay_format_id,
                 overlay_duration_frames=overlay_duration_frames,
             )
         )
@@ -634,6 +673,29 @@ def generate_match_fcpxml(
                 {"kind": "original-media", "src": sec.video_path.resolve().as_uri()},
             )
         if plan.overlay_asset_id is not None and plan.stage.overlay_path is not None:
+            if plan.overlay_format_id is not None:
+                overlay_meta = (
+                    plan.stage.overlay_video
+                    if plan.stage.overlay_video is not None
+                    else plan.stage.video
+                )
+                overlay_fd_num = overlay_meta.frame_rate_den
+                overlay_fd_den = overlay_meta.frame_rate_num
+                ET.SubElement(
+                    resources,
+                    "format",
+                    {
+                        "id": plan.overlay_format_id,
+                        "name": _format_name(overlay_meta),
+                        "frameDuration": _frame_aligned_str(1, overlay_fd_num, overlay_fd_den),
+                        "width": str(overlay_meta.width),
+                        "height": str(overlay_meta.height),
+                        "colorSpace": "1-1-1 (Rec. 709)",
+                    },
+                )
+                overlay_asset_format = plan.overlay_format_id
+            else:
+                overlay_asset_format = format_id
             overlay_asset = ET.SubElement(
                 resources,
                 "asset",
@@ -644,7 +706,7 @@ def generate_match_fcpxml(
                     "duration": _frame_aligned_str(plan.overlay_duration_frames, fd_num, fd_den),
                     "hasVideo": "1",
                     "hasAudio": "0",
-                    "format": format_id,
+                    "format": overlay_asset_format,
                     "videoSources": "1",
                 },
             )
@@ -835,6 +897,24 @@ def _frame_aligned_str(frames: int, fd_num: int, fd_den: int) -> str:
     if fd_den == 1:
         return f"{num}s"
     return f"{num}/{fd_den}s"
+
+
+def _overlay_format_differs(primary: VideoMetadata, overlay: VideoMetadata) -> bool:
+    """``True`` when the overlay needs its own ``<format>`` element.
+
+    Reusing the primary's format ID is fine when dimensions and frame rate
+    match; when either differs (smaller overlay for size savings, capped
+    fps, etc.), FCP needs the overlay's true geometry to scale it across
+    the timeline instead of pinning it at native size. ``spatialConform``
+    defaults to ``"fit"`` which preserves aspect ratio -- exactly what we
+    want when downscaling a same-aspect overlay.
+    """
+    return (
+        primary.width != overlay.width
+        or primary.height != overlay.height
+        or primary.frame_rate_num != overlay.frame_rate_num
+        or primary.frame_rate_den != overlay.frame_rate_den
+    )
 
 
 def _format_name(video: VideoMetadata) -> str:

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -25,16 +25,35 @@ gate on that before invoking :func:`render_overlay`.
 from __future__ import annotations
 
 import json
+import math
+import platform
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from fractions import Fraction
 from pathlib import Path
+from typing import Literal
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
 from .config import VideoMetadata
 from .fcpxml_gen import probe_video
+
+OverlayCodec = Literal["auto", "hevc-alpha", "prores-4444"]
+"""Pluggable encoder for the alpha overlay MOV.
+
+- ``"auto"`` (default): ``hevc-alpha`` on macOS when ``hevc_videotoolbox``
+  is advertised by the running ``ffmpeg``, otherwise ``prores-4444``.
+  Picks the smallest file the host can produce without losing alpha.
+- ``"hevc-alpha"``: Apple's HEVC with alpha via ``hevc_videotoolbox``.
+  ~10-20x smaller than ProRes 4444 for mostly-transparent text overlays.
+  macOS only; FCP imports it natively.
+- ``"prores-4444"``: original behaviour. Cross-platform, large files
+  (~330 Mbit/s @ 1080p24); use as the archival / non-Mac fallback.
+"""
+
+OVERLAY_CODECS: tuple[OverlayCodec, ...] = ("auto", "hevc-alpha", "prores-4444")
 
 
 @dataclass(frozen=True)
@@ -407,6 +426,158 @@ def _shot_times_from_audit(audit_data: dict, *, beep_offset_seconds: float) -> l
     return out
 
 
+def _ffmpeg_supports_encoder(ffmpeg_binary: str, encoder: str) -> bool:
+    """``True`` when ``ffmpeg -encoders`` advertises ``encoder``.
+
+    Mirrors the probe in :mod:`splitsmith.trim` -- a runtime check beats
+    hard-coding macOS-only encoders, since users can install ffmpeg
+    builds without VideoToolbox.
+    """
+    try:
+        proc = subprocess.run(
+            [ffmpeg_binary, "-hide_banner", "-encoders"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    return encoder in proc.stdout
+
+
+def _resolve_codec(codec: OverlayCodec, ffmpeg_binary: str) -> Literal["hevc-alpha", "prores-4444"]:
+    """Resolve ``"auto"`` against the host. Concrete codecs pass through.
+
+    ``hevc-alpha`` only makes sense on Apple platforms with VideoToolbox;
+    elsewhere we fall back to ``prores-4444`` rather than fail the export.
+    Callers asking for a concrete codec get exactly that -- failures are
+    surfaced by ffmpeg itself, not silently rewritten.
+    """
+    if codec == "hevc-alpha" or codec == "prores-4444":
+        return codec
+    if codec != "auto":
+        raise OverlayRenderError(
+            f"unknown overlay codec {codec!r}; expected one of {OVERLAY_CODECS}"
+        )
+    if platform.system() == "Darwin" and _ffmpeg_supports_encoder(
+        ffmpeg_binary, "hevc_videotoolbox"
+    ):
+        return "hevc-alpha"
+    return "prores-4444"
+
+
+def _scaled_dimensions(width: int, height: int, max_height: int | None) -> tuple[int, int]:
+    """Aspect-preserving downscale to ``max_height``. Both outputs even.
+
+    Even dims keep yuv420 / yuv444 chroma alignment happy across encoders;
+    odd dims trip ``hevc_videotoolbox`` on some macOS builds. We never
+    upscale -- a cap above the source is a no-op.
+    """
+    if max_height is None or max_height >= height:
+        return width, height
+    new_h = max(2, max_height)
+    new_w = max(2, int(round(width * (new_h / height))))
+    if new_w % 2:
+        new_w -= 1
+    if new_h % 2:
+        new_h -= 1
+    return new_w, new_h
+
+
+def _capped_frame_rate(num: int, den: int, max_fps: float | None) -> tuple[int, int]:
+    """Cap source ``num/den`` at ``max_fps`` while keeping a rational rate.
+
+    Returns a ``(numerator, denominator)`` pair the FCPXML can quote
+    literally. Strategy: divide the source by the smallest integer factor
+    that brings it under the cap, and prefer that candidate when it lands
+    within 5% of the requested cap -- this is what makes NTSC sources do
+    the right thing (60000/1001 capped at 30 -> 30000/1001 instead of
+    flattening to 30/1). When the integer-divisor candidate would be far
+    below the cap (e.g. 60 capped at 24 -> 20 fps), fall back to quoting
+    the cap as a rational so the user gets what they asked for.
+    """
+    src = Fraction(num, den)
+    if max_fps is None or float(src) <= max_fps + 1e-9:
+        return num, den
+    target = Fraction(max_fps).limit_denominator(1000)
+    if target <= 0:
+        raise OverlayRenderError(f"max_fps must be > 0, got {max_fps}")
+    factor = src / target
+    # Smallest integer ``k`` such that ``src / k <= target``. The 1e-9 nudge
+    # absorbs float rounding when ``factor`` is exactly an integer.
+    k = max(1, math.ceil(float(factor) - 1e-9))
+    candidate = src / k
+    if candidate >= target * Fraction(95, 100):
+        return candidate.numerator, candidate.denominator
+    return target.numerator, target.denominator
+
+
+def _build_ffmpeg_cmd(
+    *,
+    ffmpeg_binary: str,
+    codec: Literal["hevc-alpha", "prores-4444"],
+    width: int,
+    height: int,
+    rate: str,
+    output_path: Path,
+) -> list[str]:
+    """Encoder-specific argv. RGBA raw input is identical across codecs;
+    only the output side differs."""
+    cmd = [
+        ffmpeg_binary,
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgba",
+        "-s",
+        f"{width}x{height}",
+        "-r",
+        rate,
+        "-i",
+        "-",
+    ]
+    if codec == "hevc-alpha":
+        # ``alpha_quality`` ranges 0.0..1.0; 0.75 is a good legibility/size
+        # tradeoff for sharp text on transparent. ``hvc1`` tag is what FCP
+        # / QuickTime expect; the default ``hev1`` works in ffmpeg but is
+        # rejected by some Apple importers. ``yuva420p`` is the only alpha
+        # pixel format ``hevc_videotoolbox`` accepts.
+        cmd += [
+            "-c:v",
+            "hevc_videotoolbox",
+            "-allow_sw",
+            "1",
+            "-alpha_quality",
+            "0.75",
+            "-pix_fmt",
+            "yuva420p",
+            "-tag:v",
+            "hvc1",
+            "-r",
+            rate,
+            str(output_path),
+        ]
+    else:  # prores-4444
+        cmd += [
+            "-c:v",
+            "prores_ks",
+            "-profile:v",
+            "4444",
+            "-pix_fmt",
+            "yuva444p10le",
+            "-r",
+            rate,
+            str(output_path),
+        ]
+    return cmd
+
+
 def render_overlay(
     *,
     audit_path: Path,
@@ -418,6 +589,9 @@ def render_overlay(
     font_path: Path | None = None,
     ffmpeg_binary: str = "ffmpeg",
     probe: VideoMetadata | None = None,
+    codec: OverlayCodec = "auto",
+    max_height: int | None = None,
+    max_fps: float | None = None,
 ) -> Path:
     """Render an alpha overlay MOV alongside a trimmed clip.
 
@@ -438,6 +612,13 @@ def render_overlay(
     ``probe``: optional pre-computed metadata. When given, ``ffprobe`` is
         skipped -- useful from tests and to share one probe across the
         export's other steps.
+    ``codec``: encoder preset; see :data:`OVERLAY_CODECS`. ``"auto"``
+        produces the smallest file the host can write without losing alpha.
+    ``max_height``: cap output height; aspect-preserving downscale. The
+        FCPXML emits a separate format element so FCP scales it back up
+        over the timeline.
+    ``max_fps``: cap output frame rate. Source rate is preserved when it
+        already fits under the cap.
 
     Returns the written ``output_path``.
     """
@@ -456,9 +637,14 @@ def render_overlay(
 
     if probe is None:
         probe = probe_video(trimmed_video_path)
-    width = probe.width
-    height = probe.height
-    fps = probe.frame_rate_num / probe.frame_rate_den
+
+    if shutil.which(ffmpeg_binary) is None:
+        raise OverlayRenderError(f"ffmpeg binary not found: {ffmpeg_binary}")
+
+    resolved_codec = _resolve_codec(codec, ffmpeg_binary)
+    width, height = _scaled_dimensions(probe.width, probe.height, max_height)
+    rate_num, rate_den = _capped_frame_rate(probe.frame_rate_num, probe.frame_rate_den, max_fps)
+    fps = rate_num / rate_den
     duration_seconds = probe.duration_seconds
 
     if template is None:
@@ -473,37 +659,17 @@ def render_overlay(
         duration_seconds=duration_seconds,
     )
 
-    if shutil.which(ffmpeg_binary) is None:
-        raise OverlayRenderError(f"ffmpeg binary not found: {ffmpeg_binary}")
-
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    rate = f"{probe.frame_rate_num}/{probe.frame_rate_den}"
-    cmd = [
-        ffmpeg_binary,
-        "-y",
-        "-loglevel",
-        "error",
-        "-f",
-        "rawvideo",
-        "-pix_fmt",
-        "rgba",
-        "-s",
-        f"{width}x{height}",
-        "-r",
-        rate,
-        "-i",
-        "-",
-        "-c:v",
-        "prores_ks",
-        "-profile:v",
-        "4444",
-        "-pix_fmt",
-        "yuva444p10le",
-        "-r",
-        rate,
-        str(output_path),
-    ]
+    rate = f"{rate_num}/{rate_den}"
+    cmd = _build_ffmpeg_cmd(
+        ffmpeg_binary=ffmpeg_binary,
+        codec=resolved_codec,
+        width=width,
+        height=height,
+        rate=rate,
+        output_path=output_path,
+    )
 
     proc = subprocess.Popen(
         cmd,

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from .. import csv_gen, fcpxml_gen, overlay_render, report, trim
 from ..config import Config, ReportFiles, Shot, StageAnalysis, StageData
+from ..overlay_render import OverlayCodec
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,15 @@ class StageExportRequest:
     write_fcpxml: bool = True
     write_report: bool = True
     write_overlay: bool = False
+    # Overlay format knobs (issue #45 follow-up). ``overlay_codec="auto"``
+    # picks ``hevc-alpha`` on macOS w/ VideoToolbox (~10-20x smaller than
+    # ProRes 4444 for sparse-text overlays), else ``prores-4444``.
+    # ``overlay_max_height`` / ``overlay_max_fps`` cap the overlay's
+    # geometry / frame rate; the FCPXML emits a dedicated format element
+    # so FCP scales the smaller overlay across the timeline.
+    overlay_codec: OverlayCodec = "auto"
+    overlay_max_height: int | None = None
+    overlay_max_fps: float | None = None
 
 
 @dataclass(frozen=True)
@@ -352,6 +362,9 @@ def export_stage(
                     trimmed_video_path=mirror_target,
                     output_path=overlay_target,
                     beep_offset_seconds=pre_buffer_seconds,
+                    codec=request.overlay_codec,
+                    max_height=request.overlay_max_height,
+                    max_fps=request.overlay_max_fps,
                 )
                 overlay_path = overlay_target
             except (overlay_render.OverlayRenderError, OSError) as exc:
@@ -430,6 +443,17 @@ def export_stage(
                 # Beep offset within the lossless trim: the trim cut at
                 # ``beep_time - pre_buffer`` from source, so the beep lives
                 # ``pre_buffer`` seconds into the clip.
+                # Probe the overlay so the FCPXML can emit a dedicated
+                # ``<format>`` for it when its dims/fps differ from the
+                # primary. ffprobe failures fall back to "assume mirrors
+                # source" -- the overlay still ships, FCP just won't auto-
+                # scale it.
+                overlay_meta: fcpxml_gen.VideoMetadata | None = None
+                if fcp_overlay_path is not None:
+                    try:
+                        overlay_meta = fcpxml_gen.probe_video(fcp_overlay_path)
+                    except fcpxml_gen.FFprobeError:
+                        overlay_meta = None
                 fcpxml_gen.generate_fcpxml(
                     video_path=fcp_video,
                     video=meta,
@@ -439,6 +463,7 @@ def export_stage(
                     project_name=base,
                     config=config.output,
                     overlay_path=fcp_overlay_path,
+                    overlay_video=overlay_meta,
                     secondaries=fcp_secondaries or None,
                 )
             except (fcpxml_gen.FFprobeError, OSError) as exc:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -887,10 +887,17 @@ class ExportStageRequest(BaseModel):
     write_fcpxml: bool = True
     write_report: bool = True
     # Pre-rendered alpha overlay MOV (issue #45). Defaults False because
-    # the render is per-frame PIL + ffmpeg ProRes 4444 -- non-trivially
-    # slower than the other writers. The Analysis & Export checkbox
-    # opts-in per stage.
+    # the render is per-frame PIL + ffmpeg -- non-trivially slower than
+    # the other writers. The Analysis & Export checkbox opts-in per stage.
     write_overlay: bool = False
+    # Overlay format knobs (issue #45 follow-up). Defaults match the
+    # legacy ProRes 4444 path on platforms without VideoToolbox; on macOS
+    # ``"auto"`` switches to ``hevc-alpha`` (~10-20x smaller). Resolution
+    # and fps caps are off by default to preserve frame-for-frame parity
+    # with the source clip.
+    overlay_codec: Literal["auto", "hevc-alpha", "prores-4444"] = "auto"
+    overlay_max_height: int | None = None
+    overlay_max_fps: float | None = None
     # Multi-cam selection (issue #54). Allowlist of secondary
     # ``video_id``s to ride the FCPXML / get their own lossless trim. The
     # default ``None`` means "include every secondary with a beep" -- the
@@ -919,6 +926,12 @@ class MatchExportRequest(BaseModel):
     tail_pad_seconds: float = 5.0
     include_secondaries: bool = True
     include_overlay: bool = True
+    # Overlay format knobs forwarded to per-stage re-renders. Match the
+    # single-stage defaults so a match export with no overlay edits is
+    # byte-comparable with the per-stage export.
+    overlay_codec: Literal["auto", "hevc-alpha", "prores-4444"] = "auto"
+    overlay_max_height: int | None = None
+    overlay_max_fps: float | None = None
     project_name: str | None = None
 
 
@@ -4254,6 +4267,9 @@ def create_app(
                     write_fcpxml=req.write_fcpxml,
                     write_report=req.write_report,
                     write_overlay=req.write_overlay,
+                    overlay_codec=req.overlay_codec,
+                    overlay_max_height=req.overlay_max_height,
+                    overlay_max_fps=req.overlay_max_fps,
                 ),
                 audit_path=audit_file,
                 exports_dir=exports_dir,
@@ -4424,7 +4440,18 @@ def create_app(
                 (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists()
                 for vid in wanted_secondary_ids
             )
-            overlay_missing = req.include_overlay and not overlay_target.exists()
+            # Treat any non-default overlay format option as "force re-render"
+            # so the dialog's codec / max-height / max-fps choices actually
+            # apply when a stale overlay sits on disk. With all defaults we
+            # keep the legacy "skip if present" behaviour for fast re-stitching.
+            overlay_format_overridden = (
+                req.overlay_codec != "auto"
+                or req.overlay_max_height is not None
+                or req.overlay_max_fps is not None
+            )
+            overlay_missing = req.include_overlay and (
+                not overlay_target.exists() or overlay_format_overridden
+            )
 
             needs_per_stage = (
                 not trimmed_path.exists() or not secondary_trims_present or overlay_missing
@@ -4468,6 +4495,9 @@ def create_app(
                             write_fcpxml=True,
                             write_report=True,
                             write_overlay=req.include_overlay,
+                            overlay_codec=req.overlay_codec,
+                            overlay_max_height=req.overlay_max_height,
+                            overlay_max_fps=req.overlay_max_fps,
                         ),
                         audit_path=audit_dir / f"stage{stage_number}.json",
                         exports_dir=exports_dir,

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -427,6 +427,15 @@ export interface ExportOverview {
   stages: StageExportStatus[];
 }
 
+/** Encoder for the alpha overlay MOV.
+ *  - ``"auto"``: ``hevc-alpha`` on macOS w/ VideoToolbox, otherwise
+ *    ``prores-4444``. Default; produces the smallest file the host can
+ *    write without losing alpha.
+ *  - ``"hevc-alpha"``: ~10-20x smaller than ProRes 4444 for sparse-text
+ *    overlays. macOS only; FCP imports natively.
+ *  - ``"prores-4444"``: cross-platform / archival. Largest files. */
+export type OverlayCodec = "auto" | "hevc-alpha" | "prores-4444";
+
 export interface ExportStageRequestPayload {
   write_trim?: boolean;
   write_csv?: boolean;
@@ -435,6 +444,15 @@ export interface ExportStageRequestPayload {
   /** Render the per-frame PIL + ffmpeg overlay MOV (issue #45). Defaults
    *  off because it's the slowest writer; opt in per stage. */
   write_overlay?: boolean;
+  /** Encoder for the overlay MOV. Defaults to ``"auto"``. */
+  overlay_codec?: OverlayCodec;
+  /** Cap overlay output height (aspect preserved). FCPXML emits a
+   *  separate ``<format>`` so FCP scales the smaller overlay across the
+   *  timeline. ``null`` / undefined matches source. */
+  overlay_max_height?: number | null;
+  /** Cap overlay output frame rate. Source rate is kept when below the
+   *  cap. ``null`` / undefined matches source. */
+  overlay_max_fps?: number | null;
   /** Allowlist of secondary ``video_id``s to include in the multi-cam
    *  FCPXML / per-cam trims (issue #54). Omit (or pass ``null``) to keep
    *  the legacy "every secondary with a beep" default; pass ``[]`` to
@@ -466,6 +484,12 @@ export interface MatchExportRequestPayload {
   tail_pad_seconds?: number;
   include_secondaries?: boolean;
   include_overlay?: boolean;
+  /** Forwarded to the per-stage overlay re-render. The match handler
+   *  treats any non-default value as "force re-render" so a stale
+   *  overlay on disk doesn't shadow the dialog's format choice. */
+  overlay_codec?: OverlayCodec;
+  overlay_max_height?: number | null;
+  overlay_max_fps?: number | null;
   /** Defaults to the bound project's name. Slugified for the output
    *  filename: ``<slug>-match.fcpxml``. */
   project_name?: string | null;
@@ -1404,6 +1428,16 @@ export const api = {
         write_fcpxml: opts.write_fcpxml ?? true,
         write_report: opts.write_report ?? true,
         write_overlay: opts.write_overlay ?? false,
+        overlay_codec: opts.overlay_codec ?? "auto",
+        // Forward ``null`` to keep "match source" but only attach the key
+        // when the caller set something explicit, so the server's defaults
+        // remain authoritative when the UI doesn't care.
+        ...(opts.overlay_max_height !== undefined
+          ? { overlay_max_height: opts.overlay_max_height }
+          : {}),
+        ...(opts.overlay_max_fps !== undefined
+          ? { overlay_max_fps: opts.overlay_max_fps }
+          : {}),
         // ``undefined`` => omit (server picks the legacy "all cams with a
         // beep" default); ``null`` / ``[]`` are forwarded as-is so the
         // caller can explicitly exclude all secondaries.
@@ -1428,6 +1462,13 @@ export const api = {
         tail_pad_seconds: payload.tail_pad_seconds ?? 5.0,
         include_secondaries: payload.include_secondaries ?? true,
         include_overlay: payload.include_overlay ?? true,
+        overlay_codec: payload.overlay_codec ?? "auto",
+        ...(payload.overlay_max_height !== undefined
+          ? { overlay_max_height: payload.overlay_max_height }
+          : {}),
+        ...(payload.overlay_max_fps !== undefined
+          ? { overlay_max_fps: payload.overlay_max_fps }
+          : {}),
         ...(payload.project_name !== undefined
           ? { project_name: payload.project_name }
           : {}),

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -48,6 +48,7 @@ import {
   type Job,
   type MatchExportResult,
   type MatchProject,
+  type OverlayCodec,
   type SecondaryExportStatus,
   type StageAudit,
   type StageExportStatus,
@@ -495,6 +496,17 @@ function StageActions({
   // Overlay (issue #45) defaults off: render is slower than the other
   // writers and most users only want it once per stage.
   const [overlay, setOverlay] = useState(false);
+  // Overlay format knobs (issue #45 follow-up). Defaults match the
+  // server: ``"auto"`` codec with no resolution / fps cap. ``"source"``
+  // is a UI-only sentinel that maps to ``null`` on the wire so the
+  // renderer mirrors the trimmed clip frame-for-frame.
+  const [overlayCodec, setOverlayCodec] = useState<OverlayCodec>("auto");
+  const [overlayMaxHeight, setOverlayMaxHeight] = useState<number | "source">(
+    "source",
+  );
+  const [overlayMaxFps, setOverlayMaxFps] = useState<number | "source">(
+    "source",
+  );
   // Per-cam include/exclude (issue #54). Default-on when the cam is
   // shippable (has a beep + source reachable); resyncs whenever the row
   // refreshes from the overview so flipping a cam's role / detecting its
@@ -577,6 +589,10 @@ function StageActions({
         write_fcpxml: fcpxml,
         write_report: reportFlag,
         write_overlay: overlay,
+        overlay_codec: overlayCodec,
+        overlay_max_height:
+          overlayMaxHeight === "source" ? null : overlayMaxHeight,
+        overlay_max_fps: overlayMaxFps === "source" ? null : overlayMaxFps,
         ...(row.secondaries.length > 0
           ? { secondary_video_ids: Array.from(selectedCams) }
           : {}),
@@ -725,6 +741,18 @@ function StageActions({
         </Button>
       </div>
 
+      {overlay ? (
+        <OverlayFormatPanel
+          codec={overlayCodec}
+          onCodecChange={setOverlayCodec}
+          maxHeight={overlayMaxHeight}
+          onMaxHeightChange={setOverlayMaxHeight}
+          maxFps={overlayMaxFps}
+          onMaxFpsChange={setOverlayMaxFps}
+          disabled={busy}
+        />
+      ) : null}
+
       <SecondariesPanel
         secondaries={row.secondaries}
         selected={selectedCams}
@@ -757,6 +785,104 @@ function StageActions({
     </div>
   );
 }
+
+function OverlayFormatPanel({
+  codec,
+  onCodecChange,
+  maxHeight,
+  onMaxHeightChange,
+  maxFps,
+  onMaxFpsChange,
+  disabled,
+}: {
+  codec: OverlayCodec;
+  onCodecChange: (next: OverlayCodec) => void;
+  maxHeight: number | "source";
+  onMaxHeightChange: (next: number | "source") => void;
+  maxFps: number | "source";
+  onMaxFpsChange: (next: number | "source") => void;
+  disabled: boolean;
+}) {
+  // Width / fps presets cover the common deltas a head-cam + FCP timeline
+  // sees in practice (1080p / 720p, 30 / 24 fps); the source-matching
+  // option preserves frame-for-frame parity for users who don't want any
+  // scaling on the FCP timeline.
+  const heightOptions: { value: number | "source"; label: string }[] = [
+    { value: "source", label: "Match source" },
+    { value: 1080, label: "1080p" },
+    { value: 720, label: "720p" },
+  ];
+  const fpsOptions: { value: number | "source"; label: string }[] = [
+    { value: "source", label: "Match source" },
+    { value: 30, label: "30 fps" },
+    { value: 24, label: "24 fps" },
+  ];
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 bg-muted/10 p-2 text-xs">
+      <div className="px-1 font-medium text-muted-foreground">
+        Overlay format
+        <span className="ml-1 text-[11px]">
+          -- Auto picks HEVC w/ alpha on macOS (~10-20x smaller than ProRes
+          4444); caps tell FCP to scale a smaller overlay across the timeline
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Codec</span>
+          <select
+            className="rounded-md border border-border/60 bg-background px-2 py-1"
+            value={codec}
+            disabled={disabled}
+            onChange={(e) => onCodecChange(e.target.value as OverlayCodec)}
+          >
+            <option value="auto">Auto (recommended)</option>
+            <option value="hevc-alpha">HEVC w/ alpha (smallest, macOS)</option>
+            <option value="prores-4444">ProRes 4444 (largest, archival)</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Max height</span>
+          <select
+            className="rounded-md border border-border/60 bg-background px-2 py-1"
+            value={maxHeight === "source" ? "source" : String(maxHeight)}
+            disabled={disabled}
+            onChange={(e) =>
+              onMaxHeightChange(
+                e.target.value === "source" ? "source" : Number(e.target.value),
+              )
+            }
+          >
+            {heightOptions.map((o) => (
+              <option key={String(o.value)} value={String(o.value)}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Max fps</span>
+          <select
+            className="rounded-md border border-border/60 bg-background px-2 py-1"
+            value={maxFps === "source" ? "source" : String(maxFps)}
+            disabled={disabled}
+            onChange={(e) =>
+              onMaxFpsChange(
+                e.target.value === "source" ? "source" : Number(e.target.value),
+              )
+            }
+          >
+            {fpsOptions.map((o) => (
+              <option key={String(o.value)} value={String(o.value)}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}
+
 
 function SecondariesPanel({
   secondaries,
@@ -1072,10 +1198,20 @@ function MatchExportDialog({
   const [headPad, setHeadPad] = useState<number>(PADDING_PRESETS.full.head);
   const [tailPad, setTailPad] = useState<number>(PADDING_PRESETS.full.tail);
   const [includeSecondaries, setIncludeSecondaries] = useState(true);
-  // Overlay defaults off because the per-frame PIL + ffmpeg ProRes 4444
-  // render is the slowest writer; opt in per export. Mirrors the per-
-  // stage Generate's default.
+  // Overlay defaults off because the per-frame PIL + ffmpeg render is the
+  // slowest writer; opt in per export. Mirrors the per-stage Generate's
+  // default.
   const [includeOverlay, setIncludeOverlay] = useState(false);
+  // Match-level overlay format. Mirrors the per-stage controls: any non-
+  // default value forces a re-render even if a stale overlay sits on
+  // disk, so the user's choice here actually applies.
+  const [overlayCodec, setOverlayCodec] = useState<OverlayCodec>("auto");
+  const [overlayMaxHeight, setOverlayMaxHeight] = useState<number | "source">(
+    "source",
+  );
+  const [overlayMaxFps, setOverlayMaxFps] = useState<number | "source">(
+    "source",
+  );
   const [projectName, setProjectName] = useState(defaultProjectName);
   const [job, setJob] = useState<Job | null>(null);
   const [dialogError, setDialogError] = useState<string | null>(null);
@@ -1113,6 +1249,10 @@ function MatchExportDialog({
         tail_pad_seconds: tailPad,
         include_secondaries: includeSecondaries,
         include_overlay: includeOverlay,
+        overlay_codec: overlayCodec,
+        overlay_max_height:
+          overlayMaxHeight === "source" ? null : overlayMaxHeight,
+        overlay_max_fps: overlayMaxFps === "source" ? null : overlayMaxFps,
         project_name: projectName,
       });
       setJob(submitted);
@@ -1304,6 +1444,17 @@ function MatchExportDialog({
                 Include overlay (when present)
               </label>
             </div>
+            {includeOverlay ? (
+              <OverlayFormatPanel
+                codec={overlayCodec}
+                onCodecChange={setOverlayCodec}
+                maxHeight={overlayMaxHeight}
+                onMaxHeightChange={setOverlayMaxHeight}
+                maxFps={overlayMaxFps}
+                onMaxFpsChange={setOverlayMaxFps}
+                disabled={busy}
+              />
+            ) : null}
           </section>
 
           <section className="space-y-1">

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -327,6 +327,78 @@ def test_generate_fcpxml_omits_overlay_clip_when_file_missing(tmp_path: Path) ->
     assert nested == []
 
 
+def test_generate_fcpxml_overlay_at_source_geometry_reuses_format(tmp_path: Path) -> None:
+    """Overlay metadata matching the primary -> no extra ``<format>``
+    element. The overlay's ``asset`` reuses the timeline format ID, so
+    the XML stays byte-comparable with the pre-cap output."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    overlay = tmp_path / "v_overlay.mov"
+    overlay.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        overlay_path=overlay,
+        overlay_video=_meta_30fps(),  # explicit but identical to primary
+    )
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    assert len(formats) == 1
+    assets = root.findall("./resources/asset")
+    overlay_asset = assets[1]
+    # Reuses format_id ("r1") since geometry matches.
+    assert overlay_asset.attrib["format"] == formats[0].attrib["id"]
+
+
+def test_generate_fcpxml_overlay_with_smaller_height_emits_dedicated_format(
+    tmp_path: Path,
+) -> None:
+    """Overlay rendered at a capped height -> a second ``<format>``
+    element with the overlay's true geometry, and the overlay asset
+    references that format. FCP relies on this to scale the smaller
+    overlay across the timeline at default ``spatialConform="fit"``."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    overlay = tmp_path / "v_overlay.mov"
+    overlay.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    overlay_meta = VideoMetadata(
+        width=1280,
+        height=720,
+        duration_seconds=20.0,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),  # 1920x1080
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        overlay_path=overlay,
+        overlay_video=overlay_meta,
+    )
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    assert len(formats) == 2
+    primary_fmt, overlay_fmt = formats
+    assert primary_fmt.attrib["width"] == "1920"
+    assert primary_fmt.attrib["height"] == "1080"
+    assert overlay_fmt.attrib["width"] == "1280"
+    assert overlay_fmt.attrib["height"] == "720"
+    assets = root.findall("./resources/asset")
+    overlay_asset = assets[1]
+    assert overlay_asset.attrib["format"] == overlay_fmt.attrib["id"]
+
+
 def test_generate_fcpxml_inserts_overlay_as_lane_1_connected_clip(tmp_path: Path) -> None:
     """Overlay file present -> a second asset is registered and a lane=1
     connected ``asset-clip`` lives inside the V1 spine clip on V2."""

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -323,6 +323,7 @@ def test_render_overlay_pipes_rgba_frames_and_writes_output(
         output_path=output,
         beep_offset_seconds=0.0,
         probe=_meta_30fps(duration=1.0),  # 30 frames
+        codec="prores-4444",  # explicit so the test is host-independent
     )
 
     assert result == output
@@ -378,6 +379,7 @@ def test_render_overlay_raises_when_ffmpeg_returns_nonzero(
             output_path=tmp_path / "overlay.mov",
             beep_offset_seconds=0.0,
             probe=_meta_30fps(duration=0.1),
+            codec="prores-4444",
         )
 
 
@@ -407,6 +409,7 @@ def test_render_overlay_writes_real_prores_4444_alpha(tmp_path: Path) -> None:
         output_path=output,
         beep_offset_seconds=0.0,
         probe=_meta_30fps(duration=0.5),  # 15 frames
+        codec="prores-4444",  # this test asserts the prores path specifically
     )
 
     assert output.exists() and output.stat().st_size > 0
@@ -431,3 +434,222 @@ def test_render_overlay_writes_real_prores_4444_alpha(tmp_path: Path) -> None:
     assert info["codec_name"] == "prores"
     assert "yuva" in info["pix_fmt"]  # alpha channel present
     assert info["width"] == 320 and info["height"] == 180
+
+
+# --- format options ---------------------------------------------------------
+
+
+def _capture_render_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    audit_path: Path,
+    output: Path,
+    probe: VideoMetadata,
+    **kwargs: Any,
+) -> tuple[list[str], int]:
+    """Run :func:`render_overlay` with a stub Popen, returning the cmd
+    that would have been invoked and the bytes piped to ffmpeg's stdin."""
+    captured: dict[str, Any] = {"bytes": 0, "cmd": []}
+
+    class StubStdin:
+        def write(self, data: bytes) -> int:
+            captured["bytes"] += len(data)
+            return len(data)
+
+        def close(self) -> None:
+            return None
+
+    class StubStderr:
+        def read(self) -> bytes:
+            return b""
+
+    class StubProc:
+        def __init__(self, *, stdin: Any, stderr: Any) -> None:
+            self.stdin = stdin
+            self.stderr = stderr
+
+        def wait(self) -> int:
+            output.write_bytes(b"")
+            return 0
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd: list[str], **_: Any) -> StubProc:
+        captured["cmd"] = cmd
+        return StubProc(stdin=StubStdin(), stderr=StubStderr())
+
+    monkeypatch.setattr(overlay_render.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(overlay_render.shutil, "which", lambda _b: "/bin/ffmpeg")
+
+    overlay_render.render_overlay(
+        audit_path=audit_path,
+        trimmed_video_path=audit_path.parent / "trim.mp4",
+        output_path=output,
+        beep_offset_seconds=0.0,
+        probe=probe,
+        **kwargs,
+    )
+    return captured["cmd"], captured["bytes"]
+
+
+def _write_audit(tmp_path: Path) -> Path:
+    audit = tmp_path / "stage1.json"
+    audit.write_text(
+        json.dumps({"shots": [{"shot_number": 1, "ms_after_beep": 100}]}),
+        encoding="utf-8",
+    )
+    return audit
+
+
+def test_codec_hevc_alpha_emits_videotoolbox_cmd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Asking for ``hevc-alpha`` produces a ``hevc_videotoolbox`` cmd
+    with ``hvc1`` tagging and yuva420p (the only alpha pix-fmt the
+    encoder accepts)."""
+    cmd, _ = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=_meta_30fps(duration=0.1),
+        codec="hevc-alpha",
+    )
+    assert "hevc_videotoolbox" in cmd
+    assert "yuva420p" in cmd
+    # ``hvc1`` tag matters for FCP / QuickTime import.
+    assert "hvc1" in cmd
+    assert "-alpha_quality" in cmd
+    assert "prores_ks" not in cmd
+
+
+def test_codec_auto_falls_back_to_prores_off_darwin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``auto`` resolves to ``prores-4444`` when the host isn't macOS,
+    so non-Mac CI doesn't try to call ``hevc_videotoolbox``."""
+    monkeypatch.setattr(overlay_render.platform, "system", lambda: "Linux")
+    cmd, _ = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=_meta_30fps(duration=0.1),
+        codec="auto",
+    )
+    assert "prores_ks" in cmd
+    assert "hevc_videotoolbox" not in cmd
+
+
+def test_codec_auto_picks_hevc_on_darwin_with_videotoolbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On macOS with VideoToolbox advertised, ``auto`` switches to
+    ``hevc-alpha`` -- the size win that motivated the option."""
+    monkeypatch.setattr(overlay_render.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        overlay_render, "_ffmpeg_supports_encoder", lambda _bin, enc: enc == "hevc_videotoolbox"
+    )
+    cmd, _ = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=_meta_30fps(duration=0.1),
+        codec="auto",
+    )
+    assert "hevc_videotoolbox" in cmd
+    assert "prores_ks" not in cmd
+
+
+def test_codec_unknown_raises(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    with pytest.raises(overlay_render.OverlayRenderError, match="unknown overlay codec"):
+        overlay_render.render_overlay(
+            audit_path=audit,
+            trimmed_video_path=tmp_path / "trim.mp4",
+            output_path=tmp_path / "overlay.mov",
+            beep_offset_seconds=0.0,
+            probe=_meta_30fps(duration=0.1),
+            codec="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_max_height_downscales_canvas_aspect_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Capping height shrinks the canvas (and therefore the bytes piped
+    to ffmpeg) while keeping the aspect ratio."""
+    # 1920x1080 source -> cap at 720 -> 1280x720.
+    probe = VideoMetadata(
+        width=1920, height=1080, duration_seconds=0.1, frame_rate_num=30, frame_rate_den=1
+    )
+    cmd, byte_count = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=probe,
+        codec="prores-4444",
+        max_height=720,
+    )
+    # ``-s WxH`` argument follows ``-s`` in the cmd.
+    s_idx = cmd.index("-s")
+    assert cmd[s_idx + 1] == "1280x720"
+    # 3 frames @ 30fps for 0.1s -> 3 * 1280 * 720 * 4 bytes.
+    assert byte_count == 3 * 1280 * 720 * 4
+
+
+def test_max_height_above_source_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cap larger than the source height never upscales."""
+    cmd, _ = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=_meta_30fps(duration=0.1),  # 320x180
+        codec="prores-4444",
+        max_height=4000,
+    )
+    s_idx = cmd.index("-s")
+    assert cmd[s_idx + 1] == "320x180"
+
+
+def test_max_fps_caps_frame_count_and_rate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Capping fps drops the frame count and quotes the rate as a rational."""
+    probe = VideoMetadata(
+        width=320, height=180, duration_seconds=1.0, frame_rate_num=60, frame_rate_den=1
+    )
+    cmd, byte_count = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=probe,
+        codec="prores-4444",
+        max_fps=30,
+    )
+    # 60fps capped at 30 -> 30/1 (clean integer divisor preserved).
+    assert "30/1" in cmd
+    # 1.0s @ 30 fps = 30 frames.
+    assert byte_count == 30 * 320 * 180 * 4
+
+
+def test_max_fps_above_source_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cap above the source fps preserves the source rational unchanged."""
+    cmd, _ = _capture_render_cmd(
+        monkeypatch,
+        audit_path=_write_audit(tmp_path),
+        output=tmp_path / "overlay.mov",
+        probe=_meta_30fps(duration=0.1),  # 30/1
+        codec="prores-4444",
+        max_fps=120,
+    )
+    assert "30/1" in cmd
+
+
+def test_capped_frame_rate_keeps_rational_for_29_97() -> None:
+    """``60000/1001`` capped at 30 -> ``30000/1001`` (integer divisor)."""
+    num, den = overlay_render._capped_frame_rate(60000, 1001, 30)
+    assert (num, den) == (30000, 1001)
+
+
+def test_scaled_dimensions_forces_even() -> None:
+    """Even output dims keep yuv420 / yuv444 chroma alignment happy."""
+    w, h = overlay_render._scaled_dimensions(1921, 1081, 720)
+    assert w % 2 == 0 and h % 2 == 0

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -560,7 +560,10 @@ def test_codec_auto_picks_hevc_on_darwin_with_videotoolbox(
     assert "prores_ks" not in cmd
 
 
-def test_codec_unknown_raises(tmp_path: Path) -> None:
+def test_codec_unknown_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Stub ``which`` so the ffmpeg-not-found check (which fires on CI
+    # boxes without ffmpeg installed) doesn't shadow the codec error.
+    monkeypatch.setattr(overlay_render.shutil, "which", lambda _b: "/bin/ffmpeg")
     audit = _write_audit(tmp_path)
     with pytest.raises(overlay_render.OverlayRenderError, match="unknown overlay codec"):
         overlay_render.render_overlay(


### PR DESCRIPTION
## Summary
- Overlay MOV was hard-coded to ProRes 4444 (~330 Mbit/s at 1080p24, typically 4x the source clip). New ``OverlayCodec`` enum (``auto`` / ``hevc-alpha`` / ``prores-4444``) plus ``max_height`` / ``max_fps`` caps. ``auto`` picks ``hevc_videotoolbox`` on macOS for ~10-20x smaller files on sparse-text overlays; ProRes 4444 stays the cross-platform / archival fallback.
- FCPXML emits a dedicated ``<format>`` element when overlay geometry / fps differs from the primary so FCP scales the smaller overlay across the timeline at default ``spatialConform=\"fit\"``. NTSC rationals preserved when capping (60000/1001 → 30000/1001).
- Per-stage and match-export dialogs both expose codec / max-height / max-fps controls. The match handler treats any non-default option as \"force re-render\" so a stale overlay doesn't shadow the dialog's choice; with all defaults the legacy \"skip if present\" fast path still wins for quick re-stitches.
- New ``splitsmith overlay`` CLI subcommand: ``--audit`` / ``--video`` / ``--output`` / ``--beep-offset`` / ``--codec`` / ``--max-height`` / ``--max-fps`` / ``--font``.

## Test plan
- [x] ``uv run pytest`` -- 740 passed, 1 skipped (pre-existing untracked file ignored)
- [x] ``ruff check`` + ``black --check`` clean on changed files
- [x] ``pnpm tsc -p tsconfig.app.json --noEmit`` clean
- [ ] Manual: per-stage export dialog shows codec/height/fps selects under Overlay; submitted job passes them through
- [ ] Manual: match-export dialog shows the same controls when Include overlay is on; non-default options force a re-render
- [ ] Manual: ``splitsmith overlay --audit … --video … --output … --codec hevc-alpha`` writes a smaller MOV than ``--codec prores-4444`` for the same input
- [ ] Manual: FCP imports an HEVC-alpha overlay alongside a 4K trim and composites it correctly when ``--max-height 1080`` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)