### PR TITLE
ffmpeg MP4 renderer (#174)

### DIFF
--- a/src/splitsmith/mp4_render.py
+++ b/src/splitsmith/mp4_render.py
@@ -1,0 +1,416 @@
+"""MP4 renderer for the Composition IR via ffmpeg (issue #174).
+
+Walks ``composition.Composition`` and produces a stitched MP4 by:
+
+1. Building one ffmpeg invocation per stage that re-encodes the primary
+   with PiP secondaries and the alpha overlay composited in. Each stage
+   writes to a temp ``.mp4`` in the work directory.
+2. Concatenating the per-stage temps via the ``concat`` demuxer with
+   ``-c copy`` so the final stitch doesn't re-encode.
+
+Coverage in this PR matches the FCPXML / FCP7 renderers for the
+in-scope features:
+
+- Primary clip per stage on the base layer.
+- Secondary cams composited with optional PiP transform (scale +
+  position). The IR's pixel-space ``Transform`` (+Y up, sequence-centre
+  origin) converts to ffmpeg's ``overlay`` filter convention (+Y down,
+  top-left origin).
+- Alpha overlay composited on the topmost layer.
+- Per-stage trim via ``-ss`` / ``-t`` on the input.
+
+Out of scope for this PR (sibling issues): transitions (#195), title
+cards (#196), intro / outro segments (#173), audio mix tweaks,
+codec-tuned presets such as the YouTube preset (#204). Audio is taken
+from the primary; secondaries / overlay contribute video only.
+
+The IR is the contract: ``render_mp4`` is the second non-XML renderer
+that consumes it (FCPXML, FCP7 XML, MP4 -- three targets, one IR).
+
+Determinism / testability: command construction is split into pure
+functions (``_build_stage_command`` / ``_build_concat_command``) so
+unit tests can verify the ffmpeg invocation without shelling out. The
+runner is injectable, mirroring the pattern in
+``splitsmith.trim``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .composition import Composition, ConnectedClip, Stage, Transform
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class FFmpegError(RuntimeError):
+    """ffmpeg exited non-zero or could not be invoked."""
+
+
+def render_mp4(
+    composition: Composition,
+    *,
+    output_path: Path,
+    work_dir: Path | None = None,
+    ffmpeg_binary: str = "ffmpeg",
+    runner: Runner = subprocess.run,
+) -> None:
+    """Render ``composition`` as a stitched ``.mp4`` at ``output_path``.
+
+    ``work_dir`` is where per-stage temps live; defaults to a fresh
+    ``TemporaryDirectory`` cleaned up on return. Pass an explicit path
+    when debugging; the per-stage MP4s are easier to inspect than the
+    final concat output.
+    """
+    plans = [_plan_stage(stage, composition.sequence) for stage in composition.stages]
+    if not plans:
+        raise ValueError("render_mp4 requires at least one stage")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if work_dir is None:
+        with tempfile.TemporaryDirectory(prefix="splitsmith-mp4-") as tmp:
+            _render_with_work_dir(
+                composition,
+                plans,
+                output_path=output_path,
+                work_dir=Path(tmp),
+                ffmpeg_binary=ffmpeg_binary,
+                runner=runner,
+            )
+    else:
+        work_dir.mkdir(parents=True, exist_ok=True)
+        _render_with_work_dir(
+            composition,
+            plans,
+            output_path=output_path,
+            work_dir=work_dir,
+            ffmpeg_binary=ffmpeg_binary,
+            runner=runner,
+        )
+
+
+def _render_with_work_dir(
+    composition: Composition,
+    plans: list[_StagePlan],
+    *,
+    output_path: Path,
+    work_dir: Path,
+    ffmpeg_binary: str,
+    runner: Runner,
+) -> None:
+    stage_files: list[Path] = []
+    for idx, plan in enumerate(plans):
+        stage_out = work_dir / f"stage_{idx:03d}.mp4"
+        cmd = _build_stage_command(
+            plan,
+            sequence=composition.sequence,
+            output_path=stage_out,
+            ffmpeg_binary=ffmpeg_binary,
+        )
+        _run(cmd, runner=runner)
+        stage_files.append(stage_out)
+
+    list_path = work_dir / "concat.txt"
+    list_path.write_text(
+        "".join(f"file '{p.resolve().as_posix()}'\n" for p in stage_files),
+        encoding="utf-8",
+    )
+    cmd = _build_concat_command(
+        list_path=list_path,
+        output_path=output_path,
+        ffmpeg_binary=ffmpeg_binary,
+    )
+    _run(cmd, runner=runner)
+
+
+def _run(cmd: tuple[str, ...], *, runner: Runner) -> None:
+    try:
+        runner(list(cmd), check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise FFmpegError(f"ffmpeg binary not found: {cmd[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise FFmpegError(
+            f"ffmpeg failed (exit {exc.returncode}): "
+            f"{(exc.stderr or exc.stdout or '').strip()[-2000:] or '(no output)'}"
+        ) from exc
+
+
+# --- planning -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StagePlan:
+    """Per-stage timing + alignment derived from the IR.
+
+    ``head_trim_seconds`` is how far we ``-ss`` into the primary;
+    ``effective_seconds`` is how long the stage runs on the spine.
+    ``cam_alignments`` carries each cam's seek-into-source plus the
+    spine time the cam should appear, mirroring the head-slip math the
+    FCPXML / FCP7 renderers do in frames.
+    """
+
+    stage: Stage
+    head_trim_seconds: float
+    effective_seconds: float
+    cam_alignments: tuple[_CamAlignment, ...]
+
+
+@dataclass(frozen=True)
+class _CamAlignment:
+    cam: ConnectedClip
+    cam_seek_seconds: float  # ``-ss`` value for the cam input
+    cam_spine_start: float  # spine time when the cam first appears
+    cam_visible_seconds: float  # how long the cam shows on the spine
+
+
+def _plan_stage(stage: Stage, sequence_format) -> _StagePlan:  # type: ignore[no-untyped-def]
+    duration = stage.primary.metadata.duration_seconds
+    head_avail = max(0.0, stage.beep_offset_seconds)
+    if stage.markers:
+        last_local = max(m.time_seconds for m in stage.markers)
+    else:
+        last_local = stage.beep_offset_seconds
+    tail_avail = max(0.0, duration - last_local)
+    head_trim_seconds = max(0.0, head_avail - stage.head_pad_seconds)
+    tail_trim_seconds = max(0.0, tail_avail - stage.tail_pad_seconds)
+    effective_seconds = duration - head_trim_seconds - tail_trim_seconds
+    if effective_seconds <= 0:
+        raise ValueError(
+            f"stage {stage.name!r} would have non-positive effective duration "
+            f"after trim ({effective_seconds:.3f}s); reduce head/tail pad"
+        )
+
+    cam_alignments: list[_CamAlignment] = []
+    visible_head = head_trim_seconds  # source time of the visible head in the primary
+    for sec in stage.secondaries:
+        assert sec.beep_offset_seconds is not None  # cam role
+        # Same head-slip math as the FCPXML emitter, expressed in seconds.
+        delta = (stage.beep_offset_seconds - visible_head) - sec.beep_offset_seconds
+        if delta >= 0:
+            seek = 0.0
+            spine_start = delta
+        else:
+            seek = -delta
+            spine_start = 0.0
+        cam_total = sec.asset.metadata.duration_seconds
+        # The cam shows from spine_start until either (a) its own media
+        # runs out or (b) the stage ends.
+        cam_visible = min(cam_total - seek, effective_seconds - spine_start)
+        cam_alignments.append(
+            _CamAlignment(
+                cam=sec,
+                cam_seek_seconds=seek,
+                cam_spine_start=spine_start,
+                cam_visible_seconds=max(0.0, cam_visible),
+            )
+        )
+
+    return _StagePlan(
+        stage=stage,
+        head_trim_seconds=head_trim_seconds,
+        effective_seconds=effective_seconds,
+        cam_alignments=tuple(cam_alignments),
+    )
+
+
+# --- command construction -------------------------------------------------
+
+
+def _build_stage_command(
+    plan: _StagePlan,
+    *,
+    sequence,  # type: ignore[no-untyped-def]
+    output_path: Path,
+    ffmpeg_binary: str = "ffmpeg",
+) -> tuple[str, ...]:
+    """Build the ffmpeg invocation that renders one stage to ``output_path``.
+
+    The invocation re-encodes -- there's no general way to bake
+    overlays + PiP without re-encoding. For the non-composited subset
+    of cases (no cams, no overlay) we still re-encode for simplicity;
+    a stream-copy fast-path is a follow-up if encode time becomes a
+    problem.
+    """
+    args: list[str] = [ffmpeg_binary, "-hide_banner", "-y"]
+    stage = plan.stage
+
+    # Primary input: trim with ``-ss``/``-t`` before ``-i`` for fast
+    # seeking. The buffer in the trimmed clip absorbs any seek
+    # imprecision; same trade-off as ``trim.py`` makes.
+    args += [
+        "-ss",
+        f"{plan.head_trim_seconds:g}",
+        "-t",
+        f"{plan.effective_seconds:g}",
+        "-i",
+        str(stage.primary.path),
+    ]
+
+    # Secondary cam inputs.
+    for align in plan.cam_alignments:
+        args += [
+            "-ss",
+            f"{align.cam_seek_seconds:g}",
+            "-t",
+            f"{align.cam_visible_seconds:g}",
+            "-i",
+            str(align.cam.asset.path),
+        ]
+
+    # Overlay input (if any). Same head-trim window as the primary --
+    # the overlay was rendered to mirror the primary frame-for-frame.
+    overlay_index: int | None = None
+    if stage.overlay is not None:
+        overlay_index = 1 + len(plan.cam_alignments)
+        args += [
+            "-ss",
+            f"{plan.head_trim_seconds:g}",
+            "-t",
+            f"{plan.effective_seconds:g}",
+            "-i",
+            str(stage.overlay.asset.path),
+        ]
+
+    filter_graph = _build_stage_filter_graph(
+        plan,
+        sequence=sequence,
+        overlay_input_index=overlay_index,
+    )
+
+    args += [
+        "-filter_complex",
+        filter_graph,
+        "-map",
+        "[final]",
+        "-map",
+        "0:a?",  # primary audio when present, no error if absent
+        "-c:v",
+        "libx264",
+        "-preset",
+        "fast",
+        "-crf",
+        "20",
+        "-pix_fmt",
+        "yuv420p",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "192k",
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    ]
+    return tuple(args)
+
+
+def _build_stage_filter_graph(
+    plan: _StagePlan,
+    *,
+    sequence,  # type: ignore[no-untyped-def]
+    overlay_input_index: int | None,
+) -> str:
+    """Compose primary + cams + overlay into a single ``-filter_complex``.
+
+    Primary becomes ``[base]``; each cam is scaled (when it has a
+    transform) and overlaid at its computed corner with an ``enable``
+    expression so cams that appear late on the spine don't show until
+    their start. The overlay -- when present -- composites last so it
+    sits on top of all cams.
+    """
+    parts: list[str] = []
+    parts.append("[0:v]setpts=PTS-STARTPTS,format=yuv420p[base]")
+
+    base_label = "base"
+    for cam_idx, align in enumerate(plan.cam_alignments):
+        input_label = f"{1 + cam_idx}:v"
+        cam_label = f"cam{cam_idx}"
+        scaled_label = f"{cam_label}_scaled"
+        transform = align.cam.transform
+
+        # Each cam gets setpts-zeroed and scaled when needed.
+        scale_chain = "setpts=PTS-STARTPTS"
+        if transform is not None and transform.scale != 1.0:
+            target_w = int(round(sequence.width * transform.scale))
+            target_h = int(round(sequence.height * transform.scale))
+            scale_chain += f",scale={target_w}:{target_h}"
+        parts.append(f"[{input_label}]{scale_chain}[{scaled_label}]")
+
+        # ffmpeg's overlay filter places the secondary at top-left
+        # (X, Y) on the base. Convert from IR's centre / +Y-up to
+        # top-left / +Y-down.
+        x, y = _overlay_position(transform, sequence)
+        out_label = f"layer{cam_idx}"
+        # ``enable`` makes the cam show only during its visible window
+        # on the spine; outside that range the base shows through.
+        end_time = align.cam_spine_start + align.cam_visible_seconds
+        enable = f"between(t,{align.cam_spine_start:g},{end_time:g})"
+        parts.append(
+            f"[{base_label}][{scaled_label}]"
+            f"overlay=x={x:g}:y={y:g}:enable='{enable}'[{out_label}]"
+        )
+        base_label = out_label
+
+    if overlay_input_index is not None:
+        parts.append(f"[{overlay_input_index}:v]setpts=PTS-STARTPTS[overlay_v]")
+        parts.append(f"[{base_label}][overlay_v]overlay=0:0[withov]")
+        base_label = "withov"
+
+    parts.append(f"[{base_label}]null[final]")
+    return ";".join(parts)
+
+
+def _overlay_position(
+    transform: Transform | None,
+    sequence,  # type: ignore[no-untyped-def]
+) -> tuple[float, float]:
+    """Return the top-left (X, Y) ffmpeg ``overlay`` expects.
+
+    No transform -> (0, 0): cam covers the base full-frame, matching
+    today's stacked layout. With a transform: the cam centre lives at
+    ``(W/2 + tx, H/2 - ty)`` (sequence-centre + IR offset, Y axis
+    flipped); the top-left is that minus half the scaled clip's width
+    / height.
+    """
+    if transform is None:
+        return 0.0, 0.0
+    scale = transform.scale
+    seq_w = sequence.width
+    seq_h = sequence.height
+    centre_x = seq_w / 2.0 + transform.position[0]
+    centre_y = seq_h / 2.0 - transform.position[1]  # flip
+    clip_w = seq_w * scale
+    clip_h = seq_h * scale
+    return centre_x - clip_w / 2.0, centre_y - clip_h / 2.0
+
+
+def _build_concat_command(
+    *,
+    list_path: Path,
+    output_path: Path,
+    ffmpeg_binary: str = "ffmpeg",
+) -> tuple[str, ...]:
+    """Build the ``concat``-demuxer invocation that stitches per-stage
+    temps without re-encoding."""
+    return (
+        ffmpeg_binary,
+        "-hide_banner",
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(list_path),
+        "-c",
+        "copy",
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    )
+
+
+__all__ = ["FFmpegError", "render_mp4"]

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -20,15 +20,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from .. import composition, fcp7xml_render, fcpxml_gen
+from .. import composition, fcp7xml_render, fcpxml_gen, mp4_render
 from ..config import OutputConfig
 from .exports import audit_shots_to_engine_shots
 
 PipLayout = Literal["stacked", "pip-corners"]
 # Issue #197. ``"fcpxml"`` writes a Final Cut Pro 1.10 timeline (current
 # default). ``"fcp7xml"`` writes a Final Cut Pro 7-style xmeml file
-# importable into Premiere Pro and DaVinci Resolve.
-OutputFormat = Literal["fcpxml", "fcp7xml"]
+# importable into Premiere Pro and DaVinci Resolve. Issue #174.
+# ``"mp4"`` bakes the composition into a stitched MP4 via ffmpeg --
+# overlays / PiP burned in, no NLE round-trip needed.
+OutputFormat = Literal["fcpxml", "fcp7xml", "mp4"]
 
 
 @dataclass(frozen=True)
@@ -219,19 +221,22 @@ def export_match(
         )
 
     exports_dir.mkdir(parents=True, exist_ok=True)
-    extension = ".fcpxml" if request.output_format == "fcpxml" else ".xml"
+    extension = _OUTPUT_EXTENSIONS[request.output_format]
     output_path = exports_dir / f"{_slugify(request.project_name)}-match{extension}"
     # Match export goes through the composition IR (issue #194). The bridge
     # renderer lowers back to ``generate_match_fcpxml`` for the FCPXML path
     # so output stays byte-identical to the pre-IR emitter; the FCP7 XML
-    # path (issue #197) walks the IR directly via ``fcp7xml_render``.
+    # path (issue #197) walks the IR directly. The MP4 path (#174) shells
+    # out to ffmpeg per stage, then concat-demuxes the temps.
     comp = composition.from_stage_compositions(compositions, project_name=request.project_name)
     try:
         if request.output_format == "fcpxml":
             composition.render_fcpxml(comp, output_path=output_path, config=config)
-        else:
+        elif request.output_format == "fcp7xml":
             fcp7xml_render.render_fcp7xml(comp, output_path=output_path)
-    except (ValueError, FileNotFoundError) as exc:
+        else:
+            mp4_render.render_mp4(comp, output_path=output_path)
+    except (ValueError, FileNotFoundError, mp4_render.FFmpegError) as exc:
         raise MatchExportError(str(exc)) from exc
 
     # Compute total duration for the response. Mirrors the composer's math
@@ -255,6 +260,13 @@ def export_match(
         duration_seconds=total_seconds,
         anomalies=anomalies,
     )
+
+
+_OUTPUT_EXTENSIONS: dict[OutputFormat, str] = {
+    "fcpxml": ".fcpxml",
+    "fcp7xml": ".xml",
+    "mp4": ".mp4",
+}
 
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -945,8 +945,10 @@ class MatchExportRequest(BaseModel):
     pip_layout: Literal["stacked", "pip-corners"] = "stacked"
     # Issue #197. ``"fcpxml"`` writes Final Cut Pro 1.10 (the default).
     # ``"fcp7xml"`` writes a Final Cut Pro 7-style xmeml ``.xml``
-    # importable into Premiere Pro and DaVinci Resolve.
-    output_format: Literal["fcpxml", "fcp7xml"] = "fcpxml"
+    # importable into Premiere Pro and DaVinci Resolve. Issue #174:
+    # ``"mp4"`` bakes the stitched composition into a single MP4 via
+    # ffmpeg (overlays / PiP burned in, no NLE needed).
+    output_format: Literal["fcpxml", "fcp7xml", "mp4"] = "fcpxml"
 
 
 class RevealRequest(BaseModel):

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -497,10 +497,12 @@ export interface MatchExportRequestPayload {
    *  ``"pip-corners"`` adds an FCPXML adjust-transform so each cam lands
    *  in a rotating corner (TR -> TL -> BR -> BL) at 25% scale. */
   pip_layout?: "stacked" | "pip-corners";
-  /** Issue #197. ``"fcpxml"`` writes Final Cut Pro 1.10 (default).
-   *  ``"fcp7xml"`` writes a Final Cut Pro 7-style ``.xml`` importable
-   *  into Premiere Pro and DaVinci Resolve. */
-  output_format?: "fcpxml" | "fcp7xml";
+  /** Issue #197 / #174. ``"fcpxml"`` writes Final Cut Pro 1.10
+   *  (default). ``"fcp7xml"`` writes a Final Cut Pro 7-style ``.xml``
+   *  importable into Premiere Pro and DaVinci Resolve. ``"mp4"`` bakes
+   *  the stitched composition into a single ffmpeg-encoded MP4
+   *  (overlays / PiP burned in, no NLE needed). */
+  output_format?: "fcpxml" | "fcp7xml" | "mp4";
 }
 
 export interface MatchExportResult {

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1210,9 +1210,9 @@ function MatchExportDialog({
   // DaVinci Resolve import; coverage matches the FCPXML renderer for
   // primary / secondaries / PiP / overlay / markers, with transitions and
   // titles deferred per #195 / #196.
-  const [outputFormat, setOutputFormat] = useState<"fcpxml" | "fcp7xml">(
-    "fcpxml",
-  );
+  const [outputFormat, setOutputFormat] = useState<
+    "fcpxml" | "fcp7xml" | "mp4"
+  >("fcpxml");
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1492,12 +1492,13 @@ function MatchExportDialog({
                   disabled={busy}
                   onChange={(e) =>
                     setOutputFormat(
-                      e.target.value as "fcpxml" | "fcp7xml",
+                      e.target.value as "fcpxml" | "fcp7xml" | "mp4",
                     )
                   }
                 >
                   <option value="fcpxml">FCPXML (Final Cut Pro)</option>
                   <option value="fcp7xml">FCP7 XML (Premiere / DaVinci)</option>
+                  <option value="mp4">MP4 (baked, ffmpeg)</option>
                 </select>
               </label>
             </div>

--- a/tests/test_mp4_render.py
+++ b/tests/test_mp4_render.py
@@ -1,0 +1,368 @@
+"""Tests for the ffmpeg MP4 renderer (issue #174).
+
+Command construction is split into pure functions so tests can assert
+against the args list without shelling out. The renderer-level tests
+mock ``subprocess`` and verify the per-stage and concat invocations
+fire in the expected order; manual ffmpeg execution against real media
+is the release gate (and lives behind ``@pytest.mark.integration`` for
+when we wire it in).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from splitsmith import composition, mp4_render
+from splitsmith.config import Shot, VideoMetadata
+from splitsmith.fcpxml_gen import (
+    PipPlacement,
+    SecondaryClip,
+    StageComposition,
+)
+
+
+def _shot(n: int, t: float, s: float) -> Shot:
+    return Shot(
+        shot_number=n,
+        time_absolute=10.0 + t,
+        time_from_beep=t,
+        split=s,
+        peak_amplitude=0.5,
+        confidence=0.8,
+    )
+
+
+def _meta_30fps() -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def _basic_stage(
+    *,
+    tmp_path: Path,
+    name: str,
+    primary_name: str,
+    secondaries: tuple[SecondaryClip, ...] = (),
+    overlay_path: Path | None = None,
+    head_pad: float = 5.0,
+    tail_pad: float = 14.0,
+) -> StageComposition:
+    """Default pads keep the full clip (head_pad >= head_avail, tail_pad >=
+    tail_avail) so the alignment math is decoupled from trim math --
+    individual tests override pads when they want to exercise trimming."""
+    return StageComposition(
+        stage_name=name,
+        video_path=_make_video(tmp_path, primary_name),
+        video=_meta_30fps(),
+        shots=[_shot(1, 1.0, 1.0), _shot(2, 1.3, 0.3)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=head_pad,
+        tail_pad_seconds=tail_pad,
+        secondaries=secondaries,
+        overlay_path=overlay_path,
+        overlay_video=_meta_30fps() if overlay_path else None,
+    )
+
+
+def _build_plan(stage: StageComposition) -> tuple[Any, Any]:
+    """Return (Composition, _StagePlan) for a single-stage input."""
+    comp = composition.from_stage_compositions([stage], project_name="m")
+    plan = mp4_render._plan_stage(comp.stages[0], comp.sequence)
+    return comp, plan
+
+
+# --- planning -------------------------------------------------------------
+
+
+def test_plan_stage_computes_trim_and_alignment(tmp_path: Path) -> None:
+    """Default-helper pads keep the full clip; cam beep 5.0 == primary
+    beep so delta=0 -> spine_start=0, seek=0."""
+    secondary = _make_video(tmp_path, "cam.mp4")
+    sec = SecondaryClip(
+        video_path=secondary,
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Cam",
+    )
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
+    _, plan = _build_plan(stage)
+    assert plan.head_trim_seconds == pytest.approx(0.0)
+    assert plan.effective_seconds == pytest.approx(20.0)
+    assert len(plan.cam_alignments) == 1
+    align = plan.cam_alignments[0]
+    assert align.cam_seek_seconds == pytest.approx(0.0)
+    assert align.cam_spine_start == pytest.approx(0.0)
+
+
+def test_plan_stage_trims_head_when_pad_smaller_than_avail(tmp_path: Path) -> None:
+    """head_pad=2 on a clip with 5s before the beep -> head_trim=3s.
+    Effective = 20 - 3 - tail_trim. Last shot at clip-local 6.3s,
+    tail_avail=13.7s, tail_pad=2 -> tail_trim=11.7. Effective=5.3."""
+    stage = _basic_stage(
+        tmp_path=tmp_path,
+        name="A",
+        primary_name="a.mp4",
+        head_pad=2.0,
+        tail_pad=2.0,
+    )
+    _, plan = _build_plan(stage)
+    assert plan.head_trim_seconds == pytest.approx(3.0)
+    assert plan.effective_seconds == pytest.approx(5.3)
+
+
+def test_plan_stage_cam_late_uses_spine_offset(tmp_path: Path) -> None:
+    """Cam beep at 2.0s (3s earlier than primary's at 5.0s) -> cam needs
+    to appear 3s into the spine; ffmpeg seeks 0 into the cam."""
+    secondary = _make_video(tmp_path, "cam.mp4")
+    sec = SecondaryClip(
+        video_path=secondary,
+        video=_meta_30fps(),
+        beep_offset_seconds=2.0,
+        label="Cam",
+    )
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
+    _, plan = _build_plan(stage)
+    align = plan.cam_alignments[0]
+    assert align.cam_seek_seconds == pytest.approx(0.0)
+    assert align.cam_spine_start == pytest.approx(3.0)
+
+
+def test_plan_stage_cam_early_seeks_into_source(tmp_path: Path) -> None:
+    """Cam beep at 8.0s (3s later than primary's at 5.0s) -> cam appears
+    at spine 0 but ffmpeg seeks 3s into the cam media so beeps line up."""
+    secondary = _make_video(tmp_path, "cam.mp4")
+    sec = SecondaryClip(
+        video_path=secondary,
+        video=_meta_30fps(),
+        beep_offset_seconds=8.0,
+        label="Cam",
+    )
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
+    _, plan = _build_plan(stage)
+    align = plan.cam_alignments[0]
+    assert align.cam_seek_seconds == pytest.approx(3.0)
+    assert align.cam_spine_start == pytest.approx(0.0)
+
+
+def test_plan_stage_negative_effective_raises(tmp_path: Path) -> None:
+    primary = _make_video(tmp_path, "tiny.mp4")
+    tiny = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=0.001,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    stage = StageComposition(
+        stage_name="x",
+        video_path=primary,
+        video=tiny,
+        shots=[],
+        beep_offset_seconds=0.0,
+        head_pad_seconds=0.0,
+        tail_pad_seconds=0.0,
+    )
+    comp = composition.from_stage_compositions([stage], project_name="m")
+    with pytest.raises(ValueError, match="non-positive effective duration"):
+        mp4_render._plan_stage(comp.stages[0], comp.sequence)
+
+
+# --- stage command --------------------------------------------------------
+
+
+def test_build_stage_command_minimal(tmp_path: Path) -> None:
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
+    )
+    # Sanity: the trim window matches the plan; the only video input is
+    # the primary; no filter graph branch for cams or overlay.
+    assert "-ss" in cmd and "-t" in cmd
+    assert str(stage.video_path) in cmd
+    fg = cmd[cmd.index("-filter_complex") + 1]
+    assert "[0:v]setpts=PTS-STARTPTS,format=yuv420p[base]" in fg
+    # ``[base]null[final]`` is the no-cam-no-overlay terminal node.
+    assert "[base]null[final]" in fg
+
+
+def test_build_stage_command_pip_secondary(tmp_path: Path) -> None:
+    secondary = _make_video(tmp_path, "cam.mp4")
+    sec = SecondaryClip(
+        video_path=secondary,
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Cam",
+        pip=PipPlacement(corner="top-right"),
+    )
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
+    )
+    fg = cmd[cmd.index("-filter_complex") + 1]
+    # Cam scaled to 25% of 1920x1080 -> 480x270.
+    assert "scale=480:270" in fg
+    # ffmpeg overlay X = (1920*(1-0.25))/2 + 681.6 = 720 + 681.6 = 1401.6
+    # ffmpeg overlay Y = (1080*(1-0.25))/2 - 383.4 = 405 - 383.4 = 21.6
+    assert "overlay=x=1401.6:y=21.6" in fg
+    # ``enable`` keeps the cam visible only during its computed window.
+    assert "between(t," in fg
+
+
+def test_build_stage_command_overlay_emits_top_overlay(tmp_path: Path) -> None:
+    overlay = _make_video(tmp_path, "overlay.mov")
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", overlay_path=overlay)
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
+    )
+    fg = cmd[cmd.index("-filter_complex") + 1]
+    # The overlay input lives at index 1 (no cams) and lands as the
+    # final layer at (0,0) with full-frame coverage.
+    assert "[1:v]setpts=PTS-STARTPTS[overlay_v]" in fg
+    assert "[overlay_v]overlay=0:0[withov]" in fg
+
+
+def test_build_stage_command_pip_full_frame_when_no_transform(tmp_path: Path) -> None:
+    """A cam with no PiP lands at (0, 0) full-frame -- mirrors today's
+    stacked layout, just baked into pixels instead of FCP layers."""
+    secondary = _make_video(tmp_path, "cam.mp4")
+    sec = SecondaryClip(
+        video_path=secondary,
+        video=_meta_30fps(),
+        beep_offset_seconds=5.0,
+        label="Cam",
+    )
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
+    )
+    fg = cmd[cmd.index("-filter_complex") + 1]
+    assert "overlay=x=0:y=0" in fg
+    # No ``scale=`` filter when the cam runs at native size (default
+    # ``Transform.scale`` is 1.0; absence of any transform skips scale
+    # entirely).
+    assert "scale=" not in fg
+
+
+# --- concat command -------------------------------------------------------
+
+
+def test_build_concat_command_stream_copies(tmp_path: Path) -> None:
+    cmd = mp4_render._build_concat_command(
+        list_path=tmp_path / "list.txt",
+        output_path=tmp_path / "out.mp4",
+    )
+    assert "-f" in cmd and cmd[cmd.index("-f") + 1] == "concat"
+    # ``-c copy`` is the whole point of the concat step -- per-stage temps
+    # were already encoded to compatible codecs, no need to re-encode.
+    assert "-c" in cmd and cmd[cmd.index("-c") + 1] == "copy"
+    assert "-movflags" in cmd
+    assert cmd[cmd.index("-movflags") + 1] == "+faststart"
+
+
+# --- end-to-end orchestration --------------------------------------------
+
+
+def _ok(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+
+def test_render_mp4_runs_per_stage_then_concat(tmp_path: Path) -> None:
+    """The renderer fires N stage invocations then one concat
+    invocation, in that order."""
+    stage_a = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    stage_b = _basic_stage(tmp_path=tmp_path, name="B", primary_name="b.mp4")
+    comp = composition.from_stage_compositions([stage_a, stage_b], project_name="m")
+
+    runner = MagicMock(side_effect=_ok)
+    work = tmp_path / "work"
+    out = tmp_path / "match.mp4"
+    mp4_render.render_mp4(comp, output_path=out, work_dir=work, runner=runner)
+
+    assert runner.call_count == 3
+    args_per_call = [call.args[0] for call in runner.call_args_list]
+    # Two per-stage invocations finish with a stage-N temp path.
+    assert args_per_call[0][-1].endswith("stage_000.mp4")
+    assert args_per_call[1][-1].endswith("stage_001.mp4")
+    # Final invocation is the concat step.
+    final = args_per_call[2]
+    assert "-f" in final and final[final.index("-f") + 1] == "concat"
+    assert final[-1] == str(out)
+    # The concat list got written between the per-stage and concat
+    # steps, listing both temps in spine order.
+    list_path = work / "concat.txt"
+    assert list_path.exists()
+    contents = list_path.read_text()
+    assert "stage_000.mp4" in contents
+    assert "stage_001.mp4" in contents
+    # Spine order: A before B.
+    assert contents.index("stage_000") < contents.index("stage_001")
+
+
+def test_render_mp4_propagates_ffmpeg_error(tmp_path: Path) -> None:
+    """A non-zero ffmpeg exit surfaces as ``FFmpegError`` with the
+    captured stderr -- the export endpoint relies on this to bubble a
+    helpful message to the dialog."""
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    comp = composition.from_stage_compositions([stage], project_name="m")
+
+    def fail(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(
+            returncode=1, cmd=args[0], stderr="boom: invalid argument"
+        )
+
+    with pytest.raises(mp4_render.FFmpegError, match="boom"):
+        mp4_render.render_mp4(
+            comp,
+            output_path=tmp_path / "out.mp4",
+            work_dir=tmp_path / "work",
+            runner=fail,
+        )
+
+
+def test_render_mp4_missing_binary_raises(tmp_path: Path) -> None:
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    comp = composition.from_stage_compositions([stage], project_name="m")
+
+    def missing(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        raise FileNotFoundError(args[0][0])
+
+    with pytest.raises(mp4_render.FFmpegError, match="not found"):
+        mp4_render.render_mp4(
+            comp,
+            output_path=tmp_path / "out.mp4",
+            work_dir=tmp_path / "work",
+            ffmpeg_binary="ffmpeg-nope",
+            runner=missing,
+        )
+
+
+def test_render_mp4_requires_at_least_one_stage(tmp_path: Path) -> None:
+    """Empty stages on a Composition shouldn't even reach ffmpeg."""
+    # Build an empty composition by sidestepping the constructor's guard.
+    comp = composition.Composition(
+        project_name="m",
+        sequence=composition.SequenceFormat.from_video(_meta_30fps()),
+        stages=(),
+    )
+    with pytest.raises(ValueError, match="at least one stage"):
+        mp4_render.render_mp4(comp, output_path=tmp_path / "out.mp4", work_dir=tmp_path / "work")


### PR DESCRIPTION
Closes #174.

## Summary

Third renderer that consumes the Composition IR (#194) and produces a stitched MP4 -- overlays + PiP secondaries baked in, no NLE round-trip needed. Per-stage \`ffmpeg\` re-encodes with a \`-filter_complex\` graph, then a concat-demuxer step stream-copies the temps into the final file.

Coverage matches the FCPXML / FCP7 renderers for the in-scope features:

- Primary clip per stage with head/tail trim via \`-ss\`/\`-t\`.
- Secondary cams via \`-filter_complex\` \`overlay\`, scaled to the IR's PiP transform when set, full-frame otherwise. Coordinate convention converted (sequence-centre +Y up -> top-left +Y down).
- Alpha overlay composited as the topmost layer.
- Per-stage temps + concat demuxer = one re-encode per stage, none for the stitch.

Wired through \`MatchExportRequest.output_format = "mp4"\`. Export dialog gains "MP4 (baked, ffmpeg)" alongside the FCPXML and FCP7 XML options.

## Why per-stage + concat instead of one giant filter_complex

The single-filter-graph approach blows up fast (3 stages × (primary + 2 cams + overlay) = 12 inputs, dozens of filter nodes). Per-stage temps are easier to debug and parallelize; the disk overhead is bounded and the concat step is a fast copy.

## Test plan

- [x] 14 new unit tests in \`tests/test_mp4_render.py\` covering trim / alignment math, command construction (minimal / PiP / overlay / full-frame cam), concat command, end-to-end orchestration with a mocked subprocess, error propagation, missing-binary case.
- [x] Full Python suite: 815 passed, 4 skipped (existing integration / DTD gates).
- [x] \`tsc -b --noEmit\` clean.
- [x] \`ruff\` / \`black\` clean.
- [ ] **Release gate:** run a real export with PiP secondary + overlay; verify the MP4 plays in QuickTime / VLC, primary audio is in sync, cam lands at the expected corner, overlay renders on top.

## Out of scope (sibling issues)

- Transitions (#195) -- ignored when present on the IR.
- Title cards (#196) -- same.
- Intro / outro segments (#173) -- same.
- Audio mix beyond primary passthrough.
- YouTube-tuned codec preset (#204).
- Hardware encoder (\`h264_videotoolbox\`) auto-pick -- defaulting to \`libx264 -preset fast -crf 20\` for predictability; hardware path is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)