### PR TITLE
voter-e: conditional veto suppressed when audio is unanimous (#185)

### DIFF
--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -922,6 +922,7 @@ def build_artifacts(
         "voter_e_clip_model_id": vis.CLIP_VISUAL_MODEL_ID if voter_e_probe is not None else None,
         "voter_e_frame_offsets": list(vis.DEFAULT_FRAME_OFFSETS) if voter_e_probe is not None else None,
         "voter_e_probe_artifact": DEFAULT_VOTER_E_PROBE_FILENAME if voter_e_probe is not None else None,
+        "voter_e_audio_strong_min_votes_recommended": 4 if voter_e_probe is not None else None,
         "built_at": dt.datetime.now(dt.UTC).isoformat(),
         "default_camera_class": default_cls,
         "thresholds_by_camera_class": thresholds_by_class,

--- a/scripts/regression_voter_e.py
+++ b/scripts/regression_voter_e.py
@@ -1,12 +1,17 @@
 """Regression check for Voter E: production ensemble run on audited fixtures.
 
 Loads every head-mounted Go 3S audited fixture, runs the production
-``detect_shots_ensemble`` twice -- once with Voter E off (the legacy
-4-voter behaviour) and once with Voter E on as a precision veto -- and
-reports per-fixture and aggregate precision/recall against the labeled
-shots. This is the acceptance check required by issue #183: combined
-audio + Voter E must not regress recall vs the legacy ensemble while
-ideally lifting precision.
+``detect_shots_ensemble`` across a fusion-rule grid:
+
+* off              -- legacy 4-voter ensemble (current main without Voter E)
+* unconditional    -- Voter E veto applies to every candidate (issue #183)
+* strong3 / strong4 -- conditional veto suppressed when audio ``vote_total``
+  >= the threshold (issue #185). ``strong4`` skips Voter E whenever all
+  four audio voters agreed; ``strong3`` is the looser variant.
+
+Reports per-fixture and aggregate precision/recall against the labeled
+shots so the regression on audio-dominant stages can be quantified
+across rules.
 
 Run:
     uv run python scripts/regression_voter_e.py
@@ -16,8 +21,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-
-import numpy as np
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.ensemble import (
@@ -30,6 +33,22 @@ from splitsmith.ensemble.calibration import camera_class_from_mount
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
 TOL_MS = 75.0
+
+
+VARIANTS: list[tuple[str, EnsembleConfig, bool]] = [
+    ("off", EnsembleConfig(enable_voter_e=False), False),
+    ("unconditional", EnsembleConfig(enable_voter_e=True, e_required=True), True),
+    (
+        "strong3",
+        EnsembleConfig(enable_voter_e=True, e_required=True, e_audio_strong_min_votes=3),
+        True,
+    ),
+    (
+        "strong4",
+        EnsembleConfig(enable_voter_e=True, e_required=True, e_audio_strong_min_votes=4),
+        True,
+    ),
+]
 
 
 def _resolve_truth(truth: dict, candidates) -> list[bool]:
@@ -54,7 +73,7 @@ def _resolve_truth(truth: dict, candidates) -> list[bool]:
 def _eval(name: str, kept: list[bool], is_shot: list[bool]) -> dict:
     n_kept = sum(kept)
     n_shot = sum(is_shot)
-    n_tp = sum(1 for k, t in zip(kept, is_shot) if k and t)
+    n_tp = sum(1 for k, t in zip(kept, is_shot, strict=True) if k and t)
     n_fp = n_kept - n_tp
     n_fn = n_shot - n_tp
     precision = n_tp / n_kept if n_kept else 0.0
@@ -92,11 +111,14 @@ def main() -> int:
             continue
         fixtures.append(p)
 
-    print(f"Evaluating {len(fixtures)} head-mounted Go 3S fixtures with reachable video\n")
+    print(f"Evaluating {len(fixtures)} head-mounted Go 3S fixtures with reachable video")
+    print(f"Variants: {[v[0] for v in VARIANTS]}\n")
 
-    rows = []
-    agg_off: dict[str, int] = {"tp": 0, "fp": 0, "fn": 0}
-    agg_on: dict[str, int] = {"tp": 0, "fp": 0, "fn": 0}
+    aggregates: dict[str, dict[str, int]] = {
+        name: {"tp": 0, "fp": 0, "fn": 0} for name, _, _ in VARIANTS
+    }
+
+    rows: list[dict] = []
     for fixture_path in fixtures:
         truth = json.loads(fixture_path.read_text())
         wav = FIXTURES_DIR / f"{fixture_path.stem}.wav"
@@ -108,10 +130,11 @@ def main() -> int:
         cam_class = camera_class_from_mount((truth.get("camera") or {}).get("mount"))
         window = truth.get("fixture_window_in_source") or [0.0, 0.0]
         source_video = Path(truth["source_video"])
-        # source-video time of the beep = start of fixture window + beep within window.
         source_beep = float(window[0]) + beep
 
-        result_off = detect_shots_ensemble(
+        # The candidate universe is identical across variants -- only the
+        # kept-mask changes. Compute truth labels once.
+        result_universe = detect_shots_ensemble(
             audio,
             sr,
             beep,
@@ -120,66 +143,71 @@ def main() -> int:
             ensemble_config=EnsembleConfig(enable_voter_e=False),
             camera_class=cam_class,
         )
-        result_on = detect_shots_ensemble(
-            audio,
-            sr,
-            beep,
-            stage_t,
-            runtime,
-            ensemble_config=EnsembleConfig(enable_voter_e=True, e_required=True),
-            camera_class=cam_class,
-            video_path=source_video,
-            source_beep_time=source_beep,
-        )
+        is_shot = _resolve_truth(truth, result_universe.candidates)
 
-        is_shot = _resolve_truth(truth, result_off.candidates)
-        kept_off = [c.kept for c in result_off.candidates]
-        kept_on = [c.kept for c in result_on.candidates]
-        m_off = _eval("off", kept_off, is_shot)
-        m_on = _eval("on", kept_on, is_shot)
+        per_variant: dict[str, dict] = {}
+        for name, cfg, needs_video in VARIANTS:
+            result = detect_shots_ensemble(
+                audio,
+                sr,
+                beep,
+                stage_t,
+                runtime,
+                ensemble_config=cfg,
+                camera_class=cam_class,
+                video_path=source_video if needs_video else None,
+                source_beep_time=source_beep if needs_video else None,
+            )
+            kept = [c.kept for c in result.candidates]
+            m = _eval(name, kept, is_shot)
+            per_variant[name] = m
+            aggregates[name]["tp"] += m["tp"]
+            aggregates[name]["fp"] += m["fp"]
+            aggregates[name]["fn"] += m["fn"]
 
-        agg_off["tp"] += m_off["tp"]
-        agg_off["fp"] += m_off["fp"]
-        agg_off["fn"] += m_off["fn"]
-        agg_on["tp"] += m_on["tp"]
-        agg_on["fp"] += m_on["fp"]
-        agg_on["fn"] += m_on["fn"]
+        rows.append({"fixture": fixture_path.stem, "metrics": per_variant})
 
-        delta_p = m_on["precision"] - m_off["precision"]
-        delta_r = m_on["recall"] - m_off["recall"]
-        rows.append(
-            (fixture_path.stem, m_off, m_on, delta_p, delta_r)
-        )
-        print(
-            f"{fixture_path.stem:48s}  "
-            f"off P/R = {m_off['precision']:.3f}/{m_off['recall']:.3f} "
-            f"({m_off['tp']}/{m_off['kept']} kept; {m_off['fn']} miss)   "
-            f"on P/R = {m_on['precision']:.3f}/{m_on['recall']:.3f} "
-            f"({m_on['tp']}/{m_on['kept']} kept; {m_on['fn']} miss)   "
-            f"deltaP={delta_p:+.3f}  deltaR={delta_r:+.3f}"
-        )
+        line = f"{fixture_path.stem:48s}"
+        for name in (v[0] for v in VARIANTS):
+            m = per_variant[name]
+            line += (
+                f"  | {name:13s} P/R={m['precision']:.3f}/{m['recall']:.3f} "
+                f"({m['tp']}/{m['kept']} kept; {m['fn']} miss)"
+            )
+        print(line)
 
     def agg_pr(d: dict[str, int]) -> tuple[float, float]:
         kept = d["tp"] + d["fp"]
         gold = d["tp"] + d["fn"]
         return (d["tp"] / kept if kept else 0.0, d["tp"] / gold if gold else 0.0)
 
-    p_off, r_off = agg_pr(agg_off)
-    p_on, r_on = agg_pr(agg_on)
-    print()
-    print(
-        f"AGGREGATE   off P/R={p_off:.3f}/{r_off:.3f}   "
-        f"on P/R={p_on:.3f}/{r_on:.3f}   "
-        f"deltaP={p_on-p_off:+.3f}  deltaR={r_on-r_off:+.3f}"
-    )
-    print(
-        f"FP suppressed by Voter E: {agg_off['fp']} -> {agg_on['fp']} "
-        f"({agg_off['fp'] - agg_on['fp']} false positives removed)"
-    )
-    print(
-        f"Recall cost: {agg_off['fn']} -> {agg_on['fn']} false negatives "
-        f"(delta {agg_on['fn'] - agg_off['fn']:+d})"
-    )
+    print("\n=== aggregate ===")
+    print(f"{'variant':14s}  {'P':>6s}  {'R':>6s}  {'TP':>4s}  {'FP':>4s}  {'FN':>4s}")
+    for name in (v[0] for v in VARIANTS):
+        p, r = agg_pr(aggregates[name])
+        a = aggregates[name]
+        print(f"{name:14s}  {p:6.3f}  {r:6.3f}  " f"{a['tp']:4d}  {a['fp']:4d}  {a['fn']:4d}")
+
+    print("\n=== per-fixture recall regressions vs off ===")
+    regressions: dict[str, list[tuple[str, float]]] = {
+        name: [] for name in (v[0] for v in VARIANTS) if name != "off"
+    }
+    for row in rows:
+        off_r = row["metrics"]["off"]["recall"]
+        for name in regressions:
+            delta = row["metrics"][name]["recall"] - off_r
+            if delta < 0:
+                regressions[name].append((row["fixture"], delta))
+    for name in (v[0] for v in VARIANTS):
+        if name == "off":
+            continue
+        items = regressions[name]
+        if not items:
+            print(f"{name:14s}  no per-fixture recall regressions")
+            continue
+        print(f"{name:14s}  {len(items)} regressions:")
+        for fix, delta in items:
+            print(f"  {fix}  deltaR={delta:+.3f}")
 
     return 0
 

--- a/src/splitsmith/data/ensemble_calibration.json
+++ b/src/splitsmith/data/ensemble_calibration.json
@@ -43,6 +43,7 @@
     0.0
   ],
   "voter_e_probe_artifact": "voter_e_visual_probe.joblib",
+  "voter_e_audio_strong_min_votes_recommended": 4,
   "built_at": "2026-05-07T14:38:43.424842+00:00",
   "default_camera_class": "headcam",
   "thresholds_by_camera_class": {

--- a/src/splitsmith/ensemble/api.py
+++ b/src/splitsmith/ensemble/api.py
@@ -81,6 +81,24 @@ class EnsembleConfig(BaseModel):
             "effect when ``enable_voter_e`` is also True."
         ),
     )
+    e_audio_strong_min_votes: int | None = Field(
+        default=4,
+        description=(
+            "Issue #185: when set, suppress Voter E's veto on candidates "
+            "whose audio-side ``vote_total`` (A+B+C+D) is at or above "
+            "this value. Default ``4`` skips Voter E whenever all four "
+            "audio voters already agreed -- that's the 'audio unanimous' "
+            "signal most reliably correlated with a true shot, and "
+            "applying Voter E on top of it triggered the 50%-recall "
+            "regression on tallmilan-2026-stage2 in #183. Sweep on the "
+            "11 audited head-mount fixtures: ``4`` removes the per-"
+            "fixture regression entirely while preserving aggregate "
+            "precision lift; ``3`` makes Voter E a no-op (nothing "
+            "passes consensus with vote_total < 3); ``None`` reproduces "
+            "the unconditional veto from #183. Only takes effect when "
+            "both ``enable_voter_e`` and ``e_required`` are True."
+        ),
+    )
 
 
 class EnsembleCandidate(BaseModel):
@@ -301,7 +319,11 @@ def detect_shots_ensemble(
         c_required=cfg.c_required,
     )
     if voter_e_active and cfg.e_required:
-        keep_mask = keep_mask & ve.astype(bool)
+        veto_mask = ~ve.astype(bool)
+        if cfg.e_audio_strong_min_votes is not None:
+            audio_strong = vote_total >= int(cfg.e_audio_strong_min_votes)
+            veto_mask = veto_mask & ~audio_strong
+        keep_mask = keep_mask & ~veto_mask
 
     candidates: list[EnsembleCandidate] = []
     for i in range(n):

--- a/src/splitsmith/ensemble/calibration.py
+++ b/src/splitsmith/ensemble/calibration.py
@@ -200,6 +200,17 @@ class EnsembleCalibration(BaseModel):
             "that pre-date Voter E."
         ),
     )
+    voter_e_audio_strong_min_votes_recommended: int | None = Field(
+        default=None,
+        description=(
+            "Issue #185: provenance for the conditional-veto gate "
+            "(``EnsembleConfig.e_audio_strong_min_votes``) the corpus "
+            "supports. Informational; the live default lives in "
+            "``EnsembleConfig`` so config drift is visible at the call "
+            "site rather than buried in the calibration JSON. ``4`` "
+            "matches the head-mounted Go 3S sweep that landed in #185."
+        ),
+    )
     built_at: str = Field(
         description="ISO-8601 timestamp of when the artifacts were generated.",
     )

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -474,7 +474,11 @@ def test_detect_shots_ensemble_skips_voter_e_when_disabled(monkeypatch) -> None:
 def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, tmp_path) -> None:
     """When ``enable_voter_e`` and ``e_required`` are both True and the
     visual probe rejects two of four candidates, those two are dropped
-    from the consensus shots set even though all four pass A/B/C/D."""
+    from the consensus shots set even though all four pass A/B/C/D.
+
+    Sets ``e_audio_strong_min_votes=None`` to exercise the unconditional
+    veto path -- the new default suppresses Voter E when all four audio
+    voters agreed (#185), which would skip the veto here entirely."""
     from splitsmith.ensemble import api as ensemble_api
     from splitsmith.ensemble import features as ensemble_features
     from splitsmith.ensemble import visual as ensemble_visual
@@ -541,7 +545,9 @@ def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, t
         beep_time=5.0,
         stage_time=10.0,
         runtime=runtime,
-        ensemble_config=EnsembleConfig(enable_voter_e=True, e_required=True),
+        ensemble_config=EnsembleConfig(
+            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=None
+        ),
         video_path=fake_video,
         source_beep_time=5.0,
     )
@@ -551,8 +557,109 @@ def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, t
     assert votes_e == [1, 0, 1, 0]
     assert signals == [0.9, 0.1, 0.8, 0.05]
     # Without e_required all four would have passed (A+B+C+D=4 >= 3 + c_required=True).
-    # With e_required=True, the two below threshold are dropped.
+    # With e_required=True (and the audio-strong gate disabled), the two
+    # below threshold are dropped.
     assert kept == [True, False, True, False]
+
+
+def test_detect_shots_ensemble_voter_e_audio_strong_skips_veto(monkeypatch, tmp_path) -> None:
+    """Issue #185: when ``e_audio_strong_min_votes=4`` and a candidate has
+    audio ``vote_total=4`` (all four audio voters agreed), Voter E's veto
+    is suppressed even when ``e_required=True``. Mitigates the
+    audio-dominant clean-stage regression seen on tallmilan-2026-stage2."""
+    from splitsmith.ensemble import api as ensemble_api
+    from splitsmith.ensemble import features as ensemble_features
+    from splitsmith.ensemble import visual as ensemble_visual
+
+    runtime = _build_stub_runtime()
+    # All four candidates: Voter E says no (signal below threshold).
+    runtime.visual = _StubVisualRuntime([0.05, 0.10, 0.15, 0.20])  # type: ignore[assignment]
+    cal = runtime.calibration.model_copy(
+        update={
+            "voter_e_threshold": 0.5,
+            "voter_e_target_recall": 0.95,
+            "voter_e_clip_model_id": "stub",
+            "voter_e_frame_offsets": [0.0],
+            "voter_e_probe_artifact": "stub.joblib",
+        }
+    )
+    if cal.thresholds_by_camera_class:
+        for cls, t in cal.thresholds_by_camera_class.items():
+            cal.thresholds_by_camera_class[cls] = t.model_copy(update={"voter_e_threshold": 0.5})
+    runtime.calibration = cal
+
+    fake_shots = [
+        Shot(
+            shot_number=i + 1,
+            time_absolute=5.0 + i * 0.3,
+            time_from_beep=i * 0.3,
+            split=0.3 if i > 0 else 5.0,
+            peak_amplitude=0.4,
+            confidence=0.6,
+            notes="",
+        )
+        for i in range(4)
+    ]
+    monkeypatch.setattr(ensemble_api, "detect_shots", lambda *a, **kw: fake_shots)
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_clap_similarities",
+        lambda audio, sr, times, runtime: np.full(
+            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
+        ),
+    )
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_pann_gunshot_probs",
+        lambda audio, sr, times, runtime: np.full(len(times), 0.9, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        ensemble_visual,
+        "compute_visual_features",
+        lambda video_path, source_times, runtime, **_: np.zeros(
+            (len(source_times), 1), dtype=np.float32
+        ),
+    )
+
+    audio = np.zeros(48_000 * 20, dtype=np.float32)
+    fake_video = tmp_path / "fake.mp4"
+    fake_video.write_bytes(b"")
+
+    # All audio voters approve every candidate (vote_total=4) under the stub
+    # runtime. With audio_strong_min_votes=4, Voter E's veto is fully
+    # suppressed -> all candidates pass even though Voter E rejected each.
+    result_strong = detect_shots_ensemble(
+        audio,
+        48_000,
+        beep_time=5.0,
+        stage_time=10.0,
+        runtime=runtime,
+        ensemble_config=EnsembleConfig(
+            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=4
+        ),
+        video_path=fake_video,
+        source_beep_time=5.0,
+    )
+    assert all(c.vote_total == 4 for c in result_strong.candidates)
+    assert all(c.vote_e == 0 for c in result_strong.candidates)
+    assert all(c.kept for c in result_strong.candidates)
+
+    # Sanity: with the gate set to 5 (no audio total can satisfy it under
+    # the 4-voter audio side), the unconditional veto fires and all are
+    # dropped.
+    result_strict = detect_shots_ensemble(
+        audio,
+        48_000,
+        beep_time=5.0,
+        stage_time=10.0,
+        runtime=runtime,
+        ensemble_config=EnsembleConfig(
+            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=5
+        ),
+        video_path=fake_video,
+        source_beep_time=5.0,
+    )
+    assert all(not c.kept for c in result_strict.candidates)
 
 
 def test_candidate_times_in_source_anchors_on_beep() -> None:


