### PR TITLE
exports: drop shot-detection gate (permissive mode) (#214)

### DIFF
--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -213,10 +213,11 @@ def export_stage(
         raise StageExportError(f"failed to read audit JSON {audit_path}: {exc}") from exc
 
     shots = audit_shots_to_engine_shots(audit_data, beep_time_in_source=beep_time_in_source)
-    if not shots:
-        raise StageExportError(
-            f"audit JSON {audit_path} has no shots in shots[]; nothing to export"
-        )
+    # Empty ``shots[]`` is permissive (#214): the user may want a trim-only
+    # export. CSV / overlay / shot-markers depend on shots; the trimmed
+    # clip + FCPXML spine do not. ``report.detect_anomalies`` already
+    # surfaces "No shots detected in the stage window" for this case so
+    # the audit trail stays clean.
 
     exports_dir.mkdir(parents=True, exist_ok=True)
     base = f"stage{stage_data.stage_number}_{_slugify(stage_data.stage_name)}"
@@ -327,8 +328,11 @@ def export_stage(
 
     csv_path: Path | None = None
     if request.write_csv:
-        csv_path = exports_dir / f"{base}_splits.csv"
-        csv_gen.write_splits_csv(shots, csv_path)
+        if shots:
+            csv_path = exports_dir / f"{base}_splits.csv"
+            csv_gen.write_splits_csv(shots, csv_path)
+        else:
+            skip_reasons.append("csv not written: no shots audited")
 
     # Overlay render (issue #45). Gated on having a trimmed clip to mirror;
     # the overlay must match the trim frame-for-frame or it will drift on
@@ -337,7 +341,12 @@ def export_stage(
     overlay_path: Path | None = None
     fcp_overlay_path: Path | None = None
     overlay_target = exports_dir / f"{base}_overlay.mov"
-    if request.write_overlay:
+    if request.write_overlay and not shots:
+        # Overlay annotates shot times; with no shots there's nothing to
+        # render. Surface as a skip reason so the user sees why the
+        # checkbox didn't produce output. (#214 / #217.)
+        skip_reasons.append("overlay not written: no shots audited")
+    elif request.write_overlay:
         # Resolve the trim we'll mirror: prefer the one we just wrote, then
         # a stale lossless trim from a prior run. If none exists -- e.g.
         # source unreachable AND no prior trim -- skip with a clear reason.

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -187,8 +187,15 @@ def export_match(
         # any beep_time_in_source value works here -- we pick 0.0 so the
         # ``time_absolute`` column stays trivially defined.
         shots = audit_shots_to_engine_shots(audit_data, beep_time_in_source=0.0)
+        # Empty ``shots[]`` is permissive (#214): the stage still rides
+        # the spine as a trim-only segment. No shot markers, no chapter
+        # markers, no overlay -- those depend on shots. Surface an
+        # anomaly so the user sees which stages are exporting bare.
         if not shots:
-            raise MatchExportError(f"stage {stage_input.stage_number}: audit JSON has no shots")
+            anomalies.append(
+                f"stage {stage_input.stage_number}: no shots audited -- "
+                f"exported without shot markers / chapters / overlay"
+            )
 
         try:
             primary_meta = probe(stage_input.trimmed_path)  # type: ignore[operator]

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1424,6 +1424,30 @@ function MatchExportDialog({
             {stageNumbers.length === 1 ? "" : "s"} into one FCPXML in stage
             order. Composes from existing trims; no re-encoding.
           </CardDescription>
+          {(() => {
+            // #214 -- export is permissive about empty shots. Surface a
+            // friendly inline note when any selected stage has zero
+            // audited shots so the user knows what to expect (no shot
+            // markers, CSV, or overlay for those stages) without being
+            // gated.
+            const shotless = stages.filter(
+              (s) =>
+                stageNumbers.includes(s.stage_number) &&
+                s.audit_shot_count === 0,
+            );
+            if (shotless.length === 0) return null;
+            const stageList = shotless
+              .map((s) => `Stage ${s.stage_number}`)
+              .join(", ");
+            const verb = shotless.length === 1 ? "exports" : "export";
+            return (
+              <div className="mt-2 rounded border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+                {stageList} {verb} without shot markers, CSV, or overlay
+                (no shots audited). Detection is optional -- you can still
+                export the trim and stitched timeline.
+              </div>
+            );
+          })()}
         </CardHeader>
         <CardContent className="space-y-4 text-sm">
           {templates.length > 0 && (

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -195,26 +195,47 @@ def test_export_stage_refuses_missing_audit(tmp_path: Path) -> None:
         )
 
 
-def test_export_stage_refuses_empty_shots(tmp_path: Path) -> None:
+def test_export_stage_permissive_with_empty_shots(tmp_path: Path) -> None:
+    """#214 -- empty ``shots[]`` no longer hard-fails. The export
+    proceeds, skipping CSV / overlay (those require shots), but the
+    report still ships and surfaces "No shots detected" via the
+    standard anomaly pipeline. CSV / overlay skips also land as
+    anomalies so the user sees what was suppressed."""
     audit_path = tmp_path / "stage1.json"
     audit_path.write_text(json.dumps(_audit_payload(shots=[])), encoding="utf-8")
-    with pytest.raises(exports_mod.StageExportError):
-        exports_mod.export_stage(
-            request=exports_mod.StageExportRequest(stage_number=1),
-            audit_path=audit_path,
-            exports_dir=tmp_path / "exports",
-            source_video_path=None,
-            pre_buffer_seconds=5.0,
-            post_buffer_seconds=5.0,
-            stage_data=StageData(
-                stage_number=1,
-                stage_name="S",
-                time_seconds=8.0,
-                scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
-            ),
-            beep_time_in_source=10.0,
-            config=Config(),
-        )
+    result = exports_mod.export_stage(
+        request=exports_mod.StageExportRequest(
+            stage_number=1,
+            write_trim=False,
+            write_csv=True,
+            write_overlay=True,
+            write_fcpxml=False,
+            write_report=True,
+        ),
+        audit_path=audit_path,
+        exports_dir=tmp_path / "exports",
+        source_video_path=None,
+        pre_buffer_seconds=5.0,
+        post_buffer_seconds=5.0,
+        stage_data=StageData(
+            stage_number=1,
+            stage_name="S",
+            time_seconds=8.0,
+            scorecard_updated_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ),
+        beep_time_in_source=10.0,
+        config=Config(),
+    )
+    assert result.shots_written == 0
+    assert result.csv_path is None
+    assert result.overlay_path is None
+    assert result.report_path is not None
+    assert result.report_path.exists()
+    # CSV / overlay skips are surfaced; the standard "no shots"
+    # anomaly piggybacks via report.detect_anomalies.
+    assert any("csv not written: no shots audited" in a for a in result.anomalies)
+    assert any("overlay not written: no shots audited" in a for a in result.anomalies)
+    assert any("No shots detected" in a for a in result.anomalies)
 
 
 def test_export_stage_skips_trim_and_fcpxml_when_source_unreachable(tmp_path: Path) -> None:

--- a/tests/test_ui_match_exports.py
+++ b/tests/test_ui_match_exports.py
@@ -308,25 +308,81 @@ def test_export_match_raises_on_missing_audit(tmp_path: Path) -> None:
         )
 
 
-def test_export_match_raises_on_audit_with_no_shots(tmp_path: Path) -> None:
+def test_export_match_permissive_with_audit_with_no_shots(tmp_path: Path) -> None:
+    """#214 -- a stage with empty ``shots[]`` no longer hard-fails. The
+    spine still carries the stage as a trim-only segment; an anomaly
+    flags the missing markers."""
     audit = _make_audit(tmp_path, "stage1.json", _audit_payload([]))
     trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
-    with pytest.raises(match_exports_mod.MatchExportError, match="no shots"):
-        match_exports_mod.export_match(
-            stages=[
-                match_exports_mod.MatchStageInput(
-                    stage_number=1,
-                    stage_name="Stage 1",
-                    audit_path=audit,
-                    trimmed_path=trim,
-                    beep_offset_seconds=5.0,
-                )
-            ],
-            request=_make_request(),
-            exports_dir=tmp_path / "exports",
-            config=OutputConfig(),
-            probe=_stub_probe,
-        )
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+            )
+        ],
+        request=_make_request(),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert result.stage_count == 1
+    assert result.fcpxml_path.exists()
+    assert any("no shots audited" in a and "stage 1" in a for a in result.anomalies)
+    # Spine still carries the stage; FCPXML just has no shot markers.
+    root = ET.fromstring(result.fcpxml_path.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 1
+    markers = spine_clips[0].findall("marker")
+    assert markers == []
+
+
+def test_export_match_permissive_mixed_shotful_and_shotless_stages(tmp_path: Path) -> None:
+    """When some stages have shots and others don't, the export proceeds
+    end-to-end with markers only on the shotful ones."""
+    audit_full = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    audit_empty = _make_audit(tmp_path, "stage2.json", _audit_payload([]))
+    trim_a = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    trim_b = _make_trim(tmp_path, "stage2_trimmed.mp4")
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit_full,
+                trimmed_path=trim_a,
+                beep_offset_seconds=5.0,
+            ),
+            match_exports_mod.MatchStageInput(
+                stage_number=2,
+                stage_name="Stage 2",
+                audit_path=audit_empty,
+                trimmed_path=trim_b,
+                beep_offset_seconds=5.0,
+            ),
+        ],
+        request=_make_request(),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert result.stage_count == 2
+    # Anomaly only for the shotless stage.
+    assert any("stage 2" in a and "no shots audited" in a for a in result.anomalies)
+    assert not any("stage 1" in a and "no shots audited" in a for a in result.anomalies)
+    root = ET.fromstring(result.fcpxml_path.read_bytes())
+    clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(clips) == 2
+    # Stage 1 has a marker; stage 2 doesn't.
+    assert clips[0].findall("marker")
+    assert not clips[1].findall("marker")
 
 
 def test_export_match_raises_on_empty_stages(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #214.

## Summary

- Per-stage \`export_stage\` no longer raises on empty \`shots[]\`. CSV and overlay are skipped with explicit anomalies; the trimmed clip + FCPXML still ship.
- Match \`export_match\` no longer hard-fails when any selected stage has empty shots. The stage rides the spine as a trim-only segment with no markers / chapters; an anomaly per shotless stage surfaces it.
- The match-export dialog adds an inline amber notice listing the shotless stages with copy that frames detection as optional, not required.

## Tradeoffs

- Audit JSON file is still required to exist (the empty \`shots[]\` shape is the signal). Removing the file requirement is a separate, larger change.
- Match-level overlay paths come from per-stage exports; if a stage exported overlay-less because of #214, the match path naturally has no overlay file to wire in. The existing 'overlay missing' anomaly covers it; cleaner messaging is in scope of #217.

## Test plan

- [x] \`uv run pytest -q\` -- 874 passing (1 obsolete test rewritten, 1 new mixed-stages test added)
- [x] \`ruff check\` + \`black --check\` clean on the diff
- [x] \`tsc --noEmit\` clean on the UI
- [ ] Manual: open the match export dialog with a stage that has zero audited shots; confirm the amber notice renders and the export proceeds end-to-end with no FCPXML markers on that stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)