### PR TITLE
FCPXML stage title cards (slate, lower-third) (#196)

### DIFF
--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -132,7 +132,13 @@ class ConnectedClip:
 
 @dataclass(frozen=True)
 class Stage:
-    """One stage's contribution to the composition."""
+    """One stage's contribution to the composition.
+
+    ``title`` (issue #196) is an optional ``TitleCard`` rendered as a
+    slate (pre-stage card on the spine) or lower-third (connected
+    text clip overlaid on the primary). Renderers that don't support
+    titles ignore the field.
+    """
 
     name: str
     primary: Asset
@@ -142,6 +148,7 @@ class Stage:
     secondaries: tuple[ConnectedClip, ...] = ()
     overlay: ConnectedClip | None = None
     markers: tuple[Marker, ...] = ()
+    title: "TitleCard | None" = None
 
 
 TransitionKind = Literal["cross-dissolve", "dip-to-color"]
@@ -180,16 +187,30 @@ TitleStyle = Literal["slate", "lower-third"]
 
 @dataclass(frozen=True)
 class TitleCard:
-    """Title overlay (placeholder until #196 lands).
+    """Title overlay attached to a stage (issue #196).
 
-    ``slate`` is a short pre-stage card; ``lower-third`` is a connected
-    text clip overlapping the start of a stage. Renderers map this to a
-    target-native title primitive.
+    ``slate`` -- a short pre-stage card on the spine; extends the
+    timeline by ``duration_seconds``. Lands before the stage's
+    primary so the user reads the card, then the action begins.
+
+    ``lower-third`` -- a connected text clip on the topmost lane that
+    overlaps the start of the stage; doesn't extend the timeline.
+
+    ``font_size`` is in FCPXML points at the timeline's native scale;
+    bigger sequences may want larger sizes but Basic Title scales
+    automatically across formats.
+
+    The FCPXML renderer (this PR) emits both styles via FCP's Basic
+    Title generator. FCP7 XML / ffmpeg renderers ignore titles for
+    now -- they'll grow support in follow-up PRs.
     """
 
     text: str
     duration_seconds: float
     style: TitleStyle = "slate"
+    font_size: int = 144
+    font: str = "Helvetica"
+    color: str = "1 1 1 1"
 
 
 @dataclass(frozen=True)
@@ -234,6 +255,7 @@ def from_stage_compositions(
     *,
     project_name: str,
     transitions: SequenceProto[Transition] = (),
+    titles: dict[int, TitleCard] | None = None,
 ) -> Composition:
     """Build a :class:`Composition` from today's ``StageComposition`` inputs.
 
@@ -247,14 +269,20 @@ def from_stage_compositions(
     that the FCPXML renderer emits between consecutive stages. Each
     transition's ``from_stage_index`` / ``to_stage_index`` must point at
     valid stage positions; v1 only accepts consecutive pairs.
+
+    ``titles`` (issue #196): optional mapping from stage index to a
+    :class:`TitleCard`. The IR attaches each title to its
+    :class:`Stage`; the FCPXML renderer emits slate / lower-third
+    via FCP's Basic Title generator.
     """
+    titles_map = dict(titles) if titles else {}
     if not stages:
         raise ValueError("Composition requires at least one stage")
     base = stages[0].video
     seq = SequenceFormat.from_video(base)
 
     ir_stages: list[Stage] = []
-    for stage_comp in stages:
+    for stage_idx, stage_comp in enumerate(stages):
         secondaries: list[ConnectedClip] = []
         for sec in stage_comp.secondaries:
             transform = _pip_to_transform(sec.pip, seq) if sec.pip is not None else None
@@ -299,6 +327,7 @@ def from_stage_compositions(
                 secondaries=tuple(secondaries),
                 overlay=overlay,
                 markers=markers,
+                title=titles_map.get(stage_idx),
             )
         )
 
@@ -428,15 +457,17 @@ def render_fcpxml(
     so transitions / titles / new renderers can reach the wire.
     """
     legacy_stages = to_stage_compositions(composition)
+    has_titles = any(s.title is not None for s in composition.stages)
     if (
         len(legacy_stages) == 1
         and composition.intro is None
         and composition.outro is None
         and not composition.transitions
+        and not has_titles
     ):
-        # Single stage with no intro/outro/transitions mirrors today's
-        # per-stage path. Use generate_fcpxml so the file is byte-
-        # identical to a single-stage export.
+        # Single stage with no intro/outro/transitions/titles mirrors
+        # today's per-stage path. Use generate_fcpxml so the file is
+        # byte-identical to a single-stage export.
         stage = legacy_stages[0]
         fcpxml_gen.generate_fcpxml(
             video_path=stage.video_path,
@@ -457,6 +488,7 @@ def render_fcpxml(
         project_name=composition.project_name,
         config=config,
         transitions=_lower_transitions(composition.transitions),
+        titles=_lower_titles(composition),
     )
 
 
@@ -480,6 +512,27 @@ def _lower_transitions(
                 kind=t.kind,
                 duration_seconds=t.duration_seconds,
                 color=t.color,
+            )
+        )
+    return out
+
+
+def _lower_titles(composition: Composition) -> list[fcpxml_gen.StageTitle]:
+    """Lower per-stage IR titles to ``fcpxml_gen.StageTitle`` for the
+    legacy emitter (issue #196)."""
+    out: list[fcpxml_gen.StageTitle] = []
+    for idx, stage in enumerate(composition.stages):
+        if stage.title is None:
+            continue
+        out.append(
+            fcpxml_gen.StageTitle(
+                stage_index=idx,
+                text=stage.title.text,
+                style=stage.title.style,
+                duration_seconds=stage.title.duration_seconds,
+                font_size=stage.title.font_size,
+                font=stage.title.font,
+                color=stage.title.color,
             )
         )
     return out

--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -148,7 +148,7 @@ class Stage:
     secondaries: tuple[ConnectedClip, ...] = ()
     overlay: ConnectedClip | None = None
     markers: tuple[Marker, ...] = ()
-    title: "TitleCard | None" = None
+    title: TitleCard | None = None
 
 
 TransitionKind = Literal["cross-dissolve", "dip-to-color"]

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -152,6 +152,52 @@ def _pip_transform_attrs(
     }
 
 
+def _emit_title_clip(
+    parent: ET.Element,
+    *,
+    ref: str,
+    offset_str: str,
+    start_str: str,
+    duration_str: str,
+    title: StageTitle,
+    text_style_id: str,
+    lane: int | None = None,
+) -> ET.Element:
+    """Emit a ``<title>`` element with text + style children (issue #196).
+
+    Per FCPXML 1.10 the order inside ``<title>`` is ``param*, text*,
+    text-style-def*``; we emit a single ``<text>`` whose child
+    ``<text-style ref=...>`` references a sibling ``<text-style-def>``
+    that carries the actual font / size / colour. ``text_style_id``
+    must be unique across the document.
+    """
+    attrs = {
+        "ref": ref,
+        "offset": offset_str,
+        "start": start_str,
+        "duration": duration_str,
+        "name": title.text,
+    }
+    if lane is not None:
+        attrs["lane"] = str(lane)
+    title_el = ET.SubElement(parent, "title", attrs)
+    text_el = ET.SubElement(title_el, "text")
+    style_use = ET.SubElement(text_el, "text-style", {"ref": text_style_id})
+    style_use.text = title.text
+    style_def = ET.SubElement(title_el, "text-style-def", {"id": text_style_id})
+    ET.SubElement(
+        style_def,
+        "text-style",
+        {
+            "font": title.font,
+            "fontSize": str(title.font_size),
+            "fontColor": title.color,
+            "alignment": "center",
+        },
+    )
+    return title_el
+
+
 def _attach_pip_transform(
     asset_clip: ET.Element,
     pip: PipPlacement | None,
@@ -597,6 +643,45 @@ _TRANSITION_NAMES: dict[TransitionKind, str] = {
 }
 
 
+TitleStyle = Literal["slate", "lower-third"]
+
+# FCP's "Basic Title" generator. Stable across FCP versions and the
+# safest cross-installation pick; templates that require non-default
+# Motion library availability are intentionally avoided.
+_BASIC_TITLE_EFFECT_UID = (
+    ".../Generators.localized/Titles.localized/" "Basic Title.localized/Basic Title.motn"
+)
+
+
+@dataclass(frozen=True)
+class StageTitle:
+    """A title card associated with a stage (issue #196).
+
+    ``slate`` -- the title sits on the spine BEFORE the stage's
+    primary, extending the timeline by ``duration_seconds``. Useful
+    for "Stage 3 -- Skipper" cards that the user wants to read before
+    the action starts.
+
+    ``lower-third`` -- the title is a connected clip overlaid above
+    the primary, anchored to its visible head and showing for
+    ``duration_seconds``. Useful for an unobtrusive label that doesn't
+    interrupt the timeline.
+
+    ``font_size`` is in FCPXML points (1080p sequence default scale);
+    larger sequences may want a larger value but FCP will scale a
+    Basic Title across the timeline format -- the default works for
+    most home / matchcam exports.
+    """
+
+    stage_index: int
+    text: str
+    style: TitleStyle = "slate"
+    duration_seconds: float = 1.5
+    font_size: int = 144
+    font: str = "Helvetica"
+    color: str = "1 1 1 1"  # opaque white
+
+
 @dataclass(frozen=True)
 class StageTransition:
     """A transition between two consecutive stages on the spine (issue #195).
@@ -658,6 +743,7 @@ def generate_match_fcpxml(
     project_name: str,
     config: OutputConfig,
     transitions: list[StageTransition] | None = None,
+    titles: list[StageTitle] | None = None,
 ) -> None:
     """Write a stitched FCPXML with N stages back-to-back on the spine.
 
@@ -678,6 +764,14 @@ def generate_match_fcpxml(
     least ``duration / 2`` of effective material to overlap or the
     exporter raises ``ValueError``. ``None`` keeps today's hard-cut
     layout.
+
+    ``titles`` (issue #196): optional list of ``StageTitle``s that
+    add a ``slate`` (pre-stage card on the spine) or ``lower-third``
+    (connected text clip overlaid on the primary) per stage. Slates
+    extend the spine; lower-thirds anchor to the primary's visible
+    head. Slates combined with transitions raise ``ValueError`` --
+    a slate between two transition-joined primaries has no clean
+    visual semantic.
     """
     if not stages:
         raise ValueError("generate_match_fcpxml requires at least one stage")
@@ -685,6 +779,7 @@ def generate_match_fcpxml(
         if not stage.video_path.exists():
             raise FileNotFoundError(f"video not found: {stage.video_path}")
     transitions = list(transitions or ())
+    titles = list(titles or ())
     seen_indices: set[int] = set()
     for t in transitions:
         if t.after_stage_index in seen_indices:
@@ -700,6 +795,28 @@ def generate_match_fcpxml(
                 f"duration ({t.duration_seconds:g}s)"
             )
         seen_indices.add(t.after_stage_index)
+    seen_title_indices: set[int] = set()
+    for ti in titles:
+        if ti.stage_index in seen_title_indices:
+            raise ValueError(f"duplicate title for stage index {ti.stage_index}")
+        if not 0 <= ti.stage_index < len(stages):
+            raise ValueError(
+                f"title.stage_index={ti.stage_index} is out of range for "
+                f"{len(stages)} stages (must be in 0..{len(stages) - 1})"
+            )
+        if ti.duration_seconds <= 0:
+            raise ValueError(
+                f"title for stage {ti.stage_index} has non-positive "
+                f"duration ({ti.duration_seconds:g}s)"
+            )
+        seen_title_indices.add(ti.stage_index)
+    has_slate = any(ti.style == "slate" for ti in titles)
+    if has_slate and transitions:
+        raise ValueError(
+            "slate titles and transitions cannot be combined -- a slate "
+            "between two transition-joined primaries has no clean visual "
+            "semantic. Use lower-third titles, or remove transitions."
+        )
 
     base = stages[0].video
     for stage in stages[1:]:
@@ -965,10 +1082,39 @@ def generate_match_fcpxml(
             )
             transition_effect_ids[trans.kind] = effect_id
 
+    # Title effect resource (issue #196). One ``<effect>`` referencing
+    # FCP's Basic Title generator suffices for both slate and lower-
+    # third styles -- they're just different placements of the same
+    # generator, distinguished by where the ``<title>`` element lands
+    # (spine vs connected) and by its lane.
+    title_effect_id: str | None = None
+    if titles:
+        resource_counter += 1
+        title_effect_id = f"r{resource_counter}"
+        ET.SubElement(
+            resources,
+            "effect",
+            {
+                "id": title_effect_id,
+                "name": "Basic Title",
+                "uid": _BASIC_TITLE_EFFECT_UID,
+            },
+        )
+
+    titles_by_index: dict[int, StageTitle] = {ti.stage_index: ti for ti in titles}
+    slate_frames_by_index: dict[int, int] = {
+        idx: round(ti.duration_seconds / fd_seconds)
+        for idx, ti in titles_by_index.items()
+        if ti.style == "slate"
+    }
+    total_slate_frames = sum(slate_frames_by_index.values())
+
     library = ET.SubElement(fcpxml, "library")
     event = ET.SubElement(library, "event", {"name": "splitsmith"})
     project = ET.SubElement(event, "project", {"name": project_name})
-    total_duration_frames = sum(plan.effective_duration_frames for plan in plans)
+    total_duration_frames = (
+        sum(plan.effective_duration_frames for plan in plans) + total_slate_frames
+    )
     sequence = ET.SubElement(
         project,
         "sequence",
@@ -990,6 +1136,26 @@ def generate_match_fcpxml(
         stage = plan.stage
         head_trim_seconds = plan.head_trim_frames * fd_seconds
         eff_duration_str = _frame_aligned_str(plan.effective_duration_frames, fd_num, fd_den)
+
+        # Slate title (issue #196). Sits on the spine BEFORE the
+        # primary; bumps the cumulative offset so the primary lands
+        # after the slate. Only one slate per stage; lower-third
+        # variants are emitted as connected clips below.
+        stage_title = titles_by_index.get(stage_idx)
+        if stage_title is not None and stage_title.style == "slate":
+            assert title_effect_id is not None
+            slate_dur_frames = slate_frames_by_index[stage_idx]
+            _emit_title_clip(
+                spine,
+                ref=title_effect_id,
+                offset_str=_frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
+                start_str="0s",
+                duration_str=_frame_aligned_str(slate_dur_frames, fd_num, fd_den),
+                title=stage_title,
+                text_style_id=f"ts-slate-{stage_idx}",
+            )
+            cumulative_offset_frames += slate_dur_frames
+
         primary_clip = ET.SubElement(
             spine,
             "asset-clip",
@@ -1065,6 +1231,26 @@ def generate_match_fcpxml(
                     "duration": eff_duration_str,
                     "format": format_id,
                 },
+            )
+
+        # Lower-third title (issue #196). Connected clip on the lane
+        # above secondaries + overlay so the text always sits on top.
+        # ``offset`` anchors at the primary's visible head; the user
+        # can drag the title later in FCP if they want it elsewhere.
+        if stage_title is not None and stage_title.style == "lower-third":
+            assert title_effect_id is not None
+            lt_lane = len(plan.usable_secondaries) + 2
+            lt_dur_frames = round(stage_title.duration_seconds / fd_seconds)
+            head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
+            _emit_title_clip(
+                primary_clip,
+                ref=title_effect_id,
+                offset_str=head_trim_str,
+                start_str="0s",
+                duration_str=_frame_aligned_str(lt_dur_frames, fd_num, fd_den),
+                title=stage_title,
+                text_style_id=f"ts-lt-{stage_idx}",
+                lane=lt_lane,
             )
 
         # Markers. Each shot's clip-local source-media time stays the marker

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -37,6 +37,12 @@ OutputFormat = Literal["fcpxml", "fcp7xml", "mp4"]
 # today; FCP7 / MP4 ignore the request until they grow transition
 # support.
 TransitionKind = Literal["none", "cross-dissolve", "dip-to-color"]
+# Issue #196. ``"none"`` keeps today's title-less stitching.
+# ``"slate"`` adds a pre-stage card on the spine; ``"lower-third"`` is
+# a connected text clip overlaid on the start of the primary. Only
+# the FCPXML renderer emits titles today; FCP7 / MP4 ignore the
+# request until they grow title support.
+TitleKind = Literal["none", "slate", "lower-third"]
 
 
 @dataclass(frozen=True)
@@ -95,6 +101,11 @@ class MatchExportRequestData:
     # ignored when ``transition_kind == "none"``.
     transition_kind: TransitionKind = "none"
     transition_duration_seconds: float = 0.5
+    # Issue #196. Per-stage titles. Text defaults to the stage name;
+    # ``title_duration_seconds`` is uniform across stages. ``"none"``
+    # keeps the timeline title-less.
+    title_kind: TitleKind = "none"
+    title_duration_seconds: float = 1.5
 
 
 @dataclass(frozen=True)
@@ -251,10 +262,28 @@ def export_match(
             f"{request.output_format} renderer (issue #195 follow-ups)"
         )
         transitions = ()
+    titles = _build_uniform_titles(
+        kind=request.title_kind,
+        duration=request.title_duration_seconds,
+        stage_inputs=stages,
+    )
+    if titles and request.output_format != "fcpxml":
+        anomalies.append(
+            f"titles ignored: not yet supported by the "
+            f"{request.output_format} renderer (issue #196 follow-ups)"
+        )
+        titles = {}
+    if titles and transitions and any(t.style == "slate" for t in titles.values()):
+        # Mirror the emitter's guard at the request layer so the
+        # response carries an explicit anomaly instead of a 500-shaped
+        # error from generate_match_fcpxml.
+        anomalies.append("slate titles dropped: cannot combine with transitions " "(issue #196)")
+        titles = {}
     comp = composition.from_stage_compositions(
         compositions,
         project_name=request.project_name,
         transitions=transitions,
+        titles=titles,
     )
     try:
         if request.output_format == "fcpxml":
@@ -325,3 +354,24 @@ def _build_uniform_transitions(
         )
         for i in range(stage_count - 1)
     )
+
+
+def _build_uniform_titles(
+    *,
+    kind: TitleKind,
+    duration: float,
+    stage_inputs: list[MatchStageInput],
+) -> dict[int, composition.TitleCard]:
+    """Expand a single ``(kind, duration)`` into one ``TitleCard`` per
+    stage. Each title's text defaults to the stage name -- templating
+    will let users customise this in #198."""
+    if kind == "none":
+        return {}
+    return {
+        idx: composition.TitleCard(
+            text=stage_input.stage_name,
+            duration_seconds=duration,
+            style=kind,
+        )
+        for idx, stage_input in enumerate(stage_inputs)
+    }

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -955,6 +955,12 @@ class MatchExportRequest(BaseModel):
     # ignored" anomaly when set together with those formats.
     transition_kind: Literal["none", "cross-dissolve", "dip-to-color"] = "none"
     transition_duration_seconds: float = 0.5
+    # Issue #196. Per-stage title cards. ``"slate"`` adds a pre-stage
+    # card on the spine; ``"lower-third"`` is a connected text clip
+    # overlaid on the start of the primary. FCPXML only today;
+    # FCP7 / MP4 surface a "titles ignored" anomaly when combined.
+    title_kind: Literal["none", "slate", "lower-third"] = "none"
+    title_duration_seconds: float = 1.5
 
 
 class RevealRequest(BaseModel):
@@ -4606,6 +4612,8 @@ def create_app(
             output_format=req.output_format,
             transition_kind=req.transition_kind,
             transition_duration_seconds=req.transition_duration_seconds,
+            title_kind=req.title_kind,
+            title_duration_seconds=req.title_duration_seconds,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -512,6 +512,14 @@ export interface MatchExportRequestPayload {
    *  ``transition_kind`` is ``"none"``. Each adjacent stage's effective
    *  window must contain at least half this value of material. */
   transition_duration_seconds?: number;
+  /** Issue #196. Per-stage title cards. ``"slate"`` adds a pre-stage
+   *  card on the spine; ``"lower-third"`` is a connected text clip
+   *  overlaid on the start of the primary. FCPXML only today. */
+  title_kind?: "none" | "slate" | "lower-third";
+  /** Title duration in seconds; ignored when ``title_kind`` is
+   *  ``"none"``. Slates default to 1.5s; lower-thirds default to
+   *  3.0s but the dialog uses one input either way. */
+  title_duration_seconds?: number;
 }
 
 export interface MatchExportResult {

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1221,6 +1221,15 @@ function MatchExportDialog({
   >("none");
   const [transitionDurationSeconds, setTransitionDurationSeconds] =
     useState<number>(0.5);
+  // Issue #196. ``"none"`` keeps the timeline title-less. ``"slate"``
+  // adds a pre-stage card on the spine (extends total duration);
+  // ``"lower-third"`` overlays a small text clip at each stage's
+  // start (no spine extension). Only FCPXML emits titles today.
+  const [titleKind, setTitleKind] = useState<
+    "none" | "slate" | "lower-third"
+  >("none");
+  const [titleDurationSeconds, setTitleDurationSeconds] =
+    useState<number>(1.5);
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1275,6 +1284,8 @@ function MatchExportDialog({
         output_format: outputFormat,
         transition_kind: transitionKind,
         transition_duration_seconds: transitionDurationSeconds,
+        title_kind: titleKind,
+        title_duration_seconds: titleDurationSeconds,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1552,6 +1563,49 @@ function MatchExportDialog({
                       const v = parseFloat(e.target.value);
                       if (!Number.isNaN(v) && v > 0)
                         setTransitionDurationSeconds(v);
+                    }}
+                  />
+                  s
+                </label>
+              )}
+              <label
+                className="flex items-center gap-1.5"
+                title="Slate: pre-stage card on the timeline (extends duration). Lower-third: connected text overlay at the start of each primary. FCPXML only."
+              >
+                Titles
+                <select
+                  className="rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                  value={titleKind}
+                  disabled={busy}
+                  onChange={(e) =>
+                    setTitleKind(
+                      e.target.value as "none" | "slate" | "lower-third",
+                    )
+                  }
+                >
+                  <option value="none">None</option>
+                  <option value="slate">Slate (pre-stage)</option>
+                  <option value="lower-third">Lower third</option>
+                </select>
+              </label>
+              {titleKind !== "none" && (
+                <label
+                  className="flex items-center gap-1.5"
+                  title="Title duration in seconds. Slates add this to the total timeline; lower-thirds overlay for this many seconds at the start of each stage."
+                >
+                  Duration
+                  <input
+                    type="number"
+                    min={0.5}
+                    max={10.0}
+                    step={0.5}
+                    className="w-16 rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                    value={titleDurationSeconds}
+                    disabled={busy}
+                    onChange={(e) => {
+                      const v = parseFloat(e.target.value);
+                      if (!Number.isNaN(v) && v > 0)
+                        setTitleDurationSeconds(v);
                     }}
                   />
                   s

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -248,6 +248,46 @@ def test_fcpxml_match_with_transitions_validates(tmp_path: Path) -> None:
 
 
 @fcpxml_dtd
+def test_fcpxml_match_with_titles_validates(tmp_path: Path) -> None:
+    """Slate + lower-third titles emit ``<title>`` elements with text /
+    text-style-def children. DTD checks that the element ordering
+    inside ``<title>`` matches FCPXML's content-model rules."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_gen.StageTitle(
+                stage_index=0, text="Stage A", style="slate", duration_seconds=1.0
+            ),
+            fcpxml_gen.StageTitle(
+                stage_index=1,
+                text="Stage B",
+                style="lower-third",
+                duration_seconds=2.0,
+            ),
+        ],
+    )
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())
+
+
+@fcpxml_dtd
 def test_invalid_fcpxml_fails_validation(tmp_path: Path) -> None:
     """Sanity: hand-rolled bad FCPXML must trip the validator. Catches
     helper regressions (e.g. xmllint flags wrong / DTD path silently

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1597,6 +1597,221 @@ def test_no_transitions_emits_unchanged_spine(tmp_path: Path) -> None:
     assert root.find("./resources/effect") is None
 
 
+# --- title cards (issue #196) ---------------------------------------------
+
+
+def test_match_with_slate_title_emits_basic_title_effect(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_mod.StageTitle(
+                stage_index=0, text="Stage A", style="slate", duration_seconds=1.5
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    effects = root.findall("./resources/effect")
+    assert len(effects) == 1
+    assert effects[0].attrib["name"] == "Basic Title"
+    assert effects[0].attrib["uid"].endswith("Basic Title.motn")
+
+
+def test_slate_title_lands_on_spine_before_primary(tmp_path: Path) -> None:
+    """Slate sits on the spine ahead of the stage's primary; the
+    primary's offset shifts forward by the slate duration so playback
+    is slate -> primary."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_mod.StageTitle(
+                stage_index=0, text="Stage A", style="slate", duration_seconds=1.0
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine = root.find(".//spine")
+    assert spine is not None
+    children = list(spine)
+    # Order: title (slate), primary A, primary B (no slate on B).
+    assert children[0].tag == "title"
+    assert children[0].attrib["offset"] == "0s"
+    assert children[0].attrib["duration"] == "30/30s"  # 1s @ 30fps
+    assert children[1].tag == "asset-clip"
+    assert children[1].attrib["name"] == "A"
+    assert children[1].attrib["offset"] == "30/30s"
+
+
+def test_slate_title_carries_text_and_style_def(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_mod.StageTitle(
+                stage_index=0,
+                text="Stage A",
+                style="slate",
+                font="Helvetica",
+                font_size=144,
+                color="1 1 1 1",
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    title = root.find(".//spine/title")
+    assert title is not None
+    text_el = title.find("text")
+    assert text_el is not None
+    style_use = text_el.find("text-style")
+    assert style_use is not None
+    assert style_use.text == "Stage A"
+    style_def = title.find("text-style-def")
+    assert style_def is not None
+    assert style_use.attrib["ref"] == style_def.attrib["id"]
+    inner = style_def.find("text-style")
+    assert inner is not None
+    assert inner.attrib["font"] == "Helvetica"
+    assert inner.attrib["fontSize"] == "144"
+    assert inner.attrib["fontColor"] == "1 1 1 1"
+
+
+def test_lower_third_title_lands_as_connected_clip(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_mod.StageTitle(
+                stage_index=0,
+                text="Stage A",
+                style="lower-third",
+                duration_seconds=2.0,
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_titles = root.findall("./library/event/project/sequence/spine/title")
+    assert len(spine_titles) == 0
+    nested_title = root.find("./library/event/project/sequence/spine/asset-clip/title")
+    assert nested_title is not None
+    # Lane is above secondaries (0) + overlay slot (+1) + 1 = 2 for a
+    # stage with neither cams nor overlay.
+    assert nested_title.attrib["lane"] == "2"
+    assert nested_title.attrib["duration"] == "60/30s"  # 2s @ 30fps
+
+
+def test_slate_title_extends_sequence_duration(tmp_path: Path) -> None:
+    """Sequence duration = sum(effective) + sum(slate frames). Stage
+    A: 11s effective (330 frames). Stage B with last shot at +0.8s:
+    tail_avail = 20-5.8 = 14.2; tail_trim = 14.2-5 = 9.2s -> 276
+    frames; effective = 20-9.2 = 10.8s = 324 frames. Plus 2 slates
+    of 1s each = 60 frames. Total = 330 + 324 + 60 = 714."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        titles=[
+            fcpxml_mod.StageTitle(stage_index=0, text="A", style="slate", duration_seconds=1.0),
+            fcpxml_mod.StageTitle(stage_index=1, text="B", style="slate", duration_seconds=1.0),
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    sequence = root.find("./library/event/project/sequence")
+    assert sequence is not None
+    duration_frames = int(sequence.attrib["duration"].split("/")[0])
+    # Stage A effective = 330 frames; stage B effective = 324 frames;
+    # 2 slates @ 30 frames = 60 frames. Total = 714.
+    assert duration_frames == 330 + 324 + 60
+
+
+def test_slate_with_transitions_raises(tmp_path: Path) -> None:
+    """Combining slate titles with transitions has no clean visual
+    semantic; the emitter rejects the request explicitly."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    with pytest.raises(ValueError, match="slate titles and transitions"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            transitions=[fcpxml_mod.StageTransition(after_stage_index=0)],
+            titles=[
+                fcpxml_mod.StageTitle(stage_index=0, text="A", style="slate", duration_seconds=1.0)
+            ],
+        )
+
+
+def test_lower_third_with_transitions_is_allowed(tmp_path: Path) -> None:
+    """Lower-thirds are connected to primaries so they don't conflict
+    with stage-boundary transitions."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        transitions=[fcpxml_mod.StageTransition(after_stage_index=0)],
+        titles=[
+            fcpxml_mod.StageTitle(
+                stage_index=0, text="A", style="lower-third", duration_seconds=2.0
+            )
+        ],
+    )
+    root = ET.fromstring(out.read_bytes())
+    assert root.find(".//spine/transition") is not None
+    assert root.find(".//spine/asset-clip/title") is not None
+
+
+def test_duplicate_title_indices_raise(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    with pytest.raises(ValueError, match="duplicate title"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            titles=[
+                fcpxml_mod.StageTitle(stage_index=0, text="A", duration_seconds=1.0),
+                fcpxml_mod.StageTitle(stage_index=0, text="A2", duration_seconds=1.0),
+            ],
+        )
+
+
+def test_title_index_out_of_range_raises(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    with pytest.raises(ValueError, match="out of range"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            titles=[fcpxml_mod.StageTitle(stage_index=2, text="C", duration_seconds=1.0)],
+        )
+
+
 # --- probe_video -----------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #196.

## Summary

Emit ``<title>`` elements via FCP's Basic Title generator. Two styles:

- **slate** -- pre-stage card on the spine; extends total timeline duration by the slate length. Right for "Stage 3 -- Skipper" cards before each segment.
- **lower-third** -- connected text clip on the topmost lane, anchored to the primary's visible head. Doesn't extend the timeline; sits above secondaries / overlay so the text always reads.

## Implementation

- ``fcpxml_gen.StageTitle`` carries ``text``, ``style``, ``duration_seconds`` plus font / size / colour. ``generate_match_fcpxml`` accepts an optional list and emits a single ``<effect uid=".../Basic Title.motn">`` resource reused across all titles.
- Composition IR: ``Stage.title`` is the per-stage slot; ``from_stage_compositions(... titles=dict[int, TitleCard])`` populates them. ``_lower_titles`` maps the IR back to ``StageTitle`` for the legacy emitter.
- Slates + transitions raise ``ValueError`` -- a slate between two transition-joined primaries has no clean visual semantic. The match-export endpoint mirrors the guard with an anomaly note instead of a 500.
- Export endpoint + dialog: ``title_kind`` (``"none"`` default, ``"slate"``, ``"lower-third"``) + ``title_duration_seconds``. Title text defaults to the stage name; templates work in #198 will let users customise.
- FCP7 / MP4 surface a "titles ignored" anomaly when titles are requested with those formats; not in scope for this PR.

## Test plan

- [x] 9 new ``test_fcpxml_gen.py`` tests: effect emission, slate spine placement, slate carries text + style, lower-third connected lane allocation, slate extends sequence duration, slate+transition rejection, lower-third+transition allowed, error paths (duplicate / out-of-range).
- [x] DTD validation gains ``test_fcpxml_match_with_titles_validates`` -- emits both slate + lower-third and validates against Apple's FCPXML 1.10 DTD.
- [x] Full Python suite: 833 passed, 4 skipped.
- [x] ``tsc -b --noEmit`` clean.
- [x] ``ruff`` / ``black`` clean.
- [ ] **Release gate:** import a stitched export with each style into FCP and confirm Basic Title resolves and the text reads.

## Out of scope (filed if requested)

- FCP7 XML titles (would emit ``<generatoritem>`` referencing a Basic Title equivalent; FCP7's title primitives differ).
- ffmpeg MP4 titles (drawtext / libass; the mp4 renderer would need a title pass per stage).
- Per-stage custom title text / styling (uniform default = stage name; #198 templates surface this).
- Animated titles / motion graphics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)