### PR TITLE
PiP for secondary cams (#193)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -22,13 +22,42 @@ from __future__ import annotations
 import json
 import plistlib
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
 from fractions import Fraction
 from pathlib import Path
+from typing import Literal
 from xml.etree import ElementTree as ET
 
 from .config import OutputConfig, Shot, SplitColorThresholds, VideoMetadata
+
+PipCorner = Literal["top-right", "top-left", "bottom-right", "bottom-left"]
+
+# Corner cycle order when PiP is requested without an explicit per-cam corner.
+# Top-right first because that's where the user typically wants the headcam-
+# vs-handheld layout to land for an IPSC stage view.
+_PIP_CORNER_CYCLE: tuple[PipCorner, ...] = (
+    "top-right",
+    "top-left",
+    "bottom-right",
+    "bottom-left",
+)
+
+
+@dataclass(frozen=True)
+class PipPlacement:
+    """Picture-in-picture placement for a secondary cam (#193).
+
+    ``scale`` is a uniform multiplier applied to the cam's native size
+    (assumes the cam's resolution roughly matches the sequence -- if not,
+    the user can nudge the resulting transform in FCP). ``margin_pct`` is
+    the inset from the sequence edge expressed as a percentage of the
+    sequence width / height (so it scales sensibly across resolutions).
+    """
+
+    corner: PipCorner = "top-right"
+    scale: float = 0.25
+    margin_pct: float = 2.0
 
 
 @dataclass(frozen=True)
@@ -41,12 +70,100 @@ class SecondaryClip:
     this cam's trim -- typically equal to the project's ``pre_buffer_seconds``,
     but may be less if the cam's beep landed within the pre-buffer of the
     file (a short head wipes some of the pre-roll).
+
+    ``pip`` (issue #193): when set, the renderer adds an ``<adjust-transform>``
+    that scales and positions the cam as a corner inset over the primary.
+    ``None`` keeps today's full-frame stacked layout.
     """
 
     video_path: Path
     video: VideoMetadata
     beep_offset_seconds: float
     label: str = "Secondary cam"
+    pip: PipPlacement | None = None
+
+
+def apply_pip_corner_cycle(
+    secondaries: Iterable[SecondaryClip],
+    *,
+    default: PipPlacement | None = None,
+) -> tuple[SecondaryClip, ...]:
+    """Return ``secondaries`` with auto-assigned PiP corners (issue #193).
+
+    Cams that already carry an explicit ``pip`` keep theirs unchanged. Cams
+    without one get ``default`` (or are left alone if ``default`` is None),
+    with corners rotated through ``_PIP_CORNER_CYCLE`` in input order so a
+    multi-cam stage lands one cam per visible corner. ``scale`` /
+    ``margin_pct`` are inherited from ``default``.
+    """
+    out: list[SecondaryClip] = []
+    cycle_idx = 0
+    for sec in secondaries:
+        if sec.pip is not None or default is None:
+            out.append(sec)
+            continue
+        corner = _PIP_CORNER_CYCLE[cycle_idx % len(_PIP_CORNER_CYCLE)]
+        cycle_idx += 1
+        out.append(replace(sec, pip=replace(default, corner=corner)))
+    return tuple(out)
+
+
+def _pip_transform_attrs(
+    pip: PipPlacement,
+    *,
+    sequence_width: int,
+    sequence_height: int,
+) -> dict[str, str]:
+    """Compute ``<adjust-transform>`` attribute values for ``pip``.
+
+    FCPXML position is in pixels relative to the sequence centre with +Y
+    up. For a clip scaled by ``S``, half-extents are ``halfW*S`` /
+    ``halfH*S``; the corner placement keeps ``margin_pct`` of the sequence
+    width/height between the clip edge and the sequence edge.
+    """
+    half_w = sequence_width / 2.0
+    half_h = sequence_height / 2.0
+    clip_half_w = half_w * pip.scale
+    clip_half_h = half_h * pip.scale
+    margin_x = sequence_width * (pip.margin_pct / 100.0)
+    margin_y = sequence_height * (pip.margin_pct / 100.0)
+
+    if pip.corner in ("top-right", "bottom-right"):
+        x = half_w - clip_half_w - margin_x
+    else:
+        x = -(half_w - clip_half_w - margin_x)
+    if pip.corner in ("top-right", "top-left"):
+        y = half_h - clip_half_h - margin_y
+    else:
+        y = -(half_h - clip_half_h - margin_y)
+
+    return {
+        "scale": f"{pip.scale:g} {pip.scale:g}",
+        "position": f"{x:g} {y:g}",
+    }
+
+
+def _attach_pip_transform(
+    asset_clip: ET.Element,
+    pip: PipPlacement | None,
+    *,
+    sequence_width: int,
+    sequence_height: int,
+) -> None:
+    """Insert ``<adjust-transform>`` on ``asset_clip`` when ``pip`` is set.
+
+    The transform must precede any ``<marker>`` / nested clip children per
+    FCPXML element ordering. Secondary connected clips are leaves today, so
+    appending is fine; the explicit ``insert(0, ...)`` keeps the contract
+    correct if a future change adds children to a secondary clip.
+    """
+    if pip is None:
+        return
+    attrs = _pip_transform_attrs(
+        pip, sequence_width=sequence_width, sequence_height=sequence_height
+    )
+    transform = ET.Element("adjust-transform", attrs)
+    asset_clip.insert(0, transform)
 
 
 Runner = Callable[..., subprocess.CompletedProcess]
@@ -378,7 +495,7 @@ def generate_fcpxml(
         else:
             sec_offset_str = "0s"
             sec_start_str = _frame_aligned_str(-delta_frames, fd_num, fd_den)
-        ET.SubElement(
+        sec_clip = ET.SubElement(
             asset_clip,
             "asset-clip",
             {
@@ -390,6 +507,12 @@ def generate_fcpxml(
                 "duration": sec_duration_parent_str,
                 "format": format_id,
             },
+        )
+        _attach_pip_transform(
+            sec_clip,
+            sec.pip,
+            sequence_width=video.width,
+            sequence_height=video.height,
         )
 
     if use_overlay and overlay_duration_str is not None:
@@ -774,7 +897,7 @@ def generate_match_fcpxml(
             else:
                 sec_offset_frames = plan.head_trim_frames
                 sec_start_frames = -delta_frames
-            ET.SubElement(
+            sec_clip = ET.SubElement(
                 primary_clip,
                 "asset-clip",
                 {
@@ -786,6 +909,12 @@ def generate_match_fcpxml(
                     "duration": _frame_aligned_str(sec_dur_in_parent_frames, fd_num, fd_den),
                     "format": format_id,
                 },
+            )
+            _attach_pip_transform(
+                sec_clip,
+                sec.pip,
+                sequence_width=base.width,
+                sequence_height=base.height,
             )
 
         if plan.overlay_asset_id is not None:

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -18,10 +18,13 @@ import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from .. import fcpxml_gen
 from ..config import OutputConfig
 from .exports import audit_shots_to_engine_shots
+
+PipLayout = Literal["stacked", "pip-corners"]
 
 
 @dataclass(frozen=True)
@@ -68,6 +71,11 @@ class MatchExportRequestData:
     include_secondaries: bool
     include_overlay: bool
     project_name: str
+    # Issue #193. ``"stacked"`` keeps today's full-frame stacked layout
+    # (every secondary covers the one below). ``"pip-corners"`` adds an
+    # ``<adjust-transform>`` to each secondary so they land in rotating
+    # corners (TR -> TL -> BR -> BL) at 25% scale with a 2% inset.
+    pip_layout: PipLayout = "stacked"
 
 
 @dataclass(frozen=True)
@@ -182,6 +190,13 @@ def export_match(
                     f"{stage_input.overlay_path} -- dropped"
                 )
 
+        if request.pip_layout == "pip-corners" and secondaries:
+            laid_out = fcpxml_gen.apply_pip_corner_cycle(
+                secondaries, default=fcpxml_gen.PipPlacement()
+            )
+        else:
+            laid_out = tuple(secondaries)
+
         compositions.append(
             fcpxml_gen.StageComposition(
                 stage_name=stage_input.stage_name,
@@ -193,7 +208,7 @@ def export_match(
                 tail_pad_seconds=request.tail_pad_seconds,
                 overlay_path=overlay_path,
                 overlay_video=overlay_video,
-                secondaries=tuple(secondaries),
+                secondaries=laid_out,
             )
         )
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -939,6 +939,10 @@ class MatchExportRequest(BaseModel):
     overlay_max_height: int | None = None
     overlay_max_fps: float | None = None
     project_name: str | None = None
+    # Issue #193. ``"stacked"`` keeps secondaries full-frame (today's
+    # behaviour). ``"pip-corners"`` adds an ``<adjust-transform>`` to each
+    # secondary, rotating through TR -> TL -> BR -> BL at 25% scale.
+    pip_layout: Literal["stacked", "pip-corners"] = "stacked"
 
 
 class RevealRequest(BaseModel):
@@ -4586,6 +4590,7 @@ def create_app(
             include_secondaries=req.include_secondaries,
             include_overlay=req.include_overlay,
             project_name=project_name,
+            pip_layout=req.pip_layout,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -493,6 +493,10 @@ export interface MatchExportRequestPayload {
   /** Defaults to the bound project's name. Slugified for the output
    *  filename: ``<slug>-match.fcpxml``. */
   project_name?: string | null;
+  /** Issue #193. ``"stacked"`` keeps secondaries full-frame on V2/V3/...
+   *  ``"pip-corners"`` adds an FCPXML adjust-transform so each cam lands
+   *  in a rotating corner (TR -> TL -> BR -> BL) at 25% scale. */
+  pip_layout?: "stacked" | "pip-corners";
 }
 
 export interface MatchExportResult {

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1198,6 +1198,13 @@ function MatchExportDialog({
   const [headPad, setHeadPad] = useState<number>(PADDING_PRESETS.full.head);
   const [tailPad, setTailPad] = useState<number>(PADDING_PRESETS.full.tail);
   const [includeSecondaries, setIncludeSecondaries] = useState(true);
+  // Issue #193. ``stacked`` mirrors today's behaviour (every secondary
+  // covers the one below at full frame). ``pip-corners`` adds an FCPXML
+  // adjust-transform to each cam so they land in rotating corners at 25%
+  // scale, ready for review without manual sizing in FCP.
+  const [pipLayout, setPipLayout] = useState<"stacked" | "pip-corners">(
+    "stacked",
+  );
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1248,6 +1255,7 @@ function MatchExportDialog({
         head_pad_seconds: headPad,
         tail_pad_seconds: tailPad,
         include_secondaries: includeSecondaries,
+        pip_layout: pipLayout,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1433,6 +1441,27 @@ function MatchExportDialog({
                 />
                 Include secondary cams
               </label>
+              {includeSecondaries && anySelectedStageHasSecondaries && (
+                <label
+                  className="ml-6 flex items-center gap-1.5"
+                  title="Stacked: cams cover the primary at full size (today's default). PiP corners: each cam lands as a 25% inset in a rotating corner so the headcam stays visible."
+                >
+                  Layout
+                  <select
+                    className="rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                    value={pipLayout}
+                    disabled={busy}
+                    onChange={(e) =>
+                      setPipLayout(
+                        e.target.value as "stacked" | "pip-corners",
+                      )
+                    }
+                  >
+                    <option value="stacked">Stacked full-frame</option>
+                    <option value="pip-corners">PiP corners</option>
+                  </select>
+                </label>
+              )}
               <label className="flex items-center gap-1.5">
                 <input
                   type="checkbox"

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1134,6 +1134,248 @@ def test_match_fcpxml_raises_when_pads_collapse_duration(tmp_path: Path) -> None
 # --- probe_video -----------------------------------------------------------
 
 
+# --- PiP for secondary cams (issue #193) ----------------------------------
+
+
+def _expected_pip_attrs(
+    *,
+    seq_w: int,
+    seq_h: int,
+    scale: float,
+    margin_pct: float,
+    corner: str,
+) -> dict[str, str]:
+    half_w = seq_w / 2.0
+    half_h = seq_h / 2.0
+    clip_half_w = half_w * scale
+    clip_half_h = half_h * scale
+    margin_x = seq_w * (margin_pct / 100.0)
+    margin_y = seq_h * (margin_pct / 100.0)
+    if corner in ("top-right", "bottom-right"):
+        x = half_w - clip_half_w - margin_x
+    else:
+        x = -(half_w - clip_half_w - margin_x)
+    if corner in ("top-right", "top-left"):
+        y = half_h - clip_half_h - margin_y
+    else:
+        y = -(half_h - clip_half_h - margin_y)
+    return {"scale": f"{scale:g} {scale:g}", "position": f"{x:g} {y:g}"}
+
+
+def test_secondary_without_pip_emits_no_transform(tmp_path: Path) -> None:
+    """Default behaviour unchanged: a SecondaryClip with ``pip=None`` lands
+    full-frame on its lane, no ``<adjust-transform>``."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "cam.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=5.0,
+                label="Cam",
+            )
+        ],
+    )
+    cam_clip = ET.fromstring(out.read_bytes()).find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    assert cam_clip.find("adjust-transform") is None
+
+
+@pytest.mark.parametrize(
+    "corner",
+    ["top-right", "top-left", "bottom-right", "bottom-left"],
+)
+def test_secondary_with_pip_emits_corner_transform(corner: str, tmp_path: Path) -> None:
+    """``pip`` set -> ``<adjust-transform>`` as the cam clip's first child,
+    with scale + position computed from the sequence dims and corner."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "cam.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=5.0,
+                label="Cam",
+                pip=fcpxml_mod.PipPlacement(corner=corner),  # type: ignore[arg-type]
+            )
+        ],
+    )
+    cam_clip = ET.fromstring(out.read_bytes()).find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    transform = cam_clip.find("adjust-transform")
+    assert transform is not None
+    assert list(cam_clip)[0] is transform  # transform must precede markers / nested clips
+    expected = _expected_pip_attrs(
+        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner=corner
+    )
+    assert transform.attrib == expected
+
+
+def test_pip_position_scales_with_sequence_dimensions(tmp_path: Path) -> None:
+    """At a 4K sequence with ``scale=0.25, margin_pct=2.0`` the absolute
+    pixel position is twice the 1080p value -- the clip stays anchored to
+    the same fractional corner regardless of resolution."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"")
+    secondary = tmp_path / "cam.mp4"
+    secondary.write_bytes(b"")
+    out = tmp_path / "v.fcpxml"
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_2997(),  # 3840x2160
+        shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+        beep_offset_seconds=5.0,
+        output_path=out,
+        project_name="v",
+        config=OutputConfig(),
+        secondaries=[
+            fcpxml_mod.SecondaryClip(
+                video_path=secondary,
+                video=_meta_2997(),
+                beep_offset_seconds=5.0,
+                label="Cam",
+                pip=fcpxml_mod.PipPlacement(corner="top-right"),
+            )
+        ],
+    )
+    transform = ET.fromstring(out.read_bytes()).find(
+        ".//spine/asset-clip/asset-clip/adjust-transform"
+    )
+    assert transform is not None
+    expected = _expected_pip_attrs(
+        seq_w=3840, seq_h=2160, scale=0.25, margin_pct=2.0, corner="top-right"
+    )
+    assert transform.attrib == expected
+
+
+def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:
+    """Multiple cams without explicit pip get TR -> TL -> BR -> BL when
+    ``apply_pip_corner_cycle`` is asked to inject a default."""
+    secs = tuple(
+        fcpxml_mod.SecondaryClip(
+            video_path=Path(f"cam{i}.mp4"),
+            video=_meta_30fps(),
+            beep_offset_seconds=5.0,
+            label=f"Cam {i}",
+        )
+        for i in range(4)
+    )
+    laid_out = fcpxml_mod.apply_pip_corner_cycle(
+        secs, default=fcpxml_mod.PipPlacement(scale=0.3, margin_pct=1.5)
+    )
+    corners = [s.pip.corner for s in laid_out]  # type: ignore[union-attr]
+    assert corners == ["top-right", "top-left", "bottom-right", "bottom-left"]
+    # Default scale / margin propagate; corner is the only override.
+    for s in laid_out:
+        assert s.pip is not None
+        assert s.pip.scale == 0.3
+        assert s.pip.margin_pct == 1.5
+
+
+def test_apply_pip_corner_cycle_preserves_explicit() -> None:
+    """A cam that already carries an explicit ``pip`` keeps it; cams without
+    one rotate through the remaining corners in input order."""
+    explicit = fcpxml_mod.SecondaryClip(
+        video_path=Path("cam_main.mp4"),
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Main cam",
+        pip=fcpxml_mod.PipPlacement(corner="bottom-left", scale=0.4),
+    )
+    auto = fcpxml_mod.SecondaryClip(
+        video_path=Path("cam_aux.mp4"),
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Aux cam",
+    )
+    laid_out = fcpxml_mod.apply_pip_corner_cycle(
+        (explicit, auto), default=fcpxml_mod.PipPlacement()
+    )
+    assert laid_out[0] is explicit  # untouched
+    assert laid_out[1].pip is not None
+    assert laid_out[1].pip.corner == "top-right"  # cycle starts at TR
+
+
+def test_apply_pip_corner_cycle_default_none_is_noop() -> None:
+    """Without a default, cams that lack ``pip`` stay as-is -- this is the
+    "stacked full-frame" path used by today's exports."""
+    sec = fcpxml_mod.SecondaryClip(
+        video_path=Path("cam.mp4"),
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Cam",
+    )
+    laid_out = fcpxml_mod.apply_pip_corner_cycle((sec,), default=None)
+    assert laid_out == (sec,)
+
+
+def test_match_fcpxml_secondary_pip_uses_sequence_dims(tmp_path: Path) -> None:
+    """In the stitched composer the sequence format comes from stage 0, so
+    every PiP transform must compute against the *base* dims even when a
+    later stage's primary has a different intrinsic size."""
+    primary = _make_video(tmp_path, "primary.mp4")
+    secondary = _make_video(tmp_path, "secondary.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="s1",
+                video_path=primary,
+                video=_meta_30fps(),  # 1920x1080
+                shots=[_shot(1, time_from_beep=1.0, split=1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=5.0,
+                secondaries=(
+                    fcpxml_mod.SecondaryClip(
+                        video_path=secondary,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                        pip=fcpxml_mod.PipPlacement(corner="top-right"),
+                    ),
+                ),
+            )
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    transform = ET.fromstring(out.read_bytes()).find(
+        ".//spine/asset-clip/asset-clip/adjust-transform"
+    )
+    assert transform is not None
+    expected = _expected_pip_attrs(
+        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner="top-right"
+    )
+    assert transform.attrib == expected
+
+
+# --- probe_video -----------------------------------------------------------
+
+
 @pytest.mark.integration
 def test_probe_video_against_real_fixture(fixtures_dir: Path) -> None:
     src = fixtures_dir / "stage_sample.mp4"


### PR DESCRIPTION
Closes #193. Part of the umbrella in #192.

## Summary

- ``PipPlacement`` (\`corner\` / \`scale\` / \`margin_pct\`) on \`SecondaryClip\`. Renderer emits \`<adjust-transform>\` on each connected cam clip when set.
- \`apply_pip_corner_cycle\` auto-assigns TR -> TL -> BR -> BL in input order; explicit per-cam corners win.
- Wired through \`MatchExportRequest.pip_layout\` and a "Layout" selector in the Export dialog.
- Default behaviour unchanged. \`pip=None\` keeps today's stacked full-frame layout, byte-identical to the previous emitter.

## Why

Today secondaries stack full-frame on V2/V3/..., covering the headcam. Every match export started with the user manually scaling and positioning each cam in FCP. PiP corners reduce that to "click import."

## Math

FCPXML position is in pixels, origin at sequence centre, +Y up. For a cam scaled by \`S\` with margin \`M\` percent of sequence width/height, the cam-centre coordinate is \`(halfW - halfW*S - W*M/100, halfH - halfH*S - H*M/100)\` in the top-right corner; signs flip per-axis for the other corners. Margin scales with sequence dims so the inset looks the same across resolutions.

## Test plan

- [x] \`pytest tests/test_fcpxml_gen.py tests/test_ui_match_exports.py\` -- 55 passed (9 new for PiP)
- [x] Full Python suite: 726 passed, 1 skipped (integration probe)
- [x] \`tsc -b --noEmit\` (frontend typecheck) clean
- [ ] Manual: import a stitched FCPXML with PiP corners into Final Cut, confirm cam lands at the expected fractional corner at 1080p and 4K
- [ ] Manual: export with \`pip-corners\` selected and 3 cams; confirm corners rotate TR -> TL -> BR

## CLI

Deferred -- the \`fcpxml\` CLI command has no multi-cam input today. PiP-via-CLI lands when CLI grows secondary input; tracked in #192.

## Out of scope

- Animated PiP, drop shadows, borders.
- PiP on the overlay (it stays full-frame).
- Per-cam UI overrides for corner / scale; one global selector for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)