### PR TITLE
FCPXML stage transitions (cross-dissolve, dip-to-color) (#195)

### DIFF
--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -149,13 +149,23 @@ TransitionKind = Literal["cross-dissolve", "dip-to-color"]
 
 @dataclass(frozen=True)
 class Transition:
-    """Stage-boundary transition (placeholder until #195 lands).
+    """Stage-boundary transition (issue #195).
 
     ``from_stage_index`` / ``to_stage_index`` are positions in
-    ``Composition.stages``; consecutive indices only for v1.
+    ``Composition.stages``; consecutive indices only for v1
+    (``to_stage_index == from_stage_index + 1`` -- enforced by the
+    FCPXML emitter, ignored by other renderers until they grow
+    transition support).
+
     ``duration_seconds`` is split half-before / half-after the boundary
-    per FCPXML semantics. Renderers that don't support a given ``kind``
-    fall back to the closest supported transition and warn.
+    per FCPXML semantics. The exporter validates that each adjacent
+    stage's effective window contains at least ``duration_seconds / 2``
+    of material before emitting the timeline.
+
+    The FCPXML renderer (this PR) emits ``cross-dissolve`` and
+    ``dip-to-color`` via FCP's built-in motion templates. The FCP7 XML
+    and ffmpeg renderers ignore transitions for now -- they'll grow
+    support in follow-up PRs.
     """
 
     from_stage_index: int
@@ -223,6 +233,7 @@ def from_stage_compositions(
     stages: SequenceProto[fcpxml_gen.StageComposition],
     *,
     project_name: str,
+    transitions: SequenceProto[Transition] = (),
 ) -> Composition:
     """Build a :class:`Composition` from today's ``StageComposition`` inputs.
 
@@ -231,6 +242,11 @@ def from_stage_compositions(
     same width/height for a single shared sequence (FCP scales mismatched
     cams within a stage via per-cam formats; mismatched primaries across
     stages would need cross-fps timeline support which is out of scope).
+
+    ``transitions`` (issue #195): optional stage-boundary transitions
+    that the FCPXML renderer emits between consecutive stages. Each
+    transition's ``from_stage_index`` / ``to_stage_index`` must point at
+    valid stage positions; v1 only accepts consecutive pairs.
     """
     if not stages:
         raise ValueError("Composition requires at least one stage")
@@ -290,6 +306,7 @@ def from_stage_compositions(
         project_name=project_name,
         sequence=seq,
         stages=tuple(ir_stages),
+        transitions=tuple(transitions),
     )
 
 
@@ -411,10 +428,15 @@ def render_fcpxml(
     so transitions / titles / new renderers can reach the wire.
     """
     legacy_stages = to_stage_compositions(composition)
-    if len(legacy_stages) == 1 and composition.intro is None and composition.outro is None:
-        # Single stage with no intro/outro mirrors today's per-stage path.
-        # Use generate_fcpxml so the file is byte-identical to a
-        # single-stage export.
+    if (
+        len(legacy_stages) == 1
+        and composition.intro is None
+        and composition.outro is None
+        and not composition.transitions
+    ):
+        # Single stage with no intro/outro/transitions mirrors today's
+        # per-stage path. Use generate_fcpxml so the file is byte-
+        # identical to a single-stage export.
         stage = legacy_stages[0]
         fcpxml_gen.generate_fcpxml(
             video_path=stage.video_path,
@@ -434,7 +456,33 @@ def render_fcpxml(
         output_path=output_path,
         project_name=composition.project_name,
         config=config,
+        transitions=_lower_transitions(composition.transitions),
     )
+
+
+def _lower_transitions(
+    transitions: tuple[Transition, ...],
+) -> list[fcpxml_gen.StageTransition]:
+    """Lower IR transitions to ``fcpxml_gen.StageTransition`` for the
+    legacy emitter. v1: only consecutive transitions
+    (``to_index == from_index + 1``) are accepted."""
+    out: list[fcpxml_gen.StageTransition] = []
+    for t in transitions:
+        if t.to_stage_index != t.from_stage_index + 1:
+            raise ValueError(
+                "non-consecutive transitions are not supported "
+                f"(from_stage_index={t.from_stage_index}, "
+                f"to_stage_index={t.to_stage_index})"
+            )
+        out.append(
+            fcpxml_gen.StageTransition(
+                after_stage_index=t.from_stage_index,
+                kind=t.kind,
+                duration_seconds=t.duration_seconds,
+                color=t.color,
+            )
+        )
+    return out
 
 
 __all__ = [

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -572,6 +572,59 @@ def generate_fcpxml(
     _tag_source_application(output_path)
 
 
+TransitionKind = Literal["cross-dissolve", "dip-to-color"]
+
+# FCP's built-in transitions live under .motn templates with stable
+# names; emitting an ``<effect>`` resource that points at one of these
+# uids lets FCP resolve the transition without splitsmith bundling any
+# Motion files. Both have shipped unchanged for years -- if Apple ever
+# renames either, the FCPXML import will surface a missing-effect
+# warning and the user re-picks the transition manually.
+_TRANSITION_EFFECT_UIDS: dict[TransitionKind, str] = {
+    "cross-dissolve": (
+        ".../Transitions.localized/Dissolves.localized/"
+        "Cross Dissolve.localized/Cross Dissolve.motn"
+    ),
+    "dip-to-color": (
+        ".../Transitions.localized/Dissolves.localized/"
+        "Dip to Color Dissolve.localized/Dip to Color Dissolve.motn"
+    ),
+}
+
+_TRANSITION_NAMES: dict[TransitionKind, str] = {
+    "cross-dissolve": "Cross Dissolve",
+    "dip-to-color": "Dip to Color Dissolve",
+}
+
+
+@dataclass(frozen=True)
+class StageTransition:
+    """A transition between two consecutive stages on the spine (issue #195).
+
+    ``after_stage_index`` is the index of the stage the transition
+    sits *after* (so a transition with ``after_stage_index=0``
+    crossfades from ``stages[0]`` into ``stages[1]``). Each stage may
+    have at most one transition following it; multiple ``StageTransition``s
+    targeting the same index raises.
+
+    ``duration_seconds`` is the transition's total length; FCPXML
+    centres the transition on the cut point so each adjacent stage's
+    visible window must contain at least ``duration_seconds / 2`` of
+    material -- the exporter validates this and raises a clear error
+    otherwise.
+
+    ``color`` only applies to ``"dip-to-color"`` and accepts any FCP
+    colour string (e.g. ``"0 0 0 1"`` for opaque black). When omitted
+    FCP uses its default (black) -- explicit colour is a follow-up
+    when templating lands.
+    """
+
+    after_stage_index: int
+    kind: TransitionKind = "cross-dissolve"
+    duration_seconds: float = 0.5
+    color: str | None = None
+
+
 @dataclass(frozen=True)
 class StageComposition:
     """One stage's contribution to a stitched match-export FCPXML (issue #170).
@@ -604,6 +657,7 @@ def generate_match_fcpxml(
     output_path: Path,
     project_name: str,
     config: OutputConfig,
+    transitions: list[StageTransition] | None = None,
 ) -> None:
     """Write a stitched FCPXML with N stages back-to-back on the spine.
 
@@ -616,12 +670,36 @@ def generate_match_fcpxml(
 
     Frame-rate mixing across stages is out of scope for v1: all stages must
     share a frame rate (raises ValueError otherwise).
+
+    ``transitions`` (issue #195): optional list of ``StageTransition``s
+    that crossfade between consecutive stages. Each transition is
+    centred on its stage boundary (offset = end_of_prev - duration/2,
+    duration = transition.duration); each adjacent stage must have at
+    least ``duration / 2`` of effective material to overlap or the
+    exporter raises ``ValueError``. ``None`` keeps today's hard-cut
+    layout.
     """
     if not stages:
         raise ValueError("generate_match_fcpxml requires at least one stage")
     for stage in stages:
         if not stage.video_path.exists():
             raise FileNotFoundError(f"video not found: {stage.video_path}")
+    transitions = list(transitions or ())
+    seen_indices: set[int] = set()
+    for t in transitions:
+        if t.after_stage_index in seen_indices:
+            raise ValueError(f"duplicate transition after stage index {t.after_stage_index}")
+        if not 0 <= t.after_stage_index < len(stages) - 1:
+            raise ValueError(
+                f"transition.after_stage_index={t.after_stage_index} is out of "
+                f"range for {len(stages)} stages (must be in 0..{len(stages) - 2})"
+            )
+        if t.duration_seconds <= 0:
+            raise ValueError(
+                f"transition after stage {t.after_stage_index} has non-positive "
+                f"duration ({t.duration_seconds:g}s)"
+            )
+        seen_indices.add(t.after_stage_index)
 
     base = stages[0].video
     for stage in stages[1:]:
@@ -848,6 +926,45 @@ def generate_match_fcpxml(
                 {"kind": "original-media", "src": plan.stage.overlay_path.resolve().as_uri()},
             )
 
+    # Transition effect resources (issue #195). One ``<effect>`` per
+    # unique transition kind used; transitions on the spine reference
+    # these via ``<filter-video ref="...">``. Validate the per-stage
+    # half-duration constraint before emitting so a bad combination
+    # surfaces as a clear error rather than as broken FCPXML.
+    transition_effect_ids: dict[TransitionKind, str] = {}
+    for trans in transitions:
+        trans_frames = round(trans.duration_seconds / fd_seconds)
+        half_frames = trans_frames // 2
+        prev_plan = plans[trans.after_stage_index]
+        next_plan = plans[trans.after_stage_index + 1]
+        if half_frames > prev_plan.effective_duration_frames:
+            raise ValueError(
+                f"transition after stage {prev_plan.stage.stage_name!r} "
+                f"({trans.duration_seconds:g}s) exceeds the available material "
+                f"({prev_plan.effective_duration_frames * fd_seconds:.3f}s); "
+                "increase the stage's tail pad or shorten the transition"
+            )
+        if half_frames > next_plan.effective_duration_frames:
+            raise ValueError(
+                f"transition before stage {next_plan.stage.stage_name!r} "
+                f"({trans.duration_seconds:g}s) exceeds the available material "
+                f"({next_plan.effective_duration_frames * fd_seconds:.3f}s); "
+                "increase the stage's head pad or shorten the transition"
+            )
+        if trans.kind not in transition_effect_ids:
+            resource_counter += 1
+            effect_id = f"r{resource_counter}"
+            ET.SubElement(
+                resources,
+                "effect",
+                {
+                    "id": effect_id,
+                    "name": _TRANSITION_NAMES[trans.kind],
+                    "uid": _TRANSITION_EFFECT_UIDS[trans.kind],
+                },
+            )
+            transition_effect_ids[trans.kind] = effect_id
+
     library = ET.SubElement(fcpxml, "library")
     event = ET.SubElement(library, "event", {"name": "splitsmith"})
     project = ET.SubElement(event, "project", {"name": project_name})
@@ -866,8 +983,10 @@ def generate_match_fcpxml(
     )
     spine = ET.SubElement(sequence, "spine")
 
+    transitions_by_index: dict[int, StageTransition] = {t.after_stage_index: t for t in transitions}
+
     cumulative_offset_frames = 0
-    for plan in plans:
+    for stage_idx, plan in enumerate(plans):
         stage = plan.stage
         head_trim_seconds = plan.head_trim_frames * fd_seconds
         eff_duration_str = _frame_aligned_str(plan.effective_duration_frames, fd_num, fd_den)
@@ -967,6 +1086,33 @@ def generate_match_fcpxml(
                     "duration": frame_duration_str,
                     "value": _marker_label(shot, config.split_color_thresholds),
                 },
+            )
+
+        # Stage-boundary transition (issue #195). Centred on the cut
+        # point: transition offset = end_of_prev - duration/2,
+        # duration = transition.duration. Both adjacent stages keep
+        # their full effective_duration on the spine; FCPXML's
+        # transition straddles the boundary by half its duration on
+        # each side and FCP cross-fades using each side's overlap
+        # material.
+        next_transition = transitions_by_index.get(stage_idx)
+        if next_transition is not None:
+            tdur_frames = round(next_transition.duration_seconds / fd_seconds)
+            stage_end = cumulative_offset_frames + plan.effective_duration_frames
+            t_offset = stage_end - tdur_frames // 2
+            transition_el = ET.SubElement(
+                spine,
+                "transition",
+                {
+                    "name": _TRANSITION_NAMES[next_transition.kind],
+                    "offset": _frame_aligned_str(t_offset, fd_num, fd_den),
+                    "duration": _frame_aligned_str(tdur_frames, fd_num, fd_den),
+                },
+            )
+            ET.SubElement(
+                transition_el,
+                "filter-video",
+                {"ref": transition_effect_ids[next_transition.kind]},
             )
 
         cumulative_offset_frames += plan.effective_duration_frames

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -31,6 +31,12 @@ PipLayout = Literal["stacked", "pip-corners"]
 # ``"mp4"`` bakes the composition into a stitched MP4 via ffmpeg --
 # overlays / PiP burned in, no NLE round-trip needed.
 OutputFormat = Literal["fcpxml", "fcp7xml", "mp4"]
+# Issue #195. ``"none"`` keeps today's hard-cut stitching.
+# ``"cross-dissolve"`` / ``"dip-to-color"`` map to FCP's built-in
+# transition effects. Only the FCPXML renderer emits transitions
+# today; FCP7 / MP4 ignore the request until they grow transition
+# support.
+TransitionKind = Literal["none", "cross-dissolve", "dip-to-color"]
 
 
 @dataclass(frozen=True)
@@ -84,6 +90,11 @@ class MatchExportRequestData:
     pip_layout: PipLayout = "stacked"
     # Issue #197. Renderer chosen for this export.
     output_format: OutputFormat = "fcpxml"
+    # Issue #195. Uniform transition between every consecutive stage
+    # (or ``"none"`` for hard cuts). ``transition_duration_seconds`` is
+    # ignored when ``transition_kind == "none"``.
+    transition_kind: TransitionKind = "none"
+    transition_duration_seconds: float = 0.5
 
 
 @dataclass(frozen=True)
@@ -225,10 +236,26 @@ def export_match(
     output_path = exports_dir / f"{_slugify(request.project_name)}-match{extension}"
     # Match export goes through the composition IR (issue #194). The bridge
     # renderer lowers back to ``generate_match_fcpxml`` for the FCPXML path
-    # so output stays byte-identical to the pre-IR emitter; the FCP7 XML
-    # path (issue #197) walks the IR directly. The MP4 path (#174) shells
-    # out to ffmpeg per stage, then concat-demuxes the temps.
-    comp = composition.from_stage_compositions(compositions, project_name=request.project_name)
+    # so output stays byte-identical to the pre-IR emitter when no extra
+    # IR features are present; the FCP7 XML path (issue #197) walks the
+    # IR directly. The MP4 path (#174) shells out to ffmpeg per stage,
+    # then concat-demuxes the temps.
+    transitions = _build_uniform_transitions(
+        kind=request.transition_kind,
+        duration=request.transition_duration_seconds,
+        stage_count=len(compositions),
+    )
+    if transitions and request.output_format != "fcpxml":
+        anomalies.append(
+            f"transitions ignored: not yet supported by the "
+            f"{request.output_format} renderer (issue #195 follow-ups)"
+        )
+        transitions = ()
+    comp = composition.from_stage_compositions(
+        compositions,
+        project_name=request.project_name,
+        transitions=transitions,
+    )
     try:
         if request.output_format == "fcpxml":
             composition.render_fcpxml(comp, output_path=output_path, config=config)
@@ -276,3 +303,25 @@ def _slugify(name: str) -> str:
     """Filesystem-friendly slug. Mirrors ``exports._slugify`` so match-export
     filenames look the same as their per-stage cousins."""
     return _SLUG_RE.sub("-", name.lower()).strip("-") or "match"
+
+
+def _build_uniform_transitions(
+    *,
+    kind: TransitionKind,
+    duration: float,
+    stage_count: int,
+) -> tuple[composition.Transition, ...]:
+    """Expand a single ``(kind, duration)`` choice into N-1 transitions
+    (one between each consecutive stage pair). Returns ``()`` for the
+    no-op cases (kind == ``"none"`` or fewer than two stages)."""
+    if kind == "none" or stage_count < 2:
+        return ()
+    return tuple(
+        composition.Transition(
+            from_stage_index=i,
+            to_stage_index=i + 1,
+            kind=kind,
+            duration_seconds=duration,
+        )
+        for i in range(stage_count - 1)
+    )

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -949,6 +949,12 @@ class MatchExportRequest(BaseModel):
     # ``"mp4"`` bakes the stitched composition into a single MP4 via
     # ffmpeg (overlays / PiP burned in, no NLE needed).
     output_format: Literal["fcpxml", "fcp7xml", "mp4"] = "fcpxml"
+    # Issue #195. Uniform transition between every consecutive stage
+    # pair, or ``"none"`` for hard cuts. Currently only the FCPXML
+    # renderer emits transitions; FCP7 / MP4 surface a "transitions
+    # ignored" anomaly when set together with those formats.
+    transition_kind: Literal["none", "cross-dissolve", "dip-to-color"] = "none"
+    transition_duration_seconds: float = 0.5
 
 
 class RevealRequest(BaseModel):
@@ -4598,6 +4604,8 @@ def create_app(
             project_name=project_name,
             pip_layout=req.pip_layout,
             output_format=req.output_format,
+            transition_kind=req.transition_kind,
+            transition_duration_seconds=req.transition_duration_seconds,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -503,6 +503,15 @@ export interface MatchExportRequestPayload {
    *  the stitched composition into a single ffmpeg-encoded MP4
    *  (overlays / PiP burned in, no NLE needed). */
   output_format?: "fcpxml" | "fcp7xml" | "mp4";
+  /** Issue #195. Uniform transition between every consecutive stage
+   *  pair. ``"none"`` keeps today's hard cuts. Only FCPXML supports
+   *  transitions today; selecting one with FCP7 XML or MP4 surfaces
+   *  an anomaly note and falls back to hard cuts. */
+  transition_kind?: "none" | "cross-dissolve" | "dip-to-color";
+  /** Total transition length in seconds; ignored when
+   *  ``transition_kind`` is ``"none"``. Each adjacent stage's effective
+   *  window must contain at least half this value of material. */
+  transition_duration_seconds?: number;
 }
 
 export interface MatchExportResult {

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1213,6 +1213,14 @@ function MatchExportDialog({
   const [outputFormat, setOutputFormat] = useState<
     "fcpxml" | "fcp7xml" | "mp4"
   >("fcpxml");
+  // Issue #195. ``"none"`` is today's hard-cut stitch. Cross-dissolve
+  // is the most-used transition in IPSC match recaps; dip-to-color is
+  // for stylised cuts. Only FCPXML emits transitions today.
+  const [transitionKind, setTransitionKind] = useState<
+    "none" | "cross-dissolve" | "dip-to-color"
+  >("none");
+  const [transitionDurationSeconds, setTransitionDurationSeconds] =
+    useState<number>(0.5);
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1265,6 +1273,8 @@ function MatchExportDialog({
         include_secondaries: includeSecondaries,
         pip_layout: pipLayout,
         output_format: outputFormat,
+        transition_kind: transitionKind,
+        transition_duration_seconds: transitionDurationSeconds,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1501,6 +1511,52 @@ function MatchExportDialog({
                   <option value="mp4">MP4 (baked, ffmpeg)</option>
                 </select>
               </label>
+              <label
+                className="flex items-center gap-1.5"
+                title="Cross-dissolve / dip-to-color between consecutive stages. FCPXML only; FCP7 XML still hard-cuts."
+              >
+                Transition
+                <select
+                  className="rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                  value={transitionKind}
+                  disabled={busy}
+                  onChange={(e) =>
+                    setTransitionKind(
+                      e.target.value as
+                        | "none"
+                        | "cross-dissolve"
+                        | "dip-to-color",
+                    )
+                  }
+                >
+                  <option value="none">None (hard cuts)</option>
+                  <option value="cross-dissolve">Cross dissolve</option>
+                  <option value="dip-to-color">Dip to color</option>
+                </select>
+              </label>
+              {transitionKind !== "none" && (
+                <label
+                  className="flex items-center gap-1.5"
+                  title="Total transition length. Each adjacent stage's effective window must contain at least half this value."
+                >
+                  Duration
+                  <input
+                    type="number"
+                    min={0.1}
+                    max={3.0}
+                    step={0.1}
+                    className="w-16 rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                    value={transitionDurationSeconds}
+                    disabled={busy}
+                    onChange={(e) => {
+                      const v = parseFloat(e.target.value);
+                      if (!Number.isNaN(v) && v > 0)
+                        setTransitionDurationSeconds(v);
+                    }}
+                  />
+                  s
+                </label>
+              )}
             </div>
             {includeOverlay ? (
               <OverlayFormatPanel

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from splitsmith import composition, fcp7xml_render
+from splitsmith import composition, fcp7xml_render, fcpxml_gen
 from splitsmith.config import OutputConfig, Shot, VideoMetadata
 from splitsmith.fcpxml_gen import (
     PipPlacement,
@@ -208,6 +208,41 @@ def test_fcpxml_2997fps_validates(tmp_path: Path) -> None:
         output_path=out,
         project_name="v",
         config=OutputConfig(),
+    )
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())
+
+
+@fcpxml_dtd
+def test_fcpxml_match_with_transitions_validates(tmp_path: Path) -> None:
+    """Transitions emit ``<transition>`` + ``<filter-video>`` referencing
+    a new ``<effect>`` resource. DTD validation catches missing
+    required attributes (``effect.uid``, ``filter-video.ref``) that
+    structural assertions might miss."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    primary_c = _make_video(tmp_path, "c.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b), ("C", primary_c))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        transitions=[
+            fcpxml_gen.StageTransition(after_stage_index=0, kind="cross-dissolve"),
+            fcpxml_gen.StageTransition(after_stage_index=1, kind="dip-to-color"),
+        ],
     )
     validate_against_dtd(out, dtd=fcpxml_dtd_path())
 

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1373,6 +1373,230 @@ def test_match_fcpxml_secondary_pip_uses_sequence_dims(tmp_path: Path) -> None:
     assert transform.attrib == expected
 
 
+# --- stage transitions (issue #195) ---------------------------------------
+
+
+def _two_stage_match(tmp_path: Path) -> tuple[Path, Path, Path]:
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    return primary_a, primary_b, out
+
+
+def _basic_match_stages(primary_a: Path, primary_b: Path) -> list[fcpxml_mod.StageComposition]:
+    return [
+        fcpxml_mod.StageComposition(
+            stage_name="A",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+        fcpxml_mod.StageComposition(
+            stage_name="B",
+            video_path=primary_b,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+
+
+def test_match_with_transition_emits_effect_resource(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        transitions=[
+            fcpxml_mod.StageTransition(
+                after_stage_index=0, kind="cross-dissolve", duration_seconds=0.5
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    effects = root.findall("./resources/effect")
+    assert len(effects) == 1
+    assert effects[0].attrib["name"] == "Cross Dissolve"
+    assert effects[0].attrib["uid"].endswith("Cross Dissolve.motn")
+    transition = root.find(".//spine/transition")
+    assert transition is not None
+    assert transition.attrib["name"] == "Cross Dissolve"
+    filter_video = transition.find("filter-video")
+    assert filter_video is not None
+    assert filter_video.attrib["ref"] == effects[0].attrib["id"]
+
+
+def test_transition_offset_centred_on_boundary(tmp_path: Path) -> None:
+    """Transition at duration=0.5s @ 30fps -> 15 frames; centred on the
+    cut means offset = stage_A.end - 15 // 2 = stage_A.end - 7."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        transitions=[
+            fcpxml_mod.StageTransition(
+                after_stage_index=0, kind="cross-dissolve", duration_seconds=0.5
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    # 20s clip, beep=5, last shot at +1.0s -> tail_avail=14s, tail_pad=5
+    # trims 9s. Effective = 20 - 0 - 9 = 11s = 330 frames. Transition
+    # duration = 15 frames; half = 7. Offset = 330 - 7 = 323.
+    transition = root.find(".//spine/transition")
+    assert transition is not None
+    assert transition.attrib["offset"] == "323/30s"
+    assert transition.attrib["duration"] == "15/30s"
+
+
+def test_dip_to_color_uses_separate_effect(tmp_path: Path) -> None:
+    """A different transition kind allocates its own ``<effect>``;
+    same kind on multiple boundaries reuses one."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    primary_c = _make_video(tmp_path, "c.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        fcpxml_mod.StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b), ("C", primary_c))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        transitions=[
+            fcpxml_mod.StageTransition(after_stage_index=0, kind="cross-dissolve"),
+            fcpxml_mod.StageTransition(after_stage_index=1, kind="dip-to-color"),
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    effects = {e.attrib["name"]: e for e in root.findall("./resources/effect")}
+    assert set(effects) == {"Cross Dissolve", "Dip to Color Dissolve"}
+    transitions = root.findall(".//spine/transition")
+    assert [t.attrib["name"] for t in transitions] == [
+        "Cross Dissolve",
+        "Dip to Color Dissolve",
+    ]
+
+
+def test_transition_too_long_for_adjacent_stage_raises(tmp_path: Path) -> None:
+    """A transition longer than 2x either stage's effective window is
+    rejected so the user sees a clear error rather than malformed
+    FCPXML."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        fcpxml_mod.StageComposition(
+            stage_name="A",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=0.05,
+            tail_pad_seconds=0.05,
+        ),
+        fcpxml_mod.StageComposition(
+            stage_name="B",
+            video_path=primary_b,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+    with pytest.raises(ValueError, match="exceeds the available material"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            transitions=[
+                fcpxml_mod.StageTransition(
+                    after_stage_index=0,
+                    kind="cross-dissolve",
+                    duration_seconds=5.0,
+                )
+            ],
+        )
+
+
+def test_transition_index_out_of_range_raises(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    with pytest.raises(ValueError, match="out of range"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            transitions=[fcpxml_mod.StageTransition(after_stage_index=1, kind="cross-dissolve")],
+        )
+
+
+def test_duplicate_transitions_raise(tmp_path: Path) -> None:
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    primary_c = _make_video(tmp_path, "c.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        fcpxml_mod.StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b), ("C", primary_c))
+    ]
+    with pytest.raises(ValueError, match="duplicate transition"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            transitions=[
+                fcpxml_mod.StageTransition(after_stage_index=0),
+                fcpxml_mod.StageTransition(after_stage_index=0),
+            ],
+        )
+
+
+def test_no_transitions_emits_unchanged_spine(tmp_path: Path) -> None:
+    """The default path (no transitions) emits the same spine as
+    before -- absence of transitions must not change the output."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages, output_path=out, project_name="match", config=OutputConfig()
+    )
+    root = ET.fromstring(out.read_bytes())
+    assert root.find(".//spine/transition") is None
+    assert root.find("./resources/effect") is None
+
+
 # --- probe_video -----------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #195.

## Summary

Emit \`<transition>\` between consecutive stages on the spine. Cross-dissolve and dip-to-color resolve to FCP's built-in Motion templates via stable effect \`uid\`s; FCP picks up the transition on import without splitsmith bundling any \`.motn\` files.

- \`fcpxml_gen.StageTransition\` (\`after_stage_index\`, \`kind\`, \`duration\`, \`color\`).
- \`generate_match_fcpxml\` accepts an optional list and emits \`<transition>\` + \`<filter-video>\` referencing a new \`<effect>\` resource per unique kind. Validation: each transition's half-duration must fit inside the adjacent stages' effective windows.
- Composition IR exposes \`transitions\` through \`from_stage_compositions\` and \`render_fcpxml\`; \`_lower_transitions\` maps IR \`Transition\` -> legacy \`StageTransition\`.
- Export endpoint + dialog: \`transition_kind\` (\`"none"\` default, \`"cross-dissolve"\`, \`"dip-to-color"\`) plus \`transition_duration_seconds\`. FCP7 export with transitions surfaces an "ignored" anomaly (follow-up).

## Spine math

Transition centred on the cut: \`offset = end_of_prev - duration / 2\`, \`duration = transition.duration\`. Adjacent stages keep their full effective duration; FCP cross-fades using each side's \`duration / 2\` of overlap material.

Validation: \`half_frames > prev.effective_duration_frames\` or \`> next.effective_duration_frames\` raises \`ValueError\` with a specific message naming the offending stage.

## Test plan

- [x] 7 new \`test_fcpxml_gen.py\` tests: effect resource emission, offset math, multi-kind reuse / dedup, error paths (too long, out of range, duplicate), default-no-transition unchanged.
- [x] DTD validation gains \`test_fcpxml_match_with_transitions_validates\` -- emits cross-dissolve + dip-to-color and validates against Apple's FCPXML 1.10 DTD.
- [x] Full Python suite: 808 passed, 4 skipped.
- [x] \`tsc -b --noEmit\` clean.
- [x] \`ruff\` / \`black\` clean.
- [ ] **Release gate:** import a stitched export with transitions into Final Cut and confirm Cross Dissolve / Dip to Color resolve to the built-in generators. The \`uid\` path has been stable across FCP versions for years but Apple owns it; if it ever changes the import surfaces a missing-effect warning.

## Out of scope (filed as follow-ups if needed)

- FCP7 XML transitions (would emit \`<transitionitem>\` with effectid).
- ffmpeg MP4 transitions (xfade filter; restructures \`mp4_render\` from per-stage temps + concat-demuxer to a single filter graph or transition fragments).
- Per-boundary kind / duration overrides (uniform-only for v1; templates work in #198 will surface this).
- Custom transition presets beyond cross-dissolve / dip-to-color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)