### PR TITLE
settings: layered automation framework (#215)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numpy>=1.26.0",
     "scipy>=1.13.0",
     "pydantic>=2.7.0",
+    "pydantic-settings>=2.6.0",
     "typer>=0.12.0",
     "rich>=13.7.0",
     "pyyaml>=6.0.1",

--- a/src/splitsmith/automation.py
+++ b/src/splitsmith/automation.py
@@ -1,0 +1,215 @@
+"""Layered automation settings (issue #215).
+
+Splitsmith chains certain follow-up jobs automatically -- the canonical
+example is "user marks beep reviewed -> shot detection fires." Some
+users want the rich auto-pipeline; others (CLI / agent flows) want
+manual gates so they can decide each step. This module provides the
+layered settings stack that lets a global default, a project-level
+override, and a per-invocation CLI flag resolve cleanly into one
+effective set of toggles -- with provenance so the UI can show *why*
+a value is what it is.
+
+Resolution order, top wins: **CLI > project > global > field default**.
+
+The schema is one ``automation`` sub-object so siblings (for example
+``overlay_render_on_audit``, ``beep_detect_on_ingest``) can land later
+without re-shaping the on-disk format.
+
+Backed by ``pydantic-settings`` so the global layer composes cleanly
+with the rest of the codebase: YAML loading, env-var overrides
+(``SPLITSMITH_AUTOMATION_*``), and the standard pydantic validation
+story all come for free. The override types and the resolver are
+plain pydantic / dataclasses because they aren't loaded from any
+single source -- they're computed merges.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from . import user_config
+
+logger = logging.getLogger(__name__)
+
+
+# Field name in the YAML and on the project model. Centralised so a
+# rename touches one place.
+AUTOMATION_KEY = "automation"
+
+
+class AutomationSettings(BaseSettings):
+    """The effective set of automation toggles.
+
+    Default values are the *global fallback* applied when nothing
+    else weighs in. The same model is used as the resolved object
+    after layering -- both shapes are identical (every field has a
+    concrete value at the end), which keeps callers from juggling
+    two near-duplicate types.
+
+    Loaded from the user-config ``config.yaml`` (under the
+    ``automation`` block) and from ``SPLITSMITH_AUTOMATION_*`` env
+    vars; init args win over both.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SPLITSMITH_AUTOMATION_",
+        extra="ignore",
+        # We do the YAML load explicitly via :func:`load_global` so the
+        # settings_customise_sources hook stays simple and the test
+        # suite can construct AutomationSettings without a disk read.
+    )
+
+    shot_detect_on_beep_verified: bool = True
+    """When the user marks a beep reviewed, fire shot detection."""
+
+
+class AutomationOverride(BaseModel):
+    """Layer override -- ``None`` on a field means "inherit from below".
+
+    Used for the project-state and CLI-flag layers. Not loaded from
+    disk by pydantic-settings: project overrides ride on the project
+    JSON; CLI overrides come from typer.
+    """
+
+    shot_detect_on_beep_verified: bool | None = None
+
+
+# Where each resolved field came from. The UI uses this for the
+# provenance badge (#216).
+ProvenanceSource = Literal["cli", "project", "global", "default"]
+
+
+@dataclass(frozen=True)
+class FieldProvenance:
+    """One resolved field's source + the layer values that fed in.
+
+    ``source`` is the layer that supplied the effective value.
+    ``cli_value`` / ``project_value`` are ``None`` when that layer
+    stayed silent. ``global_value`` is always present because the
+    global settings always have a default.
+    """
+
+    source: ProvenanceSource
+    cli_value: bool | None
+    project_value: bool | None
+    global_value: bool
+
+
+@dataclass(frozen=True)
+class ResolvedAutomation:
+    """Resolved settings + per-field provenance."""
+
+    settings: AutomationSettings
+    provenance: dict[str, FieldProvenance]
+
+
+def _yaml_block(path: Path) -> dict[str, Any]:
+    """Read the ``automation`` block from ``path``. Empty dict on
+    missing file / parse error / missing block -- callers fall back
+    to the field defaults."""
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Ignoring unreadable automation block at %s: %s", path, exc)
+        return {}
+    block = data.get(AUTOMATION_KEY) if isinstance(data, dict) else None
+    if not isinstance(block, dict):
+        return {}
+    return block
+
+
+def load_global(config_path: Path | None = None) -> AutomationSettings:
+    """Load the global automation settings.
+
+    ``config_path`` defaults to the user-config ``config.yaml``; pass
+    an explicit path in tests. Env-var overrides
+    (``SPLITSMITH_AUTOMATION_*``) layer on top of the YAML and below
+    init args, mirroring pydantic-settings' standard precedence.
+    """
+    if user_config.is_disabled() and config_path is None:
+        return AutomationSettings()
+    path = config_path or (user_config.user_config_dir() / user_config.CONFIG_FILENAME)
+    block = _yaml_block(path)
+    try:
+        # Pass the YAML block as init kwargs; pydantic-settings will
+        # still let env vars override missing keys.
+        return AutomationSettings(**block)
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 -- log then fall back so a malformed config doesn't break the app
+        logger.warning("Discarding malformed automation block at %s: %s", path, exc)
+        return AutomationSettings()
+
+
+def resolve_automation(
+    *,
+    global_settings: AutomationSettings | None = None,
+    project_override: AutomationOverride | None = None,
+    cli_override: AutomationOverride | None = None,
+) -> ResolvedAutomation:
+    """Layer the three sources into one resolved set of toggles.
+
+    Resolution per field, top wins:
+
+    1. CLI override (init args from typer flags).
+    2. Project override (``MatchProject.automation``).
+    3. Global setting (loaded from ``config.yaml`` + env vars).
+    4. Field default on :class:`AutomationSettings` (only reached
+       when ``global_settings`` is None and the field isn't set
+       anywhere).
+
+    Returns a :class:`ResolvedAutomation` carrying the effective
+    settings and per-field provenance for the UI.
+    """
+    if global_settings is None:
+        global_settings = load_global()
+
+    resolved_kwargs: dict[str, Any] = {}
+    provenance: dict[str, FieldProvenance] = {}
+    for field_name in AutomationSettings.model_fields:
+        cli_val = getattr(cli_override, field_name) if cli_override is not None else None
+        proj_val = getattr(project_override, field_name) if project_override is not None else None
+        global_val = getattr(global_settings, field_name)
+        if cli_val is not None:
+            effective = cli_val
+            source: ProvenanceSource = "cli"
+        elif proj_val is not None:
+            effective = proj_val
+            source = "project"
+        else:
+            effective = global_val
+            source = "global"
+        resolved_kwargs[field_name] = effective
+        provenance[field_name] = FieldProvenance(
+            source=source,
+            cli_value=cli_val,
+            project_value=proj_val,
+            global_value=global_val,
+        )
+
+    return ResolvedAutomation(
+        settings=AutomationSettings(**resolved_kwargs),
+        provenance=provenance,
+    )
+
+
+__all__ = [
+    "AUTOMATION_KEY",
+    "AutomationOverride",
+    "AutomationSettings",
+    "FieldProvenance",
+    "ProvenanceSource",
+    "ResolvedAutomation",
+    "load_global",
+    "resolve_automation",
+]

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -33,6 +33,9 @@ from . import (
     video_match,
 )
 from . import (
+    automation as automation_settings,
+)
+from . import (
     cleanup as cleanup_mod,
 )
 from .config import (
@@ -74,6 +77,15 @@ def single(
     write_trim: bool = typer.Option(True, "--trim/--no-trim"),
     write_csv: bool = typer.Option(True, "--csv/--no-csv"),
     write_fcpxml: bool = typer.Option(True, "--fcpxml/--no-fcpxml"),
+    auto_detect: bool | None = typer.Option(
+        None,
+        "--auto-detect/--no-auto-detect",
+        help=(
+            "Whether to run shot detection after the beep. Defaults to the "
+            "global automation setting (True). Use --no-auto-detect for a "
+            "trim-only export (issue #215)."
+        ),
+    ),
     trim_mode: str | None = typer.Option(
         None,
         "--trim-mode",
@@ -104,6 +116,7 @@ def single(
         write_trim=write_trim,
         write_csv=write_csv,
         write_fcpxml=write_fcpxml,
+        auto_detect_shots=_resolve_cli_auto_detect(auto_detect),
     )
     _print_files_summary(files)
 
@@ -146,6 +159,15 @@ def process(
     write_trim: bool = typer.Option(True, "--trim/--no-trim"),
     write_csv: bool = typer.Option(True, "--csv/--no-csv"),
     write_fcpxml: bool = typer.Option(True, "--fcpxml/--no-fcpxml"),
+    auto_detect: bool | None = typer.Option(
+        None,
+        "--auto-detect/--no-auto-detect",
+        help=(
+            "Whether to run shot detection after the beep. Defaults to the "
+            "global automation setting (True). Use --no-auto-detect to skip "
+            "shot detection across the batch (issue #215)."
+        ),
+    ),
     trim_mode: str | None = typer.Option(
         None,
         "--trim-mode",
@@ -169,6 +191,7 @@ def process(
     if not match.matches:
         raise typer.Exit(code=1)
 
+    auto_detect_shots = _resolve_cli_auto_detect(auto_detect)
     for m in match.matches:
         stage = next(s for s in competitor_stages.stages if s.stage_number == m.stage_number)
         console.rule(f"[bold]Stage {stage.stage_number}: {stage.stage_name}[/]")
@@ -181,6 +204,7 @@ def process(
                 write_trim=write_trim,
                 write_csv=write_csv,
                 write_fcpxml=write_fcpxml,
+                auto_detect_shots=auto_detect_shots,
             )
         except Exception as exc:  # noqa: BLE001 -- soft-fail per SPEC error-handling rules
             console.print(f"[red]Stage {stage.stage_number} failed: {exc}[/]")
@@ -762,6 +786,24 @@ def overlay(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_cli_auto_detect(flag: bool | None) -> bool:
+    """Resolve the ``--auto-detect/--no-auto-detect`` flag against the
+    layered automation settings (#215).
+
+    ``flag is None`` means the user didn't pass either form; fall
+    through to the project (CLI doesn't know which project, so just
+    the global settings) + global default. ``True`` / ``False``
+    overrides everything else.
+    """
+    cli_override = (
+        automation_settings.AutomationOverride(shot_detect_on_beep_verified=flag)
+        if flag is not None
+        else None
+    )
+    resolved = automation_settings.resolve_automation(cli_override=cli_override)
+    return resolved.settings.shot_detect_on_beep_verified
+
+
 def _process_one(
     *,
     stage: StageData,
@@ -771,8 +813,15 @@ def _process_one(
     write_trim: bool,
     write_csv: bool,
     write_fcpxml: bool,
+    auto_detect_shots: bool = True,
 ) -> ReportFiles:
-    """End-to-end pipeline for a single (stage, video) pair. Returns the file footer."""
+    """End-to-end pipeline for a single (stage, video) pair. Returns the file footer.
+
+    ``auto_detect_shots=False`` (the CLI's ``--no-auto-detect``) skips
+    the shot-detection step. Trim, CSV (empty), and FCPXML (no
+    markers) still produce -- mirrors the permissive export gate
+    introduced in #214.
+    """
     base = f"stage{stage.stage_number}_{_slugify(stage.stage_name)}"
     audio_path = _video_to_audio_path(video)
     audio, sr = _extract_or_load_audio(video, audio_path)
@@ -783,14 +832,20 @@ def _process_one(
         f"peak={beep.peak_amplitude:.3f}  duration={beep.duration_ms:.0f}ms"
     )
 
-    shots = shot_detect.detect_shots(audio, sr, beep.time, stage.time_seconds, config.shot_detect)
-    shots, refine_diffs = _refine_shot_times(audio, sr, shots, beep.time, config)
-    if refine_diffs:
-        console.print(
-            f"  [cyan]refined {len(refine_diffs)} shot time(s)[/]: "
-            + ", ".join(f"#{i + 1} {d['drift_ms']:+.1f}ms" for i, d in enumerate(refine_diffs))
+    if auto_detect_shots:
+        shots = shot_detect.detect_shots(
+            audio, sr, beep.time, stage.time_seconds, config.shot_detect
         )
-    _print_shots_table(shots)
+        shots, refine_diffs = _refine_shot_times(audio, sr, shots, beep.time, config)
+        if refine_diffs:
+            console.print(
+                f"  [cyan]refined {len(refine_diffs)} shot time(s)[/]: "
+                + ", ".join(f"#{i + 1} {d['drift_ms']:+.1f}ms" for i, d in enumerate(refine_diffs))
+            )
+        _print_shots_table(shots)
+    else:
+        shots = []
+        console.print("  [yellow]shot detection skipped[/] (--no-auto-detect)")
 
     files = ReportFiles()
     if write_trim:
@@ -809,10 +864,14 @@ def _process_one(
         )
         console.print(f"  [green]trimmed video[/]: {files.video}")
 
-    if write_csv:
+    if write_csv and shots:
         files.csv = output_dir / f"{base}_splits.csv"
         csv_gen.write_splits_csv(shots, files.csv)
         console.print(f"  [green]splits CSV[/]:    {files.csv}")
+    elif write_csv:
+        # Mirror the permissive export gate (#214): no CSV when no
+        # shots; the trim + FCPXML still ship.
+        console.print("  [yellow]splits CSV[/]:    skipped (no shots)")
 
     if write_fcpxml and files.video and files.video.exists():
         files.fcpxml = output_dir / f"{base}.fcpxml"

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -35,6 +35,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, computed_field
 
 from .. import video_match
+from ..automation import AutomationOverride
 from ..config import BeepCandidate, StageData, StageRounds, VideoMatchConfig
 from ..video_match import match_videos_to_stages
 
@@ -497,6 +498,13 @@ class MatchProject(BaseModel):
     # a specific encoder name (e.g. ``"libx264"``) to pin the choice; the
     # next trim job uses the new value.
     trim_audit_encoder: str = "auto"
+    # Layered automation overrides (issue #215). Each field is
+    # optional; ``None`` means "inherit from the global default."
+    # Resolved at call time via :func:`splitsmith.automation.resolve_automation`
+    # with the CLI (if any) and the global settings; the resolved
+    # value drives per-event behaviour like "auto-fire shot detect
+    # after the user marks the beep reviewed."
+    automation: AutomationOverride = Field(default_factory=AutomationOverride)
 
     @classmethod
     def init(cls, root: Path, *, name: str) -> MatchProject:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -84,6 +84,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from .. import automation as automation_settings
 from .. import beep_detect, cross_align, report, user_config, video_probe
 from .. import cleanup as cleanup_module
 from .. import coach as coach_module
@@ -2066,7 +2067,18 @@ def create_app(
             # ``set_beep_reviewed``). Saves the heavy CLAP / GBDT / PANN
             # ensemble work when the beep timestamp is wrong, since
             # everything downstream of it would be garbage anyway.
-            if state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None:
+            #
+            # Layered automation gate (#215): users can disable the
+            # auto-trigger globally or per project. ``cli_override`` is
+            # always None for the server -- the daemon doesn't take
+            # CLI flags at this entry point.
+            resolved = automation_settings.resolve_automation(
+                project_override=fresh.automation,
+            )
+            if (
+                resolved.settings.shot_detect_on_beep_verified
+                and state.jobs.find_active(kind="shot_detect", stage_number=stage_number) is None
+            ):
                 state.jobs.submit(
                     kind="shot_detect",
                     stage_number=stage_number,
@@ -2317,11 +2329,18 @@ def create_app(
             # so this still runs; the auto-detect path waits for the
             # user's explicit "Mark reviewed" click which re-fires
             # shot_detect from there.
-            state.jobs.submit(
-                kind="shot_detect",
-                stage_number=stage_number,
-                fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+            #
+            # Layered automation gate (#215): a global / project
+            # opt-out can suppress this auto-trigger.
+            resolved = automation_settings.resolve_automation(
+                project_override=fresh.automation,
             )
+            if resolved.settings.shot_detect_on_beep_verified:
+                state.jobs.submit(
+                    kind="shot_detect",
+                    stage_number=stage_number,
+                    fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+                )
         handle.update(progress=1.0, message="Done")
 
     def _run_trim_for_stage(handle: JobHandle, stage_number: int) -> None:

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,136 @@
+"""Tests for the layered automation settings (#215)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith import automation
+from splitsmith.automation import (
+    AutomationOverride,
+    AutomationSettings,
+    resolve_automation,
+)
+
+# --- AutomationSettings ---------------------------------------------------
+
+
+def test_automation_settings_defaults() -> None:
+    s = AutomationSettings()
+    assert s.shot_detect_on_beep_verified is True
+
+
+def test_automation_settings_loads_from_yaml(tmp_path: Path) -> None:
+    """The global YAML's ``automation`` block populates fields."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("automation:\n  shot_detect_on_beep_verified: false\n", encoding="utf-8")
+    loaded = automation.load_global(cfg)
+    assert loaded.shot_detect_on_beep_verified is False
+
+
+def test_automation_settings_missing_block_uses_defaults(tmp_path: Path) -> None:
+    """A YAML file without an ``automation`` block is fine -- defaults apply."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("theme: dark\n", encoding="utf-8")
+    loaded = automation.load_global(cfg)
+    assert loaded.shot_detect_on_beep_verified is True
+
+
+def test_automation_settings_missing_file_uses_defaults(tmp_path: Path) -> None:
+    cfg = tmp_path / "does-not-exist.yaml"
+    loaded = automation.load_global(cfg)
+    assert loaded.shot_detect_on_beep_verified is True
+
+
+def test_automation_settings_malformed_yaml_falls_back(tmp_path: Path) -> None:
+    """A broken YAML doesn't crash the app -- the loader logs and returns
+    the field defaults."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("automation:\n  shot_detect_on_beep_verified: !!!\n", encoding="utf-8")
+    loaded = automation.load_global(cfg)
+    assert loaded.shot_detect_on_beep_verified is True
+
+
+def test_automation_settings_env_var_overrides_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``SPLITSMITH_AUTOMATION_*`` env vars trump the YAML default
+    (pydantic-settings precedence). Env init args we pass in
+    (the YAML block) lose to environment by design."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("automation:\n  shot_detect_on_beep_verified: true\n", encoding="utf-8")
+    # With pydantic-settings, env vars beat field defaults but lose
+    # to init kwargs we explicitly pass. We pass the YAML block as
+    # init kwargs, so the env var only wins when the YAML block is
+    # silent on a field. Test that path:
+    cfg2 = tmp_path / "empty.yaml"
+    cfg2.write_text("automation: {}\n", encoding="utf-8")
+    monkeypatch.setenv("SPLITSMITH_AUTOMATION_SHOT_DETECT_ON_BEEP_VERIFIED", "false")
+    loaded = automation.load_global(cfg2)
+    assert loaded.shot_detect_on_beep_verified is False
+
+
+# --- resolve_automation ---------------------------------------------------
+
+
+def test_resolve_uses_global_when_no_overrides() -> None:
+    g = AutomationSettings(shot_detect_on_beep_verified=False)
+    resolved = resolve_automation(global_settings=g)
+    assert resolved.settings.shot_detect_on_beep_verified is False
+    p = resolved.provenance["shot_detect_on_beep_verified"]
+    assert p.source == "global"
+    assert p.global_value is False
+    assert p.project_value is None
+    assert p.cli_value is None
+
+
+def test_resolve_project_override_wins_over_global() -> None:
+    g = AutomationSettings(shot_detect_on_beep_verified=True)
+    proj = AutomationOverride(shot_detect_on_beep_verified=False)
+    resolved = resolve_automation(global_settings=g, project_override=proj)
+    assert resolved.settings.shot_detect_on_beep_verified is False
+    p = resolved.provenance["shot_detect_on_beep_verified"]
+    assert p.source == "project"
+    assert p.project_value is False
+    assert p.global_value is True
+    assert p.cli_value is None
+
+
+def test_resolve_cli_override_wins_over_project_and_global() -> None:
+    g = AutomationSettings(shot_detect_on_beep_verified=True)
+    proj = AutomationOverride(shot_detect_on_beep_verified=False)
+    cli = AutomationOverride(shot_detect_on_beep_verified=True)
+    resolved = resolve_automation(global_settings=g, project_override=proj, cli_override=cli)
+    assert resolved.settings.shot_detect_on_beep_verified is True
+    p = resolved.provenance["shot_detect_on_beep_verified"]
+    assert p.source == "cli"
+    assert p.cli_value is True
+    assert p.project_value is False
+    assert p.global_value is True
+
+
+def test_resolve_project_override_with_none_field_falls_through() -> None:
+    """A project override of ``None`` on a field is the same as having
+    no override -- the global value passes through and provenance
+    reports 'global'."""
+    g = AutomationSettings(shot_detect_on_beep_verified=True)
+    proj = AutomationOverride(shot_detect_on_beep_verified=None)
+    resolved = resolve_automation(global_settings=g, project_override=proj)
+    assert resolved.settings.shot_detect_on_beep_verified is True
+    assert resolved.provenance["shot_detect_on_beep_verified"].source == "global"
+
+
+def test_resolve_no_args_loads_global_from_disk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``global_settings`` the resolver loads from the
+    user-config directory. SPLITSMITH_HOME points to a tmp dir so the
+    test doesn't read the real user's config."""
+    monkeypatch.setenv("SPLITSMITH_HOME", str(tmp_path))
+    monkeypatch.delenv("SPLITSMITH_DISABLE_USER_CONFIG", raising=False)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("automation:\n  shot_detect_on_beep_verified: false\n", encoding="utf-8")
+    resolved = resolve_automation()
+    assert resolved.settings.shot_detect_on_beep_verified is False
+    assert resolved.provenance["shot_detect_on_beep_verified"].source == "global"

--- a/uv.lock
+++ b/uv.lock
@@ -1927,6 +1927,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2480,6 +2494,7 @@ dependencies = [
     { name = "numpy" },
     { name = "panns-inference" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -2511,6 +2526,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "panns-inference", specifier = ">=0.1.1" },
     { name = "pydantic", specifier = ">=2.7.0" },
+    { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.7.0" },


### PR DESCRIPTION
Closes #215.

## Summary

- New \`splitsmith.automation\` module backed by \`pydantic-settings\`. Three pieces:
  - \`AutomationSettings\` -- the resolved + globally-loaded values, with YAML loader (\`automation\` block in \`~/.splitsmith/config.yaml\`) and \`SPLITSMITH_AUTOMATION_*\` env-var support.
  - \`AutomationOverride\` -- optional per-layer override; \`None\` on a field means inherit from below.
  - \`resolve_automation()\` -- merges CLI > project > global per field. Returns \`ResolvedAutomation\` with per-field provenance for #216.
- First field: \`shot_detect_on_beep_verified\` (default \`True\`, preserves today's behaviour). Schema is a sub-object so siblings can land later without re-shaping the YAML.
- \`MatchProject.automation\` -- new optional override on the project model.
- Server's two auto-detect callsites (\`server.py:2061\` and \`server.py:2321\`) now read the resolved value before submitting the \`shot_detect\` job.
- CLI \`single\` / \`process\` get \`--auto-detect/--no-auto-detect\`. \`_process_one\` takes \`auto_detect_shots\`; CSV is skipped when shots is empty (mirrors #214).
- Adds \`pydantic-settings>=2.6.0\`. \`uv sync\` pruned an unused \`torchaudio\` transitive in the same operation; nothing imports it.

## Tradeoffs

- Resolution lives outside pydantic-settings' \`settings_customise_sources\` hook because the three layers (CLI / project / global) are discrete sources rather than \"one settings object loaded from many places.\" Hand-rolled merge is 15 lines and easier to reason about.
- Loaded on every gate evaluation rather than cached. The work is sub-millisecond and the value can change while the daemon runs (UI editing the project's override). If hot-path cost shows up, cache by project at the state layer.
- Provenance struct is wired through but not yet exposed via HTTP -- that's #216's responsibility.

## Test plan

- [x] \`uv run pytest -q\` -- 887 passing (11 new), 4 skipped
- [x] \`ruff check\` + \`black --check\` clean
- [ ] Manual: set \`automation.shot_detect_on_beep_verified: false\` in \`~/.splitsmith/config.yaml\`, mark a beep reviewed, confirm shot_detect doesn't auto-fire
- [ ] Manual: \`splitsmith single ... --no-auto-detect\` produces a trim-only export with no CSV / FCPXML markers
- [ ] Manual: \`SPLITSMITH_AUTOMATION_SHOT_DETECT_ON_BEEP_VERIFIED=false splitsmith ui\` honours the env var when YAML doesn't set the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)