### PR TITLE
beep: HITL queue + auto-trust gate (#219 layer 3b)

### DIFF
--- a/src/splitsmith/automation.py
+++ b/src/splitsmith/automation.py
@@ -69,6 +69,23 @@ class AutomationSettings(BaseSettings):
     shot_detect_on_beep_verified: bool = True
     """When the user marks a beep reviewed, fire shot detection."""
 
+    beep_low_confidence_threshold: float = 0.6
+    """Minimum auto-detector confidence in [0, 1] required to auto-trust a beep.
+
+    Joins issue #219: an auto-detected beep with confidence at or above
+    this threshold pre-sets ``beep_reviewed=True`` (the user is offered
+    a one-click confirm but the chain doesn't wait), so shot detection
+    fires immediately. Below the threshold the beep lands in the HITL
+    queue and the user (or an agent driving the workflow) is asked to
+    pick the right candidate from the ranked list.
+
+    Empirically the labelled fixture set has ~95% top-1 precision in the
+    ``confidence >= 0.7`` band; 0.6 is the conservative default that
+    keeps a few ambiguous cases in HITL rather than wasting CLAP / GBDT
+    / PANN cycles on a beep the agent will end up correcting. Manual
+    entries always clamp confidence to 1.0 and bypass this gate.
+    """
+
 
 class AutomationOverride(BaseModel):
     """Layer override -- ``None`` on a field means "inherit from below".
@@ -79,6 +96,7 @@ class AutomationOverride(BaseModel):
     """
 
     shot_detect_on_beep_verified: bool | None = None
+    beep_low_confidence_threshold: float | None = None
 
 
 # Where each resolved field came from. The UI uses this for the
@@ -94,12 +112,17 @@ class FieldProvenance:
     ``cli_value`` / ``project_value`` are ``None`` when that layer
     stayed silent. ``global_value`` is always present because the
     global settings always have a default.
+
+    Field types are union-typed (``bool | float``) because the
+    automation block is now mixed (toggles + thresholds). The UI
+    provenance widget renders the values via JSON.stringify so the
+    union is invisible on the wire.
     """
 
     source: ProvenanceSource
-    cli_value: bool | None
-    project_value: bool | None
-    global_value: bool
+    cli_value: bool | float | None
+    project_value: bool | float | None
+    global_value: bool | float
 
 
 @dataclass(frozen=True)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1276,6 +1276,87 @@ def create_app(
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
 
+    @app.get("/api/hitl-queue")
+    def get_hitl_queue() -> JSONResponse:
+        """Items in the project that need human (or agent) attention (#219).
+
+        Walks every primary video and emits one item per beep that's
+        either missing (auto-detection found no candidate) or below the
+        ``beep_low_confidence_threshold`` automation gate -- exactly
+        the cases where the auto-trust chain didn't fire and a human
+        has to pick. Manual entries and high-confidence reviewed beeps
+        never appear here.
+
+        Response shape (stable; consumed by the SPA AND the MCP):
+
+            {
+              "items": [
+                {
+                  "kind": "beep_missing" | "beep_low_confidence",
+                  "stage_number": int,
+                  "video_id": str,
+                  "confidence": float | None,
+                  "suggested_action": str,
+                },
+                ...
+              ],
+              "threshold": float,
+            }
+
+        Ordered by stage number ascending; severity ties (a low-conf
+        and a missing on the same stage) keep their stable insertion
+        order. The SPA shows this as a project-level work queue; the
+        MCP exposes it as a resource so an agent can drive the picks.
+        """
+        project = state.load()
+        resolved = automation_settings.resolve_automation(
+            project_override=project.automation,
+        )
+        threshold = resolved.settings.beep_low_confidence_threshold
+        items: list[dict] = []
+        for stg in sorted(project.stages, key=lambda s: s.stage_number):
+            primary = next(
+                (v for v in stg.videos if v.role == "primary"),
+                None,
+            )
+            if primary is None:
+                continue
+            if primary.beep_auto_detect_failed:
+                items.append(
+                    {
+                        "kind": "beep_missing",
+                        "stage_number": stg.stage_number,
+                        "video_id": primary.video_id,
+                        "confidence": None,
+                        "suggested_action": (
+                            "Set the beep manually on the waveform: open the "
+                            "stage's ingest panel and click the beep marker."
+                        ),
+                    }
+                )
+                continue
+            if (
+                primary.beep_source == "auto"
+                and primary.beep_time is not None
+                and not primary.beep_reviewed
+            ):
+                # Either confidence is below the threshold OR the field
+                # predates layer 3a (None) -- both warrant review.
+                items.append(
+                    {
+                        "kind": "beep_low_confidence",
+                        "stage_number": stg.stage_number,
+                        "video_id": primary.video_id,
+                        "confidence": primary.beep_confidence,
+                        "suggested_action": (
+                            "Listen to the ranked candidates and pick the "
+                            "correct beep, or nudge the timestamp on the "
+                            "waveform."
+                        ),
+                    }
+                )
+        return JSONResponse({"items": items, "threshold": threshold})
+
     @app.get("/api/project/match-analysis")
     def get_match_analysis() -> JSONResponse:
         """Run the canonical video-match heuristic over the project and return
@@ -2063,10 +2144,21 @@ def create_app(
             video.beep_alignment_confidence = None
             video.beep_alignment_delta_ms = None
             video.processed["beep"] = True
-            # Auto-detected beeps need explicit user review (#71). Reset
-            # the flag here so a re-detect on a previously reviewed video
-            # invalidates the prior approval.
-            video.beep_reviewed = False
+            # Auto-detected beeps need explicit user review (#71) UNLESS
+            # the calibrated confidence (#220 layer 3a) clears the
+            # ``beep_low_confidence_threshold`` automation gate (#219).
+            # Above the threshold we auto-trust: the detector is right
+            # ~95 % of the time in that band, so making the user click
+            # to confirm every high-confidence beep adds friction
+            # without catching real problems. Below it the user has to
+            # review -- the HITL queue (``GET /api/hitl-queue``) lists
+            # exactly these. Resets to False on re-detection so the
+            # prior approval doesn't carry over to a fresh run.
+            resolved_auto = automation_settings.resolve_automation(
+                project_override=proj.automation,
+            )
+            threshold = resolved_auto.settings.beep_low_confidence_threshold
+            video.beep_reviewed = beep.confidence >= threshold
             # Sanity check: when in-stream succeeded on a secondary, ALSO
             # run cross-correlation against the primary. If the two
             # methods disagree by more than ~250 ms it usually means the

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1692,6 +1692,96 @@ def test_detect_beep_auto_trims(tmp_path: Path, monkeypatch) -> None:
     assert trim_calls[0]["stage_time"] == pytest.approx(12.0)
 
 
+def test_detect_beep_high_confidence_auto_trusts_into_beep_reviewed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """confidence >= threshold flips beep_reviewed to True without a click (#219)."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    project.stages[0].time_seconds = 12.0
+    project.save(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"X")
+
+    from splitsmith import beep_detect, trim
+    from splitsmith.ui import audio as audio_helpers
+
+    class FakeBeep:
+        time = 6.5
+        peak_amplitude = 0.42
+        duration_ms = 350.0
+        confidence = 0.92  # well above the 0.6 default threshold
+        candidates: list = []
+
+    monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "z.wav")
+    (tmp_path / "z.wav").write_bytes(b"\x00")
+    monkeypatch.setattr(beep_detect, "load_audio", lambda p: ([0.0] * 100, 48_000))
+    monkeypatch.setattr(beep_detect, "detect_beep", lambda *a, **kw: FakeBeep())
+    monkeypatch.setattr(
+        trim,
+        "trim_video",
+        lambda **kw: trim.TrimResult(
+            output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0
+        ),
+    )
+    Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.json()["id"])
+    primary_after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary_after["beep_confidence"] == pytest.approx(0.92)
+    assert primary_after["beep_reviewed"] is True
+
+
+def test_detect_beep_low_confidence_leaves_beep_for_hitl(tmp_path: Path, monkeypatch) -> None:
+    """Below-threshold beep keeps beep_reviewed=False so it lands in HITL queue."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    project.stages[0].time_seconds = 12.0
+    project.save(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"X")
+
+    from splitsmith import beep_detect, trim
+    from splitsmith.ui import audio as audio_helpers
+
+    class FakeBeep:
+        time = 6.5
+        peak_amplitude = 0.42
+        duration_ms = 200.0
+        confidence = 0.45  # below default threshold of 0.6
+        candidates: list = []
+
+    monkeypatch.setattr(audio_helpers, "ensure_primary_audio", lambda *a, **kw: tmp_path / "w.wav")
+    (tmp_path / "w.wav").write_bytes(b"\x00")
+    monkeypatch.setattr(beep_detect, "load_audio", lambda p: ([0.0] * 100, 48_000))
+    monkeypatch.setattr(beep_detect, "detect_beep", lambda *a, **kw: FakeBeep())
+    monkeypatch.setattr(
+        trim,
+        "trim_video",
+        lambda **kw: trim.TrimResult(
+            output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0
+        ),
+    )
+    Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
+
+    resp = client.post("/api/stages/1/detect-beep")
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.json()["id"])
+    primary_after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    assert primary_after["beep_confidence"] == pytest.approx(0.45)
+    assert primary_after["beep_reviewed"] is False
+    # And it should now show up in the HITL queue.
+    queue = client.get("/api/hitl-queue").json()
+    assert len(queue["items"]) == 1
+    assert queue["items"][0]["kind"] == "beep_low_confidence"
+
+
 def test_detect_beep_skips_trim_when_stage_time_zero(tmp_path: Path, monkeypatch) -> None:
     """Source-first / placeholder stages with time_seconds=0 (no scoreboard
     yet) should still let the user detect a beep -- trim just gets deferred
@@ -4929,12 +5019,18 @@ def test_get_automation_returns_resolved_settings_and_provenance(tmp_path: Path)
     resp = client.get("/api/automation")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["settings"] == {"shot_detect_on_beep_verified": True}
+    assert body["settings"] == {
+        "shot_detect_on_beep_verified": True,
+        "beep_low_confidence_threshold": 0.6,
+    }
     prov = body["provenance"]["shot_detect_on_beep_verified"]
     assert prov["source"] == "global"
     assert prov["global_value"] is True
     assert prov["project_value"] is None
     assert prov["cli_value"] is None
+    threshold_prov = body["provenance"]["beep_low_confidence_threshold"]
+    assert threshold_prov["source"] == "global"
+    assert threshold_prov["global_value"] == 0.6
 
 
 def test_get_automation_reports_project_provenance_when_overridden(
@@ -5042,6 +5138,164 @@ def test_dismiss_nudge_404_for_unknown_stage(tmp_path: Path) -> None:
         json={"stage_number": 99, "dismissed": True},
     )
     assert resp.status_code == 404
+
+
+def _build_project_with_primary(
+    root: Path,
+    name: str,
+    *,
+    beep_time: float | None,
+    beep_source: str | None,
+    beep_confidence: float | None,
+    beep_reviewed: bool,
+    beep_auto_detect_failed: bool = False,
+) -> MatchProject:
+    """Helper for HITL queue tests -- builds a project with one stage / primary."""
+    project = MatchProject.init(root, name=name)
+    primary = StageVideo(
+        path=root / "primary.mp4",
+        role="primary",
+        beep_time=beep_time,
+        beep_source=beep_source,  # type: ignore[arg-type]
+        beep_confidence=beep_confidence,
+        beep_reviewed=beep_reviewed,
+        beep_auto_detect_failed=beep_auto_detect_failed,
+    )
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=12.0, videos=[primary])
+    ]
+    project.save(root)
+    return project
+
+
+def test_hitl_queue_lists_low_confidence_auto_beep(tmp_path: Path) -> None:
+    """Auto-detected beep below the threshold lands in the queue."""
+    root = tmp_path / "match"
+    _build_project_with_primary(
+        root,
+        "HITL Low",
+        beep_time=22.5,
+        beep_source="auto",
+        beep_confidence=0.4,
+        beep_reviewed=False,
+    )
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/hitl-queue")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["threshold"] == 0.6
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["kind"] == "beep_low_confidence"
+    assert item["stage_number"] == 1
+    assert item["confidence"] == 0.4
+    assert "candidate" in item["suggested_action"].lower()
+
+
+def test_hitl_queue_lists_missing_beep(tmp_path: Path) -> None:
+    """Auto-detect failure shows up as ``beep_missing``."""
+    root = tmp_path / "match"
+    _build_project_with_primary(
+        root,
+        "HITL Missing",
+        beep_time=None,
+        beep_source="auto",
+        beep_confidence=None,
+        beep_reviewed=False,
+        beep_auto_detect_failed=True,
+    )
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/hitl-queue")
+    item = resp.json()["items"][0]
+    assert item["kind"] == "beep_missing"
+    assert item["confidence"] is None
+    assert "manual" in item["suggested_action"].lower()
+
+
+def test_hitl_queue_omits_high_confidence_reviewed_beep(tmp_path: Path) -> None:
+    """High-confidence auto-trusted beeps don't need attention."""
+    root = tmp_path / "match"
+    _build_project_with_primary(
+        root,
+        "HITL Trusted",
+        beep_time=22.5,
+        beep_source="auto",
+        beep_confidence=0.85,
+        beep_reviewed=True,  # auto-trusted via threshold gate
+    )
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/hitl-queue")
+    assert resp.json()["items"] == []
+
+
+def test_hitl_queue_omits_manual_beep(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project_with_primary(
+        root,
+        "HITL Manual",
+        beep_time=22.5,
+        beep_source="manual",
+        beep_confidence=1.0,
+        beep_reviewed=True,
+    )
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/hitl-queue")
+    assert resp.json()["items"] == []
+
+
+def test_hitl_queue_orders_by_stage_number(tmp_path: Path) -> None:
+    """Stages 3, 1, 2 with all-needs-review beeps come back in 1, 2, 3 order."""
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="HITL Order")
+    project.stages = []
+    for n in (3, 1, 2):
+        v = StageVideo(
+            path=root / f"p{n}.mp4",
+            role="primary",
+            beep_time=10.0,
+            beep_source="auto",  # type: ignore[arg-type]
+            beep_confidence=0.4,
+            beep_reviewed=False,
+        )
+        project.stages.append(
+            StageEntry(stage_number=n, stage_name=f"S{n}", time_seconds=12.0, videos=[v])
+        )
+    project.save(root)
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    resp = client.get("/api/hitl-queue")
+    stages = [item["stage_number"] for item in resp.json()["items"]]
+    assert stages == [1, 2, 3]
+
+
+def test_hitl_queue_threshold_respects_project_override(tmp_path: Path) -> None:
+    """Project-level threshold override flows through to the response."""
+    root = tmp_path / "match"
+    project = _build_project_with_primary(
+        root,
+        "HITL Threshold",
+        beep_time=22.5,
+        beep_source="auto",
+        beep_confidence=0.65,
+        beep_reviewed=False,
+    )
+    project.automation = AutomationOverride(beep_low_confidence_threshold=0.9)
+    project.save(root)
+    app = create_app(project_root=root, project_name="ignored")
+    client = TestClient(app)
+
+    body = client.get("/api/hitl-queue").json()
+    assert body["threshold"] == 0.9
+    assert body["items"][0]["confidence"] == 0.65
 
 
 def test_post_settings_patches_automation_override(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the loop on #219 by wiring the layer-3a confidence into the automation framework (#215 / #226) and adding the work-queue endpoint the SPA + MCP need to drive the HITL flow.

- `automation.beep_low_confidence_threshold: float = 0.6` -- joins the existing CLI > project > global > default resolver.
- **Auto-trust gate** in `_run_detect_beep_for_video`: auto-detection with `confidence >= threshold` pre-sets `beep_reviewed=True` so shot-detect fires without a manual review click. Below the threshold the beep lands in the HITL queue. Manual entries always clamp to 1.0 and bypass the gate.
- **`GET /api/hitl-queue`** -- walks every primary video, emits ordered items needing attention. Two kinds today:
  - `beep_missing` -- auto-detect found no candidate
  - `beep_low_confidence` -- auto-detect produced a beep but it's not yet reviewed
- Items carry `kind`, `stage_number`, `video_id`, `confidence`, `suggested_action`. The response also returns the active threshold for context.

The endpoint is the single source of truth for both the SPA's project-view work queue and the MCP resource (`shotsmith` agent flow). Layer 3c will add the candidates panel + audio playback for drilling into queue items.

## Effective behaviour on the calibration set

With the default 0.6 threshold against the 37-row eval:

- 21 high-confidence auto-trust cases (95.2% precision) -- skip review, fire shot detect immediately.
- 13 mid-band cases (38.5% precision) land in HITL.
- 3 low-band cases land in HITL.

Net: ~57% of stages auto-pipeline; the other ~43% surface in the queue with the right candidate already in the top-N list (94.6% recall from layer 2).

## Test plan

- [x] 220 tests pass (`uv run pytest tests/test_ui_server.py tests/test_automation.py tests/test_beep_detect.py`)
- [x] 6 new endpoint tests: low-confidence + missing + ordering + manual omission + high-confidence omission + project-override threshold
- [x] 2 new detection-flow tests: high-confidence auto-trusts into beep_reviewed=True, low-confidence stays False and appears in HITL queue
- [x] Existing automation provenance test extended for the new field
- [x] black + ruff clean

## Layer 3c (next, after this lands)

- Audit / project view: HITL panel that lists queue items with candidate cards (timestamp + waveform thumb + play button), one-click pick.
- MCP wrapper exposing `/api/hitl-queue` as a resource with the `suggested_action` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)