### PR TITLE
Composition IR + bridge renderer (#194)

### DIFF
--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -1,0 +1,457 @@
+"""Renderer-agnostic timeline IR (issue #194).
+
+Today ``fcpxml_gen.StageComposition`` is half a composition spec but lives
+inside the FCPXML emitter and only describes what FCPXML happens to need.
+This module extracts that into a Pydantic-style IR so the same composition
+can drive multiple renderers (FCPXML today, FCP7 XML / ffmpeg next) and so
+follow-on features (PiP / transitions / titles / templates) bind to a
+stable shape instead of branching inside a 900-line emitter.
+
+Layering:
+
+    user inputs / UI request
+        |
+        v
+    Composition (this module)         <-- IR boundary
+        |
+        v
+    render_fcpxml(...)                <-- thin bridge for now;
+        |                                 lowers IR to today's
+        v                                 ``generate_match_fcpxml`` so
+    fcpxml_gen.generate_match_fcpxml      output stays byte-identical.
+        |                                 Future PRs migrate emission
+        v                                 directly onto the IR.
+    .fcpxml on disk
+
+The IR is opinionated about *what* the user wants (primary, secondaries,
+overlay, transitions, titles); it does not know about FCPXML-specific
+plumbing (resource ids, lane numbers, attribute order). Renderers own
+those choices.
+
+Out of scope here, tracked in sibling issues:
+- ``Transition`` shape exists but isn't emitted yet (#195).
+- ``TitleCard`` / ``Segment`` exist but aren't emitted yet (#173, #196).
+- A second renderer (#197 FCP7 XML, #174 ffmpeg) lands on top of this.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence as SequenceProto
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from . import fcpxml_gen
+from .config import OutputConfig, Shot, VideoMetadata
+
+
+@dataclass(frozen=True)
+class SequenceFormat:
+    """The composition's shared sequence format.
+
+    All stages render against this. The existing match composer requires
+    a single shared frame rate across stages; the IR mirrors that
+    constraint by carrying one ``SequenceFormat`` for the whole
+    composition rather than one per stage.
+    """
+
+    width: int
+    height: int
+    frame_rate_num: int
+    frame_rate_den: int
+
+    @classmethod
+    def from_video(cls, meta: VideoMetadata) -> SequenceFormat:
+        return cls(
+            width=meta.width,
+            height=meta.height,
+            frame_rate_num=meta.frame_rate_num,
+            frame_rate_den=meta.frame_rate_den,
+        )
+
+
+@dataclass(frozen=True)
+class Asset:
+    """A single source media file with its probed metadata."""
+
+    path: Path
+    metadata: VideoMetadata
+
+
+@dataclass(frozen=True)
+class Transform:
+    """Renderer-agnostic 2D transform on a connected clip.
+
+    ``scale`` is a uniform multiplier (1.0 = native). ``position`` is in
+    pixel-units relative to the sequence centre with +Y up -- the same
+    coordinate system FCPXML's ``<adjust-transform position>`` uses, so a
+    direct emit is a string format. ffmpeg / FCP7 XML renderers convert
+    to their native conventions when they land.
+    """
+
+    scale: float = 1.0
+    position: tuple[float, float] = (0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class Marker:
+    """A shot-time marker on the primary clip.
+
+    The IR holds the raw ``Shot`` so renderers can format the label using
+    their own config (split-colour thresholds etc.) instead of receiving
+    a pre-formatted string. ``time_seconds`` is the source-time of the
+    marked frame in the primary clip's local coordinates.
+    """
+
+    time_seconds: float
+    shot: Shot
+
+
+ConnectedRole = Literal["cam", "overlay"]
+
+
+@dataclass(frozen=True)
+class ConnectedClip:
+    """A clip layered above the primary on a higher lane.
+
+    ``role="cam"`` -> a secondary head/handheld cam. ``beep_offset_seconds``
+    is the clip-local time of the beep so the renderer can align it to the
+    primary's beep frame.
+
+    ``role="overlay"`` -> the alpha overlay (audited shot times etc.). It
+    sits on the topmost lane and ignores beep alignment (the renderer
+    matches its head to the primary's visible head).
+    """
+
+    asset: Asset
+    label: str
+    role: ConnectedRole
+    beep_offset_seconds: float | None = None
+    transform: Transform | None = None
+
+
+@dataclass(frozen=True)
+class Stage:
+    """One stage's contribution to the composition."""
+
+    name: str
+    primary: Asset
+    beep_offset_seconds: float
+    head_pad_seconds: float
+    tail_pad_seconds: float
+    secondaries: tuple[ConnectedClip, ...] = ()
+    overlay: ConnectedClip | None = None
+    markers: tuple[Marker, ...] = ()
+
+
+TransitionKind = Literal["cross-dissolve", "dip-to-color"]
+
+
+@dataclass(frozen=True)
+class Transition:
+    """Stage-boundary transition (placeholder until #195 lands).
+
+    ``from_stage_index`` / ``to_stage_index`` are positions in
+    ``Composition.stages``; consecutive indices only for v1.
+    ``duration_seconds`` is split half-before / half-after the boundary
+    per FCPXML semantics. Renderers that don't support a given ``kind``
+    fall back to the closest supported transition and warn.
+    """
+
+    from_stage_index: int
+    to_stage_index: int
+    kind: TransitionKind = "cross-dissolve"
+    duration_seconds: float = 0.5
+    color: str | None = None  # dip-to-color only
+
+
+TitleStyle = Literal["slate", "lower-third"]
+
+
+@dataclass(frozen=True)
+class TitleCard:
+    """Title overlay (placeholder until #196 lands).
+
+    ``slate`` is a short pre-stage card; ``lower-third`` is a connected
+    text clip overlapping the start of a stage. Renderers map this to a
+    target-native title primitive.
+    """
+
+    text: str
+    duration_seconds: float
+    style: TitleStyle = "slate"
+
+
+@dataclass(frozen=True)
+class Segment:
+    """Intro / outro segment (placeholder until #173 lands)."""
+
+    asset: Asset
+    title: TitleCard | None = None
+
+
+@dataclass(frozen=True)
+class Composition:
+    """A complete renderer-agnostic timeline (#194)."""
+
+    project_name: str
+    sequence: SequenceFormat
+    stages: tuple[Stage, ...]
+    intro: Segment | None = None
+    outro: Segment | None = None
+    transitions: tuple[Transition, ...] = ()
+
+
+# --- conversions -----------------------------------------------------------
+
+
+def _pip_to_transform(
+    pip: fcpxml_gen.PipPlacement,
+    seq: SequenceFormat,
+) -> Transform:
+    """Resolve a ``PipPlacement`` (corner / scale / margin_pct) into a
+    renderer-agnostic ``Transform`` by asking ``PipPlacement.resolve`` for
+    pixel-space coordinates."""
+    scale, (x, y) = pip.resolve(
+        sequence_width=seq.width,
+        sequence_height=seq.height,
+    )
+    return Transform(scale=scale, position=(x, y))
+
+
+def from_stage_compositions(
+    stages: SequenceProto[fcpxml_gen.StageComposition],
+    *,
+    project_name: str,
+) -> Composition:
+    """Build a :class:`Composition` from today's ``StageComposition`` inputs.
+
+    The shared sequence format is taken from ``stages[0]`` -- the existing
+    composer requires same fps across stages, and we additionally require
+    same width/height for a single shared sequence (FCP scales mismatched
+    cams within a stage via per-cam formats; mismatched primaries across
+    stages would need cross-fps timeline support which is out of scope).
+    """
+    if not stages:
+        raise ValueError("Composition requires at least one stage")
+    base = stages[0].video
+    seq = SequenceFormat.from_video(base)
+
+    ir_stages: list[Stage] = []
+    for stage_comp in stages:
+        secondaries: list[ConnectedClip] = []
+        for sec in stage_comp.secondaries:
+            transform = _pip_to_transform(sec.pip, seq) if sec.pip is not None else None
+            secondaries.append(
+                ConnectedClip(
+                    asset=Asset(path=sec.video_path, metadata=sec.video),
+                    label=sec.label,
+                    role="cam",
+                    beep_offset_seconds=sec.beep_offset_seconds,
+                    transform=transform,
+                )
+            )
+
+        overlay: ConnectedClip | None = None
+        if stage_comp.overlay_path is not None:
+            overlay_meta = (
+                stage_comp.overlay_video
+                if stage_comp.overlay_video is not None
+                else stage_comp.video
+            )
+            overlay = ConnectedClip(
+                asset=Asset(path=stage_comp.overlay_path, metadata=overlay_meta),
+                label="Splitsmith overlay",
+                role="overlay",
+            )
+
+        markers = tuple(
+            Marker(
+                time_seconds=stage_comp.beep_offset_seconds + s.time_from_beep,
+                shot=s,
+            )
+            for s in stage_comp.shots
+        )
+
+        ir_stages.append(
+            Stage(
+                name=stage_comp.stage_name,
+                primary=Asset(path=stage_comp.video_path, metadata=stage_comp.video),
+                beep_offset_seconds=stage_comp.beep_offset_seconds,
+                head_pad_seconds=stage_comp.head_pad_seconds,
+                tail_pad_seconds=stage_comp.tail_pad_seconds,
+                secondaries=tuple(secondaries),
+                overlay=overlay,
+                markers=markers,
+            )
+        )
+
+    return Composition(
+        project_name=project_name,
+        sequence=seq,
+        stages=tuple(ir_stages),
+    )
+
+
+def to_stage_compositions(
+    composition: Composition,
+) -> list[fcpxml_gen.StageComposition]:
+    """Lower a :class:`Composition` back to ``StageComposition`` inputs.
+
+    The bridge that lets ``render_fcpxml`` reuse today's emitter without
+    forking it. ``Transform`` -> ``PipPlacement`` is lossy (we don't
+    recover the original corner / margin_pct), so we synthesise a
+    ``PipPlacement`` carrying the absolute position via a custom corner
+    that lowers to the same pixel coordinates. For now we only handle the
+    single supported case (uniform scale, axis-aligned corner) by
+    matching the IR's stored position back to a corner -- if the user
+    constructed a ``Transform`` by hand at an arbitrary position, the
+    bridge raises rather than silently snapping. Future PRs will replace
+    this bridge with direct emission and the lossy step disappears.
+    """
+    out: list[fcpxml_gen.StageComposition] = []
+    for stage in composition.stages:
+        secondaries: list[fcpxml_gen.SecondaryClip] = []
+        for sec in stage.secondaries:
+            pip = (
+                _transform_to_pip(sec.transform, composition.sequence)
+                if sec.transform is not None
+                else None
+            )
+            assert sec.beep_offset_seconds is not None  # cam role guarantees this
+            secondaries.append(
+                fcpxml_gen.SecondaryClip(
+                    video_path=sec.asset.path,
+                    video=sec.asset.metadata,
+                    beep_offset_seconds=sec.beep_offset_seconds,
+                    label=sec.label,
+                    pip=pip,
+                )
+            )
+        overlay_path = stage.overlay.asset.path if stage.overlay is not None else None
+        overlay_video = stage.overlay.asset.metadata if stage.overlay is not None else None
+        out.append(
+            fcpxml_gen.StageComposition(
+                stage_name=stage.name,
+                video_path=stage.primary.path,
+                video=stage.primary.metadata,
+                shots=[m.shot for m in stage.markers],
+                beep_offset_seconds=stage.beep_offset_seconds,
+                head_pad_seconds=stage.head_pad_seconds,
+                tail_pad_seconds=stage.tail_pad_seconds,
+                overlay_path=overlay_path,
+                overlay_video=overlay_video,
+                secondaries=tuple(secondaries),
+            )
+        )
+    return out
+
+
+def _transform_to_pip(
+    transform: Transform,
+    seq: SequenceFormat,
+) -> fcpxml_gen.PipPlacement:
+    """Recover a ``PipPlacement`` from an absolute ``Transform``.
+
+    Inverts ``_pip_to_transform``: given the stored scale + pixel
+    position, find the corner / margin_pct that would have produced
+    those values for this sequence size. Raises ``ValueError`` if the
+    transform doesn't match a corner-aligned PiP (the only kind today's
+    emitter knows how to produce).
+    """
+    px, py = transform.position
+    scale = transform.scale
+    half_w = seq.width / 2.0
+    half_h = seq.height / 2.0
+    clip_half_w = half_w * scale
+    clip_half_h = half_h * scale
+    # |abs(px) - (half_w - clip_half_w - margin_x)| ~ 0
+    # -> margin_x = half_w - clip_half_w - abs(px)
+    margin_x = half_w - clip_half_w - abs(px)
+    margin_y = half_h - clip_half_h - abs(py)
+    margin_pct_x = margin_x / seq.width * 100.0
+    margin_pct_y = margin_y / seq.height * 100.0
+    if abs(margin_pct_x - margin_pct_y) > 1e-6:
+        raise ValueError(
+            "Transform does not match a corner-aligned PiP "
+            f"(margin_pct mismatch: x={margin_pct_x}, y={margin_pct_y})"
+        )
+    if px >= 0 and py >= 0:
+        corner: fcpxml_gen.PipCorner = "top-right"
+    elif px < 0 and py >= 0:
+        corner = "top-left"
+    elif px >= 0 and py < 0:
+        corner = "bottom-right"
+    else:
+        corner = "bottom-left"
+    return fcpxml_gen.PipPlacement(
+        corner=corner,
+        scale=scale,
+        margin_pct=margin_pct_x,
+    )
+
+
+# --- renderers -------------------------------------------------------------
+
+
+def render_fcpxml(
+    composition: Composition,
+    *,
+    output_path: Path,
+    config: OutputConfig,
+) -> None:
+    """Render ``composition`` as FCPXML 1.10.
+
+    v1 implementation: lower the IR to ``StageComposition`` and call the
+    existing ``generate_match_fcpxml``. This guarantees byte-identical
+    output to today's path; a sibling test fixture compares the IR-driven
+    output against the legacy emitter on every supported input shape.
+
+    Future PRs will replace this bridge with direct emission off the IR
+    so transitions / titles / new renderers can reach the wire.
+    """
+    legacy_stages = to_stage_compositions(composition)
+    if len(legacy_stages) == 1 and composition.intro is None and composition.outro is None:
+        # Single stage with no intro/outro mirrors today's per-stage path.
+        # Use generate_fcpxml so the file is byte-identical to a
+        # single-stage export.
+        stage = legacy_stages[0]
+        fcpxml_gen.generate_fcpxml(
+            video_path=stage.video_path,
+            video=stage.video,
+            shots=stage.shots,
+            beep_offset_seconds=stage.beep_offset_seconds,
+            output_path=output_path,
+            project_name=composition.project_name,
+            config=config,
+            secondaries=list(stage.secondaries),
+            overlay_path=stage.overlay_path,
+            overlay_video=stage.overlay_video,
+        )
+        return
+    fcpxml_gen.generate_match_fcpxml(
+        stages=legacy_stages,
+        output_path=output_path,
+        project_name=composition.project_name,
+        config=config,
+    )
+
+
+__all__ = [
+    "Asset",
+    "Composition",
+    "ConnectedClip",
+    "ConnectedRole",
+    "Marker",
+    "Segment",
+    "SequenceFormat",
+    "Stage",
+    "TitleCard",
+    "TitleStyle",
+    "Transform",
+    "Transition",
+    "TransitionKind",
+    "from_stage_compositions",
+    "render_fcpxml",
+    "to_stage_compositions",
+]

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -59,6 +59,36 @@ class PipPlacement:
     scale: float = 0.25
     margin_pct: float = 2.0
 
+    def resolve(
+        self,
+        *,
+        sequence_width: int,
+        sequence_height: int,
+    ) -> tuple[float, tuple[float, float]]:
+        """Resolve to ``(scale, (x, y))`` in sequence-centre pixel space.
+
+        Position is in pixels relative to the sequence centre with +Y up
+        -- the same coordinate system FCPXML's ``<adjust-transform>``
+        uses. ``composition.Transform`` (#194) and the FCPXML emitter
+        both consume this resolved form so the corner / margin_pct
+        abstraction stays in one place.
+        """
+        half_w = sequence_width / 2.0
+        half_h = sequence_height / 2.0
+        clip_half_w = half_w * self.scale
+        clip_half_h = half_h * self.scale
+        margin_x = sequence_width * (self.margin_pct / 100.0)
+        margin_y = sequence_height * (self.margin_pct / 100.0)
+        if self.corner in ("top-right", "bottom-right"):
+            x = half_w - clip_half_w - margin_x
+        else:
+            x = -(half_w - clip_half_w - margin_x)
+        if self.corner in ("top-right", "top-left"):
+            y = half_h - clip_half_h - margin_y
+        else:
+            y = -(half_h - clip_half_h - margin_y)
+        return self.scale, (x, y)
+
 
 @dataclass(frozen=True)
 class SecondaryClip:
@@ -114,31 +144,10 @@ def _pip_transform_attrs(
     sequence_width: int,
     sequence_height: int,
 ) -> dict[str, str]:
-    """Compute ``<adjust-transform>`` attribute values for ``pip``.
-
-    FCPXML position is in pixels relative to the sequence centre with +Y
-    up. For a clip scaled by ``S``, half-extents are ``halfW*S`` /
-    ``halfH*S``; the corner placement keeps ``margin_pct`` of the sequence
-    width/height between the clip edge and the sequence edge.
-    """
-    half_w = sequence_width / 2.0
-    half_h = sequence_height / 2.0
-    clip_half_w = half_w * pip.scale
-    clip_half_h = half_h * pip.scale
-    margin_x = sequence_width * (pip.margin_pct / 100.0)
-    margin_y = sequence_height * (pip.margin_pct / 100.0)
-
-    if pip.corner in ("top-right", "bottom-right"):
-        x = half_w - clip_half_w - margin_x
-    else:
-        x = -(half_w - clip_half_w - margin_x)
-    if pip.corner in ("top-right", "top-left"):
-        y = half_h - clip_half_h - margin_y
-    else:
-        y = -(half_h - clip_half_h - margin_y)
-
+    """Format ``<adjust-transform>`` attributes for ``pip`` in this sequence."""
+    scale, (x, y) = pip.resolve(sequence_width=sequence_width, sequence_height=sequence_height)
     return {
-        "scale": f"{pip.scale:g} {pip.scale:g}",
+        "scale": f"{scale:g} {scale:g}",
         "position": f"{x:g} {y:g}",
     }
 

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from .. import fcpxml_gen
+from .. import composition, fcpxml_gen
 from ..config import OutputConfig
 from .exports import audit_shots_to_engine_shots
 
@@ -214,13 +214,13 @@ def export_match(
 
     exports_dir.mkdir(parents=True, exist_ok=True)
     output_path = exports_dir / f"{_slugify(request.project_name)}-match.fcpxml"
+    # Match export goes through the composition IR (issue #194). The bridge
+    # renderer lowers back to ``generate_match_fcpxml`` so the output stays
+    # byte-identical to the pre-IR path; future renderer work (transitions,
+    # titles, FCP7 XML, ffmpeg) replaces the bridge piece by piece.
+    comp = composition.from_stage_compositions(compositions, project_name=request.project_name)
     try:
-        fcpxml_gen.generate_match_fcpxml(
-            stages=compositions,
-            output_path=output_path,
-            project_name=request.project_name,
-            config=config,
-        )
+        composition.render_fcpxml(comp, output_path=output_path, config=config)
     except (ValueError, FileNotFoundError) as exc:
         raise MatchExportError(str(exc)) from exc
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,409 @@
+"""Tests for the composition IR (issue #194).
+
+The IR sits above ``fcpxml_gen.generate_*_fcpxml``; the bridge renderer
+(``composition.render_fcpxml``) must produce byte-identical output to the
+legacy emitter on every supported input shape so existing user workflows
+don't drift. These tests pin both the structural fields and the byte
+equivalence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith import composition, fcpxml_gen
+from splitsmith.config import OutputConfig, Shot, VideoMetadata
+from splitsmith.fcpxml_gen import (
+    PipPlacement,
+    SecondaryClip,
+    StageComposition,
+    generate_fcpxml,
+    generate_match_fcpxml,
+)
+
+
+def _shot(n: int, time_from_beep: float, split: float) -> Shot:
+    return Shot(
+        shot_number=n,
+        time_absolute=10.0 + time_from_beep,
+        time_from_beep=time_from_beep,
+        split=split,
+        peak_amplitude=0.5,
+        confidence=0.8,
+    )
+
+
+def _meta_30fps() -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _meta_2997() -> VideoMetadata:
+    return VideoMetadata(
+        width=3840,
+        height=2160,
+        duration_seconds=20.0,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+    )
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+# --- IR shape --------------------------------------------------------------
+
+
+def test_sequence_format_from_video_copies_dims_and_rate() -> None:
+    seq = composition.SequenceFormat.from_video(_meta_2997())
+    assert seq.width == 3840
+    assert seq.height == 2160
+    assert seq.frame_rate_num == 30000
+    assert seq.frame_rate_den == 1001
+
+
+@pytest.mark.parametrize(
+    "corner",
+    ["top-right", "top-left", "bottom-right", "bottom-left"],
+)
+def test_pip_placement_resolve_matches_emitter_attrs(corner: str) -> None:
+    """``PipPlacement.resolve`` is the single source of truth for both the
+    IR's ``Transform`` and the FCPXML emitter's attribute strings -- if
+    the two ever disagreed the bridge would silently drift."""
+    pip = PipPlacement(corner=corner)  # type: ignore[arg-type]
+    scale, (x, y) = pip.resolve(sequence_width=1920, sequence_height=1080)
+    attrs = fcpxml_gen._pip_transform_attrs(pip, sequence_width=1920, sequence_height=1080)
+    assert attrs["scale"] == f"{scale:g} {scale:g}"
+    assert attrs["position"] == f"{x:g} {y:g}"
+
+
+@pytest.mark.parametrize(
+    "corner",
+    ["top-right", "top-left", "bottom-right", "bottom-left"],
+)
+def test_transform_to_pip_round_trips_all_corners(corner: str) -> None:
+    """``_transform_to_pip`` must invert ``_pip_to_transform`` for every
+    corner so the bridge renderer can lower the IR back to today's
+    ``PipPlacement`` without losing information."""
+    seq = composition.SequenceFormat(width=1920, height=1080, frame_rate_num=30, frame_rate_den=1)
+    pip_in = PipPlacement(corner=corner, scale=0.3, margin_pct=2.5)  # type: ignore[arg-type]
+    transform = composition._pip_to_transform(pip_in, seq)
+    pip_out = composition._transform_to_pip(transform, seq)
+    assert pip_out.corner == pip_in.corner
+    assert pip_out.scale == pytest.approx(pip_in.scale)
+    assert pip_out.margin_pct == pytest.approx(pip_in.margin_pct)
+
+
+# --- from_stage_compositions ----------------------------------------------
+
+
+def test_from_stage_compositions_requires_at_least_one_stage() -> None:
+    with pytest.raises(ValueError, match="at least one stage"):
+        composition.from_stage_compositions([], project_name="match")
+
+
+def test_from_stage_compositions_captures_primary_fields(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "primary.mp4")
+    stage_comp = StageComposition(
+        stage_name="Stage 1",
+        video_path=primary,
+        video=_meta_30fps(),
+        shots=[_shot(1, 0.5, 0.5), _shot(2, 0.7, 0.2)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=1.5,
+        tail_pad_seconds=2.0,
+    )
+    comp = composition.from_stage_compositions([stage_comp], project_name="match")
+    assert comp.project_name == "match"
+    assert comp.sequence.width == 1920
+    assert comp.sequence.height == 1080
+    assert len(comp.stages) == 1
+    stage = comp.stages[0]
+    assert stage.name == "Stage 1"
+    assert stage.primary.path == primary
+    assert stage.primary.metadata == _meta_30fps()
+    assert stage.beep_offset_seconds == 5.0
+    assert stage.head_pad_seconds == 1.5
+    assert stage.tail_pad_seconds == 2.0
+    assert len(stage.markers) == 2
+    assert stage.markers[0].time_seconds == pytest.approx(5.5)  # beep + 0.5s
+    assert stage.markers[0].shot.shot_number == 1
+    assert stage.secondaries == ()
+    assert stage.overlay is None
+
+
+def test_from_stage_compositions_resolves_pip_against_sequence_dims(tmp_path: Path) -> None:
+    """A secondary's ``PipPlacement`` is high-level (corner / scale / margin);
+    the IR stores absolute pixel coordinates so renderers don't each have
+    to redo the math."""
+    primary = _make_video(tmp_path, "primary.mp4")
+    secondary = _make_video(tmp_path, "secondary.mp4")
+    stage_comp = StageComposition(
+        stage_name="s1",
+        video_path=primary,
+        video=_meta_30fps(),  # 1920x1080
+        shots=[_shot(1, 0.5, 0.5)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=5.0,
+        tail_pad_seconds=5.0,
+        secondaries=(
+            SecondaryClip(
+                video_path=secondary,
+                video=_meta_30fps(),
+                beep_offset_seconds=5.0,
+                label="Cam",
+                pip=PipPlacement(corner="top-right"),
+            ),
+        ),
+    )
+    comp = composition.from_stage_compositions([stage_comp], project_name="match")
+    sec = comp.stages[0].secondaries[0]
+    assert sec.transform is not None
+    # 1920x1080 sequence, scale=0.25, margin_pct=2.0:
+    # half_w=960, clip_half_w=240, margin_x=38.4 -> x = 960 - 240 - 38.4 = 681.6
+    # half_h=540, clip_half_h=135, margin_y=21.6 -> y = 540 - 135 - 21.6 = 383.4
+    assert sec.transform.scale == pytest.approx(0.25)
+    assert sec.transform.position[0] == pytest.approx(681.6)
+    assert sec.transform.position[1] == pytest.approx(383.4)
+    assert sec.beep_offset_seconds == 5.0
+    assert sec.role == "cam"
+
+
+def test_from_stage_compositions_captures_overlay(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "primary.mp4")
+    overlay = _make_video(tmp_path, "overlay.mov")
+    stage_comp = StageComposition(
+        stage_name="s1",
+        video_path=primary,
+        video=_meta_30fps(),
+        shots=[_shot(1, 0.5, 0.5)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=5.0,
+        tail_pad_seconds=5.0,
+        overlay_path=overlay,
+        overlay_video=_meta_2997(),  # different geometry from primary
+    )
+    comp = composition.from_stage_compositions([stage_comp], project_name="match")
+    ov = comp.stages[0].overlay
+    assert ov is not None
+    assert ov.role == "overlay"
+    assert ov.asset.path == overlay
+    assert ov.asset.metadata == _meta_2997()
+    assert ov.beep_offset_seconds is None
+    assert ov.transform is None
+
+
+# --- render_fcpxml byte-equivalence ---------------------------------------
+
+
+def _read(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def test_render_fcpxml_single_stage_matches_generate_fcpxml(tmp_path: Path) -> None:
+    """A single-stage composition with no intro/outro must emit the same
+    bytes as the legacy ``generate_fcpxml`` for an equivalent input."""
+    video = _make_video(tmp_path, "v.mp4")
+    legacy_out = tmp_path / "legacy.fcpxml"
+    ir_out = tmp_path / "ir.fcpxml"
+
+    shots = [_shot(1, 1.42, 1.42), _shot(2, 1.63, 0.21)]
+    generate_fcpxml(
+        video_path=video,
+        video=_meta_30fps(),
+        shots=shots,
+        beep_offset_seconds=5.0,
+        output_path=legacy_out,
+        project_name="v",
+        config=OutputConfig(),
+    )
+
+    stage_comp = StageComposition(
+        stage_name="v",  # bridge uses project_name as the asset-clip name
+        video_path=video,
+        video=_meta_30fps(),
+        shots=shots,
+        beep_offset_seconds=5.0,
+        head_pad_seconds=999.0,  # large pads -> no shrink applied at IR layer
+        tail_pad_seconds=999.0,
+    )
+    comp = composition.from_stage_compositions([stage_comp], project_name="v")
+    composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
+
+    # Single-stage path uses generate_fcpxml directly so the bytes match.
+    assert _read(legacy_out) == _read(ir_out)
+
+
+def test_render_fcpxml_match_path_matches_generate_match_fcpxml(tmp_path: Path) -> None:
+    """Multi-stage composition emits via ``generate_match_fcpxml`` -- the
+    bridge must produce identical bytes."""
+    primary_a = _make_video(tmp_path, "stage_a.mp4")
+    primary_b = _make_video(tmp_path, "stage_b.mp4")
+    legacy_out = tmp_path / "legacy.fcpxml"
+    ir_out = tmp_path / "ir.fcpxml"
+
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0), _shot(2, 1.3, 0.3)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=2.0,
+            tail_pad_seconds=2.0,
+        ),
+        StageComposition(
+            stage_name="B",
+            video_path=primary_b,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=2.0,
+            tail_pad_seconds=2.0,
+        ),
+    ]
+    generate_match_fcpxml(
+        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
+    )
+
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
+
+    assert _read(legacy_out) == _read(ir_out)
+
+
+def test_render_fcpxml_match_with_pip_secondaries_matches(tmp_path: Path) -> None:
+    """Round-trip with PiP secondaries: IR -> StageComposition recovers the
+    same ``PipPlacement`` and emits identical bytes."""
+    primary_a = _make_video(tmp_path, "stage_a.mp4")
+    secondary_a = _make_video(tmp_path, "cam_a.mp4")
+    primary_b = _make_video(tmp_path, "stage_b.mp4")
+    secondary_b = _make_video(tmp_path, "cam_b.mp4")
+    legacy_out = tmp_path / "legacy.fcpxml"
+    ir_out = tmp_path / "ir.fcpxml"
+
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary_a,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam A",
+                    pip=PipPlacement(corner="top-right"),
+                ),
+            ),
+        ),
+        StageComposition(
+            stage_name="B",
+            video_path=primary_b,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary_b,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam B",
+                    pip=PipPlacement(corner="bottom-left", scale=0.3, margin_pct=2.0),
+                ),
+            ),
+        ),
+    ]
+    generate_match_fcpxml(
+        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
+    )
+
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
+
+    assert _read(legacy_out) == _read(ir_out)
+
+
+def test_render_fcpxml_match_with_overlay_matches(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "stage.mp4")
+    overlay = _make_video(tmp_path, "overlay.mov")
+    legacy_out = tmp_path / "legacy.fcpxml"
+    ir_out = tmp_path / "ir.fcpxml"
+
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            overlay_path=overlay,
+            overlay_video=_meta_30fps(),
+        ),
+        StageComposition(
+            stage_name="B",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+    generate_match_fcpxml(
+        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
+    )
+
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
+
+    assert _read(legacy_out) == _read(ir_out)
+
+
+def test_to_stage_compositions_recovers_secondaries_without_pip(tmp_path: Path) -> None:
+    """A cam without a transform on the IR side lowers back to a
+    SecondaryClip with ``pip=None`` -- preserving the "stacked" layout."""
+    primary = _make_video(tmp_path, "primary.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="s1",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam",
+                ),
+            ),
+        )
+    ]
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    lowered = composition.to_stage_compositions(comp)
+    assert len(lowered) == 1
+    sec = lowered[0].secondaries[0]
+    assert sec.pip is None


### PR DESCRIPTION
Closes #194. Stacks on #199 (PiP) -- the IR references \`PipPlacement\`. Re-target to \`main\` after #199 merges.

## Summary

- New \`splitsmith.composition\` module with a renderer-agnostic timeline IR (\`Composition\`, \`SequenceFormat\`, \`Stage\`, \`ConnectedClip\`, \`Transform\`, \`Marker\`) plus placeholder nodes for \`Transition\` (#195), \`TitleCard\` (#196), \`Segment\` (#173).
- \`from_stage_compositions\` builds the IR from today's \`StageComposition\` inputs. PiP corner/scale/margin gets resolved into absolute pixel coordinates so renderers don't each redo the math.
- \`render_fcpxml\` is a thin bridge: lowers the IR back to \`generate_match_fcpxml\` / \`generate_fcpxml\` so output stays byte-identical to the pre-IR emitter.
- Match-export hot path now goes through the bridge.
- \`PipPlacement.resolve()\` is the new single source of truth for pixel-space PiP coordinates -- the IR's \`Transform\` and the FCPXML emitter's attribute strings both consume it.

## Why this shape

The IR is opinionated about *what* the user wants (primary, secondaries, overlay, transitions, titles); it does not know about FCPXML-specific plumbing (resource ids, lane numbers, attribute order). Renderers own those choices. This is the foundation for #195 (transitions), #196 (titles), #197 (FCP7 XML), #198 (templates), #174 (ffmpeg).

## Why a bridge instead of a direct emitter rewrite

Rewriting \`generate_match_fcpxml\` (931 LOC, the most-tested module) onto the IR in one PR is a high-risk way to introduce byte-identical output. The bridge gets the IR onto the hot path now and lets future PRs migrate emission piece by piece, each gated by snapshot tests against today's bytes.

## Test plan

- [x] 18 new IR tests (\`tests/test_composition.py\`): IR shape, PiP round-trip, byte-equivalence on single-stage / multi-stage / multi-stage with PiP / multi-stage with overlay
- [x] Full Python suite: 774 passed, 1 skipped (integration probe)
- [x] \`ruff\` / \`black\` clean
- [ ] Manual: run a real match export through the UI, confirm the file is byte-identical to a previous export of the same stages

## Out of scope (follow-ups)

- Direct emission off the IR (transitions / titles / new renderers will progressively replace the bridge).
- ffmpeg / FCP7 XML renderers (#174, #197).
- Templates (#198).
- Per-stage frame-rate / resolution mismatches in stitched timelines (existing constraint, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)