### PR TITLE
User templates for export presets (#198)

### DIFF
--- a/src/splitsmith/data/templates/action-cut.yaml
+++ b/src/splitsmith/data/templates/action-cut.yaml
@@ -1,0 +1,19 @@
+# Built-in: action cut.
+#
+# Tight pads (0.5s before beep, 1s after final shot) for a fast-moving
+# match reel. No transitions or titles -- the cut between stages is
+# the rhythm. Headcam-only export (no secondaries) so the pace stays
+# tight.
+schema_version: 1
+name: Action cut
+description: >-
+  Tight 0.5s/1.0s pads, hard cuts between stages, headcam only.
+  Right for a fast-moving social-share reel.
+head_pad_seconds: 0.5
+tail_pad_seconds: 1.0
+include_secondaries: false
+include_overlay: false
+pip_layout: stacked
+output_format: fcpxml
+transition_kind: none
+title_kind: none

--- a/src/splitsmith/data/templates/match-recap.yaml
+++ b/src/splitsmith/data/templates/match-recap.yaml
@@ -1,0 +1,20 @@
+# Built-in: match recap.
+#
+# Full pads (5s/5s) so each stage reads cleanly, lower-third titles
+# overlay the stage name, cross-dissolve between stages. Lower-third
+# (not slate) so transitions can co-exist on the timeline.
+schema_version: 1
+name: Match recap
+description: >-
+  Cross-dissolve stitches with lower-third stage labels.
+  Tail pad keeps a few seconds after the final shot.
+head_pad_seconds: 5.0
+tail_pad_seconds: 5.0
+include_secondaries: true
+include_overlay: true
+pip_layout: pip-corners
+output_format: fcpxml
+transition_kind: cross-dissolve
+transition_duration_seconds: 0.5
+title_kind: lower-third
+title_duration_seconds: 3.0

--- a/src/splitsmith/templates.py
+++ b/src/splitsmith/templates.py
@@ -1,0 +1,190 @@
+"""User templates for export presets (issue #198).
+
+Templates are YAML files describing reusable export choices -- pad
+durations, PiP layout, transition / title style, output format, etc.
+The user picks a template in the export dialog and the values
+pre-fill the form; they can tweak before submitting. The server side
+of templating is intentionally thin: load + list + validate.
+Substitution into the actual export request happens client-side so
+the contract between dialog state and template fields stays one
+clear merge.
+
+Layout:
+
+- Built-in templates ship under
+  ``src/splitsmith/data/templates/`` (read-only, packaged).
+- User templates live under ``~/.splitsmith/templates/`` and
+  override built-ins by name.
+- Templates are versioned via ``schema_version: 1``; unknown
+  versions raise with a migration hint instead of being silently
+  applied.
+
+The schema mirrors the export dialog's controls; new dialog fields
+add to ``MatchExportTemplate`` with defaults so older templates
+keep loading.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+SCHEMA_VERSION: int = 1
+
+# Default search roots. ``user_templates_dir`` is the override location;
+# ``builtin_templates_dir`` is the packaged read-only fallback. The
+# resolver merges them with user templates winning on name collision.
+USER_TEMPLATES_DIR = Path("~/.splitsmith/templates").expanduser()
+BUILTIN_TEMPLATES_DIR = Path(__file__).parent / "data" / "templates"
+
+
+class TemplateError(RuntimeError):
+    """Raised when a template fails to load (parse error, schema
+    mismatch, missing required field, etc.). The endpoint surfaces
+    this as a 400 so the user sees what's wrong with their YAML."""
+
+
+class MatchExportTemplate(BaseModel):
+    """A user-facing export preset.
+
+    All fields are optional; missing ones leave the dialog's default
+    value (or the previous selection) intact when the template is
+    applied. ``schema_version`` is required so we can migrate the
+    shape later without silently mis-interpreting old files.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(
+        ..., description="Template schema version; must equal SCHEMA_VERSION."
+    )
+    name: str | None = Field(
+        None,
+        description=("Display name in the dropdown; falls back to the file stem."),
+    )
+    description: str | None = Field(
+        None,
+        description="Free-form note shown alongside the name in the UI.",
+    )
+    head_pad_seconds: float | None = None
+    tail_pad_seconds: float | None = None
+    include_secondaries: bool | None = None
+    include_overlay: bool | None = None
+    pip_layout: Literal["stacked", "pip-corners"] | None = None
+    output_format: Literal["fcpxml", "fcp7xml", "mp4"] | None = None
+    transition_kind: Literal["none", "cross-dissolve", "dip-to-color"] | None = None
+    transition_duration_seconds: float | None = None
+    title_kind: Literal["none", "slate", "lower-third"] | None = None
+    title_duration_seconds: float | None = None
+
+
+class TemplateEntry(BaseModel):
+    """One template + its identity, returned by the listing endpoint."""
+
+    id: str  # filename stem; unique within the merged catalogue
+    source: Literal["builtin", "user"]
+    template: MatchExportTemplate
+
+
+def list_templates(
+    *,
+    builtin_dir: Path | None = None,
+    user_dir: Path | None = None,
+) -> list[TemplateEntry]:
+    """Return all valid templates from the built-in + user dirs.
+
+    User templates override built-ins by ``id`` (filename stem).
+    Invalid templates are skipped with a logged warning so one bad
+    file doesn't hide the others -- the listing endpoint exposes
+    the same reality the user sees in their templates dir.
+    """
+    builtin_dir = builtin_dir if builtin_dir is not None else BUILTIN_TEMPLATES_DIR
+    user_dir = user_dir if user_dir is not None else USER_TEMPLATES_DIR
+
+    by_id: dict[str, TemplateEntry] = {}
+    for entry in _scan_dir(builtin_dir, source="builtin"):
+        by_id[entry.id] = entry
+    for entry in _scan_dir(user_dir, source="user"):
+        by_id[entry.id] = entry  # user wins on collision
+
+    return sorted(by_id.values(), key=lambda e: (e.source != "user", e.id))
+
+
+def load_template(path: Path) -> MatchExportTemplate:
+    """Parse + validate a single template file.
+
+    Raises :class:`TemplateError` on any failure so callers get a
+    consistent error type regardless of which layer caught the
+    problem (YAML parse, schema mismatch, version skew).
+    """
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise TemplateError(f"failed to read {path}: {exc}") from exc
+    if raw is None:
+        raise TemplateError(f"{path}: file is empty or YAML-null")
+    if not isinstance(raw, dict):
+        raise TemplateError(f"{path}: top-level YAML must be a mapping, got {type(raw).__name__}")
+    if "schema_version" not in raw:
+        raise TemplateError(
+            f"{path}: missing required ``schema_version`` (expected {SCHEMA_VERSION})"
+        )
+    try:
+        version = int(raw["schema_version"])
+    except (TypeError, ValueError) as exc:
+        raise TemplateError(
+            f"{path}: schema_version must be an integer, got {raw['schema_version']!r}"
+        ) from exc
+    if version != SCHEMA_VERSION:
+        raise TemplateError(
+            f"{path}: schema_version {version} is not supported "
+            f"(expected {SCHEMA_VERSION}). Re-author against the current schema "
+            "or remove the file."
+        )
+    try:
+        return MatchExportTemplate.model_validate(raw)
+    except ValidationError as exc:
+        raise TemplateError(f"{path}: {exc}") from exc
+
+
+def _scan_dir(root: Path, *, source: Literal["builtin", "user"]) -> list[TemplateEntry]:
+    if not root.exists() or not root.is_dir():
+        return []
+    out: list[TemplateEntry] = []
+    for path in sorted(root.iterdir()):
+        if not path.is_file() or path.suffix.lower() not in (".yaml", ".yml"):
+            continue
+        try:
+            template = load_template(path)
+        except TemplateError as exc:
+            # Don't fail the whole listing on a single bad file; the
+            # user can fix it and re-list. We surface the warning
+            # only when ``SPLITSMITH_TEMPLATES_DEBUG`` is set so
+            # production runs stay quiet.
+            if os.environ.get("SPLITSMITH_TEMPLATES_DEBUG"):
+                print(f"[templates] skipping {path}: {exc}")
+            continue
+        out.append(
+            TemplateEntry(
+                id=path.stem,
+                source=source,
+                template=template,
+            )
+        )
+    return out
+
+
+__all__ = [
+    "BUILTIN_TEMPLATES_DIR",
+    "MatchExportTemplate",
+    "SCHEMA_VERSION",
+    "TemplateEntry",
+    "TemplateError",
+    "USER_TEMPLATES_DIR",
+    "list_templates",
+    "load_template",
+]

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4354,6 +4354,27 @@ def create_app(
             summary += f" ({n} {word} -- see report.txt)"
         handle.update(progress=1.0, message=f"Done: {summary}")
 
+    @app.get("/api/match/templates")
+    def list_match_templates() -> JSONResponse:
+        """List export templates from built-in + user dirs (issue #198).
+
+        Used by the export dialog to populate a "Template" dropdown.
+        Each entry carries the parsed template body so the client can
+        apply it client-side without a second request.
+        """
+        from .. import templates as templates_mod
+
+        entries = templates_mod.list_templates()
+        payload = [
+            {
+                "id": e.id,
+                "source": e.source,
+                "template": e.template.model_dump(exclude_none=True),
+            }
+            for e in entries
+        ]
+        return JSONResponse({"templates": payload})
+
     @app.post("/api/match/export")
     def export_match(req: MatchExportRequest) -> JSONResponse:
         """Stitch N stages into one FCPXML (issue #171, #172).

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -522,6 +522,31 @@ export interface MatchExportRequestPayload {
   title_duration_seconds?: number;
 }
 
+/** Body of a single export template (issue #198). Mirrors the dialog's
+ *  controls; missing fields leave the dialog default unchanged when
+ *  the template is applied. */
+export interface MatchExportTemplate {
+  schema_version: number;
+  name?: string;
+  description?: string;
+  head_pad_seconds?: number;
+  tail_pad_seconds?: number;
+  include_secondaries?: boolean;
+  include_overlay?: boolean;
+  pip_layout?: "stacked" | "pip-corners";
+  output_format?: "fcpxml" | "fcp7xml" | "mp4";
+  transition_kind?: "none" | "cross-dissolve" | "dip-to-color";
+  transition_duration_seconds?: number;
+  title_kind?: "none" | "slate" | "lower-third";
+  title_duration_seconds?: number;
+}
+
+export interface MatchExportTemplateEntry {
+  id: string;
+  source: "builtin" | "user";
+  template: MatchExportTemplate;
+}
+
 export interface MatchExportResult {
   fcpxml_path: string;
   stage_count: number;
@@ -1499,8 +1524,36 @@ export const api = {
         ...(payload.project_name !== undefined
           ? { project_name: payload.project_name }
           : {}),
+        ...(payload.pip_layout !== undefined
+          ? { pip_layout: payload.pip_layout }
+          : {}),
+        ...(payload.output_format !== undefined
+          ? { output_format: payload.output_format }
+          : {}),
+        ...(payload.transition_kind !== undefined
+          ? { transition_kind: payload.transition_kind }
+          : {}),
+        ...(payload.transition_duration_seconds !== undefined
+          ? { transition_duration_seconds: payload.transition_duration_seconds }
+          : {}),
+        ...(payload.title_kind !== undefined
+          ? { title_kind: payload.title_kind }
+          : {}),
+        ...(payload.title_duration_seconds !== undefined
+          ? { title_duration_seconds: payload.title_duration_seconds }
+          : {}),
       },
     }),
+
+  /** List export templates (issue #198). Used by the export dialog
+   *  to populate a "Template" dropdown; selecting a template
+   *  pre-fills the dialog state with its values. User templates
+   *  ship under ``~/.splitsmith/templates/`` and override built-ins
+   *  by ``id``. */
+  getMatchTemplates: () =>
+    request<{ templates: MatchExportTemplateEntry[] }>(
+      "/api/match/templates",
+    ),
 
   /** Open the OS file manager at ``path`` (selecting the file on macOS /
    *  Windows; opening the parent dir on Linux). The backend rejects paths

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -47,6 +47,7 @@ import {
   type ExportOverview,
   type Job,
   type MatchExportResult,
+  type MatchExportTemplateEntry,
   type MatchProject,
   type OverlayCodec,
   type SecondaryExportStatus,
@@ -1249,6 +1250,52 @@ function MatchExportDialog({
   const [dialogError, setDialogError] = useState<string | null>(null);
   const busy = job?.status === "pending" || job?.status === "running";
 
+  // Issue #198. Fetch available templates on mount so the dialog can
+  // offer them in a dropdown. Failures don't block the dialog --
+  // templates are an additive feature, the manual controls still
+  // work without them.
+  const [templates, setTemplates] = useState<MatchExportTemplateEntry[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getMatchTemplates()
+      .then((res) => {
+        if (!cancelled) setTemplates(res.templates);
+      })
+      .catch(() => {
+        if (!cancelled) setTemplates([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const applyTemplate = (id: string) => {
+    setSelectedTemplateId(id);
+    const entry = templates.find((t) => t.id === id);
+    if (!entry) return;
+    const t = entry.template;
+    if (t.head_pad_seconds !== undefined) setHeadPad(t.head_pad_seconds);
+    if (t.tail_pad_seconds !== undefined) setTailPad(t.tail_pad_seconds);
+    if (t.head_pad_seconds !== undefined || t.tail_pad_seconds !== undefined) {
+      // The user no longer matches one of the named presets -- reflect
+      // that so the preset chips don't claim a stale selection.
+      setPreset("custom");
+    }
+    if (t.include_secondaries !== undefined)
+      setIncludeSecondaries(t.include_secondaries);
+    if (t.include_overlay !== undefined) setIncludeOverlay(t.include_overlay);
+    if (t.pip_layout !== undefined) setPipLayout(t.pip_layout);
+    if (t.output_format !== undefined) setOutputFormat(t.output_format);
+    if (t.transition_kind !== undefined) setTransitionKind(t.transition_kind);
+    if (t.transition_duration_seconds !== undefined)
+      setTransitionDurationSeconds(t.transition_duration_seconds);
+    if (t.title_kind !== undefined) setTitleKind(t.title_kind);
+    if (t.title_duration_seconds !== undefined)
+      setTitleDurationSeconds(t.title_duration_seconds);
+  };
+
   const choosePreset = (next: PaddingPreset) => {
     setPreset(next);
     if (next !== "custom") {
@@ -1356,6 +1403,39 @@ function MatchExportDialog({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4 text-sm">
+          {templates.length > 0 && (
+            <section className="space-y-2">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Template
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  className="rounded border border-border bg-background px-2 py-1 text-sm"
+                  value={selectedTemplateId}
+                  disabled={busy}
+                  onChange={(e) => applyTemplate(e.target.value)}
+                >
+                  <option value="">(none) -- manual</option>
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.template.name ?? t.id}
+                      {t.source === "user" ? "" : " (built-in)"}
+                    </option>
+                  ))}
+                </select>
+                {selectedTemplateId &&
+                  templates.find((t) => t.id === selectedTemplateId)?.template
+                    .description && (
+                    <span className="text-xs text-muted-foreground">
+                      {
+                        templates.find((t) => t.id === selectedTemplateId)
+                          ?.template.description
+                      }
+                    </span>
+                  )}
+              </div>
+            </section>
+          )}
           <section className="space-y-2">
             <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Padding

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,161 @@
+"""Tests for the user-template loader (issue #198).
+
+Templates pre-fill the export dialog; bad files surface as
+``TemplateError`` so the listing endpoint can show a clear message
+instead of returning whatever the YAML parser felt like raising.
+The schema_version gate is the future-proofing pin -- a v2 file
+loaded by a v1 binary must be rejected, not silently misinterpreted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith import templates as templates_mod
+from splitsmith.templates import (
+    BUILTIN_TEMPLATES_DIR,
+    SCHEMA_VERSION,
+    MatchExportTemplate,
+    TemplateError,
+    list_templates,
+    load_template,
+)
+
+
+def test_builtin_templates_load(tmp_path: Path) -> None:
+    """The shipped built-ins must parse cleanly -- a regression here
+    means the dialog dropdown ships broken to every user."""
+    entries = list_templates(builtin_dir=BUILTIN_TEMPLATES_DIR, user_dir=tmp_path)
+    ids = {e.id for e in entries}
+    assert "match-recap" in ids
+    assert "action-cut" in ids
+    for e in entries:
+        assert e.source == "builtin"
+        assert e.template.schema_version == SCHEMA_VERSION
+
+
+def test_user_templates_override_builtins(tmp_path: Path) -> None:
+    """A user file with the same stem as a built-in wins -- lets
+    the user redefine ``match-recap`` without touching the package."""
+    custom = tmp_path / "match-recap.yaml"
+    custom.write_text(
+        "schema_version: 1\nname: My recap\nhead_pad_seconds: 1.0\n",
+        encoding="utf-8",
+    )
+    entries = list_templates(builtin_dir=BUILTIN_TEMPLATES_DIR, user_dir=tmp_path)
+    by_id = {e.id: e for e in entries}
+    assert by_id["match-recap"].source == "user"
+    assert by_id["match-recap"].template.name == "My recap"
+    # Other built-ins still visible.
+    assert by_id["action-cut"].source == "builtin"
+
+
+def test_user_only_template_lands_with_user_source(tmp_path: Path) -> None:
+    custom = tmp_path / "vertical.yaml"
+    custom.write_text(
+        "schema_version: 1\nname: Vertical\noutput_format: mp4\n",
+        encoding="utf-8",
+    )
+    entries = list_templates(builtin_dir=BUILTIN_TEMPLATES_DIR, user_dir=tmp_path)
+    custom_entry = next(e for e in entries if e.id == "vertical")
+    assert custom_entry.source == "user"
+    assert custom_entry.template.output_format == "mp4"
+
+
+def test_load_template_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "future.yaml"
+    p.write_text("schema_version: 999\nname: Future\n", encoding="utf-8")
+    with pytest.raises(TemplateError, match="schema_version 999 is not supported"):
+        load_template(p)
+
+
+def test_load_template_rejects_missing_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "noversion.yaml"
+    p.write_text("name: No version\n", encoding="utf-8")
+    with pytest.raises(TemplateError, match="missing required ``schema_version``"):
+        load_template(p)
+
+
+def test_load_template_rejects_unknown_field(tmp_path: Path) -> None:
+    """``extra="forbid"`` catches typos. Without this guard a user
+    typing ``transitions_kind`` (vs ``transition_kind``) would see
+    no effect when applying the template -- silent failure."""
+    p = tmp_path / "typo.yaml"
+    p.write_text(
+        "schema_version: 1\ntransitions_kind: cross-dissolve\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(TemplateError):
+        load_template(p)
+
+
+def test_load_template_rejects_bad_yaml(tmp_path: Path) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("schema_version: 1\nname: [unclosed\n", encoding="utf-8")
+    with pytest.raises(TemplateError, match="failed to read"):
+        load_template(p)
+
+
+def test_load_template_rejects_non_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "list.yaml"
+    p.write_text("- schema_version: 1\n", encoding="utf-8")
+    with pytest.raises(TemplateError, match="top-level YAML must be a mapping"):
+        load_template(p)
+
+
+def test_invalid_files_skip_in_listing_without_breaking_others(
+    tmp_path: Path,
+) -> None:
+    """One bad file shouldn't hide all the other valid ones; the
+    listing endpoint should keep working so the user can still pick
+    a template while they fix the broken file."""
+    good = tmp_path / "good.yaml"
+    good.write_text("schema_version: 1\nname: Good\n", encoding="utf-8")
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("schema_version: 999\n", encoding="utf-8")
+    entries = list_templates(builtin_dir=tmp_path / "_empty", user_dir=tmp_path)
+    ids = {e.id for e in entries}
+    assert "good" in ids
+    assert "bad" not in ids
+
+
+def test_template_validates_literal_choices(tmp_path: Path) -> None:
+    """``output_format`` is constrained to a Literal; an invalid
+    value gets caught at parse time instead of confusing the
+    server later."""
+    p = tmp_path / "weird.yaml"
+    p.write_text(
+        "schema_version: 1\noutput_format: avi\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(TemplateError):
+        load_template(p)
+
+
+def test_match_export_template_round_trip() -> None:
+    """``model_dump(exclude_none=True)`` drops unset fields -- the
+    listing endpoint relies on this so unset values don't override
+    dialog defaults when applied client-side."""
+    t = MatchExportTemplate(
+        schema_version=1,
+        head_pad_seconds=2.0,
+        title_kind="slate",
+    )
+    payload = t.model_dump(exclude_none=True)
+    assert payload == {
+        "schema_version": 1,
+        "head_pad_seconds": 2.0,
+        "title_kind": "slate",
+    }
+
+
+def test_list_templates_handles_missing_dirs(tmp_path: Path) -> None:
+    """Fresh installs may not have either dir present; the loader
+    must not raise."""
+    entries = templates_mod.list_templates(
+        builtin_dir=tmp_path / "missing-builtin",
+        user_dir=tmp_path / "missing-user",
+    )
+    assert entries == []


### PR DESCRIPTION
Closes #198. Closes the umbrella's last in-scope item alongside the FCP7 / MP4 / transitions / titles work that landed earlier today.

## Summary

Reusable YAML export presets that pre-fill the export dialog. The user picks a template in a new "Template" dropdown; dialog state gets set to the template values; user tweaks and submits as normal.

## What ships

- ``splitsmith/templates.py`` -- ``MatchExportTemplate`` (Pydantic, ``extra="forbid"``) + loader + listing helper.
- Two built-in templates under ``src/splitsmith/data/templates/``:
  - **match-recap**: full pads, PiP corners, lower-third titles, cross-dissolve.
  - **action-cut**: tight 0.5s/1.0s pads, headcam only, hard cuts.
- ``GET /api/match/templates`` returns the merged catalogue (built-ins + ``~/.splitsmith/templates/`` user files).
- Export dialog: "Template" dropdown above the Padding section. Selecting a template sets all matching dialog controls. The dropdown is hidden when no templates are present so a fresh checkout's dialog isn't cluttered.

## Why client-side merge

Templates set dialog state, not server-side overrides. The contract stays "what you see in the dialog is exactly what gets submitted" -- one merge, in one place, the user can inspect. A future CLI / scripting flow can grow a server-side merge later without breaking the dialog model.

## Schema versioning

``schema_version: 1`` is required. Unknown versions raise with a migration hint instead of being silently mis-applied. ``extra="forbid"`` catches typos (``transitions_kind`` vs ``transition_kind``) at load time so a broken template surfaces in the listing rather than silently no-op'ing.

Adding a new dialog field later: extend ``MatchExportTemplate`` with a default of ``None``, update the Pydantic + TS schema. Old templates keep loading; the new field defaults to "leave dialog state unchanged."

## Test plan

- [x] 12 new ``tests/test_templates.py`` covering: built-in templates load, user overrides built-in, version skew rejected, missing version rejected, unknown field rejected, bad YAML rejected, non-mapping rejected, invalid files skip in listing without breaking siblings, literal validation, ``model_dump(exclude_none=True)`` round-trip, missing-dirs no-op.
- [x] Full Python suite: 845 passed, 4 skipped.
- [x] ``tsc -b --noEmit`` clean.
- [x] ``ruff`` / ``black`` clean.
- [ ] Manual: drop a custom template under ``~/.splitsmith/templates/`` and confirm it appears in the dropdown and overrides any built-in with the same stem.

## Out of scope (filed if requested)

- CLI ``--template`` flag (the dialog covers the main user flow; CLI consumers can come later).
- ``splitsmith template show <name>`` (debug helper from the issue body; defer until anyone asks).
- Server-side template merge (today the client applies templates; server-side merge would let scripted exports use templates without the dialog).
- Intro / outro template fields (``segment`` IR slot is empty until #173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)