### PR TITLE
Intro / outro segments on the spine (#173)

### DIFF
--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -215,9 +215,18 @@ class TitleCard:
 
 @dataclass(frozen=True)
 class Segment:
-    """Intro / outro segment (placeholder until #173 lands)."""
+    """Intro / outro segment (issue #173).
+
+    Plays before stage 0 (intro) or after stage N-1 (outro) on the
+    spine. ``name`` is the on-timeline label that surfaces in FCP's
+    inspector; falls back to the asset's file stem when empty.
+
+    ``title`` is reserved for a future "auto-overlay a TitleCard on
+    the segment" feature; the FCPXML renderer ignores it for now.
+    """
 
     asset: Asset
+    name: str = ""
     title: TitleCard | None = None
 
 
@@ -256,6 +265,8 @@ def from_stage_compositions(
     project_name: str,
     transitions: SequenceProto[Transition] = (),
     titles: dict[int, TitleCard] | None = None,
+    intro: Segment | None = None,
+    outro: Segment | None = None,
 ) -> Composition:
     """Build a :class:`Composition` from today's ``StageComposition`` inputs.
 
@@ -274,6 +285,11 @@ def from_stage_compositions(
     :class:`TitleCard`. The IR attaches each title to its
     :class:`Stage`; the FCPXML renderer emits slate / lower-third
     via FCP's Basic Title generator.
+
+    ``intro`` / ``outro`` (issue #173): optional :class:`Segment`s
+    placed before stage 0 / after stage N-1 on the spine. The
+    segment's video must match the timeline frame rate; the FCPXML
+    renderer raises ``ValueError`` otherwise.
     """
     titles_map = dict(titles) if titles else {}
     if not stages:
@@ -336,6 +352,8 @@ def from_stage_compositions(
         sequence=seq,
         stages=tuple(ir_stages),
         transitions=tuple(transitions),
+        intro=intro,
+        outro=outro,
     )
 
 
@@ -489,6 +507,27 @@ def render_fcpxml(
         config=config,
         transitions=_lower_transitions(composition.transitions),
         titles=_lower_titles(composition),
+        intro=_lower_segment(composition.intro),
+        outro=_lower_segment(composition.outro),
+    )
+
+
+def _lower_segment(
+    segment: Segment | None,
+) -> fcpxml_gen.IntroOutroSegment | None:
+    """Lower an IR :class:`Segment` to ``fcpxml_gen.IntroOutroSegment``.
+
+    v1 ignores ``segment.title`` -- the FCPXML emitter doesn't paint a
+    title onto an intro/outro yet (auto-overlay would need a slate-
+    style ``<title>`` connected to the segment's asset-clip; tracked
+    as a follow-up).
+    """
+    if segment is None:
+        return None
+    return fcpxml_gen.IntroOutroSegment(
+        video_path=segment.asset.path,
+        video=segment.asset.metadata,
+        name=segment.name,
     )
 
 

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -683,6 +683,23 @@ class StageTitle:
 
 
 @dataclass(frozen=True)
+class IntroOutroSegment:
+    """A video clip placed before / after the match stages on the spine
+    (issue #173).
+
+    The clip plays at native duration; the user is responsible for
+    pre-trimming. The clip's frame rate must match the timeline (we
+    reject mismatched rates rather than rate-converting silently --
+    cross-fps timelines are out of scope for v1, mirroring the
+    constraint on stage primaries).
+    """
+
+    video_path: Path
+    video: VideoMetadata
+    name: str = ""  # falls back to file stem when empty
+
+
+@dataclass(frozen=True)
 class StageTransition:
     """A transition between two consecutive stages on the spine (issue #195).
 
@@ -744,6 +761,8 @@ def generate_match_fcpxml(
     config: OutputConfig,
     transitions: list[StageTransition] | None = None,
     titles: list[StageTitle] | None = None,
+    intro: IntroOutroSegment | None = None,
+    outro: IntroOutroSegment | None = None,
 ) -> None:
     """Write a stitched FCPXML with N stages back-to-back on the spine.
 
@@ -772,12 +791,24 @@ def generate_match_fcpxml(
     head. Slates combined with transitions raise ``ValueError`` --
     a slate between two transition-joined primaries has no clean
     visual semantic.
+
+    ``intro`` / ``outro`` (issue #173): optional video clips placed
+    before stage 0 / after stage N-1 on the spine. Frame rate must
+    match the timeline (raises ``ValueError`` otherwise). Transitions
+    only fire between stage primaries today; the intro -> stage 0 and
+    stage N-1 -> outro boundaries stay as hard cuts (the user can
+    crossfade them manually in FCP if desired).
     """
     if not stages:
         raise ValueError("generate_match_fcpxml requires at least one stage")
     for stage in stages:
         if not stage.video_path.exists():
             raise FileNotFoundError(f"video not found: {stage.video_path}")
+    for label, segment in (("intro", intro), ("outro", outro)):
+        if segment is None:
+            continue
+        if not segment.video_path.exists():
+            raise FileNotFoundError(f"{label} video not found: {segment.video_path}")
     transitions = list(transitions or ())
     titles = list(titles or ())
     seen_indices: set[int] = set()
@@ -829,6 +860,19 @@ def generate_match_fcpxml(
                 f"(stage 0: {base.frame_rate_num}/{base.frame_rate_den}, "
                 f"stage with {stage.video_path.name}: "
                 f"{stage.video.frame_rate_num}/{stage.video.frame_rate_den})"
+            )
+    for label, segment in (("intro", intro), ("outro", outro)):
+        if segment is None:
+            continue
+        if (
+            segment.video.frame_rate_num != base.frame_rate_num
+            or segment.video.frame_rate_den != base.frame_rate_den
+        ):
+            raise ValueError(
+                f"{label} frame rate "
+                f"({segment.video.frame_rate_num}/{segment.video.frame_rate_den}) "
+                f"does not match the timeline "
+                f"({base.frame_rate_num}/{base.frame_rate_den})"
             )
 
     frame_duration = Fraction(base.frame_rate_den, base.frame_rate_num)
@@ -1109,11 +1153,58 @@ def generate_match_fcpxml(
     }
     total_slate_frames = sum(slate_frames_by_index.values())
 
+    # Intro / outro asset resources (issue #173). One ``<asset>`` per
+    # segment; the spine references it via ``asset-clip``. Frame rate
+    # matches the timeline (validated above) so we reuse format_id.
+    intro_asset_id: str | None = None
+    intro_duration_frames = 0
+    if intro is not None:
+        resource_counter += 1
+        intro_asset_id = f"r{resource_counter}"
+        intro_duration_frames = round(intro.video.duration_seconds / fd_seconds)
+    outro_asset_id: str | None = None
+    outro_duration_frames = 0
+    if outro is not None:
+        resource_counter += 1
+        outro_asset_id = f"r{resource_counter}"
+        outro_duration_frames = round(outro.video.duration_seconds / fd_seconds)
+    for segment, asset_id, dur_frames in (
+        (intro, intro_asset_id, intro_duration_frames),
+        (outro, outro_asset_id, outro_duration_frames),
+    ):
+        if segment is None:
+            continue
+        assert asset_id is not None
+        seg_asset = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": asset_id,
+                "name": segment.name or segment.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(dur_frames, fd_num, fd_den),
+                "hasVideo": "1",
+                "hasAudio": "1",
+                "format": format_id,
+                "videoSources": "1",
+                "audioSources": "1",
+                "audioChannels": "2",
+            },
+        )
+        ET.SubElement(
+            seg_asset,
+            "media-rep",
+            {"kind": "original-media", "src": segment.video_path.resolve().as_uri()},
+        )
+
     library = ET.SubElement(fcpxml, "library")
     event = ET.SubElement(library, "event", {"name": "splitsmith"})
     project = ET.SubElement(event, "project", {"name": project_name})
     total_duration_frames = (
-        sum(plan.effective_duration_frames for plan in plans) + total_slate_frames
+        sum(plan.effective_duration_frames for plan in plans)
+        + total_slate_frames
+        + intro_duration_frames
+        + outro_duration_frames
     )
     sequence = ET.SubElement(
         project,
@@ -1132,6 +1223,23 @@ def generate_match_fcpxml(
     transitions_by_index: dict[int, StageTransition] = {t.after_stage_index: t for t in transitions}
 
     cumulative_offset_frames = 0
+
+    # Intro segment (issue #173): plays first, full duration.
+    if intro_asset_id is not None and intro is not None:
+        ET.SubElement(
+            spine,
+            "asset-clip",
+            {
+                "ref": intro_asset_id,
+                "offset": _frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
+                "name": intro.name or intro.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(intro_duration_frames, fd_num, fd_den),
+                "format": format_id,
+            },
+        )
+        cumulative_offset_frames += intro_duration_frames
+
     for stage_idx, plan in enumerate(plans):
         stage = plan.stage
         head_trim_seconds = plan.head_trim_frames * fd_seconds
@@ -1302,6 +1410,21 @@ def generate_match_fcpxml(
             )
 
         cumulative_offset_frames += plan.effective_duration_frames
+
+    # Outro segment (issue #173): plays after the last stage's primary.
+    if outro_asset_id is not None and outro is not None:
+        ET.SubElement(
+            spine,
+            "asset-clip",
+            {
+                "ref": outro_asset_id,
+                "offset": _frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
+                "name": outro.name or outro.video_path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(outro_duration_frames, fd_num, fd_den),
+                "format": format_id,
+            },
+        )
 
     ET.indent(fcpxml, space="    ")
     tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)

--- a/src/splitsmith/templates.py
+++ b/src/splitsmith/templates.py
@@ -80,6 +80,8 @@ class MatchExportTemplate(BaseModel):
     transition_duration_seconds: float | None = None
     title_kind: Literal["none", "slate", "lower-third"] | None = None
     title_duration_seconds: float | None = None
+    intro_path: str | None = None  # filesystem path; ``~`` expands at apply time
+    outro_path: str | None = None
 
 
 class TemplateEntry(BaseModel):

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -106,6 +106,12 @@ class MatchExportRequestData:
     # keeps the timeline title-less.
     title_kind: TitleKind = "none"
     title_duration_seconds: float = 1.5
+    # Issue #173. Optional intro / outro video clips placed before
+    # stage 0 / after stage N-1. Frame rate must match the timeline;
+    # the path must exist on disk. ``None`` keeps the export
+    # stage-only (today's behaviour).
+    intro_path: Path | None = None
+    outro_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -279,11 +285,27 @@ def export_match(
         # error from generate_match_fcpxml.
         anomalies.append("slate titles dropped: cannot combine with transitions " "(issue #196)")
         titles = {}
+    intro_segment = _resolve_segment(
+        request.intro_path,
+        label="intro",
+        probe=probe,
+        anomalies=anomalies,
+        renderer=request.output_format,
+    )
+    outro_segment = _resolve_segment(
+        request.outro_path,
+        label="outro",
+        probe=probe,
+        anomalies=anomalies,
+        renderer=request.output_format,
+    )
     comp = composition.from_stage_compositions(
         compositions,
         project_name=request.project_name,
         transitions=transitions,
         titles=titles,
+        intro=intro_segment,
+        outro=outro_segment,
     )
     try:
         if request.output_format == "fcpxml":
@@ -353,6 +375,42 @@ def _build_uniform_transitions(
             duration_seconds=duration,
         )
         for i in range(stage_count - 1)
+    )
+
+
+def _resolve_segment(
+    path: Path | None,
+    *,
+    label: str,
+    probe: object,
+    anomalies: list[str],
+    renderer: OutputFormat,
+) -> composition.Segment | None:
+    """Probe an intro/outro path into an IR ``Segment``.
+
+    Missing files surface as anomalies (not hard errors) so the export
+    proceeds without the segment -- mirrors the overlay/secondary
+    handling. Mismatched renderer / fps issues become anomalies too.
+    """
+    if path is None:
+        return None
+    if renderer != "fcpxml":
+        anomalies.append(
+            f"{label} ignored: not yet supported by the "
+            f"{renderer} renderer (issue #173 follow-ups)"
+        )
+        return None
+    if not path.exists():
+        anomalies.append(f"{label} dropped: video missing at {path}")
+        return None
+    try:
+        meta = probe(path)  # type: ignore[operator]
+    except fcpxml_gen.FFprobeError as exc:
+        anomalies.append(f"{label} dropped: {exc}")
+        return None
+    return composition.Segment(
+        asset=composition.Asset(path=path, metadata=meta),
+        name=label.capitalize(),
     )
 
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -961,6 +961,12 @@ class MatchExportRequest(BaseModel):
     # FCP7 / MP4 surface a "titles ignored" anomaly when combined.
     title_kind: Literal["none", "slate", "lower-third"] = "none"
     title_duration_seconds: float = 1.5
+    # Issue #173. Optional intro / outro video paths. Server expands
+    # ``~`` and probes the file to validate frame rate against the
+    # timeline. Missing files surface as anomalies; non-fatal so the
+    # rest of the export still ships.
+    intro_path: str | None = None
+    outro_path: str | None = None
 
 
 class RevealRequest(BaseModel):
@@ -4635,6 +4641,8 @@ def create_app(
             transition_duration_seconds=req.transition_duration_seconds,
             title_kind=req.title_kind,
             title_duration_seconds=req.title_duration_seconds,
+            intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
+            outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -520,6 +520,14 @@ export interface MatchExportRequestPayload {
    *  ``"none"``. Slates default to 1.5s; lower-thirds default to
    *  3.0s but the dialog uses one input either way. */
   title_duration_seconds?: number;
+  /** Issue #173. Filesystem path to an optional intro clip placed
+   *  before stage 0 on the spine. ``~`` expands server-side. Frame
+   *  rate must match the timeline; missing files surface as
+   *  anomalies (non-fatal). FCPXML only today. */
+  intro_path?: string | null;
+  /** Filesystem path to an optional outro clip placed after the
+   *  last stage. Same semantics as ``intro_path``. */
+  outro_path?: string | null;
 }
 
 /** Body of a single export template (issue #198). Mirrors the dialog's
@@ -539,6 +547,8 @@ export interface MatchExportTemplate {
   transition_duration_seconds?: number;
   title_kind?: "none" | "slate" | "lower-third";
   title_duration_seconds?: number;
+  intro_path?: string;
+  outro_path?: string;
 }
 
 export interface MatchExportTemplateEntry {
@@ -1541,6 +1551,12 @@ export const api = {
           : {}),
         ...(payload.title_duration_seconds !== undefined
           ? { title_duration_seconds: payload.title_duration_seconds }
+          : {}),
+        ...(payload.intro_path !== undefined
+          ? { intro_path: payload.intro_path }
+          : {}),
+        ...(payload.outro_path !== undefined
+          ? { outro_path: payload.outro_path }
           : {}),
       },
     }),

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1231,6 +1231,12 @@ function MatchExportDialog({
   >("none");
   const [titleDurationSeconds, setTitleDurationSeconds] =
     useState<number>(1.5);
+  // Issue #173. Optional intro / outro video clips. Empty string =
+  // disabled. The server expands ``~`` and probes the file; missing
+  // paths surface as anomalies (non-fatal) rather than failing the
+  // whole export.
+  const [introPath, setIntroPath] = useState<string>("");
+  const [outroPath, setOutroPath] = useState<string>("");
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1294,6 +1300,8 @@ function MatchExportDialog({
     if (t.title_kind !== undefined) setTitleKind(t.title_kind);
     if (t.title_duration_seconds !== undefined)
       setTitleDurationSeconds(t.title_duration_seconds);
+    if (t.intro_path !== undefined) setIntroPath(t.intro_path);
+    if (t.outro_path !== undefined) setOutroPath(t.outro_path);
   };
 
   const choosePreset = (next: PaddingPreset) => {
@@ -1333,6 +1341,8 @@ function MatchExportDialog({
         transition_duration_seconds: transitionDurationSeconds,
         title_kind: titleKind,
         title_duration_seconds: titleDurationSeconds,
+        intro_path: introPath || undefined,
+        outro_path: outroPath || undefined,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1691,6 +1701,36 @@ function MatchExportDialog({
                   s
                 </label>
               )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <label
+                className="flex items-center gap-1.5"
+                title="Optional video clip placed before the first stage. Frame rate must match the timeline. ~ expands to your home directory. Leave blank to skip."
+              >
+                Intro clip
+                <input
+                  type="text"
+                  placeholder="~/match-intro.mov"
+                  className="flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                  value={introPath}
+                  disabled={busy}
+                  onChange={(e) => setIntroPath(e.target.value)}
+                />
+              </label>
+              <label
+                className="flex items-center gap-1.5"
+                title="Optional video clip placed after the last stage. Same constraints as the intro."
+              >
+                Outro clip
+                <input
+                  type="text"
+                  placeholder="~/match-outro.mov"
+                  className="flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-sm"
+                  value={outroPath}
+                  disabled={busy}
+                  onChange={(e) => setOutroPath(e.target.value)}
+                />
+              </label>
             </div>
             {includeOverlay ? (
               <OverlayFormatPanel

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -288,6 +288,44 @@ def test_fcpxml_match_with_titles_validates(tmp_path: Path) -> None:
 
 
 @fcpxml_dtd
+def test_fcpxml_match_with_intro_outro_validates(tmp_path: Path) -> None:
+    """Intro / outro emit ``<asset>`` + ``<media-rep>`` resources and
+    spine ``<asset-clip>``s framing the stages. DTD checks asset
+    structure (required ``id`` / ``hasVideo`` / ``hasAudio``) and
+    spine ordering."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    intro_path = _make_video(tmp_path, "intro.mp4")
+    outro_path = _make_video(tmp_path, "outro.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=fcpxml_gen.IntroOutroSegment(
+            video_path=intro_path, video=_meta_30fps(), name="Intro"
+        ),
+        outro=fcpxml_gen.IntroOutroSegment(
+            video_path=outro_path, video=_meta_30fps(), name="Outro"
+        ),
+    )
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())
+
+
+@fcpxml_dtd
 def test_invalid_fcpxml_fails_validation(tmp_path: Path) -> None:
     """Sanity: hand-rolled bad FCPXML must trip the validator. Catches
     helper regressions (e.g. xmllint flags wrong / DTD path silently

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1597,6 +1597,185 @@ def test_no_transitions_emits_unchanged_spine(tmp_path: Path) -> None:
     assert root.find("./resources/effect") is None
 
 
+# --- intro / outro segments (issue #173) ---------------------------------
+
+
+def _intro_segment(tmp_path: Path, name: str = "intro.mp4") -> fcpxml_mod.IntroOutroSegment:
+    p = _make_video(tmp_path, name)
+    return fcpxml_mod.IntroOutroSegment(
+        video_path=p,
+        video=VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=5.0,
+            frame_rate_num=30,
+            frame_rate_den=1,
+        ),
+        name="Intro",
+    )
+
+
+def test_intro_lands_on_spine_before_stage_zero(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    intro = _intro_segment(tmp_path, "intro.mp4")
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=intro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine = root.find(".//spine")
+    assert spine is not None
+    children = list(spine)
+    assert children[0].tag == "asset-clip"
+    assert children[0].attrib["name"] == "Intro"
+    assert children[0].attrib["offset"] == "0s"
+    # 5s @ 30fps = 150 frames.
+    assert children[0].attrib["duration"] == "150/30s"
+    assert children[1].attrib["name"] == "A"
+    assert children[1].attrib["offset"] == "150/30s"
+
+
+def test_outro_lands_after_last_stage(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    outro_path = _make_video(tmp_path, "outro.mp4")
+    outro = fcpxml_mod.IntroOutroSegment(
+        video_path=outro_path,
+        video=_meta_30fps(),
+        name="Outro",
+    )
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        outro=outro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    children = list(root.find(".//spine"))  # type: ignore[arg-type]
+    # Last spine child is the outro.
+    assert children[-1].tag == "asset-clip"
+    assert children[-1].attrib["name"] == "Outro"
+
+
+def test_intro_extends_sequence_duration(tmp_path: Path) -> None:
+    """Sequence duration grows by the intro's frame count."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    intro = _intro_segment(tmp_path, "intro.mp4")
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=intro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    sequence = root.find("./library/event/project/sequence")
+    assert sequence is not None
+    duration_frames = int(sequence.attrib["duration"].split("/")[0])
+    # Stage A: 330, Stage B: 324, intro: 150 -> 804.
+    assert duration_frames == 330 + 324 + 150
+
+
+def test_intro_with_mismatched_frame_rate_raises(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    bad_intro = fcpxml_mod.IntroOutroSegment(
+        video_path=_make_video(tmp_path, "intro_60fps.mp4"),
+        video=VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=5.0,
+            frame_rate_num=60,
+            frame_rate_den=1,
+        ),
+        name="Bad",
+    )
+    with pytest.raises(ValueError, match="intro frame rate"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            intro=bad_intro,
+        )
+
+
+def test_intro_missing_file_raises_filenotfound(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    intro = fcpxml_mod.IntroOutroSegment(
+        video_path=tmp_path / "does-not-exist.mp4",
+        video=_meta_30fps(),
+        name="Intro",
+    )
+    with pytest.raises(FileNotFoundError, match="intro video"):
+        generate_match_fcpxml(
+            stages=stages,
+            output_path=out,
+            project_name="match",
+            config=OutputConfig(),
+            intro=intro,
+        )
+
+
+def test_intro_and_outro_both_emit(tmp_path: Path) -> None:
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    intro = _intro_segment(tmp_path, "intro.mp4")
+    outro = fcpxml_mod.IntroOutroSegment(
+        video_path=_make_video(tmp_path, "outro.mp4"),
+        video=intro.video,
+        name="Outro",
+    )
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=intro,
+        outro=outro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    children = list(root.find(".//spine"))  # type: ignore[arg-type]
+    assert [c.attrib.get("name") for c in children] == [
+        "Intro",
+        "A",
+        "B",
+        "Outro",
+    ]
+
+
+def test_intro_outro_emit_assets(tmp_path: Path) -> None:
+    """Each segment gets its own ``<asset>`` resource pointing at the
+    file via ``<media-rep>``."""
+    primary_a, primary_b, out = _two_stage_match(tmp_path)
+    stages = _basic_match_stages(primary_a, primary_b)
+    intro = _intro_segment(tmp_path, "intro.mp4")
+    outro = fcpxml_mod.IntroOutroSegment(
+        video_path=_make_video(tmp_path, "outro.mp4"),
+        video=intro.video,
+        name="Outro",
+    )
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=intro,
+        outro=outro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    asset_names = [a.attrib["name"] for a in root.findall("./resources/asset")]
+    assert "Intro" in asset_names
+    assert "Outro" in asset_names
+
+
 # --- title cards (issue #196) ---------------------------------------------
 
 


### PR DESCRIPTION
Closes #173.

## Summary

Optional user-supplied video clips placed before stage 0 and after stage N-1 on the spine, framing the match. Plays at native duration; frame rate must match the timeline.

- ``fcpxml_gen.IntroOutroSegment`` (video_path, video, name).
- ``generate_match_fcpxml`` grows ``intro=`` / ``outro=`` params; emits matching ``<asset>`` resources + spine clips. Sequence total duration grows by each segment's frame count.
- Composition IR's ``Segment`` gains a ``name`` field. ``from_stage_compositions`` accepts intro / outro; the bridge lowers them via ``_lower_segment``.
- Match-export endpoint + dialog: ``intro_path`` / ``outro_path`` text inputs (``~`` expands server-side). Missing files surface as anomalies; FCP7 / MP4 surface "ignored" anomalies until they grow segment support.
- Templates picked up new ``intro_path`` / ``outro_path`` fields so a preset can wire a sponsor card / outro slate.

## Why text inputs, not file pickers

A web app's stock file picker either uploads bytes (heavy for a video) or returns sandboxed paths the server can't read. The text-path approach matches how splitsmith already lets users point at media on disk (project setup, USB sources). ``~`` expansion server-side covers the obvious ergonomics.

## Test plan

- [x] 7 new ``test_fcpxml_gen.py`` tests: intro lands first on spine, outro lands last, sequence duration grows, fps mismatch rejected, missing file raises, intro+outro both emit, asset resources emitted with media-rep.
- [x] DTD validation gains ``test_fcpxml_match_with_intro_outro_validates``.
- [x] Full Python suite: 853 passed, 4 skipped.
- [x] ``tsc -b --noEmit`` clean.
- [x] ``ruff`` / ``black`` clean.
- [ ] **Release gate:** import a stitched export with intro + outro into FCP and confirm playback order is intro -> stage 0 -> ... -> stage N-1 -> outro.

## Out of scope (filed if requested)

- Auto-overlaid title on the segment (``Segment.title`` slot exists but the FCPXML emitter ignores it; would emit a slate-style ``<title>`` connected to the segment's asset-clip).
- FCP7 XML / MP4 segment support (anomaly notes guide users to use FCPXML for now).
- Cross-fps intro/outro (rate-converting on import is the editor's job; we won't paper over rate mismatches silently).
- Transitions touching intro/outro boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)