### PR TITLE
beep: HITL queue panel on ingest + confidence on candidates (#219 layer 3c)

### DIFF
--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -1138,10 +1138,11 @@ function CandidateRow({
       </div>
       <div
         className="mt-0.5 pl-7 text-[11px] text-muted-foreground"
-        title={`Silence-preference score: ${candidate.score.toFixed(2)} (run peak / pre-window mean). Peak amplitude on the bandpassed envelope: ${candidate.peak_amplitude.toFixed(3)}. Duration: ${candidate.duration_ms.toFixed(0)} ms.`}
+        title={`Calibrated detector confidence in [0, 1] (#220 layer 3a). Components: silence-preference ${candidate.silence_score.toFixed(2)} (run peak / pre-window max), tonal concentration ${candidate.tonal_score.toFixed(2)} (energy in IPSC fundamental band). Duration: ${candidate.duration_ms.toFixed(0)} ms; peak ${candidate.peak_amplitude.toFixed(3)}.`}
       >
-        score {candidate.score.toFixed(1)} &middot; peak {candidate.peak_amplitude.toFixed(2)}{" "}
-        &middot; {Math.round(candidate.duration_ms)} ms
+        conf {candidate.confidence.toFixed(2)} &middot; tonal{" "}
+        {candidate.tonal_score.toFixed(2)} &middot;{" "}
+        {Math.round(candidate.duration_ms)} ms
       </div>
     </li>
   );

--- a/src/splitsmith/ui_static/src/components/HitlQueuePanel.tsx
+++ b/src/splitsmith/ui_static/src/components/HitlQueuePanel.tsx
@@ -1,0 +1,212 @@
+/**
+ * HITL queue panel for the Ingest page (#219).
+ *
+ * Polls ``GET /api/hitl-queue`` and renders the items the auto-trust
+ * gate didn't clear: beeps that the auto-detector either missed or
+ * produced with confidence below the project's
+ * ``automation.beep_low_confidence_threshold``. Each item links the
+ * user to the relevant stage's beep section so they can listen to
+ * the ranked candidates and pick.
+ *
+ * The panel is intentionally light. The candidate cards + audio
+ * playback already live in :file:`BeepSection.tsx` -- this component
+ * is just the index that tells the user what's left to do.
+ *
+ * Empty state: when the queue is empty (every primary either auto-
+ * trusted or manually confirmed), we render a calm "All beeps
+ * confirmed" line so the panel disappears visually without
+ * unmounting -- avoids the layout jump when one stage flips state.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { AlertCircle, ArrowRight, Volume2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  api,
+  type HitlItemKind,
+  type HitlQueueItem,
+  type HitlQueueResponse,
+} from "@/lib/api";
+
+const KIND_LABELS: Record<HitlItemKind, string> = {
+  beep_low_confidence: "Low confidence",
+  beep_missing: "No beep found",
+};
+
+const KIND_VARIANTS: Record<HitlItemKind, "outline" | "destructive"> = {
+  beep_low_confidence: "outline",
+  beep_missing: "destructive",
+};
+
+export interface HitlQueuePanelProps {
+  /** Optional: external trigger to refetch. Bumping the value forces
+   *  a queue reload; useful when the Ingest page just promoted a
+   *  candidate and wants the list to refresh without waiting for the
+   *  poll. */
+  refreshKey?: number;
+  /** Called when the user clicks "Open stage" on an item. The Ingest
+   *  page scrolls / navigates to the stage row. Defaults to a noop. */
+  onJumpToStage?: (stageNumber: number, videoId: string) => void;
+  /** Override poll interval in ms. Default 5 s; tests pass 0 to
+   *  disable polling. */
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+export function HitlQueuePanel({
+  refreshKey = 0,
+  onJumpToStage,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+}: HitlQueuePanelProps) {
+  const [queue, setQueue] = useState<HitlQueueResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      const next = await api.getHitlQueue();
+      setQueue(next);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload, refreshKey]);
+
+  useEffect(() => {
+    if (!pollIntervalMs) return;
+    const id = window.setInterval(() => {
+      void reload();
+    }, pollIntervalMs);
+    return () => window.clearInterval(id);
+  }, [reload, pollIntervalMs]);
+
+  const items = queue?.items ?? [];
+  const threshold = queue?.threshold ?? 0.6;
+
+  return (
+    <Card data-testid="hitl-queue-panel">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <CardTitle className="text-base">Needs review</CardTitle>
+            <CardDescription className="text-xs">
+              Beeps the detector flagged as uncertain. Pick the right
+              candidate or set the time on the waveform. Auto-trust
+              fires at confidence &ge; {threshold.toFixed(2)}.
+            </CardDescription>
+          </div>
+          {!loading && items.length > 0 ? (
+            <Badge variant="outline" className="shrink-0 tabular-nums">
+              {items.length}
+            </Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive">
+            Failed to load HITL queue: {error}
+          </p>
+        ) : items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            All beeps confirmed. Detect-beep results above the
+            confidence threshold land here when the auto-trust gate
+            doesn't fire.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {items.map((item) => (
+              <HitlQueueRow
+                key={`${item.stage_number}-${item.video_id}-${item.kind}`}
+                item={item}
+                onJumpToStage={onJumpToStage}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HitlQueueRow({
+  item,
+  onJumpToStage,
+}: {
+  item: HitlQueueItem;
+  onJumpToStage?: (stageNumber: number, videoId: string) => void;
+}) {
+  const Icon = item.kind === "beep_missing" ? AlertCircle : Volume2;
+  return (
+    <li
+      className="flex items-center gap-3 rounded-md border bg-muted/20 px-2.5 py-2 text-sm"
+      data-testid={`hitl-row-${item.stage_number}-${item.kind}`}
+    >
+      <Icon
+        className={`size-4 shrink-0 ${
+          item.kind === "beep_missing"
+            ? "text-destructive"
+            : "text-muted-foreground"
+        }`}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium tabular-nums">
+            Stage {item.stage_number}
+          </span>
+          <Badge
+            variant={KIND_VARIANTS[item.kind]}
+            className="shrink-0 text-[10px] uppercase tracking-wide"
+          >
+            {KIND_LABELS[item.kind]}
+          </Badge>
+          {item.confidence !== null ? (
+            <span
+              className="text-xs tabular-nums text-muted-foreground"
+              title="Calibrated detector confidence in [0, 1]"
+            >
+              conf {item.confidence.toFixed(2)}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {item.suggested_action}
+        </p>
+      </div>
+      {onJumpToStage ? (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="shrink-0 gap-1"
+          onClick={() => onJumpToStage(item.stage_number, item.video_id)}
+        >
+          Open
+          <ArrowRight className="size-3.5" />
+        </Button>
+      ) : null}
+    </li>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/SettingProvenance.tsx
+++ b/src/splitsmith/ui_static/src/components/SettingProvenance.tsx
@@ -35,9 +35,10 @@ const SOURCE_CLASSES: Record<AutomationProvenanceSource, string> = {
   default: "border-border bg-muted text-muted-foreground",
 };
 
-function formatValue(value: boolean | null | undefined): string {
+function formatValue(value: boolean | number | null | undefined): string {
   if (value === true) return "on";
   if (value === false) return "off";
+  if (typeof value === "number") return value.toString();
   return "(unset)";
 }
 

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -14,14 +14,22 @@ export type VideoRole = "primary" | "secondary" | "ignored";
 export type BeepSource = "auto" | "manual" | "aligned";
 
 /** One ranked beep candidate emitted by ``detect-beep`` (issue #22).
- *  ``score`` is silence-preference (run_peak / pre-window mean); higher =
- *  more confident. ``beep_candidates[0]`` matches the promoted ``beep_time``
- *  on the parent ``StageVideo``. */
+ *  ``score`` is the composite ranking score: silence-preference tilted by
+ *  tonal concentration and duration plausibility. ``confidence`` is the
+ *  calibrated [0, 1] threshold value (#219 / #220 layer 3a) -- >=0.7
+ *  the auto-trust band, < 0.6 lands in the HITL queue. The raw
+ *  ``silence_score`` and ``tonal_score`` components are surfaced so the
+ *  candidate card can explain *why* a confidence is what it is.
+ *  ``beep_candidates[0]`` matches the promoted ``beep_time`` on the
+ *  parent ``StageVideo``. */
 export interface BeepCandidate {
   time: number;
   score: number;
   peak_amplitude: number;
   duration_ms: number;
+  silence_score: number;
+  tonal_score: number;
+  confidence: number;
 }
 
 /** Response from POST /api/stages/{n}/videos/{vid}/beep/snap. The user
@@ -62,6 +70,15 @@ export interface StageVideo {
   beep_reviewed: boolean;
   beep_peak_amplitude: number | null;
   beep_duration_ms: number | null;
+  /** Calibrated detector confidence in [0, 1] for the chosen beep
+   *  (#219 / #220 layer 3a). Manual entries clamp to 1.0; auto-detected
+   *  beeps carry the value the formula in ``beep_detect`` produced.
+   *  Null on legacy projects from before this field existed and on
+   *  ``beep_source == "aligned"`` where the detector confidence isn't
+   *  meaningful for a secondary. The HITL queue uses this against
+   *  ``automation.beep_low_confidence_threshold`` to decide whether
+   *  the beep needs review. */
+  beep_confidence: number | null;
   /** Ranked alternative candidates from the most recent auto-detection run.
    *  Empty when the project predates issue #22 or after a manual override. */
   beep_candidates: BeepCandidate[];
@@ -301,6 +318,11 @@ export interface ProjectSettingsPatch {
 /** Mirror of ``splitsmith.automation.AutomationOverride`` (#215). */
 export interface AutomationOverride {
   shot_detect_on_beep_verified?: boolean | null;
+  /** HITL gate threshold (#219). Auto-detected beeps with confidence
+   *  at or above this value pre-flip ``beep_reviewed`` so the
+   *  shot-detect chain fires; below it the beep lands in the HITL
+   *  queue and the user (or an agent) has to pick. Range [0, 1]. */
+  beep_low_confidence_threshold?: number | null;
 }
 
 /** Mirror of the resolved-settings shape returned by ``GET /api/automation``
@@ -309,6 +331,7 @@ export interface AutomationOverride {
 export interface ResolvedAutomationResponse {
   settings: {
     shot_detect_on_beep_verified: boolean;
+    beep_low_confidence_threshold: number;
   };
   provenance: Record<string, AutomationFieldProvenance>;
 }
@@ -319,11 +342,35 @@ export type AutomationProvenanceSource =
   | "global"
   | "default";
 
+/** Per-field source + values. ``cli_value`` / ``project_value`` /
+ *  ``global_value`` are bool-or-number because the automation block now
+ *  mixes toggles and thresholds. The provenance widget renders via
+ *  JSON.stringify so the union is invisible at the call site. */
 export interface AutomationFieldProvenance {
   source: AutomationProvenanceSource;
-  cli_value: boolean | null;
-  project_value: boolean | null;
-  global_value: boolean;
+  cli_value: boolean | number | null;
+  project_value: boolean | number | null;
+  global_value: boolean | number;
+}
+
+export type HitlItemKind = "beep_low_confidence" | "beep_missing";
+
+/** One row in the project's HITL queue (#219). Items are ordered by
+ *  stage_number ascending. ``confidence`` is null for ``beep_missing``
+ *  entries (no candidate was produced) and populated for
+ *  ``beep_low_confidence`` entries (the threshold value the auto-trust
+ *  gate measured against is in ``HitlQueueResponse.threshold``). */
+export interface HitlQueueItem {
+  kind: HitlItemKind;
+  stage_number: number;
+  video_id: string;
+  confidence: number | null;
+  suggested_action: string;
+}
+
+export interface HitlQueueResponse {
+  items: HitlQueueItem[];
+  threshold: number;
 }
 
 export interface NonEmptyOldDir {
@@ -1148,6 +1195,13 @@ export const api = {
 
   getAutomation: () =>
     request<ResolvedAutomationResponse>("/api/automation"),
+
+  /** Project-level work queue: beeps the auto-trust gate (#219) didn't
+   *  clear -- either missing (auto-detect found nothing) or below the
+   *  ``beep_low_confidence_threshold``. The HITL panel polls this on
+   *  the Ingest page; the MCP wrapper exposes it as a resource so an
+   *  agent can drive the picks. */
+  getHitlQueue: () => request<HitlQueueResponse>("/api/hitl-queue"),
 
   dismissNudge: (stageNumber: number, dismissed: boolean) =>
     request<MatchProject>("/api/project/nudges/dismiss", {

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -39,6 +39,7 @@ import {
 import { BeepSection } from "@/components/BeepSection";
 import { CleanupDialog } from "@/components/CleanupDialog";
 import { FolderPicker } from "@/components/FolderPicker";
+import { HitlQueuePanel } from "@/components/HitlQueuePanel";
 import { MountSelect } from "@/components/MountSelect";
 import { SettingProvenance } from "@/components/SettingProvenance";
 import { Badge } from "@/components/ui/badge";
@@ -511,6 +512,19 @@ export function Ingest() {
       {project ? (
         <>
           <ReadyBanner project={project} analysis={analysis} />
+          {project.stages.length > 0 ? (
+            <HitlQueuePanel
+              onJumpToStage={(stageNumber) => {
+                // Stage rows tag themselves with id="stage-row-{n}"
+                // (added below). Falling back to no-op when the row
+                // hasn't rendered yet keeps the click safe.
+                const el = document.getElementById(`stage-row-${stageNumber}`);
+                if (el) {
+                  el.scrollIntoView({ behavior: "smooth", block: "start" });
+                }
+              }}
+            />
+          ) : null}
           <UnassignedSection
             project={project}
             analysis={analysis}
@@ -1779,7 +1793,13 @@ function AutomationSettingsPanel({
   // resolved value): "inherit", "true", or "false". Resolution is
   // shown via the badge + the helper line so the user sees both
   // layers at once without the select lying about its state.
-  const projectValue: boolean | null | undefined = shotDetectProv?.project_value;
+  // ``project_value`` is union-typed (bool | number) since the
+  // automation block now mixes toggles and thresholds; this select
+  // controls a boolean toggle only, so anything non-boolean is
+  // treated as "inherit".
+  const projectValueRaw = shotDetectProv?.project_value;
+  const projectValue: boolean | null | undefined =
+    typeof projectValueRaw === "boolean" ? projectValueRaw : null;
   const selectValue: "inherit" | "on" | "off" =
     projectValue === true ? "on" : projectValue === false ? "off" : "inherit";
 
@@ -2531,6 +2551,9 @@ function StageCard({
 
   return (
     <Card
+      // Stable anchor for the HITL queue panel (#219): clicking
+      // "Open" on a low-confidence row scrolls to this stage.
+      id={`stage-row-${stage.stage_number}`}
       className={cn(
         hasConflict && "border-status-warning",
         canAccept && "border-dashed border-ring/50",


### PR DESCRIPTION
## Summary

Surfaces the layer-3b `GET /api/hitl-queue` endpoint in the SPA so the user sees what the auto-trust gate didn't clear without scanning every stage card. Threads the calibrated confidence through the per-candidate cards.

- **`HitlQueuePanel.tsx`** -- polls `/api/hitl-queue` every 5s, renders one row per item: kind badge (`Low confidence` / `No beep found`), stage number, confidence chip, `suggested_action` text, "Open" button.
- **"Open" scrolls to the relevant `StageCard`** via a new `id="stage-row-{n}"` anchor. No-op when the row hasn't rendered yet (defensive).
- **Candidate card surface** now reads `conf 0.84 . tonal 0.96 . 340 ms` -- calibrated value first, components in the tooltip.
- **Type plumbing**: `BeepCandidate.confidence` / `silence_score` / `tonal_score`, `StageVideo.beep_confidence`, `automation.beep_low_confidence_threshold` added to the TS mirror types. `AutomationFieldProvenance` value type widens to `boolean | number` since the automation block now mixes toggles and thresholds; `SettingProvenance` handles both, the shot-detect-on-beep-verified select narrows back to bool via a type guard.

## UI verification status

- TypeScript typecheck clean (`npm run typecheck`)
- Production build clean (`npm run build`)
- I have NOT driven a browser end-to-end. Visual checks owed:
  - Empty state ("All beeps confirmed") on a project with no flagged stages
  - Populated state (low-confidence + missing items)
  - "Open" button scrolls smoothly to the right stage card
  - Confidence chip on candidate rows reads sensibly

## Out of scope (layer 3c follow-ups)

- MCP wrapper exposing `/api/hitl-queue` as a resource (separate repo).
- "Next" / "Prev" navigation between queue items inside the candidate picker.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Python tests still 224/224 (`uv run pytest tests/test_ui_server.py tests/test_automation.py tests/test_beep_detect.py`)
- [ ] Manual browser verification (owed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)