### PR TITLE
FCP7 XML renderer for Premiere / DaVinci import (#197)

### DIFF
--- a/src/splitsmith/fcp7xml_render.py
+++ b/src/splitsmith/fcp7xml_render.py
@@ -1,0 +1,571 @@
+"""FCP7 XML (xmeml) renderer for the Composition IR (issue #197).
+
+Walks ``composition.Composition`` and emits a Final Cut Pro 7-style
+``.xml`` file. Premiere Pro and DaVinci Resolve both import this format
+via ``File > Import``; one renderer covers most of the non-FCP NLE world
+without reverse-engineering binary project files.
+
+Coverage in this PR:
+
+- Primary clip per stage on V1, in/out trimmed to the head/tail pads.
+- Secondary cams as connected clips on V2..VN, time-aligned to the
+  primary's beep frame using the same head-slip math as
+  ``fcpxml_gen.generate_match_fcpxml``.
+- PiP via the FCP7 "Basic Motion" filter (Scale + Center). The IR's
+  ``Transform`` is in pixel-space with +Y up; FCP7 uses normalized units
+  with +Y down, so we convert.
+- Alpha overlay on the topmost track, full-frame.
+- Per-shot markers under each primary clipitem.
+
+Out of scope (sibling issues): transitions (#195), title cards (#196),
+intro/outro segments (#173), audio mix tweaks. ``Composition.transitions``
+/ ``intro`` / ``outro`` are silently ignored by this renderer for now;
+when those features land they'll add to the emit path here.
+
+Frame rate convention: FCP7 carries an integer ``timebase`` plus a
+boolean ``ntsc`` flag. Fractional NTSC rates (29.97 / 59.94 / 23.976)
+map to ``timebase`` rounded up plus ``ntsc=TRUE``; whole-number rates
+map to ``timebase`` plus ``ntsc=FALSE``. Frame counts in the XML are
+non-drop-frame integer frames at the actual rate.
+
+Compatibility caveat: importing into Premiere / DaVinci is the release
+gate -- the unit tests cover structural correctness (timebase, lane
+allocation, marker frame math) but a manual import check is required
+before the format is considered done.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from .composition import (
+    Composition,
+    ConnectedClip,
+    Stage,
+    Transform,
+)
+
+
+def render_fcp7xml(
+    composition: Composition,
+    *,
+    output_path: Path,
+) -> None:
+    """Render ``composition`` as FCP7 XML at ``output_path``.
+
+    The renderer is self-contained: it doesn't shell out, doesn't probe
+    media, and produces a single ``.xml`` file the user can drop into
+    Premiere or DaVinci. ``output_path`` is overwritten in place.
+    """
+    seq = composition.sequence
+    timebase, ntsc = _fcp7_rate(seq.frame_rate_num, seq.frame_rate_den)
+
+    plans = [
+        _plan_stage(stage, seq.frame_rate_num, seq.frame_rate_den) for stage in composition.stages
+    ]
+    total_frames = sum(p.effective_duration_frames for p in plans)
+    max_secondaries = max((len(stage.secondaries) for stage in composition.stages), default=0)
+    has_overlay = any(stage.overlay is not None for stage in composition.stages)
+
+    xmeml = ET.Element("xmeml", {"version": "5"})
+    project = ET.SubElement(xmeml, "project")
+    _text(project, "name", composition.project_name)
+    children = ET.SubElement(project, "children")
+
+    sequence = ET.SubElement(children, "sequence", {"id": "sequence-1"})
+    _text(sequence, "name", composition.project_name)
+    _text(sequence, "duration", str(total_frames))
+    _emit_rate(sequence, timebase, ntsc)
+
+    media = ET.SubElement(sequence, "media")
+    video = ET.SubElement(media, "video")
+    _emit_video_format(video, seq.width, seq.height, timebase, ntsc)
+
+    file_ids: dict[Path, str] = {}
+
+    # V1: primaries.
+    track_v1 = ET.SubElement(video, "track")
+    _emit_track_flags(track_v1)
+    cumulative = 0
+    for plan in plans:
+        _emit_primary_clipitem(
+            track_v1,
+            plan=plan,
+            spine_offset_frames=cumulative,
+            file_ids=file_ids,
+            timebase=timebase,
+            ntsc=ntsc,
+            sequence_width=seq.width,
+            sequence_height=seq.height,
+        )
+        cumulative += plan.effective_duration_frames
+
+    # V2..VN: secondary cams. One track per cam-index across stages so a
+    # stage with N cams uses tracks V2..V(N+1). Stages with fewer cams
+    # leave gaps on the higher tracks; FCP7 readers handle gaps natively.
+    for cam_index in range(max_secondaries):
+        track = ET.SubElement(video, "track")
+        _emit_track_flags(track)
+        cumulative = 0
+        for plan in plans:
+            stage = plan.stage
+            if cam_index < len(stage.secondaries):
+                sec = stage.secondaries[cam_index]
+                _emit_secondary_clipitem(
+                    track,
+                    stage=stage,
+                    secondary=sec,
+                    plan=plan,
+                    spine_offset_frames=cumulative,
+                    file_ids=file_ids,
+                    timebase=timebase,
+                    ntsc=ntsc,
+                    sequence_width=seq.width,
+                    sequence_height=seq.height,
+                )
+            cumulative += plan.effective_duration_frames
+
+    # Overlay on the topmost track, full-frame, head-aligned to each
+    # stage's visible head (no transform). Skipped entirely when no stage
+    # carries an overlay.
+    if has_overlay:
+        track = ET.SubElement(video, "track")
+        _emit_track_flags(track)
+        cumulative = 0
+        for plan in plans:
+            if plan.stage.overlay is not None:
+                _emit_overlay_clipitem(
+                    track,
+                    overlay=plan.stage.overlay,
+                    plan=plan,
+                    spine_offset_frames=cumulative,
+                    file_ids=file_ids,
+                    timebase=timebase,
+                    ntsc=ntsc,
+                )
+            cumulative += plan.effective_duration_frames
+
+    ET.indent(xmeml, space="    ")
+    tree_bytes = ET.tostring(xmeml, encoding="utf-8", xml_declaration=True)
+    decl_end = tree_bytes.index(b"?>") + 2
+    output_path.write_bytes(
+        tree_bytes[:decl_end] + b"\n<!DOCTYPE xmeml>\n" + tree_bytes[decl_end + 1 :]
+    )
+
+
+# --- planning -------------------------------------------------------------
+
+
+class _StagePlan:
+    """Per-stage timing plan in frames (mirrors ``fcpxml_gen``'s math).
+
+    ``primary_duration_frames`` is the source clip length in frames,
+    ``head_trim_frames`` is how many frames to skip from the head, and
+    ``effective_duration_frames`` is what lands on the spine. We
+    duplicate the math here rather than importing the FCPXML emitter's
+    private helpers; the IR is the layer they're meant to share, not
+    each other's internals.
+    """
+
+    __slots__ = (
+        "stage",
+        "primary_duration_frames",
+        "head_trim_frames",
+        "head_trim_seconds",
+        "effective_duration_frames",
+        "fps",
+    )
+
+    def __init__(
+        self,
+        *,
+        stage: Stage,
+        primary_duration_frames: int,
+        head_trim_frames: int,
+        head_trim_seconds: float,
+        effective_duration_frames: int,
+        fps: float,
+    ) -> None:
+        self.stage = stage
+        self.primary_duration_frames = primary_duration_frames
+        self.head_trim_frames = head_trim_frames
+        self.head_trim_seconds = head_trim_seconds
+        self.effective_duration_frames = effective_duration_frames
+        self.fps = fps
+
+
+def _plan_stage(stage: Stage, frame_rate_num: int, frame_rate_den: int) -> _StagePlan:
+    fps = frame_rate_num / frame_rate_den
+    fd_seconds = frame_rate_den / frame_rate_num
+    primary_duration_frames = round(stage.primary.metadata.duration_seconds / fd_seconds)
+
+    head_avail = max(0.0, stage.beep_offset_seconds)
+    if stage.markers:
+        # IR's marker.time_seconds is clip-local source time; the last
+        # shot's local time = beep + max(time_from_beep). Since markers
+        # carry the raw Shot we just use marker.time_seconds.
+        last_local = max(m.time_seconds for m in stage.markers)
+    else:
+        last_local = stage.beep_offset_seconds
+    tail_avail = max(0.0, stage.primary.metadata.duration_seconds - last_local)
+
+    head_trim_seconds = max(0.0, head_avail - stage.head_pad_seconds)
+    tail_trim_seconds = max(0.0, tail_avail - stage.tail_pad_seconds)
+    head_trim_frames = round(head_trim_seconds / fd_seconds)
+    tail_trim_frames = round(tail_trim_seconds / fd_seconds)
+    effective = primary_duration_frames - head_trim_frames - tail_trim_frames
+    if effective <= 0:
+        raise ValueError(
+            f"stage {stage.name!r} would have non-positive effective duration "
+            f"after trim ({effective} frames); reduce head/tail pad or check "
+            "the trimmed clip length"
+        )
+    return _StagePlan(
+        stage=stage,
+        primary_duration_frames=primary_duration_frames,
+        head_trim_frames=head_trim_frames,
+        head_trim_seconds=head_trim_seconds,
+        effective_duration_frames=effective,
+        fps=fps,
+    )
+
+
+# --- emit helpers ---------------------------------------------------------
+
+
+def _text(parent: ET.Element, tag: str, value: str) -> ET.Element:
+    el = ET.SubElement(parent, tag)
+    el.text = value
+    return el
+
+
+def _bool(parent: ET.Element, tag: str, value: bool) -> ET.Element:
+    return _text(parent, tag, "TRUE" if value else "FALSE")
+
+
+def _emit_rate(parent: ET.Element, timebase: int, ntsc: bool) -> None:
+    rate = ET.SubElement(parent, "rate")
+    _text(rate, "timebase", str(timebase))
+    _bool(rate, "ntsc", ntsc)
+
+
+def _emit_track_flags(track: ET.Element) -> None:
+    """Default per-track flags Premiere expects; absent flags surface as
+    "track disabled" warnings on import."""
+    _bool(track, "enabled", True)
+    _bool(track, "locked", False)
+
+
+def _emit_video_format(
+    video: ET.Element,
+    width: int,
+    height: int,
+    timebase: int,
+    ntsc: bool,
+) -> None:
+    fmt = ET.SubElement(video, "format")
+    sample = ET.SubElement(fmt, "samplecharacteristics")
+    _text(sample, "width", str(width))
+    _text(sample, "height", str(height))
+    _text(sample, "pixelaspectratio", "square")
+    _text(sample, "fielddominance", "none")
+    _emit_rate(sample, timebase, ntsc)
+
+
+def _file_id_for(path: Path, file_ids: dict[Path, str]) -> tuple[str, bool]:
+    """Allocate (or look up) a stable file id for ``path``.
+
+    Returns ``(id, is_first_use)``. First use emits the full ``<file>``
+    body; subsequent uses emit just ``<file id="..."/>`` so the file's
+    metadata isn't repeated.
+    """
+    resolved = path.resolve()
+    if resolved in file_ids:
+        return file_ids[resolved], False
+    file_id = f"file-{len(file_ids) + 1}"
+    file_ids[resolved] = file_id
+    return file_id, True
+
+
+def _emit_file(
+    parent: ET.Element,
+    *,
+    path: Path,
+    duration_frames: int,
+    width: int,
+    height: int,
+    timebase: int,
+    ntsc: bool,
+    file_ids: dict[Path, str],
+    has_audio: bool,
+) -> None:
+    file_id, first_use = _file_id_for(path, file_ids)
+    if not first_use:
+        ET.SubElement(parent, "file", {"id": file_id})
+        return
+    file_el = ET.SubElement(parent, "file", {"id": file_id})
+    _text(file_el, "name", path.name)
+    _text(file_el, "pathurl", path.resolve().as_uri())
+    _emit_rate(file_el, timebase, ntsc)
+    _text(file_el, "duration", str(duration_frames))
+    media = ET.SubElement(file_el, "media")
+    video = ET.SubElement(media, "video")
+    sample = ET.SubElement(video, "samplecharacteristics")
+    _text(sample, "width", str(width))
+    _text(sample, "height", str(height))
+    if has_audio:
+        audio = ET.SubElement(media, "audio")
+        _text(audio, "channelcount", "2")
+
+
+def _emit_primary_clipitem(
+    track: ET.Element,
+    *,
+    plan: _StagePlan,
+    spine_offset_frames: int,
+    file_ids: dict[Path, str],
+    timebase: int,
+    ntsc: bool,
+    sequence_width: int,
+    sequence_height: int,
+) -> None:
+    stage = plan.stage
+    clip = ET.SubElement(
+        track,
+        "clipitem",
+        {"id": f"clipitem-primary-{_safe_id(stage.name)}-{spine_offset_frames}"},
+    )
+    _text(clip, "name", stage.name)
+    _text(clip, "duration", str(plan.primary_duration_frames))
+    _emit_rate(clip, timebase, ntsc)
+    _text(clip, "start", str(spine_offset_frames))
+    _text(clip, "end", str(spine_offset_frames + plan.effective_duration_frames))
+    _text(clip, "in", str(plan.head_trim_frames))
+    _text(clip, "out", str(plan.head_trim_frames + plan.effective_duration_frames))
+    _emit_file(
+        clip,
+        path=stage.primary.path,
+        duration_frames=plan.primary_duration_frames,
+        width=stage.primary.metadata.width,
+        height=stage.primary.metadata.height,
+        timebase=timebase,
+        ntsc=ntsc,
+        file_ids=file_ids,
+        has_audio=True,
+    )
+    fd_seconds = stage.primary.metadata.frame_rate_den / stage.primary.metadata.frame_rate_num
+    for marker in stage.markers:
+        # The IR stores marker.time_seconds in clip-local source time;
+        # FCP7 markers ride inside the clipitem and use source-frame
+        # coordinates (same as our ``in`` value), so no spine math here.
+        frame = round(marker.time_seconds / fd_seconds)
+        if (
+            frame < plan.head_trim_frames
+            or frame >= plan.head_trim_frames + plan.effective_duration_frames
+        ):
+            continue
+        _emit_marker(clip, frame=frame, label=_marker_label(marker))
+
+
+def _emit_secondary_clipitem(
+    track: ET.Element,
+    *,
+    stage: Stage,
+    secondary: ConnectedClip,
+    plan: _StagePlan,
+    spine_offset_frames: int,
+    file_ids: dict[Path, str],
+    timebase: int,
+    ntsc: bool,
+    sequence_width: int,
+    sequence_height: int,
+) -> None:
+    """Emit one cam clipitem aligned so its beep matches the primary's
+    visible-head beep frame. Mirrors the head-slip math from the FCPXML
+    emitter (``fcpxml_gen.generate_match_fcpxml``)."""
+    fd_seconds = stage.primary.metadata.frame_rate_den / stage.primary.metadata.frame_rate_num
+    sec_meta = secondary.asset.metadata
+    sec_duration_frames = round(sec_meta.duration_seconds / fd_seconds)
+    assert secondary.beep_offset_seconds is not None  # cam role guarantees this
+    delta_frames = round(
+        ((stage.beep_offset_seconds - plan.head_trim_seconds) - secondary.beep_offset_seconds)
+        / fd_seconds
+    )
+    if delta_frames >= 0:
+        cam_spine_offset = spine_offset_frames + delta_frames
+        cam_in = 0
+    else:
+        cam_spine_offset = spine_offset_frames
+        cam_in = -delta_frames
+    cam_visible_frames = sec_duration_frames - cam_in
+    cam_end = cam_spine_offset + cam_visible_frames
+
+    clip = ET.SubElement(
+        track,
+        "clipitem",
+        {"id": f"clipitem-cam-{_safe_id(secondary.label)}-{cam_spine_offset}"},
+    )
+    _text(clip, "name", secondary.label)
+    _text(clip, "duration", str(sec_duration_frames))
+    _emit_rate(clip, timebase, ntsc)
+    _text(clip, "start", str(cam_spine_offset))
+    _text(clip, "end", str(cam_end))
+    _text(clip, "in", str(cam_in))
+    _text(clip, "out", str(sec_duration_frames))
+    _emit_file(
+        clip,
+        path=secondary.asset.path,
+        duration_frames=sec_duration_frames,
+        width=sec_meta.width,
+        height=sec_meta.height,
+        timebase=timebase,
+        ntsc=ntsc,
+        file_ids=file_ids,
+        has_audio=True,
+    )
+    if secondary.transform is not None:
+        _emit_basic_motion_filter(
+            clip,
+            transform=secondary.transform,
+            sequence_width=sequence_width,
+            sequence_height=sequence_height,
+        )
+
+
+def _emit_overlay_clipitem(
+    track: ET.Element,
+    *,
+    overlay: ConnectedClip,
+    plan: _StagePlan,
+    spine_offset_frames: int,
+    file_ids: dict[Path, str],
+    timebase: int,
+    ntsc: bool,
+) -> None:
+    """Emit the alpha overlay clipitem. The overlay was rendered to mirror
+    the primary frame-for-frame so we trim it the same way: ``in`` skips
+    by the primary's head_trim, ``out`` runs for ``effective_duration``."""
+    fd_seconds = overlay.asset.metadata.frame_rate_den / overlay.asset.metadata.frame_rate_num
+    overlay_duration_frames = round(overlay.asset.metadata.duration_seconds / fd_seconds)
+    clip = ET.SubElement(
+        track,
+        "clipitem",
+        {"id": f"clipitem-overlay-{spine_offset_frames}"},
+    )
+    _text(clip, "name", overlay.label)
+    _text(clip, "duration", str(overlay_duration_frames))
+    _emit_rate(clip, timebase, ntsc)
+    _text(clip, "start", str(spine_offset_frames))
+    _text(clip, "end", str(spine_offset_frames + plan.effective_duration_frames))
+    _text(clip, "in", str(plan.head_trim_frames))
+    _text(clip, "out", str(plan.head_trim_frames + plan.effective_duration_frames))
+    _emit_file(
+        clip,
+        path=overlay.asset.path,
+        duration_frames=overlay_duration_frames,
+        width=overlay.asset.metadata.width,
+        height=overlay.asset.metadata.height,
+        timebase=timebase,
+        ntsc=ntsc,
+        file_ids=file_ids,
+        has_audio=False,
+    )
+
+
+def _emit_marker(parent: ET.Element, *, frame: int, label: str) -> None:
+    marker = ET.SubElement(parent, "marker")
+    _text(marker, "name", label)
+    _text(marker, "in", str(frame))
+    # FCP itself emits 1-frame ranges for point markers; Premiere reads
+    # both ``out=in+1`` and ``out=-1``, but the +1 form survives a
+    # round-trip through DaVinci more reliably.
+    _text(marker, "out", str(frame + 1))
+
+
+def _emit_basic_motion_filter(
+    parent: ET.Element,
+    *,
+    transform: Transform,
+    sequence_width: int,
+    sequence_height: int,
+) -> None:
+    """Emit a Basic Motion filter that scales + positions the clip.
+
+    FCP7 Basic Motion uses normalised coordinates: (0, 0) is sequence
+    centre, +1.0 horiz means the clip centre sits at the right edge,
+    +1.0 vert means the BOTTOM edge (FCP7 Y axis flips relative to
+    FCPXML's). Scale is in percent (25 = 25% of native).
+    """
+    horiz = transform.position[0] / (sequence_width / 2.0)
+    vert = -transform.position[1] / (sequence_height / 2.0)
+
+    filt = ET.SubElement(parent, "filter")
+    effect = ET.SubElement(filt, "effect")
+    _text(effect, "name", "Basic Motion")
+    _text(effect, "effectid", "basic")
+    _text(effect, "effectcategory", "motion")
+    _text(effect, "effecttype", "motion")
+    _text(effect, "mediatype", "video")
+    # Scale parameter (percent).
+    scale_param = ET.SubElement(effect, "parameter")
+    _text(scale_param, "name", "Scale")
+    _text(scale_param, "parameterid", "scale")
+    _text(scale_param, "value", f"{transform.scale * 100:g}")
+    _text(scale_param, "valuemin", "0")
+    _text(scale_param, "valuemax", "1000")
+    # Center parameter (normalised horiz/vert).
+    center_param = ET.SubElement(effect, "parameter")
+    _text(center_param, "name", "Center")
+    _text(center_param, "parameterid", "center")
+    value = ET.SubElement(center_param, "value")
+    _text(value, "horiz", f"{horiz:g}")
+    _text(value, "vert", f"{vert:g}")
+
+
+def _marker_label(marker: object) -> str:
+    """Best-effort marker label.
+
+    The IR's ``Marker.shot`` carries the underlying ``Shot``; we don't
+    re-import the FCPXML emitter's split-colour banding here -- a
+    minimal "Shot N / split" label is enough for FCP7 import. The
+    FCPXML renderer does the richer banding because FCP-the-editor
+    reads it; Premiere/DaVinci show plain text.
+    """
+    shot = getattr(marker, "shot", None)
+    if shot is None:
+        return "Marker"
+    n = getattr(shot, "shot_number", "?")
+    split = getattr(shot, "split", None)
+    if split is None:
+        return f"Shot {n}"
+    return f"Shot {n} / {split:.2f}s"
+
+
+def _safe_id(label: str) -> str:
+    """xmeml ``id`` attributes are CDATA but most importers expect them
+    to be word-shaped. Strip whitespace / punctuation to keep ids stable
+    and importer-friendly."""
+    return "".join(c if c.isalnum() else "-" for c in label).strip("-") or "x"
+
+
+# --- frame rate -----------------------------------------------------------
+
+
+def _fcp7_rate(frame_rate_num: int, frame_rate_den: int) -> tuple[int, bool]:
+    """Convert ``num/den`` to FCP7's ``(timebase, ntsc)`` pair.
+
+    NTSC fractional rates (29.97 / 59.94 / 23.976) carry a rounded
+    timebase plus ``ntsc=TRUE``. Whole-number rates carry an exact
+    timebase plus ``ntsc=FALSE``.
+    """
+    fps = frame_rate_num / frame_rate_den
+    rounded = round(fps)
+    # An exact integer frame rate (30 / 25 / 24) is non-NTSC.
+    if abs(fps - rounded) < 1e-6:
+        return rounded, False
+    # Otherwise it's an NTSC fractional rate (29.97 = 30000/1001 etc.).
+    return rounded, True
+
+
+__all__ = ["render_fcp7xml"]

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -20,11 +20,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from .. import composition, fcpxml_gen
+from .. import composition, fcp7xml_render, fcpxml_gen
 from ..config import OutputConfig
 from .exports import audit_shots_to_engine_shots
 
 PipLayout = Literal["stacked", "pip-corners"]
+# Issue #197. ``"fcpxml"`` writes a Final Cut Pro 1.10 timeline (current
+# default). ``"fcp7xml"`` writes a Final Cut Pro 7-style xmeml file
+# importable into Premiere Pro and DaVinci Resolve.
+OutputFormat = Literal["fcpxml", "fcp7xml"]
 
 
 @dataclass(frozen=True)
@@ -76,6 +80,8 @@ class MatchExportRequestData:
     # ``<adjust-transform>`` to each secondary so they land in rotating
     # corners (TR -> TL -> BR -> BL) at 25% scale with a 2% inset.
     pip_layout: PipLayout = "stacked"
+    # Issue #197. Renderer chosen for this export.
+    output_format: OutputFormat = "fcpxml"
 
 
 @dataclass(frozen=True)
@@ -213,14 +219,18 @@ def export_match(
         )
 
     exports_dir.mkdir(parents=True, exist_ok=True)
-    output_path = exports_dir / f"{_slugify(request.project_name)}-match.fcpxml"
+    extension = ".fcpxml" if request.output_format == "fcpxml" else ".xml"
+    output_path = exports_dir / f"{_slugify(request.project_name)}-match{extension}"
     # Match export goes through the composition IR (issue #194). The bridge
-    # renderer lowers back to ``generate_match_fcpxml`` so the output stays
-    # byte-identical to the pre-IR path; future renderer work (transitions,
-    # titles, FCP7 XML, ffmpeg) replaces the bridge piece by piece.
+    # renderer lowers back to ``generate_match_fcpxml`` for the FCPXML path
+    # so output stays byte-identical to the pre-IR emitter; the FCP7 XML
+    # path (issue #197) walks the IR directly via ``fcp7xml_render``.
     comp = composition.from_stage_compositions(compositions, project_name=request.project_name)
     try:
-        composition.render_fcpxml(comp, output_path=output_path, config=config)
+        if request.output_format == "fcpxml":
+            composition.render_fcpxml(comp, output_path=output_path, config=config)
+        else:
+            fcp7xml_render.render_fcp7xml(comp, output_path=output_path)
     except (ValueError, FileNotFoundError) as exc:
         raise MatchExportError(str(exc)) from exc
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -943,6 +943,10 @@ class MatchExportRequest(BaseModel):
     # behaviour). ``"pip-corners"`` adds an ``<adjust-transform>`` to each
     # secondary, rotating through TR -> TL -> BR -> BL at 25% scale.
     pip_layout: Literal["stacked", "pip-corners"] = "stacked"
+    # Issue #197. ``"fcpxml"`` writes Final Cut Pro 1.10 (the default).
+    # ``"fcp7xml"`` writes a Final Cut Pro 7-style xmeml ``.xml``
+    # importable into Premiere Pro and DaVinci Resolve.
+    output_format: Literal["fcpxml", "fcp7xml"] = "fcpxml"
 
 
 class RevealRequest(BaseModel):
@@ -4591,6 +4595,7 @@ def create_app(
             include_overlay=req.include_overlay,
             project_name=project_name,
             pip_layout=req.pip_layout,
+            output_format=req.output_format,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -497,6 +497,10 @@ export interface MatchExportRequestPayload {
    *  ``"pip-corners"`` adds an FCPXML adjust-transform so each cam lands
    *  in a rotating corner (TR -> TL -> BR -> BL) at 25% scale. */
   pip_layout?: "stacked" | "pip-corners";
+  /** Issue #197. ``"fcpxml"`` writes Final Cut Pro 1.10 (default).
+   *  ``"fcp7xml"`` writes a Final Cut Pro 7-style ``.xml`` importable
+   *  into Premiere Pro and DaVinci Resolve. */
+  output_format?: "fcpxml" | "fcp7xml";
 }
 
 export interface MatchExportResult {

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1205,6 +1205,14 @@ function MatchExportDialog({
   const [pipLayout, setPipLayout] = useState<"stacked" | "pip-corners">(
     "stacked",
   );
+  // Issue #197. ``fcpxml`` is Final Cut Pro 1.10 (the editor splitsmith was
+  // built around). ``fcp7xml`` is the legacy xmeml format Premiere Pro and
+  // DaVinci Resolve import; coverage matches the FCPXML renderer for
+  // primary / secondaries / PiP / overlay / markers, with transitions and
+  // titles deferred per #195 / #196.
+  const [outputFormat, setOutputFormat] = useState<"fcpxml" | "fcp7xml">(
+    "fcpxml",
+  );
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1256,6 +1264,7 @@ function MatchExportDialog({
         tail_pad_seconds: tailPad,
         include_secondaries: includeSecondaries,
         pip_layout: pipLayout,
+        output_format: outputFormat,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1471,6 +1480,25 @@ function MatchExportDialog({
                   onChange={(e) => setIncludeOverlay(e.target.checked)}
                 />
                 Include overlay (when present)
+              </label>
+              <label
+                className="flex items-center gap-1.5"
+                title="FCPXML: Final Cut Pro 1.10 (default). FCP7 XML: legacy xmeml file importable into Premiere Pro and DaVinci Resolve."
+              >
+                Format
+                <select
+                  className="rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                  value={outputFormat}
+                  disabled={busy}
+                  onChange={(e) =>
+                    setOutputFormat(
+                      e.target.value as "fcpxml" | "fcp7xml",
+                    )
+                  }
+                >
+                  <option value="fcpxml">FCPXML (Final Cut Pro)</option>
+                  <option value="fcp7xml">FCP7 XML (Premiere / DaVinci)</option>
+                </select>
               </label>
             </div>
             {includeOverlay ? (

--- a/tests/test_fcp7xml_render.py
+++ b/tests/test_fcp7xml_render.py
@@ -1,0 +1,502 @@
+"""Tests for the FCP7 XML renderer (issue #197).
+
+These tests pin the structural shape Premiere / DaVinci expect and the
+frame-math conversions from the IR's float seconds. Manual import in the
+target NLEs is the release gate -- we cover what's mechanically testable
+without an actual NLE in the loop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from splitsmith import composition, fcp7xml_render
+from splitsmith.config import Shot, VideoMetadata
+from splitsmith.fcpxml_gen import (
+    PipPlacement,
+    SecondaryClip,
+    StageComposition,
+)
+
+
+def _shot(n: int, time_from_beep: float, split: float) -> Shot:
+    return Shot(
+        shot_number=n,
+        time_absolute=10.0 + time_from_beep,
+        time_from_beep=time_from_beep,
+        split=split,
+        peak_amplitude=0.5,
+        confidence=0.8,
+    )
+
+
+def _meta_30fps() -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _meta_2997() -> VideoMetadata:
+    return VideoMetadata(
+        width=3840,
+        height=2160,
+        duration_seconds=20.0,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+    )
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def _stage(
+    *,
+    tmp_path: Path,
+    name: str,
+    primary_name: str,
+    meta: VideoMetadata = None,  # type: ignore[assignment]
+    head_pad: float = 5.0,
+    tail_pad: float = 5.0,
+    secondaries: tuple[SecondaryClip, ...] = (),
+    overlay_path: Path | None = None,
+) -> StageComposition:
+    return StageComposition(
+        stage_name=name,
+        video_path=_make_video(tmp_path, primary_name),
+        video=meta if meta is not None else _meta_30fps(),
+        shots=[_shot(1, 1.0, 1.0), _shot(2, 1.3, 0.3)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=head_pad,
+        tail_pad_seconds=tail_pad,
+        secondaries=secondaries,
+        overlay_path=overlay_path,
+        overlay_video=meta if meta is not None else _meta_30fps(),
+    )
+
+
+def _render(stages: list[StageComposition], tmp_path: Path) -> ET.Element:
+    out = tmp_path / "match.xml"
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    fcp7xml_render.render_fcp7xml(comp, output_path=out)
+    raw = out.read_bytes()
+    assert raw.startswith(b"<?xml")
+    assert b"<!DOCTYPE xmeml>" in raw
+    return ET.fromstring(raw)
+
+
+# --- frame rate conversion ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("num", "den", "expected_timebase", "expected_ntsc"),
+    [
+        (30, 1, 30, False),
+        (24, 1, 24, False),
+        (25, 1, 25, False),
+        (60, 1, 60, False),
+        (30000, 1001, 30, True),
+        (60000, 1001, 60, True),
+        (24000, 1001, 24, True),
+    ],
+)
+def test_fcp7_rate_conversion(
+    num: int, den: int, expected_timebase: int, expected_ntsc: bool
+) -> None:
+    timebase, ntsc = fcp7xml_render._fcp7_rate(num, den)
+    assert timebase == expected_timebase
+    assert ntsc is expected_ntsc
+
+
+# --- xmeml shape ----------------------------------------------------------
+
+
+def test_render_emits_xmeml_v5_with_doctype(tmp_path: Path) -> None:
+    stages = [_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")]
+    out = tmp_path / "match.xml"
+    comp = composition.from_stage_compositions(stages, project_name="match")
+    fcp7xml_render.render_fcp7xml(comp, output_path=out)
+    raw = out.read_bytes()
+    assert raw.startswith(b"<?xml")
+    assert b"<!DOCTYPE xmeml>" in raw
+    root = ET.fromstring(raw)
+    assert root.tag == "xmeml"
+    assert root.attrib["version"] == "5"
+
+
+def test_sequence_carries_dims_and_timebase(tmp_path: Path) -> None:
+    stages = [_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", meta=_meta_2997())]
+    root = _render(stages, tmp_path)
+    sample = root.find(".//sequence/media/video/format/samplecharacteristics")
+    assert sample is not None
+    assert sample.findtext("width") == "3840"
+    assert sample.findtext("height") == "2160"
+    assert sample.findtext("rate/timebase") == "30"
+    assert sample.findtext("rate/ntsc") == "TRUE"
+
+
+def test_sequence_duration_sums_effective_stage_lengths(tmp_path: Path) -> None:
+    """Default pads (5/5) on a 20s clip with shots at +1.0/+1.3:
+    head_avail=5, tail_avail=20-(5+1.3)=13.7. head_pad>=head_avail keeps
+    everything (head_trim=0); tail_pad=5 < tail_avail=13.7 trims 8.7s
+    off the tail. Effective per stage = 600 - 0 - 261 = 339 frames; two
+    stages = 678."""
+    stages = [
+        _stage(tmp_path=tmp_path, name="A", primary_name="a.mp4"),
+        _stage(tmp_path=tmp_path, name="B", primary_name="b.mp4"),
+    ]
+    root = _render(stages, tmp_path)
+    assert root.findtext("./project/children/sequence/duration") == "678"
+
+
+# --- track / clipitem layout ---------------------------------------------
+
+
+def test_single_stage_lands_one_clipitem_on_v1(tmp_path: Path) -> None:
+    stages = [_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")]
+    root = _render(stages, tmp_path)
+    tracks = root.findall(".//sequence/media/video/track")
+    assert len(tracks) == 1
+    assert len(tracks[0].findall("clipitem")) == 1
+
+
+def test_multi_stage_lands_back_to_back_on_v1(tmp_path: Path) -> None:
+    stages = [
+        _stage(tmp_path=tmp_path, name="A", primary_name="a.mp4"),
+        _stage(tmp_path=tmp_path, name="B", primary_name="b.mp4"),
+    ]
+    root = _render(stages, tmp_path)
+    v1 = root.find(".//sequence/media/video/track")
+    assert v1 is not None
+    clips = v1.findall("clipitem")
+    assert len(clips) == 2
+    # Each stage's effective window = 339 frames (see duration test); back-
+    # to-back placement -> stage A ends where stage B starts.
+    assert clips[0].findtext("start") == "0"
+    assert clips[0].findtext("end") == "339"
+    assert clips[1].findtext("start") == "339"
+    assert clips[1].findtext("end") == "678"
+
+
+def test_secondary_cam_lands_on_v2_with_alignment(tmp_path: Path) -> None:
+    """Cam beep at clip-local 2.0s, primary beep at 5.0s -> cam needs to
+    sit later on the spine by 3s = 90 frames."""
+    primary = _make_video(tmp_path, "a.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=2.0,
+                    label="Cam",
+                ),
+            ),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    tracks = root.findall(".//sequence/media/video/track")
+    assert len(tracks) == 2  # V1 + V2
+    cam_clip = tracks[1].find("clipitem")
+    assert cam_clip is not None
+    # head_pad=5 >= beep=5 -> head_trim=0, so visible head matches beep_offset=5.
+    # delta = (5 - 0) - 2 = 3s = 90 frames -> cam start = 90, in = 0.
+    assert cam_clip.findtext("start") == "90"
+    assert cam_clip.findtext("in") == "0"
+
+
+def test_overlay_lands_on_topmost_track(tmp_path: Path) -> None:
+    """When secondaries and overlay are present, overlay is on the track
+    above all cams -- highest visual layer."""
+    overlay = _make_video(tmp_path, "overlay.mov")
+    primary = _make_video(tmp_path, "a.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam",
+                ),
+            ),
+            overlay_path=overlay,
+            overlay_video=_meta_30fps(),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    tracks = root.findall(".//sequence/media/video/track")
+    assert len(tracks) == 3  # V1 primary + V2 cam + V3 overlay
+    top = tracks[-1]
+    overlay_clip = top.find("clipitem")
+    assert overlay_clip is not None
+    assert overlay_clip.findtext("name") == "Splitsmith overlay"
+
+
+def test_two_secondaries_use_v2_and_v3(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "a.mp4")
+    cam_a = _make_video(tmp_path, "cam_a.mp4")
+    cam_b = _make_video(tmp_path, "cam_b.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=cam_a,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam A",
+                ),
+                SecondaryClip(
+                    video_path=cam_b,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam B",
+                ),
+            ),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    tracks = root.findall(".//sequence/media/video/track")
+    assert len(tracks) == 3  # V1, V2 (Cam A), V3 (Cam B)
+    assert tracks[1].find("clipitem").findtext("name") == "Cam A"  # type: ignore[union-attr]
+    assert tracks[2].find("clipitem").findtext("name") == "Cam B"  # type: ignore[union-attr]
+
+
+# --- file references ------------------------------------------------------
+
+
+def test_repeated_asset_use_emits_id_only_reference(tmp_path: Path) -> None:
+    """The same primary used across two stages should declare a ``<file>``
+    body once and reference it by id thereafter."""
+    primary = _make_video(tmp_path, "shared.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+        StageComposition(
+            stage_name="B",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+    root = _render(stages, tmp_path)
+    file_decls = [f for f in root.findall(".//file") if f.find("pathurl") is not None]
+    file_refs = [f for f in root.findall(".//file") if f.find("pathurl") is None]
+    assert len(file_decls) == 1
+    assert len(file_refs) == 1
+    assert file_refs[0].attrib["id"] == file_decls[0].attrib["id"]
+
+
+# --- markers --------------------------------------------------------------
+
+
+def test_markers_land_at_clip_local_frames(tmp_path: Path) -> None:
+    """Shot 1 at beep+1.0s on a 5s-beep stage -> 6.0s clip-local = 180
+    frames at 30fps."""
+    stages = [_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")]
+    root = _render(stages, tmp_path)
+    markers = root.findall(".//track[1]/clipitem/marker")
+    assert len(markers) == 2
+    assert markers[0].findtext("in") == "180"
+    assert markers[0].findtext("out") == "181"
+    assert "Shot 1" in markers[0].findtext("name")  # type: ignore[operator]
+
+
+def test_markers_outside_visible_window_are_dropped(tmp_path: Path) -> None:
+    """Tight tail pad (0.0s) collapses tail; a shot at +5.0s lands beyond
+    the visible window and must be skipped."""
+    primary = _make_video(tmp_path, "a.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[
+                _shot(1, 1.0, 1.0),  # 6s clip-local, in window
+                _shot(2, 14.5, 13.5),  # 19.5s clip-local; pad=0 -> visible end ~6s
+            ],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=0.0,
+        )
+    ]
+    root = _render(stages, tmp_path)
+    markers = root.findall(".//clipitem/marker")
+    assert len(markers) == 1
+
+
+# --- PiP via Basic Motion -------------------------------------------------
+
+
+def test_pip_emits_basic_motion_filter(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "a.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam",
+                    pip=PipPlacement(corner="top-right"),
+                ),
+            ),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    cam_clip = root.findall(".//sequence/media/video/track")[1].find("clipitem")
+    assert cam_clip is not None
+    effect = cam_clip.find("filter/effect")
+    assert effect is not None
+    assert effect.findtext("effectid") == "basic"
+    params = {p.findtext("parameterid"): p for p in effect.findall("parameter")}
+    assert params["scale"].findtext("value") == "25"  # 0.25 * 100
+    # 1080p sequence, scale=0.25, margin=2.0%:
+    # IR position = (681.6, 383.4) (FCPXML coords, +Y up)
+    # FCP7 horiz = 681.6 / 960 = 0.71 (rounded)
+    # FCP7 vert = -383.4 / 540 = -0.71 (FCP7 +Y down -> sign flips)
+    horiz = float(params["center"].find("value/horiz").text)  # type: ignore[arg-type, union-attr]
+    vert = float(params["center"].find("value/vert").text)  # type: ignore[arg-type, union-attr]
+    assert horiz == pytest.approx(0.71, abs=0.01)
+    assert vert == pytest.approx(-0.71, abs=0.01)
+
+
+def test_pip_y_axis_flips_for_bottom_corners(tmp_path: Path) -> None:
+    """Sanity: a bottom-* corner on the IR (+Y up means py < 0) maps to
+    FCP7 vert > 0 (since FCP7 +Y is down)."""
+    primary = _make_video(tmp_path, "a.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam",
+                    pip=PipPlacement(corner="bottom-right"),
+                ),
+            ),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    vert = root.find(
+        ".//track[2]/clipitem/filter/effect/parameter[parameterid='center']/value/vert"
+    )
+    assert vert is not None
+    assert float(vert.text) > 0  # type: ignore[arg-type]
+
+
+def test_no_pip_emits_no_filter(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "a.mp4")
+    secondary = _make_video(tmp_path, "cam.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+            secondaries=(
+                SecondaryClip(
+                    video_path=secondary,
+                    video=_meta_30fps(),
+                    beep_offset_seconds=5.0,
+                    label="Cam",
+                ),
+            ),
+        )
+    ]
+    root = _render(stages, tmp_path)
+    cam_clip = root.findall(".//sequence/media/video/track")[1].find("clipitem")
+    assert cam_clip is not None
+    assert cam_clip.find("filter") is None
+
+
+# --- error paths ----------------------------------------------------------
+
+
+def test_negative_effective_duration_raises(tmp_path: Path) -> None:
+    """Same guard as the FCPXML emitter: trims that collapse the visible
+    window to zero raise rather than emitting a malformed timeline."""
+    primary = _make_video(tmp_path, "tiny.mp4")
+    tiny_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=0.001,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    stages = [
+        StageComposition(
+            stage_name="x",
+            video_path=primary,
+            video=tiny_meta,
+            shots=[],
+            beep_offset_seconds=0.0,
+            head_pad_seconds=0.0,
+            tail_pad_seconds=0.0,
+        )
+    ]
+    comp = composition.from_stage_compositions(stages, project_name="m")
+    with pytest.raises(ValueError, match="non-positive effective duration"):
+        fcp7xml_render.render_fcp7xml(comp, output_path=tmp_path / "out.xml")


### PR DESCRIPTION
Closes #197. Stacks on #200 (Composition IR) which stacks on #199 (PiP). Re-target each step as the parent merges.

## Summary

Second renderer that consumes the Composition IR (#194) and emits a Final Cut Pro 7-style xmeml \`.xml\`. Premiere Pro and DaVinci Resolve both import this format -- one renderer covers most of the non-FCP NLE world without touching binary \`.prproj\`.

Coverage matches the FCPXML renderer for the in-scope features:
- Primary clip per stage on V1, in/out trimmed to head/tail pads.
- Secondary cams as connected clipitems on V2..VN, beep-aligned via the same head-slip math as \`generate_match_fcpxml\`.
- PiP via the FCP7 Basic Motion filter (Scale + Center). IR's pixel-space \`Transform\` (+Y up) converts to FCP7 normalised units (+Y down).
- Alpha overlay on the topmost track.
- Per-shot markers under each primary clipitem.

## UI wiring

\`MatchExportRequest.output_format\` (new) picks the renderer. Export dialog gains a "Format" selector: "FCPXML (Final Cut Pro)" vs "FCP7 XML (Premiere / DaVinci)". Default unchanged (FCPXML), so existing flows are byte-identical.

## Out of scope

- Transitions (#195), titles (#196), intro/outro (#173) -- the IR has slots for these but the FCP7 renderer ignores them until they land in the IR-driven emit path.
- Audio mix tweaks beyond pass-through.
- Native Premiere \`.prproj\` (binary, reverse-engineered libs are partial / brittle).

## Frame-rate handling

FCP7 uses an integer \`timebase\` + \`ntsc\` boolean. Mapping table covered by tests:
- 30 / 25 / 24 / 60 -> timebase = N, ntsc = FALSE
- 30000/1001 (29.97), 60000/1001 (59.94), 24000/1001 (23.976) -> rounded timebase, ntsc = TRUE

## Test plan

- [x] 22 new tests in \`tests/test_fcp7xml_render.py\` covering frame-rate conversion, xmeml v5 shape, multi-track lane allocation, file-id reuse across stages, marker frame math, PiP filter emission with Y-axis flip.
- [x] Full Python suite: 796 passed, 1 skipped (integration probe).
- [x] \`tsc -b --noEmit\` clean.
- [x] \`ruff\` / \`black\` clean.
- [ ] **Release gate:** import a 2-stage stitched export with PiP secondary into Premiere Pro -> primary on V1, cam in top-right corner, markers visible, audio synced.
- [ ] **Release gate:** same in DaVinci Resolve.
- [ ] Manual: NTSC fractional source (29.97) imports without timebase warnings in both NLEs.

## Compatibility caveats

xmeml is documented but importer behaviour varies. Known gotchas:
- Premiere reads our \`out=in+1\` markers as point markers; DaVinci does too. If a release-gate import shows ranges instead of points, switch to \`out=-1\` and document.
- Basic Motion is the most cross-compatible transform filter but its \`scale\` and \`center\` semantics differ across versions of Premiere. Tests pin our mapping; manual import will tell us if we drift.
- Whole-number timebase + \`ntsc=TRUE\` is the standard FCP7 convention even though it's mathematically odd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)