### PR TITLE
youtube: ffmpeg encode preset for YouTube uploads (#212, #204 layer 2)

### DIFF
--- a/src/splitsmith/mp4_render.py
+++ b/src/splitsmith/mp4_render.py
@@ -58,6 +58,7 @@ def render_mp4(
     work_dir: Path | None = None,
     ffmpeg_binary: str = "ffmpeg",
     runner: Runner = subprocess.run,
+    youtube_preset: bool = False,
 ) -> None:
     """Render ``composition`` as a stitched ``.mp4`` at ``output_path``.
 
@@ -65,6 +66,10 @@ def render_mp4(
     ``TemporaryDirectory`` cleaned up on return. Pass an explicit path
     when debugging; the per-stage MP4s are easier to inspect than the
     final concat output.
+
+    ``youtube_preset`` swaps the default per-stage encode for YouTube's
+    recommended H.264 profile / GOP / colour tags (issue #204 layer 2).
+    The concat step keeps stream-copy in either case.
     """
     plans = [_plan_stage(stage, composition.sequence) for stage in composition.stages]
     if not plans:
@@ -80,6 +85,7 @@ def render_mp4(
                 work_dir=Path(tmp),
                 ffmpeg_binary=ffmpeg_binary,
                 runner=runner,
+                youtube_preset=youtube_preset,
             )
     else:
         work_dir.mkdir(parents=True, exist_ok=True)
@@ -90,6 +96,7 @@ def render_mp4(
             work_dir=work_dir,
             ffmpeg_binary=ffmpeg_binary,
             runner=runner,
+            youtube_preset=youtube_preset,
         )
 
 
@@ -101,6 +108,7 @@ def _render_with_work_dir(
     work_dir: Path,
     ffmpeg_binary: str,
     runner: Runner,
+    youtube_preset: bool = False,
 ) -> None:
     stage_files: list[Path] = []
     for idx, plan in enumerate(plans):
@@ -110,6 +118,7 @@ def _render_with_work_dir(
             sequence=composition.sequence,
             output_path=stage_out,
             ffmpeg_binary=ffmpeg_binary,
+            youtube_preset=youtube_preset,
         )
         _run(cmd, runner=runner)
         stage_files.append(stage_out)
@@ -226,6 +235,7 @@ def _build_stage_command(
     sequence,  # type: ignore[no-untyped-def]
     output_path: Path,
     ffmpeg_binary: str = "ffmpeg",
+    youtube_preset: bool = False,
 ) -> tuple[str, ...]:
     """Build the ffmpeg invocation that renders one stage to ``output_path``.
 
@@ -234,6 +244,9 @@ def _build_stage_command(
     of cases (no cams, no overlay) we still re-encode for simplicity;
     a stream-copy fast-path is a follow-up if encode time becomes a
     problem.
+
+    ``youtube_preset`` swaps the encode params (codec, GOP, colour
+    tags, audio bitrate) to YouTube's recommended profile.
     """
     args: list[str] = [ffmpeg_binary, "-hide_banner", "-y"]
     stage = plan.stage
@@ -288,23 +301,85 @@ def _build_stage_command(
         "[final]",
         "-map",
         "0:a?",  # primary audio when present, no error if absent
+    ]
+    args += list(_encode_args(sequence, youtube_preset=youtube_preset))
+    args += [str(output_path)]
+    return tuple(args)
+
+
+def _encode_args(
+    sequence,  # type: ignore[no-untyped-def]
+    *,
+    youtube_preset: bool,
+) -> tuple[str, ...]:
+    """Return the ``-c:v`` ... ``-movflags +faststart`` slice of the
+    ffmpeg invocation. The default profile keeps today's lossy-but-fast
+    encode (CRF 20, AAC 192k); ``youtube_preset`` swaps in YouTube's
+    recommended params (issue #204 layer 2).
+
+    Resolution / fps inform GOP only -- 2 seconds at the sequence frame
+    rate, rounded to the nearest frame. Quality is CRF 18 universally;
+    YouTube re-encodes regardless, so a single-pass quality target is
+    enough and avoids the extra runner invocation a true two-pass
+    encode would require.
+    """
+    if not youtube_preset:
+        return (
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "20",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-movflags",
+            "+faststart",
+        )
+    fps = sequence.frame_rate_num / max(1, sequence.frame_rate_den)
+    gop = max(1, int(round(fps * 2)))
+    return (
         "-c:v",
         "libx264",
         "-preset",
-        "fast",
+        "slow",
+        "-profile:v",
+        "high",
+        "-level",
+        "4.2",
         "-crf",
-        "20",
+        "18",
         "-pix_fmt",
         "yuv420p",
+        "-g",
+        str(gop),
+        "-keyint_min",
+        str(gop),
+        "-sc_threshold",
+        "0",  # closed GOP -- no scene-cut keyframes between the fixed boundaries
+        "-color_primaries",
+        "bt709",
+        "-color_trc",
+        "bt709",
+        "-colorspace",
+        "bt709",
+        "-color_range",
+        "tv",
         "-c:a",
         "aac",
         "-b:a",
-        "192k",
+        "384k",
+        "-ar",
+        "48000",
+        "-ac",
+        "2",
         "-movflags",
         "+faststart",
-        str(output_path),
-    ]
-    return tuple(args)
+    )
 
 
 def _build_stage_filter_graph(

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -119,6 +119,11 @@ class MatchExportRequestData:
     # writes the sidecar but no chapter markers (those renderers
     # don't carry chapters yet).
     youtube_sidecar: bool = False
+    # Issue #204 layer 2. Encode the MP4 with YouTube's recommended
+    # H.264 profile / GOP / colour / audio params. Only meaningful for
+    # ``output_format == "mp4"`` -- gets surfaced as an anomaly when
+    # set against a non-MP4 renderer.
+    youtube_preset: bool = False
 
 
 @dataclass(frozen=True)
@@ -321,13 +326,23 @@ def export_match(
         outro=outro_segment,
         chapter_markers=embed_chapter_markers,
     )
+    youtube_preset_active = request.youtube_preset and request.output_format == "mp4"
+    if request.youtube_preset and request.output_format != "mp4":
+        anomalies.append(
+            f"youtube encode preset ignored: only the mp4 renderer "
+            f"applies it (current renderer: {request.output_format})"
+        )
     try:
         if request.output_format == "fcpxml":
             composition.render_fcpxml(comp, output_path=output_path, config=config)
         elif request.output_format == "fcp7xml":
             fcp7xml_render.render_fcp7xml(comp, output_path=output_path)
         else:
-            mp4_render.render_mp4(comp, output_path=output_path)
+            mp4_render.render_mp4(
+                comp,
+                output_path=output_path,
+                youtube_preset=youtube_preset_active,
+            )
     except (ValueError, FileNotFoundError, mp4_render.FFmpegError) as exc:
         raise MatchExportError(str(exc)) from exc
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -972,6 +972,10 @@ class MatchExportRequest(BaseModel):
     # also gets chapter markers embedded so they survive an NLE
     # round-trip into an MP4 chapter atom.
     youtube_sidecar: bool = False
+    # Issue #204 layer 2. Encode the MP4 with YouTube's recommended
+    # H.264 profile / GOP / colour / audio params. Only meaningful for
+    # ``output_format == "mp4"``; ignored otherwise (anomaly surfaced).
+    youtube_preset: bool = False
 
 
 class RevealRequest(BaseModel):
@@ -4649,6 +4653,7 @@ def create_app(
             intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
             outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
             youtube_sidecar=req.youtube_sidecar,
+            youtube_preset=req.youtube_preset,
         )
         try:
             result = match_export_helpers.export_match(

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -533,6 +533,10 @@ export interface MatchExportRequestPayload {
    *  chapter markers embedded so they survive an NLE round-trip
    *  into an MP4 chapter atom. */
   youtube_sidecar?: boolean;
+  /** Issue #204 layer 2. Encode the MP4 with YouTube's recommended
+   *  H.264 profile / GOP / colour / audio params. Only meaningful
+   *  when ``output_format == "mp4"``. */
+  youtube_preset?: boolean;
 }
 
 /** Body of a single export template (issue #198). Mirrors the dialog's
@@ -1565,6 +1569,9 @@ export const api = {
           : {}),
         ...(payload.youtube_sidecar !== undefined
           ? { youtube_sidecar: payload.youtube_sidecar }
+          : {}),
+        ...(payload.youtube_preset !== undefined
+          ? { youtube_preset: payload.youtube_preset }
           : {}),
       },
     }),

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1242,6 +1242,12 @@ function MatchExportDialog({
   // markers in the timeline so they round-trip through FCP into
   // the MP4 chapter atom.
   const [youtubeSidecar, setYoutubeSidecar] = useState<boolean>(false);
+  // Issue #204 layer 2. YouTube-tuned encode preset for the MP4
+  // renderer (H.264 High, CRF 18, 2s closed GOP, BT.709 tags, AAC
+  // 384k 48k stereo, +faststart). Only meaningful when the chosen
+  // output format is "mp4"; the request layer surfaces an anomaly
+  // if it's set against another renderer.
+  const [youtubePreset, setYoutubePreset] = useState<boolean>(false);
   // Overlay defaults off because the per-frame PIL + ffmpeg render is the
   // slowest writer; opt in per export. Mirrors the per-stage Generate's
   // default.
@@ -1349,6 +1355,7 @@ function MatchExportDialog({
         intro_path: introPath || undefined,
         outro_path: outroPath || undefined,
         youtube_sidecar: youtubeSidecar,
+        youtube_preset: youtubePreset,
         include_overlay: includeOverlay,
         overlay_codec: overlayCodec,
         overlay_max_height:
@@ -1749,6 +1756,19 @@ function MatchExportDialog({
                   onChange={(e) => setYoutubeSidecar(e.target.checked)}
                 />
                 YouTube sidecar (chapters + .srt)
+              </label>
+              <label
+                className="flex items-center gap-1.5"
+                title="Encode the MP4 with YouTube's recommended H.264 profile, 2s closed GOP, BT.709 colour tags, and AAC 384k 48k stereo. Only applies when output format is MP4."
+              >
+                <input
+                  type="checkbox"
+                  className="size-4 accent-primary"
+                  checked={youtubePreset && outputFormat === "mp4"}
+                  disabled={busy || outputFormat !== "mp4"}
+                  onChange={(e) => setYoutubePreset(e.target.checked)}
+                />
+                YouTube encode preset (MP4 only)
               </label>
             </div>
             {includeOverlay ? (

--- a/tests/test_mp4_render.py
+++ b/tests/test_mp4_render.py
@@ -356,6 +356,126 @@ def test_render_mp4_missing_binary_raises(tmp_path: Path) -> None:
         )
 
 
+# --- youtube preset (#204 layer 2) ---------------------------------------
+
+
+def _meta_60fps() -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=60,
+        frame_rate_den=1,
+    )
+
+
+def test_default_encode_args_match_today(tmp_path: Path) -> None:
+    """Without the preset the encode params keep today's CRF 20 / fast /
+    AAC 192k profile -- the byte-equivalence guarantee for existing
+    consumers."""
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
+    )
+    assert "-crf" in cmd and cmd[cmd.index("-crf") + 1] == "20"
+    assert "-preset" in cmd and cmd[cmd.index("-preset") + 1] == "fast"
+    assert cmd[cmd.index("-b:a") + 1] == "192k"
+    # YouTube-specific tags must NOT leak into the default profile.
+    assert "-color_primaries" not in cmd
+    assert "-profile:v" not in cmd
+    assert "-g" not in cmd
+
+
+def test_youtube_preset_emits_recommended_codec_params_30fps(tmp_path: Path) -> None:
+    stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    comp, plan = _build_plan(stage)
+    cmd = mp4_render._build_stage_command(
+        plan,
+        sequence=comp.sequence,
+        output_path=tmp_path / "stage.mp4",
+        youtube_preset=True,
+    )
+    # H.264 High @ Level 4.2, CRF 18, slow preset.
+    assert cmd[cmd.index("-c:v") + 1] == "libx264"
+    assert cmd[cmd.index("-preset") + 1] == "slow"
+    assert cmd[cmd.index("-profile:v") + 1] == "high"
+    assert cmd[cmd.index("-level") + 1] == "4.2"
+    assert cmd[cmd.index("-crf") + 1] == "18"
+    assert cmd[cmd.index("-pix_fmt") + 1] == "yuv420p"
+    # 2s GOP at 30fps -> 60.
+    assert cmd[cmd.index("-g") + 1] == "60"
+    assert cmd[cmd.index("-keyint_min") + 1] == "60"
+    assert cmd[cmd.index("-sc_threshold") + 1] == "0"
+    # rec.709 colour tags so YouTube doesn't autodetect wrong.
+    assert cmd[cmd.index("-color_primaries") + 1] == "bt709"
+    assert cmd[cmd.index("-color_trc") + 1] == "bt709"
+    assert cmd[cmd.index("-colorspace") + 1] == "bt709"
+    # AAC-LC 48k stereo at the upper end of YouTube's recommended range.
+    assert cmd[cmd.index("-c:a") + 1] == "aac"
+    assert cmd[cmd.index("-b:a") + 1] == "384k"
+    assert cmd[cmd.index("-ar") + 1] == "48000"
+    assert cmd[cmd.index("-ac") + 1] == "2"
+    # +faststart so the moov atom lands at the head -- progressive
+    # streaming + faster YouTube ingest.
+    assert cmd[cmd.index("-movflags") + 1] == "+faststart"
+
+
+def test_youtube_preset_doubles_gop_at_60fps(tmp_path: Path) -> None:
+    """2s GOP at 60fps -> 120 keyframe interval. Resolution doesn't
+    change the GOP -- only the source frame rate does."""
+    stage = StageComposition(
+        stage_name="A",
+        video_path=_make_video(tmp_path, "a.mp4"),
+        video=_meta_60fps(),
+        shots=[_shot(1, 1.0, 1.0)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=10.0,
+        tail_pad_seconds=20.0,
+    )
+    comp = composition.from_stage_compositions([stage], project_name="m")
+    plan = mp4_render._plan_stage(comp.stages[0], comp.sequence)
+    cmd = mp4_render._build_stage_command(
+        plan,
+        sequence=comp.sequence,
+        output_path=tmp_path / "stage.mp4",
+        youtube_preset=True,
+    )
+    assert cmd[cmd.index("-g") + 1] == "120"
+    assert cmd[cmd.index("-keyint_min") + 1] == "120"
+
+
+def test_youtube_preset_threads_through_render_mp4(tmp_path: Path) -> None:
+    """Passing ``youtube_preset=True`` to ``render_mp4`` reaches the
+    per-stage encode -- per-stage cmd carries CRF 18; the concat step
+    stays stream-copy regardless."""
+    stage_a = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
+    stage_b = _basic_stage(tmp_path=tmp_path, name="B", primary_name="b.mp4")
+    comp = composition.from_stage_compositions([stage_a, stage_b], project_name="m")
+
+    runner = MagicMock(side_effect=_ok)
+    work = tmp_path / "work"
+    out = tmp_path / "match.mp4"
+    mp4_render.render_mp4(
+        comp,
+        output_path=out,
+        work_dir=work,
+        runner=runner,
+        youtube_preset=True,
+    )
+
+    args_per_call = [call.args[0] for call in runner.call_args_list]
+    # Both per-stage invocations carry the YouTube codec params.
+    for stage_cmd in args_per_call[:2]:
+        assert stage_cmd[stage_cmd.index("-crf") + 1] == "18"
+        assert stage_cmd[stage_cmd.index("-profile:v") + 1] == "high"
+        assert stage_cmd[stage_cmd.index("-color_primaries") + 1] == "bt709"
+    # Concat is stream-copy; no codec swap there.
+    concat = args_per_call[2]
+    assert "-c" in concat and concat[concat.index("-c") + 1] == "copy"
+    assert "-crf" not in concat
+
+
 def test_render_mp4_requires_at_least_one_stage(tmp_path: Path) -> None:
     """Empty stages on a Composition shouldn't even reach ffmpeg."""
     # Build an empty composition by sidestepping the constructor's guard.

--- a/tests/test_ui_match_exports.py
+++ b/tests/test_ui_match_exports.py
@@ -400,3 +400,95 @@ def test_export_match_slugifies_project_name_for_filename(tmp_path: Path) -> Non
         probe=_stub_probe,
     )
     assert result.fcpxml_path.name == "region-cup-2026-may-match.fcpxml"
+
+
+# --- youtube preset (#204 layer 2) ---------------------------------------
+
+
+def test_youtube_preset_anomaly_when_renderer_is_not_mp4(tmp_path: Path) -> None:
+    """The preset only applies to the MP4 renderer; setting it together
+    with an FCPXML / FCP7 export must not silently mis-encode anything
+    -- it surfaces as an anomaly so the user sees the mismatch."""
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+            )
+        ],
+        request=match_exports_mod.MatchExportRequestData(
+            stage_numbers=(1,),
+            head_pad_seconds=10.0,
+            tail_pad_seconds=20.0,
+            include_secondaries=True,
+            include_overlay=True,
+            project_name="match",
+            output_format="fcpxml",
+            youtube_preset=True,
+        ),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert any("youtube encode preset ignored" in a for a in result.anomalies)
+
+
+def test_youtube_preset_threads_through_to_mp4_renderer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the user picks output_format=mp4 with youtube_preset=True
+    the orchestrator forwards the flag to ``mp4_render.render_mp4``."""
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+
+    captured: dict[str, object] = {}
+
+    def fake_render_mp4(comp, *, output_path, **kwargs):  # type: ignore[no-untyped-def]
+        captured["youtube_preset"] = kwargs.get("youtube_preset")
+        # Touch the output so downstream code that checks existence works.
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"")
+
+    monkeypatch.setattr(match_exports_mod.mp4_render, "render_mp4", fake_render_mp4)
+
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+            )
+        ],
+        request=match_exports_mod.MatchExportRequestData(
+            stage_numbers=(1,),
+            head_pad_seconds=10.0,
+            tail_pad_seconds=20.0,
+            include_secondaries=True,
+            include_overlay=True,
+            project_name="match",
+            output_format="mp4",
+            youtube_preset=True,
+        ),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert captured["youtube_preset"] is True
+    # No anomaly when the preset matches the renderer.
+    assert not any("youtube encode preset" in a for a in result.anomalies)
+    assert result.fcpxml_path.suffix == ".mp4"


### PR DESCRIPTION
Closes #212.
Layer 2 of #204 (parent: #192).

## Summary

- \`mp4_render.render_mp4(youtube_preset=True)\` swaps the per-stage encode for YouTube's recommended H.264 profile: High @ Level 4.2, CRF 18, slow x264 preset, 2s closed GOP, BT.709 colour tags, AAC 384k 48k stereo, +faststart. Concat step stays stream-copy.
- GOP is sequence-frame-rate-aware: 60 keyframes at 30fps, 120 at 60fps.
- \`MatchExportRequestData.youtube_preset\` carries the flag from the FastAPI body to the renderer; Export.tsx gates the checkbox on \`output_format=mp4\`. Set against another renderer it surfaces as an anomaly.

## Tradeoffs

- Single-pass CRF over two-pass bitrate. YouTube re-encodes regardless, so a quality target is enough; two-pass would force a second runner invocation per stage and complicate the pure-function test surface.
- Resolution doesn't change the GOP or quality target -- only frame rate does. 720p / 1080p / 4K all use CRF 18 + 2s GOP.

## Test plan

- [x] \`uv run pytest -q\` -- 873 passing (6 new), 4 skipped
- [x] \`ruff check\` + \`black --check\` clean on the diff
- [x] \`tsc --noEmit\` clean on the UI
- [ ] Manual: enable preset, export an MP4, \`ffprobe\` the result for \`profile=High\`, \`level=42\`, \`color_primaries=bt709\`, \`g=60\`, \`b:a=384k\`, \`movflags=+faststart\`
- [ ] Manual: upload to a private YouTube channel and confirm no surprise re-encode warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)