### PR TITLE
beep: labeled calibration fixture suite + eval harness (#220 layer 1)

### DIFF
--- a/scripts/build_beep_calibration.py
+++ b/scripts/build_beep_calibration.py
@@ -1,0 +1,195 @@
+"""Build the labeled beep calibration manifest from existing audit JSONs.
+
+This is the layer-1 inventory step for issue #220 (``beep: improve
+detection accuracy``). It walks ``tests/fixtures/*.json``, pulls out
+ground-truth beep positions, classifies each fixture by camera mount
+and seeds heuristic failure-mode tags, then writes:
+
+    tests/fixtures/beep_calibration/manifest.yaml
+
+The manifest is the input to ``scripts/eval_beep_detector.py`` -- it
+defines WHAT to evaluate. The detector itself is unchanged here; this
+script never imports ``beep_detect``.
+
+Run::
+
+    uv run python scripts/build_beep_calibration.py
+    uv run python scripts/build_beep_calibration.py --dry-run
+    uv run python scripts/build_beep_calibration.py --preserve-tags
+
+Hand-edit ``manifest.yaml`` to add fine-grained tags (``cross-bay``,
+``steel-fp-observed``, ``ro-chatter``, ``low-spl``, ...) -- these are
+the buckets the layer-2 detector work measures against. By default a
+re-run will overwrite the tags from the auto-heuristics; pass
+``--preserve-tags`` to keep your hand-tagging when re-running.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from splitsmith.beep_calibration import (
+    DEFAULT_TOLERANCE_MS,
+    BeepCalibrationManifest,
+    BeepFixtureEntry,
+    auto_tags,
+    compute_full_beep_time,
+    derive_camera_kind,
+    load_manifest,
+    read_audit_json,
+    save_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
+FULL_DIR = FIXTURES_DIR / "full"
+MANIFEST_PATH = FIXTURES_DIR / "beep_calibration" / "manifest.yaml"
+
+# Audit JSON suffixes that aren't real fixtures. Anything with one of
+# these substrings in the filename is skipped; the substring set comes
+# from the existing tests/fixtures/ tree (.bak, before-promote, etc.).
+NON_FIXTURE_MARKERS = (
+    ".bak",
+    ".before-",
+    "promotion-report",
+    "candidates",
+    "peaks-",
+)
+
+
+def is_fixture_audit_json(path: Path) -> bool:
+    """Filter out backup / report JSONs that share the fixture directory."""
+    if path.suffix != ".json":
+        return False
+    name = path.name
+    return not any(marker in name for marker in NON_FIXTURE_MARKERS)
+
+
+def build_entry(audit_path: Path) -> BeepFixtureEntry | None:
+    """Translate one audit JSON into a manifest entry, or return None.
+
+    Returns ``None`` for JSONs that aren't fixture audits (no
+    ``beep_time``, missing matching WAV, etc.) -- callers should treat
+    those as "skip silently".
+    """
+    audit = read_audit_json(audit_path)
+    if not isinstance(audit, dict):
+        return None
+    beep_time = audit.get("beep_time")
+    if beep_time is None:
+        return None
+    stem = audit_path.stem
+    clip_wav = audit_path.with_suffix(".wav")
+    if not clip_wav.exists():
+        return None
+
+    camera_kind = derive_camera_kind(audit.get("camera"))
+    camera_id = (audit.get("camera") or {}).get("id")
+    tolerance_ms = float(audit.get("tolerance_ms") or DEFAULT_TOLERANCE_MS)
+
+    full_wav_rel: str | None = None
+    full_beep: float | None = None
+    full_duration: float | None = None
+    full_sidecar = FULL_DIR / f"{stem}_full.json"
+    full_wav = FULL_DIR / f"{stem}_full.wav"
+    fws = audit.get("fixture_window_in_source")
+    if full_sidecar.exists() and full_wav.exists() and isinstance(fws, list) and len(fws) == 2:
+        sidecar = read_audit_json(full_sidecar)
+        full_window = sidecar.get("full_window_in_source")
+        if isinstance(full_window, list) and len(full_window) == 2:
+            full_beep = compute_full_beep_time(
+                fixture_window_in_source=(float(fws[0]), float(fws[1])),
+                full_window_in_source=(float(full_window[0]), float(full_window[1])),
+                clip_beep_time=float(beep_time),
+            )
+            full_wav_rel = full_wav.relative_to(FIXTURES_DIR).as_posix()
+            full_duration = float(sidecar.get("extracted_seconds") or 0.0) or None
+
+    tags = auto_tags(
+        camera_kind=camera_kind,
+        ground_truth_in_full=full_beep,
+        stage_rounds=audit.get("stage_rounds"),
+    )
+
+    return BeepFixtureEntry(
+        stem=stem,
+        camera_kind=camera_kind,
+        camera_id=camera_id,
+        clip_wav=clip_wav.relative_to(FIXTURES_DIR).as_posix(),
+        ground_truth_in_clip=float(beep_time),
+        tolerance_ms=tolerance_ms,
+        full_wav=full_wav_rel,
+        ground_truth_in_full=full_beep,
+        full_duration_s=full_duration,
+        tags=tags,
+    )
+
+
+def build_manifest(
+    fixtures_dir: Path = FIXTURES_DIR,
+    *,
+    preserve_tags: bool = False,
+    existing: BeepCalibrationManifest | None = None,
+) -> BeepCalibrationManifest:
+    """Walk ``fixtures_dir`` and return the rebuilt manifest.
+
+    ``preserve_tags=True`` merges hand-edited tags from ``existing`` --
+    the auto-heuristic tags are unioned with whatever the user added.
+    """
+    prior_tags: dict[str, list[str]] = {}
+    if preserve_tags and existing is not None:
+        prior_tags = {e.stem: list(e.tags) for e in existing.fixtures}
+
+    entries: list[BeepFixtureEntry] = []
+    for audit_path in sorted(fixtures_dir.iterdir()):
+        if not is_fixture_audit_json(audit_path):
+            continue
+        entry = build_entry(audit_path)
+        if entry is None:
+            continue
+        if preserve_tags and entry.stem in prior_tags:
+            merged = list(dict.fromkeys(entry.tags + prior_tags[entry.stem]))
+            entry = entry.model_copy(update={"tags": merged})
+        entries.append(entry)
+    return BeepCalibrationManifest(fixtures=entries)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the would-be manifest summary; don't write the YAML.",
+    )
+    parser.add_argument(
+        "--preserve-tags",
+        action="store_true",
+        help="Keep hand-edited tags when rebuilding (union with auto tags).",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=MANIFEST_PATH,
+        help=f"Output manifest path (default: {MANIFEST_PATH}).",
+    )
+    args = parser.parse_args()
+
+    existing = load_manifest(args.manifest) if args.preserve_tags else None
+    manifest = build_manifest(preserve_tags=args.preserve_tags, existing=existing)
+
+    print(f"Discovered {len(manifest.fixtures)} fixtures:")
+    for entry in manifest.fixtures:
+        full = " + full" if entry.full_wav else ""
+        tags = ",".join(entry.tags) if entry.tags else "-"
+        print(f"  {entry.stem}  ({entry.camera_kind}{full})  tags={tags}")
+
+    if args.dry_run:
+        print("\n(dry-run -- not writing)")
+        return
+    save_manifest(manifest, args.manifest)
+    print(f"\nWrote {args.manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_beep_detector.py
+++ b/scripts/eval_beep_detector.py
@@ -1,0 +1,280 @@
+"""Run the current beep detector against every calibration fixture.
+
+This is the layer-1 baseline harness for issue #220. It reads the
+manifest produced by ``build_beep_calibration.py``, runs
+``splitsmith.beep_detect.detect_beep`` against both the trimmed clip
+WAV and (when available) the wide-window full WAV, scores each call
+against the recorded ground truth, and prints:
+
+* a per-fixture table (clip + full track),
+* per-tag bucket aggregates (handheld vs headcam, late-beep, ...),
+* an overall recall summary.
+
+The output is the reference baseline. Layer-2 detector changes should
+re-run this script and improve recall / precision against it.
+
+Run::
+
+    uv run python scripts/eval_beep_detector.py
+    uv run python scripts/eval_beep_detector.py --json out/beep_eval.json
+    uv run python scripts/eval_beep_detector.py --tag late-beep
+    uv run python scripts/eval_beep_detector.py --track full
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from splitsmith.beep_calibration import (
+    BeepFixtureEntry,
+    EvalSummary,
+    FixtureEvalResult,
+    evaluate_detection,
+    load_manifest,
+    summarize,
+)
+from splitsmith.beep_detect import BeepNotFoundError, detect_beep, load_audio
+from splitsmith.config import BeepDetectConfig
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
+MANIFEST_PATH = FIXTURES_DIR / "beep_calibration" / "manifest.yaml"
+
+
+def run_one(
+    *,
+    stem: str,
+    track: str,
+    wav_path: Path,
+    ground_truth_s: float,
+    tolerance_ms: float,
+    tags: Iterable[str],
+    config: BeepDetectConfig,
+) -> FixtureEvalResult:
+    """Load ``wav_path``, run the detector, and score the result."""
+    try:
+        audio, sample_rate = load_audio(wav_path)
+    except Exception as exc:  # missing file, codec issue
+        return evaluate_detection(
+            stem=stem,
+            track=track,
+            tags=tags,
+            ground_truth_s=ground_truth_s,
+            tolerance_ms=tolerance_ms,
+            detected_time_s=None,
+            detected_score=None,
+            error_kind=f"load_failed: {exc!s}",
+        )
+
+    try:
+        result = detect_beep(audio, sample_rate, config)
+    except BeepNotFoundError:
+        return evaluate_detection(
+            stem=stem,
+            track=track,
+            tags=tags,
+            ground_truth_s=ground_truth_s,
+            tolerance_ms=tolerance_ms,
+            detected_time_s=None,
+            detected_score=None,
+            error_kind="not_found",
+        )
+    except Exception as exc:  # config / numeric edge cases
+        return evaluate_detection(
+            stem=stem,
+            track=track,
+            tags=tags,
+            ground_truth_s=ground_truth_s,
+            tolerance_ms=tolerance_ms,
+            detected_time_s=None,
+            detected_score=None,
+            error_kind=f"exception: {exc!s}",
+        )
+
+    winner_score = result.candidates[0].score if result.candidates else None
+    runner_up_times = [c.time for c in result.candidates[1:]]
+    return evaluate_detection(
+        stem=stem,
+        track=track,
+        tags=tags,
+        ground_truth_s=ground_truth_s,
+        tolerance_ms=tolerance_ms,
+        detected_time_s=result.time,
+        detected_score=winner_score,
+        candidate_times_s=runner_up_times,
+    )
+
+
+def evaluate_entry(
+    entry: BeepFixtureEntry,
+    *,
+    fixtures_dir: Path,
+    config: BeepDetectConfig,
+    tracks: tuple[str, ...],
+) -> list[FixtureEvalResult]:
+    """Run the detector on each requested track for one fixture."""
+    out: list[FixtureEvalResult] = []
+    if "clip" in tracks:
+        out.append(
+            run_one(
+                stem=entry.stem,
+                track="clip",
+                wav_path=fixtures_dir / entry.clip_wav,
+                ground_truth_s=entry.ground_truth_in_clip,
+                tolerance_ms=entry.tolerance_ms,
+                tags=entry.tags,
+                config=config,
+            )
+        )
+    if "full" in tracks and entry.full_wav and entry.ground_truth_in_full is not None:
+        out.append(
+            run_one(
+                stem=entry.stem,
+                track="full",
+                wav_path=fixtures_dir / entry.full_wav,
+                ground_truth_s=entry.ground_truth_in_full,
+                tolerance_ms=entry.tolerance_ms,
+                tags=entry.tags,
+                config=config,
+            )
+        )
+    return out
+
+
+def format_row(r: FixtureEvalResult) -> str:
+    if r.detected_time_s is None:
+        return (
+            f"  [{r.track:4}] {r.stem:55} MISS ({r.error_kind})  " f"truth={r.ground_truth_s:.3f}s"
+        )
+    err_ms = (r.error_s or 0.0) * 1000.0
+    flag = "OK" if r.correct_top1 else ("topN" if r.correct_in_topn else "FAIL")
+    score = f"  score={r.detected_score:.1f}" if r.detected_score is not None else ""
+    return (
+        f"  [{r.track:4}] {r.stem:55} {flag:4}  "
+        f"det={r.detected_time_s:.3f}s  truth={r.ground_truth_s:.3f}s  "
+        f"err={err_ms:+.1f} ms{score}"
+    )
+
+
+def format_bucket(name: str, summary: EvalSummary) -> str:
+    return (
+        f"  {name:18}  n={summary.total:3}  "
+        f"top1={summary.top1_hits:3} ({summary.recall_top1 * 100:5.1f}%)  "
+        f"topN={summary.topn_hits:3} ({summary.recall_topn * 100:5.1f}%)  "
+        f"miss={summary.not_found:2}  err={summary.exceptions:2}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--manifest", type=Path, default=MANIFEST_PATH, help="Manifest YAML to evaluate."
+    )
+    parser.add_argument(
+        "--track",
+        action="append",
+        choices=["clip", "full"],
+        help="Run only the given tracks (default: both).",
+    )
+    parser.add_argument(
+        "--tag", action="append", help="Restrict to fixtures with this tag (repeatable)."
+    )
+    parser.add_argument(
+        "--stem", action="append", help="Restrict to fixtures with this stem (repeatable)."
+    )
+    parser.add_argument(
+        "--json", type=Path, help="Write the per-fixture results to this JSON file."
+    )
+    args = parser.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    if not manifest.fixtures:
+        raise SystemExit(
+            f"manifest empty or missing at {args.manifest}; "
+            "run scripts/build_beep_calibration.py first."
+        )
+
+    selected: list[BeepFixtureEntry] = []
+    for entry in manifest.fixtures:
+        if args.tag and not any(t in entry.tags for t in args.tag):
+            continue
+        if args.stem and entry.stem not in args.stem:
+            continue
+        selected.append(entry)
+    if not selected:
+        raise SystemExit("no fixtures matched the filters")
+
+    tracks = tuple(args.track) if args.track else ("clip", "full")
+    config = BeepDetectConfig()
+
+    results: list[FixtureEvalResult] = []
+    for entry in selected:
+        results.extend(
+            evaluate_entry(entry, fixtures_dir=FIXTURES_DIR, config=config, tracks=tracks)
+        )
+
+    print(f"Evaluated {len(selected)} fixtures across {len(results)} (fixture, track) rows.\n")
+    print("Per-fixture results:")
+    for r in results:
+        print(format_row(r))
+
+    overall = summarize(results)
+    print("\nOverall:")
+    print(format_bucket("ALL", overall))
+    if overall.by_tag:
+        print("\nPer tag:")
+        for tag in sorted(overall.by_tag):
+            print(format_bucket(tag, overall.by_tag[tag]))
+
+    if args.json:
+        payload = {
+            "config": config.model_dump(),
+            "results": [
+                {
+                    "stem": r.stem,
+                    "track": r.track,
+                    "tags": list(r.tags),
+                    "ground_truth_s": r.ground_truth_s,
+                    "tolerance_s": r.tolerance_s,
+                    "detected_time_s": r.detected_time_s,
+                    "detected_score": r.detected_score,
+                    "error_s": r.error_s,
+                    "correct_top1": r.correct_top1,
+                    "correct_in_topn": r.correct_in_topn,
+                    "candidate_count": r.candidate_count,
+                    "error_kind": r.error_kind,
+                }
+                for r in results
+            ],
+            "summary": {
+                "total": overall.total,
+                "top1_hits": overall.top1_hits,
+                "topn_hits": overall.topn_hits,
+                "not_found": overall.not_found,
+                "exceptions": overall.exceptions,
+                "recall_top1": overall.recall_top1,
+                "recall_topn": overall.recall_topn,
+                "by_tag": {
+                    tag: {
+                        "total": s.total,
+                        "top1_hits": s.top1_hits,
+                        "topn_hits": s.topn_hits,
+                        "not_found": s.not_found,
+                        "exceptions": s.exceptions,
+                        "recall_top1": s.recall_top1,
+                        "recall_topn": s.recall_topn,
+                    }
+                    for tag, s in overall.by_tag.items()
+                },
+            },
+        }
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(payload, indent=2, default=str))
+        print(f"\nWrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/splitsmith/beep_calibration.py
+++ b/src/splitsmith/beep_calibration.py
@@ -1,0 +1,320 @@
+"""Beep-detector calibration suite -- manifest, ground truth, eval aggregation.
+
+This module is the pure-data backbone of the layer-1 work for issue #220
+(``beep: improve detection accuracy``). The detector itself lives in
+``splitsmith.beep_detect``; this module only describes WHAT to detect and
+HOW to score the result.
+
+Two tracks share the suite:
+
+* **Clip track** -- the ~10-50 s WAV files already checked into
+  ``tests/fixtures/`` (post-trim, with 0.5 s or 5 s pre-beep padding).
+  Always available; covers the trivial-baseline case + handheld iPhone
+  clips with 5 s of pre-beep noise.
+* **Full track** -- the wide-window WAVs produced by
+  ``scripts/extract_full_fixture_audio.py`` under ``tests/fixtures/full/``.
+  Covers late-beep / cross-bay scenarios that don't appear in the trimmed
+  clips. Optional: only present when the source MP4s have been extracted
+  on this machine.
+
+The ``ground_truth_in_clip`` and ``ground_truth_in_full`` fields express
+the beep position in seconds within each respective WAV's coordinate
+frame. ``detect_beep`` returns clip-relative or full-relative depending
+on which audio buffer it's fed -- pick the matching ground truth.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+# Tolerance the audit JSONs themselves use (``tolerance_ms``). A detected
+# beep is "correct" if it lands within this many ms of ground truth.
+DEFAULT_TOLERANCE_MS = 100.0
+
+# Heuristic thresholds applied during manifest build to seed failure-mode
+# tags. These are SUGGESTIONS the user can override by hand-editing the
+# ``tags`` list in ``manifest.yaml``.
+LATE_BEEP_THRESHOLD_S = 10.0
+VERY_LATE_BEEP_THRESHOLD_S = 30.0
+STEEL_PRONE_PLATES_THRESHOLD = 1  # any popper / plate count
+
+
+class BeepFixtureEntry(BaseModel):
+    """One fixture's calibration metadata.
+
+    The manifest is a list of these. Field semantics:
+
+    * ``stem`` -- audit JSON / WAV basename (no extension).
+    * ``camera_kind`` -- ``head`` for body-mounted cameras (Insta360 GO),
+      ``hand`` for handheld phones. The detector should be robust to both
+      but the failure-modes differ.
+    * ``camera_id`` -- the audit JSON's camera.id, kept for filtering.
+    * ``clip_wav`` -- path to the post-trim WAV. Relative to
+      ``tests/fixtures/``.
+    * ``ground_truth_in_clip`` -- beep time in seconds, relative to start
+      of ``clip_wav``. Pulled directly from the audit JSON's ``beep_time``.
+    * ``full_wav`` / ``ground_truth_in_full`` / ``full_duration_s`` --
+      populated when ``scripts/extract_full_fixture_audio.py`` has been
+      run; ``full_wav`` is relative to ``tests/fixtures/``.
+    * ``tags`` -- failure-mode buckets. See module-level constants for
+      the heuristic auto-tags; humans can add finer tags (``cross-bay``,
+      ``steel-fp``, ``ro-chatter``, ...) by editing manifest.yaml.
+    """
+
+    stem: str
+    camera_kind: str
+    camera_id: str | None = None
+    clip_wav: str
+    ground_truth_in_clip: float
+    tolerance_ms: float = DEFAULT_TOLERANCE_MS
+    full_wav: str | None = None
+    ground_truth_in_full: float | None = None
+    full_duration_s: float | None = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class BeepCalibrationManifest(BaseModel):
+    """Top-level manifest persisted to ``manifest.yaml``."""
+
+    fixtures: list[BeepFixtureEntry] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FixtureEvalResult:
+    """Outcome of running the detector against one fixture's audio buffer.
+
+    ``track`` distinguishes the clip vs full evaluation since the same
+    ``stem`` produces two rows when both wavs are present.
+    """
+
+    stem: str
+    track: str  # "clip" or "full"
+    tags: tuple[str, ...]
+    ground_truth_s: float
+    tolerance_s: float
+    detected_time_s: float | None
+    detected_score: float | None
+    error_s: float | None  # detected - ground_truth, None if missed
+    correct_top1: bool
+    correct_in_topn: bool  # any candidate within tolerance
+    candidate_count: int
+    error_kind: str | None = None  # "not_found", "exception", or None
+
+
+@dataclass
+class EvalSummary:
+    """Aggregated eval result. Used to print the report and gate CI."""
+
+    total: int = 0
+    top1_hits: int = 0
+    topn_hits: int = 0
+    not_found: int = 0
+    exceptions: int = 0
+    by_tag: dict[str, EvalSummary] = field(default_factory=dict)
+
+    @property
+    def recall_top1(self) -> float:
+        return (self.top1_hits / self.total) if self.total else 0.0
+
+    @property
+    def recall_topn(self) -> float:
+        return (self.topn_hits / self.total) if self.total else 0.0
+
+
+def derive_camera_kind(camera_block: dict | None) -> str:
+    """Map an audit-JSON ``camera`` dict to ``head`` / ``hand`` / ``unknown``.
+
+    The audit schema uses ``mount`` = ``head`` | ``hand`` directly, but a
+    few legacy fixtures don't have the camera block at all -- treat those
+    as ``unknown`` so the manifest stays explicit instead of guessing.
+    """
+    if not isinstance(camera_block, dict):
+        return "unknown"
+    mount = camera_block.get("mount")
+    if mount in ("head", "hand"):
+        return mount
+    return "unknown"
+
+
+def auto_tags(
+    *,
+    camera_kind: str,
+    ground_truth_in_full: float | None,
+    stage_rounds: dict | None,
+) -> list[str]:
+    """Seed failure-mode tags from audit-JSON facts.
+
+    Always-applicable:
+    * ``handheld`` / ``headcam`` -- from camera mount.
+
+    Conditional (full-audio-only):
+    * ``late-beep`` -- beep > 10 s into source. Today's 30 s search cap
+      still catches it but silence-preference scoring can drift.
+    * ``very-late-beep`` -- beep > 30 s into source. Current detector
+      hard-fails on these (search window cap).
+    * ``steel-prone`` -- stage has poppers or plates; raises the chance
+      of a steel-ring false positive being scored above the beep.
+    """
+    tags: list[str] = []
+    if camera_kind == "head":
+        tags.append("headcam")
+    elif camera_kind == "hand":
+        tags.append("handheld")
+    if ground_truth_in_full is not None:
+        if ground_truth_in_full >= VERY_LATE_BEEP_THRESHOLD_S:
+            tags.append("very-late-beep")
+        elif ground_truth_in_full >= LATE_BEEP_THRESHOLD_S:
+            tags.append("late-beep")
+    if isinstance(stage_rounds, dict):
+        plates = int(stage_rounds.get("plates") or 0)
+        poppers = int(stage_rounds.get("poppers") or 0)
+        if plates + poppers >= STEEL_PRONE_PLATES_THRESHOLD:
+            tags.append("steel-prone")
+    return tags
+
+
+def compute_full_beep_time(
+    *,
+    fixture_window_in_source: tuple[float, float],
+    full_window_in_source: tuple[float, float],
+    clip_beep_time: float,
+) -> float:
+    """Translate the audit's clip-relative beep into the full-WAV's frame.
+
+    The audit JSON pins the beep within a TRIMMED clip whose start sits
+    at ``fixture_window_in_source[0]`` in source-time. The full WAV
+    starts at ``full_window_in_source[0]``. Both are seconds-into-source.
+    The beep position in the full WAV is therefore::
+
+        full_beep = (fws[0] - full[0]) + clip_beep_time
+    """
+    fws_start = fixture_window_in_source[0]
+    full_start = full_window_in_source[0]
+    return (fws_start - full_start) + clip_beep_time
+
+
+def evaluate_detection(
+    *,
+    stem: str,
+    track: str,
+    tags: Iterable[str],
+    ground_truth_s: float,
+    tolerance_ms: float,
+    detected_time_s: float | None,
+    detected_score: float | None,
+    candidate_times_s: Iterable[float] = (),
+    error_kind: str | None = None,
+) -> FixtureEvalResult:
+    """Score one detector call against the ground truth.
+
+    ``candidate_times_s`` are the runner-up candidate timestamps the
+    detector surfaced (``BeepDetection.candidates[1:].time``). They count
+    toward ``correct_in_topn`` even when the top-1 winner was wrong --
+    this is the signal that matters for the HITL flow (#219): if the
+    real beep is in the top-N list, the human can pick it without
+    typing a timestamp.
+    """
+    tol_s = tolerance_ms / 1000.0
+    if detected_time_s is None:
+        return FixtureEvalResult(
+            stem=stem,
+            track=track,
+            tags=tuple(tags),
+            ground_truth_s=ground_truth_s,
+            tolerance_s=tol_s,
+            detected_time_s=None,
+            detected_score=detected_score,
+            error_s=None,
+            correct_top1=False,
+            correct_in_topn=False,
+            candidate_count=0,
+            error_kind=error_kind or "not_found",
+        )
+    error = detected_time_s - ground_truth_s
+    correct_top1 = abs(error) <= tol_s
+    candidates = list(candidate_times_s)
+    correct_in_topn = correct_top1 or any(abs(c - ground_truth_s) <= tol_s for c in candidates)
+    return FixtureEvalResult(
+        stem=stem,
+        track=track,
+        tags=tuple(tags),
+        ground_truth_s=ground_truth_s,
+        tolerance_s=tol_s,
+        detected_time_s=detected_time_s,
+        detected_score=detected_score,
+        error_s=error,
+        correct_top1=correct_top1,
+        correct_in_topn=correct_in_topn,
+        candidate_count=len(candidates) + 1,
+        error_kind=error_kind,
+    )
+
+
+def summarize(results: Iterable[FixtureEvalResult]) -> EvalSummary:
+    """Aggregate per-fixture results into an overall + per-tag summary."""
+    overall = EvalSummary()
+    for r in results:
+        overall.total += 1
+        if r.correct_top1:
+            overall.top1_hits += 1
+        if r.correct_in_topn:
+            overall.topn_hits += 1
+        if r.error_kind == "not_found":
+            overall.not_found += 1
+        elif r.error_kind == "exception":
+            overall.exceptions += 1
+        for tag in r.tags:
+            bucket = overall.by_tag.setdefault(tag, EvalSummary())
+            bucket.total += 1
+            if r.correct_top1:
+                bucket.top1_hits += 1
+            if r.correct_in_topn:
+                bucket.topn_hits += 1
+            if r.error_kind == "not_found":
+                bucket.not_found += 1
+            elif r.error_kind == "exception":
+                bucket.exceptions += 1
+    return overall
+
+
+def load_manifest(path: Path) -> BeepCalibrationManifest:
+    """Read a manifest YAML. Missing file returns an empty manifest."""
+    import yaml
+
+    if not path.exists():
+        return BeepCalibrationManifest()
+    raw = yaml.safe_load(path.read_text()) or {}
+    return BeepCalibrationManifest.model_validate(raw)
+
+
+def save_manifest(manifest: BeepCalibrationManifest, path: Path) -> None:
+    """Write a manifest YAML in a stable, hand-editable format."""
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = manifest.model_dump(exclude_none=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, indent=2))
+
+
+def fixtures_with_full_audio(
+    manifest: BeepCalibrationManifest,
+    fixtures_dir: Path,
+) -> list[BeepFixtureEntry]:
+    """Subset of the manifest where the full-track WAV exists on disk."""
+    rows = []
+    for entry in manifest.fixtures:
+        if not entry.full_wav:
+            continue
+        if (fixtures_dir / entry.full_wav).exists():
+            rows.append(entry)
+    return rows
+
+
+def read_audit_json(path: Path) -> dict:
+    """Thin wrapper -- only exists so tests can stub the read."""
+    return json.loads(path.read_text())

--- a/tests/fixtures/beep_calibration/README.md
+++ b/tests/fixtures/beep_calibration/README.md
@@ -1,0 +1,58 @@
+# Beep calibration suite
+
+Layer-1 deliverable for [#220](../../../../issues/220) (`beep: improve
+detection accuracy`). This directory holds the labeled fixture index +
+baseline scores that the layer-2 detector improvements measure against.
+
+## Files
+
+* `manifest.yaml` — committed. Per-fixture ground truth + tags. Generated
+  by `scripts/build_beep_calibration.py` from `tests/fixtures/*.json`.
+  Hand-edit the `tags` list to add fine-grained failure-mode buckets
+  (e.g. `cross-bay`, `steel-fp-observed`, `low-spl`); rebuild with
+  `--preserve-tags` to keep them on a re-run.
+* `baseline.json` — committed. Snapshot of the current detector's
+  recall / per-tag stats. Compare against future runs.
+
+## Tracks
+
+Each fixture supports up to two evaluation tracks:
+
+* **clip** — the post-trim WAV in `tests/fixtures/<stem>.wav`. Always
+  available. Headcam clips have ~0.5 s pre-beep; iPhone clips have ~5 s.
+* **full** — the wide-window WAV in `tests/fixtures/full/<stem>_full.wav`.
+  Optional. Produced by `scripts/extract_full_fixture_audio.py` from
+  the source MP4 listed in `tests/fixtures/full/_sources.yaml`. Covers
+  the late-beep / cross-bay scenarios that don't appear in the clip.
+
+iPhone fixtures have no source MP4 wired up, so they are clip-only.
+
+## Usage
+
+Rebuild manifest after adding new audited fixtures or extracting more
+full-source audio:
+
+```bash
+uv run python scripts/build_beep_calibration.py
+uv run python scripts/build_beep_calibration.py --preserve-tags  # keep hand-edits
+```
+
+Run the detector against the suite and print recall per bucket:
+
+```bash
+uv run python scripts/eval_beep_detector.py
+uv run python scripts/eval_beep_detector.py --tag handheld
+uv run python scripts/eval_beep_detector.py --track full
+uv run python scripts/eval_beep_detector.py --json out/run.json
+```
+
+## Auto-tag rules
+
+* `handheld` / `headcam` — from `audit.camera.mount`.
+* `late-beep` — beep > 10 s into source (full track only).
+* `very-late-beep` — beep > 30 s into source (current detector hard-fails
+  due to its 30 s `search_window_s` cap).
+* `steel-prone` — `stage_rounds.plates + stage_rounds.poppers >= 1`.
+
+Add `cross-bay`, `steel-fp-observed`, `low-spl`, `ro-chatter`, etc. by
+hand once a fixture is reviewed.

--- a/tests/fixtures/beep_calibration/baseline.json
+++ b/tests/fixtures/beep_calibration/baseline.json
@@ -1,0 +1,691 @@
+{
+  "config": {
+    "freq_min_hz": 2000,
+    "freq_max_hz": 5000,
+    "min_duration_ms": 150,
+    "min_amplitude": 0.05,
+    "min_abs_peak": 0.04,
+    "silence_window_s": 1.5,
+    "silence_pre_skip_s": 0.2,
+    "search_window_s": 30.0,
+    "top_n_candidates": 5
+  },
+  "results": [
+    {
+      "stem": "beep-test",
+      "track": "clip",
+      "tags": [],
+      "ground_truth_s": 4.877,
+      "tolerance_s": 0.02,
+      "detected_time_s": 4.877083333333333,
+      "detected_score": 6050.912090243303,
+      "error_s": 8.333333333343518e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage1-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 4.99975,
+      "detected_score": 81.26305856879668,
+      "error_s": -0.00025000000000030553,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage1",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 132.11914367051946,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage1",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 22.9417,
+      "tolerance_s": 0.015,
+      "detected_time_s": 22.941729166666665,
+      "detected_score": 35.08542466412034,
+      "error_s": 2.9166666664082186e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage2-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 5.000229166666666,
+      "detected_score": 38.06752411024251,
+      "error_s": 0.0002291666666662806,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage2",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 2347.701351334532,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage2",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 17.6261,
+      "tolerance_s": 0.015,
+      "detected_time_s": 17.6260625,
+      "detected_score": 27.800113565473012,
+      "error_s": -3.750000000124487e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage3-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": null,
+      "detected_score": null,
+      "error_s": null,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 0,
+      "error_kind": "not_found"
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage3",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 52.59200093953135,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 2,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage3",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 25.4267,
+      "tolerance_s": 0.015,
+      "detected_time_s": 25.426729166666668,
+      "detected_score": 17.291687671567942,
+      "error_s": 2.91666666676349e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage5-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 5.000208333333333,
+      "detected_score": 33.71748231777052,
+      "error_s": 0.00020833333333314386,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 2,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage5",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.49383333333333335,
+      "detected_score": 113.92997311267499,
+      "error_s": -0.006166666666666654,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 3,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage5",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "steel-prone"
+      ],
+      "ground_truth_s": 6.522,
+      "tolerance_s": 0.015,
+      "detected_time_s": 12.175729166666667,
+      "detected_score": 11.471020124317086,
+      "error_s": 5.6537291666666665,
+      "correct_top1": false,
+      "correct_in_topn": true,
+      "candidate_count": 3,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage6-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 3.292,
+      "tolerance_s": 0.015,
+      "detected_time_s": null,
+      "detected_score": null,
+      "error_s": null,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 0,
+      "error_kind": "not_found"
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage6",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 341.81809651145323,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage6",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 14.1252,
+      "tolerance_s": 0.015,
+      "detected_time_s": 14.125229166666667,
+      "detected_score": 24.151088327623683,
+      "error_s": 2.91666666676349e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage7-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 4.99975,
+      "detected_score": 12.934565618928646,
+      "error_s": -0.00025000000000030553,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage7",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5000208333333334,
+      "detected_score": 50.038693824169556,
+      "error_s": 2.0833333333358794e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage7",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 17.3027,
+      "tolerance_s": 0.015,
+      "detected_time_s": 13.611875,
+      "detected_score": 22.44801742154941,
+      "error_s": -3.690825000000002,
+      "correct_top1": false,
+      "correct_in_topn": true,
+      "candidate_count": 2,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage8-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 5.000166666666667,
+      "detected_score": 11.489182992616835,
+      "error_s": 0.00016666666666687036,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage8",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 31.646755513459052,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 3,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-blacksmith-2026-stage8",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 25.3944,
+      "tolerance_s": 0.015,
+      "detected_time_s": 25.394375,
+      "detected_score": 24.84577465730274,
+      "error_s": -2.5000000000829914e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage2-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": 5.000416666666666,
+      "detected_score": 66.71628000323034,
+      "error_s": 0.0004166666666662877,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage2",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 290.4498285567559,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage2",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 28.7817,
+      "tolerance_s": 0.015,
+      "detected_time_s": 28.78172916666667,
+      "detected_score": 14.306837987132761,
+      "error_s": 2.91666666676349e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage3",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5000208333333334,
+      "detected_score": 12979.619350493773,
+      "error_s": 2.0833333333358794e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage4-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": null,
+      "detected_score": null,
+      "error_s": null,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 0,
+      "error_kind": "not_found"
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage4",
+      "track": "clip",
+      "tags": [
+        "headcam"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.1,
+      "detected_time_s": 19.04325,
+      "detected_score": 421.6534498151464,
+      "error_s": 14.04325,
+      "correct_top1": false,
+      "correct_in_topn": true,
+      "candidate_count": 5,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage5-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld"
+      ],
+      "ground_truth_s": 1.1507,
+      "tolerance_s": 0.015,
+      "detected_time_s": 1.1506875,
+      "detected_score": 25.772087826605777,
+      "error_s": -1.2499999999970868e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage5",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.5,
+      "detected_score": 16.949652295339945,
+      "error_s": 0.0,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage5",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep"
+      ],
+      "ground_truth_s": 15.0302,
+      "tolerance_s": 0.015,
+      "detected_time_s": 15.030166666666666,
+      "detected_score": 52.937002507816466,
+      "error_s": -3.3333333334439885e-05,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage6-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": null,
+      "detected_score": null,
+      "error_s": null,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 0,
+      "error_kind": "not_found"
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage6",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 0.501125,
+      "detected_score": 812.8434802018494,
+      "error_s": 0.0011250000000000426,
+      "correct_top1": true,
+      "correct_in_topn": true,
+      "candidate_count": 2,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage6",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 20.454,
+      "tolerance_s": 0.015,
+      "detected_time_s": 26.8686875,
+      "detected_score": 38.08577835748842,
+      "error_s": 6.414687499999999,
+      "correct_top1": false,
+      "correct_in_topn": true,
+      "candidate_count": 2,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage7-apple-iphone17pro",
+      "track": "clip",
+      "tags": [
+        "handheld",
+        "steel-prone"
+      ],
+      "ground_truth_s": 5.0,
+      "tolerance_s": 0.015,
+      "detected_time_s": null,
+      "detected_score": null,
+      "error_s": null,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 0,
+      "error_kind": "not_found"
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage7",
+      "track": "clip",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 0.5,
+      "tolerance_s": 0.015,
+      "detected_time_s": 3.1420208333333335,
+      "detected_score": 34.51542327414717,
+      "error_s": 2.6420208333333335,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 1,
+      "error_kind": null
+    },
+    {
+      "stem": "stage-shots-tallmilan-2026-stage7",
+      "track": "full",
+      "tags": [
+        "headcam",
+        "late-beep",
+        "steel-prone"
+      ],
+      "ground_truth_s": 21.879,
+      "tolerance_s": 0.015,
+      "detected_time_s": 24.521020833333335,
+      "detected_score": 34.51542327414717,
+      "error_s": 2.6420208333333335,
+      "correct_top1": false,
+      "correct_in_topn": false,
+      "candidate_count": 1,
+      "error_kind": null
+    }
+  ],
+  "summary": {
+    "total": 37,
+    "top1_hits": 26,
+    "topn_hits": 30,
+    "not_found": 5,
+    "exceptions": 0,
+    "recall_top1": 0.7027027027027027,
+    "recall_topn": 0.8108108108108109,
+    "by_tag": {
+      "handheld": {
+        "total": 12,
+        "top1_hits": 7,
+        "topn_hits": 7,
+        "not_found": 5,
+        "exceptions": 0,
+        "recall_top1": 0.5833333333333334,
+        "recall_topn": 0.5833333333333334
+      },
+      "steel-prone": {
+        "total": 19,
+        "top1_hits": 12,
+        "topn_hits": 14,
+        "not_found": 3,
+        "exceptions": 0,
+        "recall_top1": 0.631578947368421,
+        "recall_topn": 0.7368421052631579
+      },
+      "headcam": {
+        "total": 24,
+        "top1_hits": 18,
+        "topn_hits": 22,
+        "not_found": 0,
+        "exceptions": 0,
+        "recall_top1": 0.75,
+        "recall_topn": 0.9166666666666666
+      },
+      "late-beep": {
+        "total": 20,
+        "top1_hits": 16,
+        "topn_hits": 18,
+        "not_found": 0,
+        "exceptions": 0,
+        "recall_top1": 0.8,
+        "recall_topn": 0.9
+      }
+    }
+  }
+}

--- a/tests/fixtures/beep_calibration/manifest.yaml
+++ b/tests/fixtures/beep_calibration/manifest.yaml
@@ -1,0 +1,263 @@
+fixtures:
+- stem: beep-test
+  camera_kind: unknown
+  clip_wav: beep-test.wav
+  ground_truth_in_clip: 4.877
+  tolerance_ms: 20.0
+  tags: []
+- stem: stage-shots-blacksmith-2026-stage1-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage1-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage1
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage1.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage1_full.wav
+  ground_truth_in_full: 22.9417
+  full_duration_s: 104.337567
+  tags:
+  - headcam
+  - late-beep
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage2-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage2-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-blacksmith-2026-stage2
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage2.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage2_full.wav
+  ground_truth_in_full: 17.6261
+  full_duration_s: 276.409467
+  tags:
+  - headcam
+  - late-beep
+- stem: stage-shots-blacksmith-2026-stage3-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage3-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage3
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage3.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage3_full.wav
+  ground_truth_in_full: 25.4267
+  full_duration_s: 85.12
+  tags:
+  - headcam
+  - late-beep
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage5-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage5-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage5
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage5.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage5_full.wav
+  ground_truth_in_full: 6.522
+  full_duration_s: 191.14
+  tags:
+  - headcam
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage6-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage6-apple-iphone17pro.wav
+  ground_truth_in_clip: 3.292
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-blacksmith-2026-stage6
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage6.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage6_full.wav
+  ground_truth_in_full: 14.1252
+  full_duration_s: 61.14
+  tags:
+  - headcam
+  - late-beep
+- stem: stage-shots-blacksmith-2026-stage7-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage7-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-blacksmith-2026-stage7
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage7.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage7_full.wav
+  ground_truth_in_full: 17.3027
+  full_duration_s: 77.143733
+  tags:
+  - headcam
+  - late-beep
+- stem: stage-shots-blacksmith-2026-stage8-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-blacksmith-2026-stage8-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-blacksmith-2026-stage8
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-blacksmith-2026-stage8.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-blacksmith-2026-stage8_full.wav
+  ground_truth_in_full: 25.3944
+  full_duration_s: 113.246467
+  tags:
+  - headcam
+  - late-beep
+  - steel-prone
+- stem: stage-shots-tallmilan-2026-stage2-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-tallmilan-2026-stage2-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-tallmilan-2026-stage2
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage2.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-tallmilan-2026-stage2_full.wav
+  ground_truth_in_full: 28.7817
+  full_duration_s: 122.889433
+  tags:
+  - headcam
+  - late-beep
+- stem: stage-shots-tallmilan-2026-stage3
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage3.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  tags:
+  - headcam
+  - steel-prone
+- stem: stage-shots-tallmilan-2026-stage4-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-tallmilan-2026-stage4-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-tallmilan-2026-stage4
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage4.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 100.0
+  tags:
+  - headcam
+- stem: stage-shots-tallmilan-2026-stage5-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-tallmilan-2026-stage5-apple-iphone17pro.wav
+  ground_truth_in_clip: 1.1507
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+- stem: stage-shots-tallmilan-2026-stage5
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage5.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-tallmilan-2026-stage5_full.wav
+  ground_truth_in_full: 15.0302
+  full_duration_s: 172.839333
+  tags:
+  - headcam
+  - late-beep
+- stem: stage-shots-tallmilan-2026-stage6-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-tallmilan-2026-stage6-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-tallmilan-2026-stage6
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage6.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-tallmilan-2026-stage6_full.wav
+  ground_truth_in_full: 20.454
+  full_duration_s: 399.565833
+  tags:
+  - headcam
+  - late-beep
+  - steel-prone
+- stem: stage-shots-tallmilan-2026-stage7-apple-iphone17pro
+  camera_kind: hand
+  camera_id: apple-iphone17pro
+  clip_wav: stage-shots-tallmilan-2026-stage7-apple-iphone17pro.wav
+  ground_truth_in_clip: 5.0
+  tolerance_ms: 15.0
+  tags:
+  - handheld
+  - steel-prone
+- stem: stage-shots-tallmilan-2026-stage7
+  camera_kind: head
+  camera_id: go3s
+  clip_wav: stage-shots-tallmilan-2026-stage7.wav
+  ground_truth_in_clip: 0.5
+  tolerance_ms: 15.0
+  full_wav: full/stage-shots-tallmilan-2026-stage7_full.wav
+  ground_truth_in_full: 21.879
+  full_duration_s: 101.5014
+  tags:
+  - headcam
+  - late-beep
+  - steel-prone

--- a/tests/test_beep_calibration.py
+++ b/tests/test_beep_calibration.py
@@ -1,0 +1,274 @@
+"""Unit tests for the beep calibration helpers (issue #220 layer 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.beep_calibration import (
+    DEFAULT_TOLERANCE_MS,
+    BeepCalibrationManifest,
+    BeepFixtureEntry,
+    auto_tags,
+    compute_full_beep_time,
+    derive_camera_kind,
+    evaluate_detection,
+    fixtures_with_full_audio,
+    load_manifest,
+    save_manifest,
+    summarize,
+)
+
+
+def test_derive_camera_kind_handles_missing_block() -> None:
+    assert derive_camera_kind(None) == "unknown"
+    assert derive_camera_kind({}) == "unknown"
+    assert derive_camera_kind({"mount": "head"}) == "head"
+    assert derive_camera_kind({"mount": "hand"}) == "hand"
+    assert derive_camera_kind({"mount": "shoulder"}) == "unknown"
+
+
+def test_compute_full_beep_time_offset_from_source_window() -> None:
+    # Audit pinned the beep at 0.5 s into a clip that starts 22.4417 s into
+    # the raw video. The full WAV starts 0.0 s into the raw video. Beep in
+    # full-WAV coordinates is fws[0] - full[0] + clip_beep = 22.9417 s.
+    full_beep = compute_full_beep_time(
+        fixture_window_in_source=(22.4417, 67.2017),
+        full_window_in_source=(0.0, 100.0),
+        clip_beep_time=0.5,
+    )
+    assert full_beep == pytest.approx(22.9417)
+
+
+def test_compute_full_beep_time_with_padded_full_window() -> None:
+    # If the full WAV was extracted with --pre-pad 5 it starts 5 s before
+    # the audited window; the beep should land 5 s deeper into the full WAV.
+    full_beep = compute_full_beep_time(
+        fixture_window_in_source=(22.0, 67.0),
+        full_window_in_source=(17.0, 80.0),  # pre-pad 5 s
+        clip_beep_time=0.5,
+    )
+    assert full_beep == pytest.approx(5.0 + 0.5)
+
+
+def test_auto_tags_seed_from_camera_and_rounds() -> None:
+    tags = auto_tags(
+        camera_kind="head",
+        ground_truth_in_full=12.0,
+        stage_rounds={"plates": 3, "poppers": 0},
+    )
+    assert "headcam" in tags
+    assert "late-beep" in tags
+    assert "steel-prone" in tags
+    assert "very-late-beep" not in tags
+
+
+def test_auto_tags_marks_very_late_only_above_30s() -> None:
+    tags = auto_tags(
+        camera_kind="hand",
+        ground_truth_in_full=45.0,
+        stage_rounds={"plates": 0, "poppers": 0},
+    )
+    assert "handheld" in tags
+    assert "very-late-beep" in tags
+    assert "late-beep" not in tags  # mutually exclusive
+    assert "steel-prone" not in tags
+
+
+def test_auto_tags_no_full_track_skips_late_buckets() -> None:
+    # Clip-only fixtures (iPhone with source_video=None) have no full beep
+    # time. The late-beep tags require source-time info, so they shouldn't
+    # appear -- the clip itself only spans 5 s of pre-beep padding.
+    tags = auto_tags(camera_kind="hand", ground_truth_in_full=None, stage_rounds=None)
+    assert tags == ["handheld"]
+
+
+def test_evaluate_detection_marks_top1_within_tolerance() -> None:
+    result = evaluate_detection(
+        stem="x",
+        track="clip",
+        tags=["headcam"],
+        ground_truth_s=1.0,
+        tolerance_ms=100.0,
+        detected_time_s=1.05,
+        detected_score=42.0,
+    )
+    assert result.correct_top1 is True
+    assert result.correct_in_topn is True
+    assert result.error_s == pytest.approx(0.05)
+    assert result.error_kind is None
+
+
+def test_evaluate_detection_marks_topn_when_winner_wrong_but_runner_up_right() -> None:
+    result = evaluate_detection(
+        stem="x",
+        track="clip",
+        tags=[],
+        ground_truth_s=1.0,
+        tolerance_ms=50.0,
+        detected_time_s=3.5,  # wrong
+        detected_score=10.0,
+        candidate_times_s=[3.5, 1.02, 8.0],  # second is right
+    )
+    assert result.correct_top1 is False
+    assert result.correct_in_topn is True
+
+
+def test_evaluate_detection_records_not_found() -> None:
+    result = evaluate_detection(
+        stem="x",
+        track="clip",
+        tags=[],
+        ground_truth_s=1.0,
+        tolerance_ms=50.0,
+        detected_time_s=None,
+        detected_score=None,
+        error_kind="not_found",
+    )
+    assert result.correct_top1 is False
+    assert result.correct_in_topn is False
+    assert result.error_kind == "not_found"
+    assert result.error_s is None
+
+
+def test_summarize_aggregates_overall_and_per_tag() -> None:
+    rows = [
+        evaluate_detection(
+            stem="a",
+            track="clip",
+            tags=["headcam"],
+            ground_truth_s=1.0,
+            tolerance_ms=50.0,
+            detected_time_s=1.0,
+            detected_score=10.0,
+        ),
+        evaluate_detection(
+            stem="b",
+            track="clip",
+            tags=["handheld"],
+            ground_truth_s=5.0,
+            tolerance_ms=50.0,
+            detected_time_s=None,
+            detected_score=None,
+            error_kind="not_found",
+        ),
+        evaluate_detection(
+            stem="c",
+            track="full",
+            tags=["headcam", "late-beep"],
+            ground_truth_s=20.0,
+            tolerance_ms=100.0,
+            detected_time_s=25.0,
+            detected_score=5.0,
+            candidate_times_s=[25.0, 20.05],
+        ),
+    ]
+    summary = summarize(rows)
+    assert summary.total == 3
+    assert summary.top1_hits == 1
+    assert summary.topn_hits == 2
+    assert summary.not_found == 1
+    assert summary.recall_top1 == pytest.approx(1 / 3)
+    headcam = summary.by_tag["headcam"]
+    assert headcam.total == 2
+    assert headcam.top1_hits == 1
+    assert headcam.topn_hits == 2
+    handheld = summary.by_tag["handheld"]
+    assert handheld.not_found == 1
+
+
+def test_manifest_yaml_round_trip(tmp_path: Path) -> None:
+    manifest = BeepCalibrationManifest(
+        fixtures=[
+            BeepFixtureEntry(
+                stem="stage-a",
+                camera_kind="head",
+                clip_wav="stage-a.wav",
+                ground_truth_in_clip=0.5,
+                tags=["headcam"],
+            ),
+            BeepFixtureEntry(
+                stem="stage-b",
+                camera_kind="hand",
+                clip_wav="stage-b.wav",
+                ground_truth_in_clip=5.0,
+                full_wav="full/stage-b_full.wav",
+                ground_truth_in_full=27.5,
+                full_duration_s=120.0,
+                tags=["handheld", "late-beep"],
+            ),
+        ]
+    )
+    out = tmp_path / "manifest.yaml"
+    save_manifest(manifest, out)
+    loaded = load_manifest(out)
+    assert loaded.model_dump() == manifest.model_dump()
+
+
+def test_load_manifest_returns_empty_when_missing(tmp_path: Path) -> None:
+    out = tmp_path / "missing.yaml"
+    loaded = load_manifest(out)
+    assert loaded.fixtures == []
+
+
+def test_fixtures_with_full_audio_filters_to_existing_files(tmp_path: Path) -> None:
+    (tmp_path / "full").mkdir()
+    (tmp_path / "full" / "stage-b_full.wav").write_bytes(b"")
+    manifest = BeepCalibrationManifest(
+        fixtures=[
+            BeepFixtureEntry(
+                stem="stage-a",
+                camera_kind="head",
+                clip_wav="stage-a.wav",
+                ground_truth_in_clip=0.5,
+                full_wav="full/stage-a_full.wav",  # missing on disk
+                ground_truth_in_full=10.0,
+            ),
+            BeepFixtureEntry(
+                stem="stage-b",
+                camera_kind="hand",
+                clip_wav="stage-b.wav",
+                ground_truth_in_clip=5.0,
+                full_wav="full/stage-b_full.wav",  # exists
+                ground_truth_in_full=20.0,
+            ),
+            BeepFixtureEntry(
+                stem="stage-c",
+                camera_kind="head",
+                clip_wav="stage-c.wav",
+                ground_truth_in_clip=0.5,
+                # no full_wav at all
+            ),
+        ]
+    )
+    rows = fixtures_with_full_audio(manifest, tmp_path)
+    assert [r.stem for r in rows] == ["stage-b"]
+
+
+def test_default_tolerance_constant_matches_audit_convention() -> None:
+    # Most audit JSONs use tolerance_ms = 100 (~ 5 frames at 60 fps).
+    # If this changes, callers need to know -- pin it.
+    assert DEFAULT_TOLERANCE_MS == 100.0
+
+
+def test_committed_manifest_references_existing_wavs(fixtures_dir: Path) -> None:
+    """The committed manifest must stay in sync with the wavs on disk.
+
+    Catches silent rot: a fixture rename or wav removal would otherwise
+    only surface when ``eval_beep_detector.py`` runs. Full-track wavs
+    are gitignored, so we only enforce existence for the clip wav and
+    skip the full wav check when the developer hasn't extracted yet.
+    """
+    manifest_path = fixtures_dir / "beep_calibration" / "manifest.yaml"
+    if not manifest_path.exists():
+        pytest.skip("calibration manifest not built yet")
+    manifest = load_manifest(manifest_path)
+    assert manifest.fixtures, "manifest is empty -- run build_beep_calibration.py"
+    for entry in manifest.fixtures:
+        clip = fixtures_dir / entry.clip_wav
+        assert clip.exists(), f"{entry.stem}: clip wav missing at {clip}"
+        if entry.full_wav and entry.ground_truth_in_full is not None:
+            assert (
+                entry.ground_truth_in_full >= 0.0
+            ), f"{entry.stem}: negative full beep time -- check fws/full window math"


### PR DESCRIPTION
## Summary

Layer 1 of #220 (`beep: improve detection accuracy`). Builds the data scaffolding that layer 2 (detector improvements) and layer 3 (#219 confidence / HITL) measure against. The detector itself is unchanged.

- `splitsmith.beep_calibration` -- manifest schema, ground-truth math, eval aggregation
- `scripts/build_beep_calibration.py` -- auto-tags fixtures (handheld/headcam, late-beep, steel-prone), `--preserve-tags` for hand-edits
- `scripts/eval_beep_detector.py` -- per-fixture + per-tag recall, optional JSON dump
- `tests/fixtures/beep_calibration/{manifest.yaml,baseline.json,README.md}` -- 26 fixtures indexed, 11 with wide-window audio

## Baseline (current detector defaults)

| Bucket | n | top-1 | top-N | miss |
|---|---|---|---|---|
| ALL | 37 | 70.3% | 81.1% | 5 |
| handheld | 12 | 58.3% | 58.3% | 5 |
| headcam | 24 | 75.0% | 91.7% | 0 |
| late-beep | 20 | 80.0% | 90.0% | 0 |
| steel-prone | 19 | 63.2% | 73.7% | 3 |

All 5 MISSes are iPhone clips (amplitude thresholds too strict for handheld). 4 wrong-winner-but-in-top-N show silence-preference drifting to mid-stage transients. Concrete targets for layer 2.

## Test plan

- [x] 16 unit tests pass (`uv run pytest tests/test_beep_calibration.py`)
- [x] `tests/test_beep_detect.py` still green (no regressions)
- [x] `uv run python scripts/build_beep_calibration.py` regenerates manifest cleanly
- [x] `uv run python scripts/eval_beep_detector.py` reproduces the baseline numbers above
- [x] `uv run black --check` + `uv run ruff check` pass on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)