### PR TITLE
ui: settings provenance primitive + automation panel (#216)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -801,6 +801,12 @@ class SettingsRequest(BaseModel):
     # post = pad after stage end. Both must be non-negative.
     trim_pre_buffer_seconds: float | None = None
     trim_post_buffer_seconds: float | None = None
+    # Layered automation override (#215). ``None`` keeps the current
+    # value; pass an :class:`AutomationOverride`-shaped dict with
+    # field values (or nulls) to set / clear individual project-level
+    # overrides. The resolved effective value is exposed via
+    # ``GET /api/automation``.
+    automation: automation_settings.AutomationOverride | None = None
     confirm: bool = False
 
 
@@ -1202,6 +1208,35 @@ def create_app(
     @app.get("/api/project")
     def get_project() -> JSONResponse:
         return JSONResponse(state.load().model_dump(mode="json"))
+
+    @app.get("/api/automation")
+    def get_automation() -> JSONResponse:
+        """Resolved automation settings + per-field provenance (#215 / #216).
+
+        Combines the global YAML / env-var defaults with the bound
+        project's override. The SPA renders provenance badges next to
+        each toggle so users see which layer set the current value.
+        ``cli_value`` is always None on the daemon path -- the server
+        doesn't take per-call CLI flags.
+        """
+        project = state.load()
+        resolved = automation_settings.resolve_automation(
+            project_override=project.automation,
+        )
+        return JSONResponse(
+            {
+                "settings": resolved.settings.model_dump(mode="json"),
+                "provenance": {
+                    field: {
+                        "source": prov.source,
+                        "cli_value": prov.cli_value,
+                        "project_value": prov.project_value,
+                        "global_value": prov.global_value,
+                    }
+                    for field, prov in resolved.provenance.items()
+                },
+            }
+        )
 
     @app.get("/api/project/match-analysis")
     def get_match_analysis() -> JSONResponse:
@@ -1761,6 +1796,13 @@ def create_app(
                     detail=f"{buf_field} must be non-negative, got {value}",
                 )
             setattr(project, buf_field, value)
+
+        # #215 -- patch the automation override on the project.
+        # Replacing the whole sub-object keeps the patch shape simple
+        # (the override is small enough that field-level merging would
+        # add complexity without a real benefit).
+        if req.automation is not None:
+            project.automation = req.automation
 
         # Make sure each configured directory is creatable; surface a 400
         # rather than failing later in detect-beep / trim / export.

--- a/src/splitsmith/ui_static/src/components/SettingProvenance.tsx
+++ b/src/splitsmith/ui_static/src/components/SettingProvenance.tsx
@@ -1,0 +1,65 @@
+/** Settings provenance badge (#216).
+ *
+ * Renders a tiny pill next to a setting label that names *which layer*
+ * supplied the current effective value. Hover reveals every layer's
+ * value so the user can answer "why is this off?" without diving
+ * into config files.
+ *
+ * Layers, ordered top wins: ``cli`` > ``project`` > ``global`` >
+ * ``default``. The CLI layer is rare in the UI (the daemon doesn't
+ * take per-call CLI flags), but the badge handles it for completeness.
+ */
+
+import type {
+  AutomationFieldProvenance,
+  AutomationProvenanceSource,
+} from "@/lib/api";
+
+const SOURCE_LABEL: Record<AutomationProvenanceSource, string> = {
+  cli: "CLI",
+  project: "Project",
+  global: "Global",
+  default: "Default",
+};
+
+const SOURCE_CLASSES: Record<AutomationProvenanceSource, string> = {
+  // Project override -- the user actively chose this for the project.
+  // Stand out a bit to make the override visible at a glance.
+  project: "border-primary/40 bg-primary/10 text-primary",
+  // CLI override -- transient and dev-only; same accent as project so
+  // the pattern reads consistently.
+  cli: "border-primary/40 bg-primary/10 text-primary",
+  // Global / default come from layers the user usually doesn't see.
+  // Muted styling keeps them present-but-quiet.
+  global: "border-border bg-muted text-muted-foreground",
+  default: "border-border bg-muted text-muted-foreground",
+};
+
+function formatValue(value: boolean | null | undefined): string {
+  if (value === true) return "on";
+  if (value === false) return "off";
+  return "(unset)";
+}
+
+export function SettingProvenance({
+  provenance,
+}: {
+  provenance: AutomationFieldProvenance;
+}) {
+  const label = SOURCE_LABEL[provenance.source];
+  const tooltipLines = [
+    `Effective source: ${label}`,
+    `CLI: ${formatValue(provenance.cli_value)}`,
+    `Project: ${formatValue(provenance.project_value)}`,
+    `Global: ${formatValue(provenance.global_value)}`,
+  ].join("\n");
+  return (
+    <span
+      title={tooltipLines}
+      className={`inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium ${SOURCE_CLASSES[provenance.source]}`}
+      aria-label={`Setting source: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -145,6 +145,10 @@ export interface MatchProject {
   thumbs_dir: string | null;
   trim_pre_buffer_seconds: number;
   trim_post_buffer_seconds: number;
+  /** #215 -- project-level automation override. Each field is optional;
+   *  a ``null`` (or missing) value means the project inherits from the
+   *  global default. Resolved view available via ``getAutomation()``. */
+  automation: AutomationOverride;
 }
 
 /** GET /api/scoreboard/source response. ``mode === "local"`` means the
@@ -284,7 +288,39 @@ export interface ProjectSettingsPatch {
   thumbs_dir?: string | null;
   trim_pre_buffer_seconds?: number | null;
   trim_post_buffer_seconds?: number | null;
+  /** #215 -- project-level automation override. Replaces the whole
+   *  override object; pass field values (or null to clear an
+   *  override back to the global default). */
+  automation?: AutomationOverride | null;
   confirm?: boolean;
+}
+
+/** Mirror of ``splitsmith.automation.AutomationOverride`` (#215). */
+export interface AutomationOverride {
+  shot_detect_on_beep_verified?: boolean | null;
+}
+
+/** Mirror of the resolved-settings shape returned by ``GET /api/automation``
+ *  (#216). The SPA renders ``<SettingProvenance>`` next to each toggle by
+ *  reading the matching ``provenance`` entry. */
+export interface ResolvedAutomationResponse {
+  settings: {
+    shot_detect_on_beep_verified: boolean;
+  };
+  provenance: Record<string, AutomationFieldProvenance>;
+}
+
+export type AutomationProvenanceSource =
+  | "cli"
+  | "project"
+  | "global"
+  | "default";
+
+export interface AutomationFieldProvenance {
+  source: AutomationProvenanceSource;
+  cli_value: boolean | null;
+  project_value: boolean | null;
+  global_value: boolean;
 }
 
 export interface NonEmptyOldDir {
@@ -1106,6 +1142,9 @@ export const api = {
       method: "POST",
       json: patch,
     }),
+
+  getAutomation: () =>
+    request<ResolvedAutomationResponse>("/api/automation"),
 
   moveAssignment: (
     videoPath: string,

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -38,6 +38,7 @@ import { BeepSection } from "@/components/BeepSection";
 import { CleanupDialog } from "@/components/CleanupDialog";
 import { FolderPicker } from "@/components/FolderPicker";
 import { MountSelect } from "@/components/MountSelect";
+import { SettingProvenance } from "@/components/SettingProvenance";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,6 +59,7 @@ import {
   type MatchAnalysis,
   type MatchProject,
   type NonEmptyOldDirsDetail,
+  type ResolvedAutomationResponse,
   type ScoreboardErrorDetail,
   type ScoreboardMatchRef,
   type ScoreboardShooterRef,
@@ -477,6 +479,15 @@ export function Ingest() {
 
       {project ? (
         <SettingsSection project={project} busy={busy} setBusy={setBusy} setError={setError} onProjectUpdate={setProject} />
+      ) : null}
+
+      {project ? (
+        <AutomationSettingsPanel
+          busy={busy}
+          setBusy={setBusy}
+          setError={setError}
+          onProjectUpdate={setProject}
+        />
       ) : null}
 
       {project ? (
@@ -1539,6 +1550,141 @@ function SettingsSection({
         </CardContent>
       ) : null}
       {cleanupOpen ? <CleanupDialog onClose={() => setCleanupOpen(false)} /> : null}
+    </Card>
+  );
+}
+
+/** Project-level automation panel (#215 / #216).
+ *
+ * Renders a collapsible card with each automation toggle, a tristate
+ * select that lets the user inherit / override per project, and a
+ * SettingProvenance badge that names the layer supplying the current
+ * effective value.
+ *
+ * Pulls from ``GET /api/automation`` so the badge and the select are
+ * driven by the same resolution logic the server uses; writes flow
+ * through the existing ``POST /api/project/settings`` endpoint with
+ * the ``automation`` patch field.
+ */
+function AutomationSettingsPanel({
+  busy,
+  setBusy,
+  setError,
+  onProjectUpdate,
+}: {
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  setError: (msg: string | null) => void;
+  onProjectUpdate: (p: MatchProject) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [resolved, setResolved] = useState<ResolvedAutomationResponse | null>(
+    null,
+  );
+
+  const reload = useCallback(async () => {
+    try {
+      const r = await api.getAutomation();
+      setResolved(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [setError]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const setShotDetect = async (value: boolean | null) => {
+    setBusy(true);
+    try {
+      const updated = await api.updateSettings({
+        automation: { shot_detect_on_beep_verified: value },
+      });
+      onProjectUpdate(updated);
+      setError(null);
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const shotDetectProv = resolved?.provenance.shot_detect_on_beep_verified;
+  // The ``select`` reflects the project-level *override* (not the
+  // resolved value): "inherit", "true", or "false". Resolution is
+  // shown via the badge + the helper line so the user sees both
+  // layers at once without the select lying about its state.
+  const projectValue: boolean | null | undefined = shotDetectProv?.project_value;
+  const selectValue: "inherit" | "on" | "off" =
+    projectValue === true ? "on" : projectValue === false ? "off" : "inherit";
+
+  return (
+    <Card>
+      <CardHeader
+        className="cursor-pointer"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <CardTitle className="flex items-center justify-between gap-2 text-base">
+          <span className="flex items-center gap-2">
+            <FolderInput className="size-4" />
+            Automation
+          </span>
+          <span className="text-xs font-normal text-muted-foreground">
+            {expanded ? "Hide" : "Configure"}
+          </span>
+        </CardTitle>
+        <CardDescription>
+          When splitsmith runs the next step automatically. Override
+          per project; the global default lives in your config.yaml.
+        </CardDescription>
+      </CardHeader>
+      {expanded ? (
+        <CardContent className="space-y-3">
+          {resolved && shotDetectProv ? (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="font-medium">
+                  Auto-detect shots after beep verified
+                </span>
+                <SettingProvenance provenance={shotDetectProv} />
+                <span className="text-xs text-muted-foreground">
+                  effective:{" "}
+                  {resolved.settings.shot_detect_on_beep_verified
+                    ? "on"
+                    : "off"}
+                </span>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                When you mark a beep reviewed, splitsmith fires the
+                CLAP / GBDT / PANN ensemble to seed audited shots.
+                Turn off if you only want trim + export, or to gate
+                detection manually.
+              </div>
+              <select
+                className="rounded border border-border bg-background px-2 py-1 text-sm"
+                value={selectValue}
+                disabled={busy}
+                onChange={(e) => {
+                  const v = e.target.value as "inherit" | "on" | "off";
+                  void setShotDetect(
+                    v === "inherit" ? null : v === "on" ? true : false,
+                  );
+                }}
+              >
+                <option value="inherit">
+                  Use global default ({shotDetectProv.global_value ? "on" : "off"})
+                </option>
+                <option value="on">Always on (project override)</option>
+                <option value="off">Always off (project override)</option>
+              </select>
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground">Loading...</div>
+          )}
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
+from splitsmith.automation import AutomationOverride
 from splitsmith.thumbnail import ThumbnailError
 from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
 from splitsmith.ui.server import create_app
@@ -4907,3 +4908,67 @@ def test_cleanup_endpoints_409_when_no_project_bound(tmp_path: Path) -> None:
     client = TestClient(app)
     assert client.get("/api/project/cleanup/plan?categories=audio").status_code == 409
     assert client.post("/api/project/cleanup", json={"categories": ["audio"]}).status_code == 409
+
+
+# --- automation settings (#216) ---------------------------------------------
+
+
+def test_get_automation_returns_resolved_settings_and_provenance(tmp_path: Path) -> None:
+    """No overrides -> source is 'global', current value is the field
+    default. Smoke-test that the response shape matches what the SPA's
+    SettingProvenance component expects."""
+    root = tmp_path / "match"
+    MatchProject.init(root, name="Auto Match").save(root)
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/automation")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["settings"] == {"shot_detect_on_beep_verified": True}
+    prov = body["provenance"]["shot_detect_on_beep_verified"]
+    assert prov["source"] == "global"
+    assert prov["global_value"] is True
+    assert prov["project_value"] is None
+    assert prov["cli_value"] is None
+
+
+def test_get_automation_reports_project_provenance_when_overridden(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="Override Match")
+    project.automation = AutomationOverride(shot_detect_on_beep_verified=False)
+    project.save(root)
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/automation")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["settings"]["shot_detect_on_beep_verified"] is False
+    prov = body["provenance"]["shot_detect_on_beep_verified"]
+    assert prov["source"] == "project"
+    assert prov["project_value"] is False
+    assert prov["global_value"] is True
+
+
+def test_post_settings_patches_automation_override(tmp_path: Path) -> None:
+    """Round-trip: post an automation override, then GET /api/automation
+    sees it as the project layer."""
+    root = tmp_path / "match"
+    MatchProject.init(root, name="Patch Match").save(root)
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/project/settings",
+        json={"automation": {"shot_detect_on_beep_verified": False}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["automation"]["shot_detect_on_beep_verified"] is False
+
+    auto = client.get("/api/automation").json()
+    assert auto["settings"]["shot_detect_on_beep_verified"] is False
+    assert auto["provenance"]["shot_detect_on_beep_verified"]["source"] == "project"


### PR DESCRIPTION
Closes #216.

## Summary

- \`<SettingProvenance>\` -- new cross-cutting React component (\`src/splitsmith/ui_static/src/components/SettingProvenance.tsx\`) that renders a small badge next to a setting label naming the layer that won (CLI / Project / Global / Default). Hover tooltip lists every layer's value.
- New \`GET /api/automation\` endpoint returns the resolved settings + per-field provenance, mirroring the \`ResolvedAutomation\` shape from #215.
- \`SettingsRequest\` grows an optional \`automation\` patch field that replaces the project's \`AutomationOverride\` whole-cloth.
- First adopter: new project-level \"Automation\" card on the Ingest page (\`AutomationSettingsPanel\`) with a tristate select (\"Use global default\" / \"Always on\" / \"Always off\") for \`shot_detect_on_beep_verified\` and the provenance badge.

## Tradeoffs

- The select reflects the **project override** (inherit / on / off), not the resolved value. Resolution is shown via the badge + an \"effective: on/off\" helper line. Felt cleaner than a tristate that lies about its state when the global flips.
- Provenance struct comes back as a plain dict on the wire rather than a typed sub-object per field. The TS type splits each field's record so callers get autocompletion regardless. If we add many more fields we can revisit.

## Test plan

- [x] \`uv run pytest -q\` -- 905 passing (3 new), 4 skipped
- [x] \`tsc --noEmit\` clean on the UI
- [x] \`ruff check\` + \`black --check\` clean
- [ ] Manual: open Ingest, expand Automation card; flip the select; confirm the badge updates from Global -> Project and the helper line tracks
- [ ] Manual: set the override back to \"Use global default\"; confirm the badge returns to Global
- [ ] Manual: edit \`~/.splitsmith/config.yaml\` to set \`automation.shot_detect_on_beep_verified: false\`; reload; confirm the inherit-mode helper text shows \"effective: off\" and the global label says \"off\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)