### PR TITLE
YouTube sidecar + FCPXML chapter markers (#204 layer 1)

### DIFF
--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -232,7 +232,15 @@ class Segment:
 
 @dataclass(frozen=True)
 class Composition:
-    """A complete renderer-agnostic timeline (#194)."""
+    """A complete renderer-agnostic timeline (#194).
+
+    ``chapter_markers`` (issue #204): when ``True``, renderers emit
+    NLE-native chapter markers at each stage's visible head + on the
+    intro / outro segments. The FCPXML renderer carries them as
+    ``<chapter-marker>``; FCP / Premiere / DaVinci forward chapter
+    markers into the chapter atom on MP4 export, which is what
+    YouTube reads. Off by default to keep existing exports unchanged.
+    """
 
     project_name: str
     sequence: SequenceFormat
@@ -240,6 +248,7 @@ class Composition:
     intro: Segment | None = None
     outro: Segment | None = None
     transitions: tuple[Transition, ...] = ()
+    chapter_markers: bool = False
 
 
 # --- conversions -----------------------------------------------------------
@@ -267,6 +276,7 @@ def from_stage_compositions(
     titles: dict[int, TitleCard] | None = None,
     intro: Segment | None = None,
     outro: Segment | None = None,
+    chapter_markers: bool = False,
 ) -> Composition:
     """Build a :class:`Composition` from today's ``StageComposition`` inputs.
 
@@ -354,6 +364,7 @@ def from_stage_compositions(
         transitions=tuple(transitions),
         intro=intro,
         outro=outro,
+        chapter_markers=chapter_markers,
     )
 
 
@@ -482,6 +493,7 @@ def render_fcpxml(
         and composition.outro is None
         and not composition.transitions
         and not has_titles
+        and not composition.chapter_markers
     ):
         # Single stage with no intro/outro/transitions/titles mirrors
         # today's per-stage path. Use generate_fcpxml so the file is
@@ -509,6 +521,7 @@ def render_fcpxml(
         titles=_lower_titles(composition),
         intro=_lower_segment(composition.intro),
         outro=_lower_segment(composition.outro),
+        chapter_markers=composition.chapter_markers,
     )
 
 

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -763,6 +763,7 @@ def generate_match_fcpxml(
     titles: list[StageTitle] | None = None,
     intro: IntroOutroSegment | None = None,
     outro: IntroOutroSegment | None = None,
+    chapter_markers: bool = False,
 ) -> None:
     """Write a stitched FCPXML with N stages back-to-back on the spine.
 
@@ -798,6 +799,12 @@ def generate_match_fcpxml(
     only fire between stage primaries today; the intro -> stage 0 and
     stage N-1 -> outro boundaries stay as hard cuts (the user can
     crossfade them manually in FCP if desired).
+
+    ``chapter_markers`` (issue #204): emit a ``<chapter-marker>`` on
+    the first frame of each primary (and on intro / outro segments)
+    so an NLE-side MP4 export carries chapter timestamps. Off by
+    default to keep existing exports unchanged; the YouTube sidecar
+    flow turns it on so chapters survive the round-trip through FCP.
     """
     if not stages:
         raise ValueError("generate_match_fcpxml requires at least one stage")
@@ -1226,7 +1233,7 @@ def generate_match_fcpxml(
 
     # Intro segment (issue #173): plays first, full duration.
     if intro_asset_id is not None and intro is not None:
-        ET.SubElement(
+        intro_clip = ET.SubElement(
             spine,
             "asset-clip",
             {
@@ -1238,6 +1245,16 @@ def generate_match_fcpxml(
                 "format": format_id,
             },
         )
+        if chapter_markers:
+            ET.SubElement(
+                intro_clip,
+                "chapter-marker",
+                {
+                    "start": "0s",
+                    "duration": frame_duration_str,
+                    "value": intro.name or "Intro",
+                },
+            )
         cumulative_offset_frames += intro_duration_frames
 
     for stage_idx, plan in enumerate(plans):
@@ -1361,6 +1378,23 @@ def generate_match_fcpxml(
                 lane=lt_lane,
             )
 
+        # Chapter marker on the visible head of the primary (#204).
+        # FCP / FCP7 / Premiere all forward chapter markers into the
+        # MP4 chapter atom on export, which is the upload-ready
+        # signal YouTube reads. Marker start = head_trim_frames (the
+        # in-source frame where playback starts), so it lands on the
+        # spine at the stage's beginning.
+        if chapter_markers:
+            ET.SubElement(
+                primary_clip,
+                "chapter-marker",
+                {
+                    "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                    "duration": frame_duration_str,
+                    "value": stage.stage_name,
+                },
+            )
+
         # Markers. Each shot's clip-local source-media time stays the marker
         # ``start``; FCP only renders markers within [primary.start,
         # primary.start + duration], so we drop shots outside that window
@@ -1413,7 +1447,7 @@ def generate_match_fcpxml(
 
     # Outro segment (issue #173): plays after the last stage's primary.
     if outro_asset_id is not None and outro is not None:
-        ET.SubElement(
+        outro_clip = ET.SubElement(
             spine,
             "asset-clip",
             {
@@ -1425,6 +1459,16 @@ def generate_match_fcpxml(
                 "format": format_id,
             },
         )
+        if chapter_markers:
+            ET.SubElement(
+                outro_clip,
+                "chapter-marker",
+                {
+                    "start": "0s",
+                    "duration": frame_duration_str,
+                    "value": outro.name or "Outro",
+                },
+            )
 
     ET.indent(fcpxml, space="    ")
     tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from .. import composition, fcp7xml_render, fcpxml_gen, mp4_render
+from .. import composition, fcp7xml_render, fcpxml_gen, mp4_render, youtube_sidecar
 from ..config import OutputConfig
 from .exports import audit_shots_to_engine_shots
 
@@ -112,6 +112,13 @@ class MatchExportRequestData:
     # stage-only (today's behaviour).
     intro_path: Path | None = None
     outro_path: Path | None = None
+    # Issue #204 layer 1. Generate a YouTube-shaped JSON sidecar
+    # alongside the export, plus a per-shot ``.srt`` and chapter
+    # markers in the FCPXML so they survive the NLE round-trip into
+    # an MP4 chapter atom. Off by default; enabling on FCP7 / MP4
+    # writes the sidecar but no chapter markers (those renderers
+    # don't carry chapters yet).
+    youtube_sidecar: bool = False
 
 
 @dataclass(frozen=True)
@@ -299,6 +306,12 @@ def export_match(
         anomalies=anomalies,
         renderer=request.output_format,
     )
+    # Chapter markers in the FCPXML output: only useful when YouTube
+    # sidecar is requested AND the renderer actually carries chapter
+    # markers (FCPXML today; FCP7 / MP4 follow-ups). When the user
+    # picks a non-FCPXML format with sidecar on, we still write the
+    # JSON sidecar but skip embedding chapters.
+    embed_chapter_markers = request.youtube_sidecar and request.output_format == "fcpxml"
     comp = composition.from_stage_compositions(
         compositions,
         project_name=request.project_name,
@@ -306,6 +319,7 @@ def export_match(
         titles=titles,
         intro=intro_segment,
         outro=outro_segment,
+        chapter_markers=embed_chapter_markers,
     )
     try:
         if request.output_format == "fcpxml":
@@ -316,6 +330,26 @@ def export_match(
             mp4_render.render_mp4(comp, output_path=output_path)
     except (ValueError, FileNotFoundError, mp4_render.FFmpegError) as exc:
         raise MatchExportError(str(exc)) from exc
+
+    # YouTube sidecar (#204 layer 1). Walks the same IR the renderer
+    # consumed; carries chapter timestamps + tags + a captions .srt.
+    # Renderer-agnostic so the user can route to FCPXML / FCP7 / MP4
+    # and still get the upload-ready text fields.
+    if request.youtube_sidecar:
+        srt_path = output_path.with_suffix(".srt")
+        sidecar_path = output_path.with_name(output_path.stem + "-youtube.json")
+        youtube_sidecar.write_srt(comp, srt_path)
+        sidecar = youtube_sidecar.build_sidecar(
+            comp,
+            captions_path=srt_path.relative_to(exports_dir),
+            output_video=output_path.relative_to(exports_dir),
+        )
+        youtube_sidecar.write_sidecar(sidecar, sidecar_path)
+        if request.output_format != "fcpxml":
+            anomalies.append(
+                "youtube chapter markers embedded only on FCPXML "
+                "(FCP7 / MP4 chapter atoms are #204 follow-ups)"
+            )
 
     # Compute total duration for the response. Mirrors the composer's math
     # (head_avail / tail_avail per stage, frame-aligned). Cheaper than

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -967,6 +967,11 @@ class MatchExportRequest(BaseModel):
     # rest of the export still ships.
     intro_path: str | None = None
     outro_path: str | None = None
+    # Issue #204 layer 1. Generate a YouTube-shaped JSON sidecar
+    # alongside the export plus a per-shot ``.srt``. FCPXML route
+    # also gets chapter markers embedded so they survive an NLE
+    # round-trip into an MP4 chapter atom.
+    youtube_sidecar: bool = False
 
 
 class RevealRequest(BaseModel):
@@ -4643,6 +4648,7 @@ def create_app(
             title_duration_seconds=req.title_duration_seconds,
             intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
             outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
+            youtube_sidecar=req.youtube_sidecar,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -528,6 +528,11 @@ export interface MatchExportRequestPayload {
   /** Filesystem path to an optional outro clip placed after the
    *  last stage. Same semantics as ``intro_path``. */
   outro_path?: string | null;
+  /** Issue #204. Generate a YouTube-shaped JSON sidecar alongside
+   *  the export plus a per-shot ``.srt``. FCPXML route also gets
+   *  chapter markers embedded so they survive an NLE round-trip
+   *  into an MP4 chapter atom. */
+  youtube_sidecar?: boolean;
 }
 
 /** Body of a single export template (issue #198). Mirrors the dialog's
@@ -1557,6 +1562,9 @@ export const api = {
           : {}),
         ...(payload.outro_path !== undefined
           ? { outro_path: payload.outro_path }
+          : {}),
+        ...(payload.youtube_sidecar !== undefined
+          ? { youtube_sidecar: payload.youtube_sidecar }
           : {}),
       },
     }),

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1237,6 +1237,11 @@ function MatchExportDialog({
   // whole export.
   const [introPath, setIntroPath] = useState<string>("");
   const [outroPath, setOutroPath] = useState<string>("");
+  // Issue #204. YouTube sidecar writes match-youtube.json + .srt
+  // alongside the export and (FCPXML route only) embeds chapter
+  // markers in the timeline so they round-trip through FCP into
+  // the MP4 chapter atom.
+  const [youtubeSidecar, setYoutubeSidecar] = useState<boolean>(false);
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1343,6 +1348,7 @@ function MatchExportDialog({
         title_duration_seconds: titleDurationSeconds,
         intro_path: introPath || undefined,
         outro_path: outroPath || undefined,
+        youtube_sidecar: youtubeSidecar,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1730,6 +1736,19 @@ function MatchExportDialog({
                   disabled={busy}
                   onChange={(e) => setOutroPath(e.target.value)}
                 />
+              </label>
+              <label
+                className="flex items-center gap-1.5"
+                title="Generate a YouTube-shaped JSON sidecar (title, chapter timestamps, tags) plus a per-shot .srt. The FCPXML route also embeds chapter markers so they round-trip into the MP4 chapter atom."
+              >
+                <input
+                  type="checkbox"
+                  className="size-4 accent-primary"
+                  checked={youtubeSidecar}
+                  disabled={busy}
+                  onChange={(e) => setYoutubeSidecar(e.target.checked)}
+                />
+                YouTube sidecar (chapters + .srt)
               </label>
             </div>
             {includeOverlay ? (

--- a/src/splitsmith/youtube_sidecar.py
+++ b/src/splitsmith/youtube_sidecar.py
@@ -1,0 +1,293 @@
+"""YouTube sidecar metadata for match exports (issue #204 layer 1).
+
+Walks the :class:`composition.Composition` after the export has been
+built and writes a JSON sidecar plus an optional ``.srt`` alongside
+the main output. The sidecar carries everything the user would
+otherwise paste into YouTube Studio by hand: title, description with
+per-stage chapter timestamps, tags, and a captions reference.
+
+YouTube auto-converts ``MM:SS Title`` lines in the description into
+chapter markers as long as the first chapter is at ``0:00`` and there
+are at least three of them. We pad with an "Intro" anchor at 0:00
+when the user has an intro segment so the requirement holds even on
+two-stage matches.
+
+Layer 2 (codec-tuned MP4) and Layer 3 (Data-API direct upload) are
+follow-ups; nothing here depends on them. The sidecar is renderer-
+agnostic -- works whether the matched output is .fcpxml / .xml / .mp4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .composition import Composition, Marker, Segment, Stage
+
+
+@dataclass(frozen=True)
+class Chapter:
+    """A YouTube description chapter. Renders to ``MM:SS Title`` (or
+    ``H:MM:SS Title`` for matches longer than an hour)."""
+
+    start_seconds: float
+    title: str
+
+
+class YouTubeSidecar(BaseModel):
+    """The full sidecar payload written to disk as JSON.
+
+    Fields mirror what YouTube Studio asks for so the user can copy /
+    paste each section verbatim or feed the JSON to a future Data API
+    upload helper. ``description`` already contains the chapter
+    timestamps embedded as ``MM:SS Title`` lines.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    description: str
+    chapters: list[dict[str, float | str]] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    category: str = "Sports"
+    captions_path: str | None = None
+    output_video: str | None = None  # relative path to the .mp4/.fcpxml when known
+
+
+def build_sidecar(
+    composition: Composition,
+    *,
+    title: str | None = None,
+    description_lead: str | None = None,
+    tags: list[str] | None = None,
+    captions_path: Path | None = None,
+    output_video: Path | None = None,
+) -> YouTubeSidecar:
+    """Build a :class:`YouTubeSidecar` from a composition.
+
+    ``title`` defaults to the composition's project name; pass an
+    explicit string to override (e.g. ``"<match> -- <date>"``).
+
+    ``description_lead`` is prepended above the auto-generated
+    chapter list -- room for a one-paragraph match summary, sponsor
+    callouts, etc. Trailing whitespace is normalised so the chapter
+    timestamps always land cleanly without YouTube munging.
+    """
+    chapters = _compute_chapters(composition)
+    description = _format_description(
+        chapters,
+        lead=description_lead,
+        sequence=composition,
+    )
+    return YouTubeSidecar(
+        title=title or composition.project_name,
+        description=description,
+        chapters=[{"start_seconds": c.start_seconds, "title": c.title} for c in chapters],
+        tags=list(tags or _default_tags(composition)),
+        captions_path=str(captions_path) if captions_path is not None else None,
+        output_video=str(output_video) if output_video is not None else None,
+    )
+
+
+def write_sidecar(sidecar: YouTubeSidecar, output_path: Path) -> None:
+    """Write the sidecar JSON, indented for hand-editing."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        sidecar.model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+
+def write_srt(composition: Composition, output_path: Path) -> None:
+    """Emit shot markers as an ``.srt`` so YouTube can use them as
+    closed captions. One short caption per shot at its spine time;
+    duration is half a second so each label flashes during the shot
+    rather than lingering."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    counter = 1
+    cursor = _spine_offset_seconds_intro(composition)
+    for stage_idx, stage in enumerate(composition.stages):
+        stage_spine_start, stage_visible_head = _stage_spine_window(composition, stage_idx, cursor)
+        effective = _effective_seconds(stage)
+        for marker in stage.markers:
+            local_offset = marker.time_seconds - stage_visible_head
+            # Drop markers outside the visible window so the caption
+            # track doesn't reference frames the timeline trimmed
+            # away. Mirrors the FCPXML emitter's marker-drop check.
+            if not 0.0 <= local_offset < effective:
+                continue
+            t = stage_spine_start + local_offset
+            lines.append(_srt_block(counter, t, t + 0.5, _marker_caption(marker)))
+            counter += 1
+        cursor += _stage_spine_duration(composition, stage_idx)
+    output_path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+# --- internals -------------------------------------------------------------
+
+
+def _compute_chapters(composition: Composition) -> list[Chapter]:
+    """One chapter per stage; an "Intro" anchor at 0:00 when the
+    composition has an intro segment so YouTube's three-chapter
+    minimum is met for short matches."""
+    chapters: list[Chapter] = []
+    cursor = 0.0
+    if composition.intro is not None:
+        chapters.append(Chapter(start_seconds=0.0, title=_segment_label(composition.intro)))
+        cursor += composition.intro.asset.metadata.duration_seconds
+    for stage_idx, stage in enumerate(composition.stages):
+        # Account for slate before the stage primary.
+        if stage.title is not None and stage.title.style == "slate":
+            cursor += stage.title.duration_seconds
+        chapters.append(
+            Chapter(
+                start_seconds=cursor,
+                title=stage.name or f"Stage {stage_idx + 1}",
+            )
+        )
+        cursor += _effective_seconds(stage)
+    if composition.outro is not None:
+        chapters.append(
+            Chapter(
+                start_seconds=cursor,
+                title=_segment_label(composition.outro),
+            )
+        )
+    return chapters
+
+
+def _format_description(
+    chapters: list[Chapter],
+    *,
+    lead: str | None,
+    sequence: Composition,
+) -> str:
+    """Assemble the description with the auto-generated chapter list.
+
+    Chapters are appended *after* the lead with a blank line separator
+    so YouTube's parser sees them on their own paragraph. Times use
+    ``H:MM:SS`` past the hour mark; YouTube accepts both.
+    """
+    parts: list[str] = []
+    if lead:
+        parts.append(lead.rstrip())
+        parts.append("")
+    parts.append("Chapters:")
+    for c in chapters:
+        parts.append(f"{_format_chapter_time(c.start_seconds)} {c.title}")
+    parts.append("")
+    parts.append(f"-- Generated by splitsmith ({sequence.project_name})")
+    return "\n".join(parts)
+
+
+def _format_chapter_time(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    if hours > 0:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def _default_tags(composition: Composition) -> list[str]:
+    """Tags that consistently apply to splitsmith exports. Users can
+    extend / replace via the ``tags`` argument when generating."""
+    return ["IPSC", "match", composition.project_name]
+
+
+def _segment_label(segment: Segment) -> str:
+    return segment.name or "Intro"
+
+
+def _effective_seconds(stage: Stage) -> float:
+    """Mirror the FCPXML emitter's per-stage trim math (in seconds).
+
+    The renderer enforces frame alignment and we live with seconds
+    here because YouTube chapters resolve at second granularity --
+    sub-second precision wouldn't survive the description anyway.
+    """
+    duration = stage.primary.metadata.duration_seconds
+    head_avail = max(0.0, stage.beep_offset_seconds)
+    if stage.markers:
+        last_local = max(m.time_seconds for m in stage.markers)
+    else:
+        last_local = stage.beep_offset_seconds
+    tail_avail = max(0.0, duration - last_local)
+    head_trim = max(0.0, head_avail - stage.head_pad_seconds)
+    tail_trim = max(0.0, tail_avail - stage.tail_pad_seconds)
+    return max(0.0, duration - head_trim - tail_trim)
+
+
+def _stage_spine_duration(composition: Composition, stage_idx: int) -> float:
+    """Total spine time the stage occupies (slate + effective)."""
+    stage = composition.stages[stage_idx]
+    extra = 0.0
+    if stage.title is not None and stage.title.style == "slate":
+        extra = stage.title.duration_seconds
+    return extra + _effective_seconds(stage)
+
+
+def _spine_offset_seconds_intro(composition: Composition) -> float:
+    return composition.intro.asset.metadata.duration_seconds if composition.intro else 0.0
+
+
+def _stage_spine_window(
+    composition: Composition,
+    stage_idx: int,
+    cursor: float,
+) -> tuple[float, float]:
+    """Return (spine_offset, visible_head_in_source_time) for a stage.
+
+    ``visible_head`` is the source-time of the stage's first visible
+    frame -- i.e., where the per-stage head trim leaves off. The .srt
+    walker subtracts this from each marker's source-time to land on
+    the spine.
+    """
+    stage = composition.stages[stage_idx]
+    spine_offset = cursor
+    if stage.title is not None and stage.title.style == "slate":
+        spine_offset += stage.title.duration_seconds
+    head_avail = max(0.0, stage.beep_offset_seconds)
+    head_trim = max(0.0, head_avail - stage.head_pad_seconds)
+    return spine_offset, head_trim
+
+
+def _srt_block(index: int, start: float, end: float, text: str) -> str:
+    """Format a single .srt block. SRT timestamps are always
+    ``HH:MM:SS,mmm``; YouTube and most browsers accept this."""
+    return f"{index}\n{_srt_time(start)} --> {_srt_time(end)}\n{text}\n"
+
+
+def _srt_time(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = seconds - hours * 3600 - minutes * 60
+    whole = int(secs)
+    millis = int(round((secs - whole) * 1000))
+    if millis == 1000:
+        whole += 1
+        millis = 0
+    return f"{hours:02d}:{minutes:02d}:{whole:02d},{millis:03d}"
+
+
+def _marker_caption(marker: Marker) -> str:
+    shot = marker.shot
+    n = getattr(shot, "shot_number", "?")
+    split = getattr(shot, "split", None)
+    if split is None:
+        return f"Shot {n}"
+    return f"Shot {n} ({split:.2f}s)"
+
+
+__all__ = [
+    "Chapter",
+    "YouTubeSidecar",
+    "build_sidecar",
+    "write_sidecar",
+    "write_srt",
+]

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -326,6 +326,40 @@ def test_fcpxml_match_with_intro_outro_validates(tmp_path: Path) -> None:
 
 
 @fcpxml_dtd
+def test_fcpxml_match_with_chapter_markers_validates(tmp_path: Path) -> None:
+    """Chapter markers (issue #204) emit ``<chapter-marker>`` on each
+    primary + intro / outro asset-clip. DTD validates element /
+    attribute structure against Apple's schema."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    intro_path = _make_video(tmp_path, "intro.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=fcpxml_gen.IntroOutroSegment(
+            video_path=intro_path, video=_meta_30fps(), name="Intro"
+        ),
+        chapter_markers=True,
+    )
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())
+
+
+@fcpxml_dtd
 def test_invalid_fcpxml_fails_validation(tmp_path: Path) -> None:
     """Sanity: hand-rolled bad FCPXML must trip the validator. Catches
     helper regressions (e.g. xmllint flags wrong / DTD path silently

--- a/tests/test_youtube_sidecar.py
+++ b/tests/test_youtube_sidecar.py
@@ -1,0 +1,342 @@
+"""Tests for the YouTube sidecar (issue #204 layer 1).
+
+Walks a synthetic Composition end-to-end and pins the chapter math,
+description format, and .srt output. The actual JSON sidecar is
+small + Pydantic-validated; covered with one round-trip assertion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from splitsmith import composition, youtube_sidecar
+from splitsmith.config import Shot, VideoMetadata
+from splitsmith.fcpxml_gen import StageComposition
+
+
+def _shot(n: int, t: float, s: float) -> Shot:
+    return Shot(
+        shot_number=n,
+        time_absolute=10.0 + t,
+        time_from_beep=t,
+        split=s,
+        peak_amplitude=0.5,
+        confidence=0.8,
+    )
+
+
+def _meta_30fps(duration: float = 20.0) -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=duration,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _make_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"")
+    return p
+
+
+def _two_stage_composition(tmp_path: Path) -> composition.Composition:
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    stages = [
+        StageComposition(
+            stage_name="Stage 1 -- Skipper",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0), _shot(2, 1.3, 0.3)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+        StageComposition(
+            stage_name="Stage 2 -- Long Range",
+            video_path=primary_b,
+            video=_meta_30fps(),
+            shots=[_shot(1, 0.8, 0.8)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+    return composition.from_stage_compositions(stages, project_name="Bromma Spring")
+
+
+# --- chapters --------------------------------------------------------------
+
+
+def test_chapters_one_per_stage_with_correct_offsets(tmp_path: Path) -> None:
+    """Stage A effective = 11s (head_pad=5 covers head; tail_pad=5
+    leaves 5s after last shot at 6.3s -> tail_trim=8.7 -> 11.3 ->
+    rounded 11s in seconds-precision math). Stage B starts at 11s."""
+    comp = _two_stage_composition(tmp_path)
+    chapters = youtube_sidecar._compute_chapters(comp)
+    assert [c.title for c in chapters] == [
+        "Stage 1 -- Skipper",
+        "Stage 2 -- Long Range",
+    ]
+    assert chapters[0].start_seconds == 0.0
+    # Stage A effective: 20 - 0 (head_trim=0) - max(0, 13.7-5) = 20-8.7 = 11.3.
+    assert abs(chapters[1].start_seconds - 11.3) < 0.001
+
+
+def test_intro_adds_chapter_anchor(tmp_path: Path) -> None:
+    primary_a = _make_video(tmp_path, "a.mp4")
+    intro = composition.Segment(
+        asset=composition.Asset(
+            path=_make_video(tmp_path, "intro.mp4"),
+            metadata=_meta_30fps(duration=5.0),
+        ),
+        name="Intro",
+    )
+    stage = StageComposition(
+        stage_name="Stage 1",
+        video_path=primary_a,
+        video=_meta_30fps(),
+        shots=[_shot(1, 1.0, 1.0)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=5.0,
+        tail_pad_seconds=5.0,
+    )
+    comp = composition.from_stage_compositions([stage], project_name="m", intro=intro)
+    chapters = youtube_sidecar._compute_chapters(comp)
+    assert chapters[0].title == "Intro"
+    assert chapters[0].start_seconds == 0.0
+    assert chapters[1].title == "Stage 1"
+    # Intro is 5s -> stage 1 starts at 5.0.
+    assert chapters[1].start_seconds == 5.0
+
+
+def test_slate_titles_shift_chapter_offsets(tmp_path: Path) -> None:
+    """A slate before stage 0 pushes its chapter time forward."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    stages = [
+        StageComposition(
+            stage_name=f"S{i}",
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for i, p in ((0, primary_a), (1, primary_b))
+    ]
+    comp = composition.from_stage_compositions(
+        stages,
+        project_name="m",
+        titles={
+            0: composition.TitleCard(text="S0", style="slate", duration_seconds=2.0),
+            1: composition.TitleCard(text="S1", style="slate", duration_seconds=2.0),
+        },
+    )
+    chapters = youtube_sidecar._compute_chapters(comp)
+    # Slate S0 = 2s -> stage 0 chapter at 2s. Stage 0 effective ~11s
+    # -> stage 1 slate starts at 13s, stage 1 chapter at 15s.
+    assert chapters[0].start_seconds == 2.0
+    assert abs(chapters[1].start_seconds - 15.0) < 0.001
+
+
+def test_format_chapter_time_under_hour() -> None:
+    assert youtube_sidecar._format_chapter_time(0) == "0:00"
+    assert youtube_sidecar._format_chapter_time(65.7) == "1:05"
+    assert youtube_sidecar._format_chapter_time(120) == "2:00"
+
+
+def test_format_chapter_time_over_hour() -> None:
+    """YouTube reads ``H:MM:SS`` past 60 minutes; both forms work but
+    the explicit hour reads cleanly in long match recaps."""
+    assert youtube_sidecar._format_chapter_time(3661) == "1:01:01"
+    assert youtube_sidecar._format_chapter_time(7200) == "2:00:00"
+
+
+# --- sidecar payload ------------------------------------------------------
+
+
+def test_build_sidecar_round_trips_through_json(tmp_path: Path) -> None:
+    comp = _two_stage_composition(tmp_path)
+    sidecar = youtube_sidecar.build_sidecar(comp)
+    out = tmp_path / "match-youtube.json"
+    youtube_sidecar.write_sidecar(sidecar, out)
+    parsed = json.loads(out.read_text())
+    assert parsed["title"] == "Bromma Spring"
+    # Description has chapter lines we can validate.
+    assert "0:00 Stage 1 -- Skipper" in parsed["description"]
+    assert "Chapters:" in parsed["description"]
+    assert parsed["chapters"][0]["title"] == "Stage 1 -- Skipper"
+    assert parsed["chapters"][0]["start_seconds"] == 0.0
+    # Default tags include the project name + IPSC.
+    assert "Bromma Spring" in parsed["tags"]
+
+
+def test_build_sidecar_uses_lead_above_chapters(tmp_path: Path) -> None:
+    comp = _two_stage_composition(tmp_path)
+    sidecar = youtube_sidecar.build_sidecar(
+        comp,
+        description_lead="Match recap from Bromma PK.",
+    )
+    desc_lines = sidecar.description.split("\n")
+    assert desc_lines[0] == "Match recap from Bromma PK."
+    # Chapter section comes after a blank line.
+    assert "Chapters:" in desc_lines[2]
+
+
+def test_build_sidecar_overrides_title_and_tags(tmp_path: Path) -> None:
+    comp = _two_stage_composition(tmp_path)
+    sidecar = youtube_sidecar.build_sidecar(
+        comp,
+        title="Bromma Spring 2026 -- Match Recap",
+        tags=["IPSC", "Production Optics", "Bromma PK"],
+    )
+    assert sidecar.title == "Bromma Spring 2026 -- Match Recap"
+    assert "Production Optics" in sidecar.tags
+    # Project default tags are NOT auto-merged; the override replaces.
+    assert "Bromma Spring" not in sidecar.tags
+
+
+# --- .srt output ----------------------------------------------------------
+
+
+def test_write_srt_emits_one_block_per_visible_shot(tmp_path: Path) -> None:
+    comp = _two_stage_composition(tmp_path)
+    out = tmp_path / "match.srt"
+    youtube_sidecar.write_srt(comp, out)
+    blocks = [b for b in out.read_text().split("\n\n") if b.strip()]
+    # Stage A has 2 shots at +1.0s and +1.3s; Stage B has 1 shot at
+    # +0.8s. All inside the visible windows -> 3 captions.
+    assert len(blocks) == 3
+    # First block points at stage A's shot 1. With head_trim=0, the
+    # visible window starts at source-time 0; the beep is at +5s and
+    # shot 1 is at +6s (clip-local). No intro / slate -> spine time
+    # equals visible-window time = 6.0s.
+    first = blocks[0].splitlines()
+    assert first[0] == "1"
+    assert first[1].startswith("00:00:06,000")
+    assert "Shot 1" in first[2]
+
+
+def test_write_srt_skips_shots_outside_visible_window(tmp_path: Path) -> None:
+    """Tighter pads collapse the tail; out-of-window shots are
+    skipped so the caption track doesn't reference vanished frames."""
+    primary = _make_video(tmp_path, "a.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[
+                _shot(1, 1.0, 1.0),  # 6s clip-local, in window
+                _shot(2, 14.5, 13.5),  # 19.5s clip-local, beyond tail
+            ],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=0.0,
+        )
+    ]
+    comp = composition.from_stage_compositions(stages, project_name="m")
+    out = tmp_path / "match.srt"
+    youtube_sidecar.write_srt(comp, out)
+    blocks = [b for b in out.read_text().split("\n\n") if b.strip()]
+    assert len(blocks) == 1
+    assert "Shot 1" in blocks[0]
+
+
+def test_write_srt_handles_empty_composition(tmp_path: Path) -> None:
+    """A stage with no markers must not raise; we still write an
+    empty file so the caller can reference it consistently."""
+    primary = _make_video(tmp_path, "a.mp4")
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary,
+            video=_meta_30fps(),
+            shots=[],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+    ]
+    comp = composition.from_stage_compositions(stages, project_name="m")
+    out = tmp_path / "match.srt"
+    youtube_sidecar.write_srt(comp, out)
+    assert out.exists()
+    assert out.read_text() == ""
+
+
+# --- chapter markers in FCPXML --------------------------------------------
+
+
+def test_fcpxml_with_chapter_markers_emits_one_per_stage(tmp_path: Path) -> None:
+    """The FCPXML emitter carries chapter markers when the IR's
+    ``chapter_markers`` flag is on, so an NLE-side MP4 export gets a
+    populated chapter atom without any extra plumbing."""
+    from xml.etree import ElementTree as ET
+
+    from splitsmith.config import OutputConfig
+    from splitsmith.fcpxml_gen import generate_match_fcpxml
+
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        chapter_markers=True,
+    )
+    root = ET.fromstring(out.read_bytes())
+    chapter_markers = root.findall(".//chapter-marker")
+    assert len(chapter_markers) == 2
+    assert {m.attrib["value"] for m in chapter_markers} == {"A", "B"}
+
+
+def test_fcpxml_chapter_markers_off_by_default(tmp_path: Path) -> None:
+    """Existing exports stay unchanged when the flag isn't set."""
+    from xml.etree import ElementTree as ET
+
+    from splitsmith.config import OutputConfig
+    from splitsmith.fcpxml_gen import generate_match_fcpxml
+
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name=name,
+            video_path=p,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        )
+        for name, p in (("A", primary_a), ("B", primary_b))
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    assert root.find(".//chapter-marker") is None


### PR DESCRIPTION
Closes #204 layer 1. Layer 2 (codec-tuned MP4 preset) and layer 3 (Data API upload) stay deferred.

## Summary

Walk the Composition IR after the export is built and write:

1. ``<slug>-match-youtube.json`` -- YouTube-shaped sidecar (title, description with chapter timestamps, tags, captions reference).
2. ``<slug>-match.srt`` -- per-shot captions track.
3. ``<chapter-marker>`` on each primary + intro / outro clip in the FCPXML so chapters survive an NLE-side MP4 export into the chapter atom YouTube reads.

Renderer-agnostic by design: the sidecar walks the IR, so the user can route through FCPXML / FCP7 XML / MP4 and still get the upload-ready metadata. The FCPXML chapter-marker embedding kicks in only when the user picks the FCPXML route + sidecar; non-FCPXML routes surface a "chapter atoms not yet supported" anomaly note (filed as a #204 follow-up).

## Why chapters in the FCPXML

Per the user's feedback while iterating: the YouTube sidecar is renderer-agnostic, but the chapters should *also* travel inside the timeline so they make it through an NLE round-trip. FCPXML's ``<chapter-marker>`` is exactly that pipeline -- FCP / Premiere / DaVinci forward chapter markers into the MP4 chapter atom on export, which is what YouTube reads.

## Implementation

- ``splitsmith.youtube_sidecar`` -- ``build_sidecar``, ``write_sidecar``, ``write_srt``. Chapter math accounts for intro segments + slate titles (each shifts the chapter offsets forward).
- ``fcpxml_gen.generate_match_fcpxml`` grows ``chapter_markers: bool = False``. Off by default so existing exports stay byte-identical.
- ``Composition`` carries ``chapter_markers``; ``from_stage_compositions`` accepts the flag; the bridge passes through.
- Match-export endpoint + dialog: ``youtube_sidecar`` checkbox.

## Test plan

- [x] 13 new ``test_youtube_sidecar.py`` tests: chapter math (per-stage offsets, intro adds anchor, slates shift offsets, MM:SS / H:MM:SS formatting), JSON round-trip, description lead, override title / tags, .srt one-block-per-visible-shot, .srt skips out-of-window markers, .srt empty composition, FCPXML chapter markers emitted with the flag, FCPXML chapter markers off by default.
- [x] DTD validation: ``test_fcpxml_match_with_chapter_markers_validates``.
- [x] Full Python suite: 867 passed, 4 skipped.
- [x] ``tsc -b --noEmit`` clean.
- [x] ``ruff`` / ``black`` clean.
- [ ] **Release gate:** import a stitched FCPXML with sidecar enabled into FCP, export to MP4, upload to YouTube; chapters should appear in the description and the chapter atom.

## Out of scope (filed as follow-ups)

- FCP7 XML / MP4 chapter-atom support.
- YouTube-tuned codec preset for the MP4 renderer (Layer 2).
- Direct upload via YouTube Data API + OAuth (Layer 3).
- Auto-thumbnail extraction (mentioned in the umbrella body; defer until anyone asks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)