### PR TITLE
overlay: clarify gating + messaging when no shots audited (#217)

### DIFF
--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -232,7 +232,19 @@ def export_match(
 
         overlay_path: Path | None = None
         overlay_video = None
-        if request.include_overlay and stage_input.overlay_path is not None:
+        if request.include_overlay and not shots:
+            # Shotless stages can't have an overlay -- it annotates shot
+            # times. The shotless anomaly above already signals it; don't
+            # double up unless the user explicitly opted in. (#217)
+            pass
+        elif request.include_overlay and stage_input.overlay_path is None:
+            # Overlay was requested but never rendered for this stage.
+            # Surface explicitly so the user knows why the timeline is bare.
+            anomalies.append(
+                f"stage {stage_input.stage_number}: overlay not available -- "
+                f"run the per-stage Generate with the Overlay toggle enabled"
+            )
+        elif request.include_overlay and stage_input.overlay_path is not None:
             if stage_input.overlay_path.exists():
                 try:
                     overlay_video = probe(stage_input.overlay_path)  # type: ignore[operator]

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -1619,16 +1619,37 @@ function MatchExportDialog({
                   </select>
                 </label>
               )}
-              <label className="flex items-center gap-1.5">
-                <input
-                  type="checkbox"
-                  className="size-4 accent-primary"
-                  checked={includeOverlay}
-                  disabled={busy}
-                  onChange={(e) => setIncludeOverlay(e.target.checked)}
-                />
-                Include overlay (when present)
-              </label>
+              {(() => {
+                // #217 -- overlay annotates shot times, so it needs at
+                // least one audited shot across the selection. Disable
+                // the checkbox with a tooltip when nothing in scope has
+                // shots; the per-stage / match exports still skip it
+                // gracefully if it slips through.
+                const anyShots = stages.some(
+                  (s) =>
+                    stageNumbers.includes(s.stage_number) &&
+                    s.audit_shot_count > 0,
+                );
+                const overlayDisabled = busy || !anyShots;
+                const overlayTooltip = anyShots
+                  ? "Composite the per-shot overlay onto the timeline."
+                  : "Overlay needs at least one audited shot across the selection.";
+                return (
+                  <label
+                    className="flex items-center gap-1.5"
+                    title={overlayTooltip}
+                  >
+                    <input
+                      type="checkbox"
+                      className="size-4 accent-primary"
+                      checked={includeOverlay && anyShots}
+                      disabled={overlayDisabled}
+                      onChange={(e) => setIncludeOverlay(e.target.checked)}
+                    />
+                    Include overlay (when present)
+                  </label>
+                );
+              })()}
               <label
                 className="flex items-center gap-1.5"
                 title="FCPXML: Final Cut Pro 1.10 (default). FCP7 XML: legacy xmeml file importable into Premiere Pro and DaVinci Resolve."

--- a/tests/test_ui_match_exports.py
+++ b/tests/test_ui_match_exports.py
@@ -228,6 +228,63 @@ def test_export_match_drops_secondaries_when_flag_off(tmp_path: Path) -> None:
     assert nested == []
 
 
+def test_export_match_overlay_requested_but_unrendered_emits_clear_anomaly(
+    tmp_path: Path,
+) -> None:
+    """#217 -- when overlay is requested but the per-stage Generate
+    didn't render one (overlay_path is None), the anomaly tells the
+    user where to enable it rather than silently dropping the layer."""
+    audit = _make_audit(
+        tmp_path,
+        "stage1.json",
+        _audit_payload([{"shot_number": 1, "ms_after_beep": 500}]),
+    )
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+                overlay_path=None,
+            )
+        ],
+        request=_make_request(),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert any("overlay not available" in a and "Overlay toggle" in a for a in result.anomalies)
+
+
+def test_export_match_overlay_silent_for_shotless_stages(tmp_path: Path) -> None:
+    """#217 -- shotless stages already surface a 'no shots audited'
+    anomaly that mentions overlay; don't emit a second 'overlay not
+    available' line for the same stage."""
+    audit = _make_audit(tmp_path, "stage1.json", _audit_payload([]))
+    trim = _make_trim(tmp_path, "stage1_trimmed.mp4")
+    result = match_exports_mod.export_match(
+        stages=[
+            match_exports_mod.MatchStageInput(
+                stage_number=1,
+                stage_name="Stage 1",
+                audit_path=audit,
+                trimmed_path=trim,
+                beep_offset_seconds=5.0,
+                overlay_path=None,
+            )
+        ],
+        request=_make_request(),
+        exports_dir=tmp_path / "exports",
+        config=OutputConfig(),
+        probe=_stub_probe,
+    )
+    assert any("no shots audited" in a for a in result.anomalies)
+    assert not any("overlay not available" in a for a in result.anomalies)
+
+
 def test_export_match_records_anomaly_for_missing_secondary(tmp_path: Path) -> None:
     audit = _make_audit(
         tmp_path,


### PR DESCRIPTION
Closes #217.

## Summary

- Match-export overlay branch now triages cleanly:
  - Shotless stages: silent (the existing 'no shots audited' anomaly already mentions overlay -- no double-up).
  - Overlay requested but never rendered: 'overlay not available -- run the per-stage Generate with the Overlay toggle enabled'.
  - Overlay file missing / probe failed: existing 'missing at' / 'dropped' messages stay.
- Export.tsx disables the Overlay checkbox with an explanatory tooltip when no selected stage has audited shots. Tooltip: 'Overlay needs at least one audited shot across the selection.'
- Two new tests cover the renderer-side messaging.

## Test plan

- [x] \`uv run pytest -q\` -- 876 passing (2 new), 4 skipped
- [x] \`ruff check\` + \`black --check\` clean
- [x] \`tsc --noEmit\` clean
- [ ] Manual: open match dialog with mixed shotful + shotless selection; confirm overlay checkbox stays enabled (tooltip mentions threshold)
- [ ] Manual: open dialog with all-shotless selection; confirm overlay checkbox is disabled with the explanatory tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)