### PR DESCRIPTION
## Summary

Adds the conditional-veto knob #185 calls for. When all four audio voters (A/B/C/D) already agreed on a candidate, that's the strongest pre-Voter-E signal we have for "this is a real shot," and applying Voter E's precision veto on top of it loses true shots more often than it catches false positives. The fix is a per-candidate gate.

`EnsembleConfig.e_audio_strong_min_votes` (default `4`) suppresses Voter E's `e_required` veto for candidates whose audio `vote_total >= threshold`. The unconditional behaviour from #183 stays available via `e_audio_strong_min_votes=None` so the previous calibration is reproducible.

## Sweep on the 11 audited head-mount fixtures

| variant | P | R | TP | FP | FN | regressions vs off |
|---|---|---|---|---|---|---|
| off (legacy 4-voter) | 0.871 | 0.962 | 202 | 30 | 8 | -- |
| unconditional (#183) | 0.907 | 0.933 | 196 | 20 | 14 | tallmilan-2 -0.500 R |
| strong3 | 0.871 | 0.962 | 202 | 30 | 8 | none (no-op: consensus already requires >= 3) |
| **strong4** (default) | **0.874** | **0.962** | **202** | **29** | **8** | **none** |

`strong4` is the new default: it removes the per-fixture recall regression entirely while keeping aggregate precision positive vs the legacy ensemble. Larger precision wins require richer fusion (proposals tracked in #186 / #187 territory).

## What landed

- `EnsembleConfig.e_audio_strong_min_votes: int | None = 4` -- the gate. `detect_shots_ensemble` honours it inside the existing `e_required` branch.
- `EnsembleCalibration.voter_e_audio_strong_min_votes_recommended` provenance + build script emits `4`. Live default lives in `EnsembleConfig` so config drift is visible at the call site, not buried in JSON.
- `scripts/regression_voter_e.py` grows a sweep grid and reports per-fixture recall regressions vs off.
- New test: synthetic case where all four audio voters approve and Voter E rejects -- candidates pass under `strong4`, get vetoed under `e_audio_strong_min_votes=5` (a stricter gate). Existing #183 e_required test now passes `e_audio_strong_min_votes=None` to exercise the unconditional veto path explicitly.

## Test plan

- [x] 30/30 ensemble unit tests pass (`uv run pytest tests/test_ensemble.py`)
- [x] Production-path sweep (`uv run python scripts/regression_voter_e.py`) matches the table above on the 11 audited fixtures
- [x] Lint + format clean on changed files

## Closes

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
