### PR TITLE
match export: lift mixed-frame-rate restriction (FCPXML / FCP7) (#233)

### DIFF
--- a/src/splitsmith/fcp7xml_render.py
+++ b/src/splitsmith/fcp7xml_render.py
@@ -45,6 +45,7 @@ from .composition import (
     Stage,
     Transform,
 )
+from .config import VideoMetadata
 
 
 def render_fcp7xml(
@@ -292,14 +293,18 @@ def _emit_file(
     parent: ET.Element,
     *,
     path: Path,
-    duration_frames: int,
-    width: int,
-    height: int,
-    timebase: int,
-    ntsc: bool,
+    meta: VideoMetadata,
     file_ids: dict[Path, str],
     has_audio: bool,
 ) -> None:
+    """Emit a ``<file>`` referencing the source media.
+
+    The ``<rate>`` and ``<duration>`` come from the source's own
+    metadata (#233): for mixed-rate timelines the underlying file's
+    frame rate must match its actual encoding so xmeml-aware readers
+    (Premiere, Resolve) conform correctly. The clipitem above this
+    file keeps the sequence rate for spine-relative timing.
+    """
     file_id, first_use = _file_id_for(path, file_ids)
     if not first_use:
         ET.SubElement(parent, "file", {"id": file_id})
@@ -307,13 +312,15 @@ def _emit_file(
     file_el = ET.SubElement(parent, "file", {"id": file_id})
     _text(file_el, "name", path.name)
     _text(file_el, "pathurl", path.resolve().as_uri())
-    _emit_rate(file_el, timebase, ntsc)
-    _text(file_el, "duration", str(duration_frames))
+    file_timebase, file_ntsc = _fcp7_rate(meta.frame_rate_num, meta.frame_rate_den)
+    _emit_rate(file_el, file_timebase, file_ntsc)
+    file_fd = meta.frame_rate_den / meta.frame_rate_num
+    _text(file_el, "duration", str(round(meta.duration_seconds / file_fd)))
     media = ET.SubElement(file_el, "media")
     video = ET.SubElement(media, "video")
     sample = ET.SubElement(video, "samplecharacteristics")
-    _text(sample, "width", str(width))
-    _text(sample, "height", str(height))
+    _text(sample, "width", str(meta.width))
+    _text(sample, "height", str(meta.height))
     if has_audio:
         audio = ET.SubElement(media, "audio")
         _text(audio, "channelcount", "2")
@@ -346,11 +353,7 @@ def _emit_primary_clipitem(
     _emit_file(
         clip,
         path=stage.primary.path,
-        duration_frames=plan.primary_duration_frames,
-        width=stage.primary.metadata.width,
-        height=stage.primary.metadata.height,
-        timebase=timebase,
-        ntsc=ntsc,
+        meta=stage.primary.metadata,
         file_ids=file_ids,
         has_audio=True,
     )
@@ -416,11 +419,7 @@ def _emit_secondary_clipitem(
     _emit_file(
         clip,
         path=secondary.asset.path,
-        duration_frames=sec_duration_frames,
-        width=sec_meta.width,
-        height=sec_meta.height,
-        timebase=timebase,
-        ntsc=ntsc,
+        meta=sec_meta,
         file_ids=file_ids,
         has_audio=True,
     )
@@ -463,11 +462,7 @@ def _emit_overlay_clipitem(
     _emit_file(
         clip,
         path=overlay.asset.path,
-        duration_frames=overlay_duration_frames,
-        width=overlay.asset.metadata.width,
-        height=overlay.asset.metadata.height,
-        timebase=timebase,
-        ntsc=ntsc,
+        meta=overlay.asset.metadata,
         file_ids=file_ids,
         has_audio=False,
     )

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -856,31 +856,12 @@ def generate_match_fcpxml(
             "semantic. Use lower-third titles, or remove transitions."
         )
 
+    # Sequence rate / size is taken from stage 0; per-asset rates and
+    # sizes can differ and are emitted as their own ``<format>`` so FCP
+    # conforms each asset to the timeline at edit time. The previous
+    # hard guard on mixed rates (#233) was unnecessarily restrictive --
+    # FCPXML supports per-asset formats by design.
     base = stages[0].video
-    for stage in stages[1:]:
-        if (
-            stage.video.frame_rate_num != base.frame_rate_num
-            or stage.video.frame_rate_den != base.frame_rate_den
-        ):
-            raise ValueError(
-                "mixed frame rates across stages are not supported "
-                f"(stage 0: {base.frame_rate_num}/{base.frame_rate_den}, "
-                f"stage with {stage.video_path.name}: "
-                f"{stage.video.frame_rate_num}/{stage.video.frame_rate_den})"
-            )
-    for label, segment in (("intro", intro), ("outro", outro)):
-        if segment is None:
-            continue
-        if (
-            segment.video.frame_rate_num != base.frame_rate_num
-            or segment.video.frame_rate_den != base.frame_rate_den
-        ):
-            raise ValueError(
-                f"{label} frame rate "
-                f"({segment.video.frame_rate_num}/{segment.video.frame_rate_den}) "
-                f"does not match the timeline "
-                f"({base.frame_rate_num}/{base.frame_rate_den})"
-            )
 
     frame_duration = Fraction(base.frame_rate_den, base.frame_rate_num)
     fd_num = base.frame_rate_den
@@ -910,17 +891,54 @@ def generate_match_fcpxml(
     # stage (each stage's overlay sits above that stage's secondaries only).
     resource_counter = 1  # r1 already used by format
 
+    # Multi-rate / multi-resolution support (#233). Each unique
+    # (frame_rate, width, height) tuple gets its own ``<format>``;
+    # assets reference theirs so FCP conforms to the sequence rate at
+    # edit time. The sequence's own format covers stage 0 by default.
+    formats_by_key: dict[tuple[int, int, int, int], str] = {
+        (base.frame_rate_num, base.frame_rate_den, base.width, base.height): format_id
+    }
+
+    def _format_id_for(meta: VideoMetadata) -> str:
+        """Return the format id for an asset matching ``meta``'s rate +
+        resolution. Allocates and emits a new ``<format>`` resource
+        when no existing one matches."""
+        nonlocal resource_counter
+        key = (meta.frame_rate_num, meta.frame_rate_den, meta.width, meta.height)
+        existing = formats_by_key.get(key)
+        if existing is not None:
+            return existing
+        resource_counter += 1
+        new_id = f"r{resource_counter}"
+        formats_by_key[key] = new_id
+        meta_fd_num = meta.frame_rate_den
+        meta_fd_den = meta.frame_rate_num
+        ET.SubElement(
+            resources,
+            "format",
+            {
+                "id": new_id,
+                "name": _format_name(meta),
+                "frameDuration": _frame_aligned_str(1, meta_fd_num, meta_fd_den),
+                "width": str(meta.width),
+                "height": str(meta.height),
+                "colorSpace": "1-1-1 (Rec. 709)",
+            },
+        )
+        return new_id
+
     @dataclass
     class _StagePlan:
         stage: StageComposition
         primary_id: str
+        primary_format_id: str
         primary_duration_frames: int
         head_trim_frames: int
         effective_duration_frames: int
-        # cam, asset_id, sec_dur_in_parent_frames
-        usable_secondaries: list[tuple[SecondaryClip, str, int]]
+        # cam, asset_id, asset_format_id, sec_dur_in_parent_frames
+        usable_secondaries: list[tuple[SecondaryClip, str, str, int]]
         overlay_asset_id: str | None
-        overlay_format_id: str | None  # None when overlay reuses the timeline format
+        overlay_format_id: str | None
         overlay_duration_frames: int  # in parent frame units; 0 when no overlay
 
     plans: list[_StagePlan] = []
@@ -955,26 +973,31 @@ def generate_match_fcpxml(
                 "or check the trimmed clip length"
             )
 
+        # Each asset references the format matching its source rate +
+        # resolution; ``_format_id_for`` allocates + emits the
+        # ``<format>`` resource on first sighting (#233). Format
+        # resources land in the XML in discovery order, interleaved
+        # with asset emissions further down.
+        primary_format_id = _format_id_for(stage.video)
         resource_counter += 1
         primary_id = f"r{resource_counter}"
 
-        usable_secondaries: list[tuple[SecondaryClip, str, int]] = []
+        usable_secondaries: list[tuple[SecondaryClip, str, str, int]] = []
         for sec in stage.secondaries:
             if not sec.video_path.exists():
                 continue
+            sec_format_id = _format_id_for(sec.video)
             resource_counter += 1
             sec_id = f"r{resource_counter}"
             sec_dur_in_parent_frames = int(round(sec.video.duration_seconds / fd_seconds))
-            usable_secondaries.append((sec, sec_id, sec_dur_in_parent_frames))
+            usable_secondaries.append((sec, sec_id, sec_format_id, sec_dur_in_parent_frames))
 
         overlay_asset_id: str | None = None
         overlay_format_id: str | None = None
         overlay_duration_frames = 0
         if stage.overlay_path is not None and stage.overlay_path.exists():
             overlay_meta = stage.overlay_video if stage.overlay_video is not None else stage.video
-            if _overlay_format_differs(stage.video, overlay_meta):
-                resource_counter += 1
-                overlay_format_id = f"r{resource_counter}"
+            overlay_format_id = _format_id_for(overlay_meta)
             resource_counter += 1
             overlay_asset_id = f"r{resource_counter}"
             overlay_duration_frames = int(round(overlay_meta.duration_seconds / fd_seconds))
@@ -983,6 +1006,7 @@ def generate_match_fcpxml(
             _StagePlan(
                 stage=stage,
                 primary_id=primary_id,
+                primary_format_id=primary_format_id,
                 primary_duration_frames=primary_duration_frames,
                 head_trim_frames=head_trim_frames,
                 effective_duration_frames=effective_duration_frames,
@@ -994,7 +1018,10 @@ def generate_match_fcpxml(
         )
 
     # Emit assets in the same order resource IDs were assigned so the XML
-    # reads top-to-bottom in stage order.
+    # reads top-to-bottom in stage order. Each asset references its own
+    # ``<format>`` (allocated above via ``_format_id_for``); the spine
+    # asset-clips below stay in the sequence's frame_duration so FCP
+    # conforms each asset at edit time (#233).
     for plan in plans:
         primary_asset = ET.SubElement(
             resources,
@@ -1006,7 +1033,7 @@ def generate_match_fcpxml(
                 "duration": _frame_aligned_str(plan.primary_duration_frames, fd_num, fd_den),
                 "hasVideo": "1",
                 "hasAudio": "1",
-                "format": format_id,
+                "format": plan.primary_format_id,
                 "videoSources": "1",
                 "audioSources": "1",
                 "audioChannels": "2",
@@ -1017,7 +1044,7 @@ def generate_match_fcpxml(
             "media-rep",
             {"kind": "original-media", "src": plan.stage.video_path.resolve().as_uri()},
         )
-        for sec, sec_id, _sec_dur_in_parent_frames in plan.usable_secondaries:
+        for sec, sec_id, sec_format_id, _sec_dur_in_parent_frames in plan.usable_secondaries:
             sec_asset = ET.SubElement(
                 resources,
                 "asset",
@@ -1039,7 +1066,7 @@ def generate_match_fcpxml(
                     ),
                     "hasVideo": "1",
                     "hasAudio": "1",
-                    "format": format_id,
+                    "format": sec_format_id,
                     "videoSources": "1",
                     "audioSources": "1",
                     "audioChannels": "2",
@@ -1051,29 +1078,7 @@ def generate_match_fcpxml(
                 {"kind": "original-media", "src": sec.video_path.resolve().as_uri()},
             )
         if plan.overlay_asset_id is not None and plan.stage.overlay_path is not None:
-            if plan.overlay_format_id is not None:
-                overlay_meta = (
-                    plan.stage.overlay_video
-                    if plan.stage.overlay_video is not None
-                    else plan.stage.video
-                )
-                overlay_fd_num = overlay_meta.frame_rate_den
-                overlay_fd_den = overlay_meta.frame_rate_num
-                ET.SubElement(
-                    resources,
-                    "format",
-                    {
-                        "id": plan.overlay_format_id,
-                        "name": _format_name(overlay_meta),
-                        "frameDuration": _frame_aligned_str(1, overlay_fd_num, overlay_fd_den),
-                        "width": str(overlay_meta.width),
-                        "height": str(overlay_meta.height),
-                        "colorSpace": "1-1-1 (Rec. 709)",
-                    },
-                )
-                overlay_asset_format = plan.overlay_format_id
-            else:
-                overlay_asset_format = format_id
+            assert plan.overlay_format_id is not None  # set whenever overlay_asset_id is
             overlay_asset = ET.SubElement(
                 resources,
                 "asset",
@@ -1084,7 +1089,7 @@ def generate_match_fcpxml(
                     "duration": _frame_aligned_str(plan.overlay_duration_frames, fd_num, fd_den),
                     "hasVideo": "1",
                     "hasAudio": "0",
-                    "format": overlay_asset_format,
+                    "format": plan.overlay_format_id,
                     "videoSources": "1",
                 },
             )
@@ -1161,27 +1166,33 @@ def generate_match_fcpxml(
     total_slate_frames = sum(slate_frames_by_index.values())
 
     # Intro / outro asset resources (issue #173). One ``<asset>`` per
-    # segment; the spine references it via ``asset-clip``. Frame rate
-    # matches the timeline (validated above) so we reuse format_id.
+    # segment; the spine references it via ``asset-clip``. Per-asset
+    # ``<format>`` lets the segment carry a different frame rate than
+    # the timeline (#233); FCP conforms at edit time.
     intro_asset_id: str | None = None
+    intro_format_id: str | None = None
     intro_duration_frames = 0
     if intro is not None:
+        intro_format_id = _format_id_for(intro.video)
         resource_counter += 1
         intro_asset_id = f"r{resource_counter}"
         intro_duration_frames = round(intro.video.duration_seconds / fd_seconds)
     outro_asset_id: str | None = None
+    outro_format_id: str | None = None
     outro_duration_frames = 0
     if outro is not None:
+        outro_format_id = _format_id_for(outro.video)
         resource_counter += 1
         outro_asset_id = f"r{resource_counter}"
         outro_duration_frames = round(outro.video.duration_seconds / fd_seconds)
-    for segment, asset_id, dur_frames in (
-        (intro, intro_asset_id, intro_duration_frames),
-        (outro, outro_asset_id, outro_duration_frames),
+    for segment, asset_id, asset_format, dur_frames in (
+        (intro, intro_asset_id, intro_format_id, intro_duration_frames),
+        (outro, outro_asset_id, outro_format_id, outro_duration_frames),
     ):
         if segment is None:
             continue
         assert asset_id is not None
+        assert asset_format is not None
         seg_asset = ET.SubElement(
             resources,
             "asset",
@@ -1192,7 +1203,7 @@ def generate_match_fcpxml(
                 "duration": _frame_aligned_str(dur_frames, fd_num, fd_den),
                 "hasVideo": "1",
                 "hasAudio": "1",
-                "format": format_id,
+                "format": asset_format,
                 "videoSources": "1",
                 "audioSources": "1",
                 "audioChannels": "2",
@@ -1303,7 +1314,7 @@ def generate_match_fcpxml(
         # follows from delta = (beep_offset - head_trim) - sec_beep in
         # frames; a non-negative delta places the cam later in the parent's
         # local time, a negative delta skips into the cam's own media.
-        for lane_idx, (sec, sec_id, sec_dur_in_parent_frames) in enumerate(
+        for lane_idx, (sec, sec_id, _sec_format_id, sec_dur_in_parent_frames) in enumerate(
             plan.usable_secondaries, start=1
         ):
             delta_frames = round(

--- a/src/splitsmith/mp4_render.py
+++ b/src/splitsmith/mp4_render.py
@@ -74,6 +74,29 @@ def render_mp4(
     plans = [_plan_stage(stage, composition.sequence) for stage in composition.stages]
     if not plans:
         raise ValueError("render_mp4 requires at least one stage")
+
+    # The concat-demuxer pipeline (stream-copy) requires every per-stage
+    # temp share the same frame rate as the sequence. The FCPXML / FCP7
+    # path lifted this restriction in #233 because their NLE readers
+    # conform per-asset rates; the MP4 path can't conform without
+    # re-encoding through an ``fps=`` filter, which is a larger
+    # change than this issue's scope. Surface a clear error naming the
+    # offenders so the user knows whether to switch renderer or
+    # convert sources externally.
+    seq = composition.sequence
+    mismatched: list[str] = []
+    for stage in composition.stages:
+        meta = stage.primary.metadata
+        if meta.frame_rate_num != seq.frame_rate_num or meta.frame_rate_den != seq.frame_rate_den:
+            mismatched.append(f"{stage.name} ({meta.frame_rate_num}/{meta.frame_rate_den})")
+    if mismatched:
+        raise ValueError(
+            f"mp4 renderer requires all stages at the timeline frame rate "
+            f"({seq.frame_rate_num}/{seq.frame_rate_den}); these stages differ: "
+            + ", ".join(mismatched)
+            + ". Switch to the FCPXML or FCP7 renderer (which conform "
+            "per-asset rates) or convert the sources to a shared rate first."
+        )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     if work_dir is None:

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -360,6 +360,46 @@ def test_fcpxml_match_with_chapter_markers_validates(tmp_path: Path) -> None:
 
 
 @fcpxml_dtd
+def test_fcpxml_match_with_mixed_frame_rates_validates(tmp_path: Path) -> None:
+    """#233 -- per-stage primaries at different frame rates each get
+    their own ``<format>`` resource; the sequence + spine math stay in
+    stage 0's frame_duration so FCP conforms each asset at edit time.
+    The structural test in test_fcpxml_gen.py covers the format ID
+    plumbing; this gate confirms the result still validates against
+    Apple's DTD."""
+    primary_a = _make_video(tmp_path, "a.mp4")
+    primary_b = _make_video(tmp_path, "b.mp4")
+    out = tmp_path / "match.fcpxml"
+    stages = [
+        StageComposition(
+            stage_name="A",
+            video_path=primary_a,
+            video=_meta_30fps(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+        StageComposition(
+            stage_name="B",
+            video_path=primary_b,
+            video=_meta_2997(),
+            shots=[_shot(1, 1.0, 1.0)],
+            beep_offset_seconds=5.0,
+            head_pad_seconds=5.0,
+            tail_pad_seconds=5.0,
+        ),
+    ]
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="mixed-rates",
+        config=OutputConfig(),
+    )
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())
+
+
+@fcpxml_dtd
 def test_invalid_fcpxml_fails_validation(tmp_path: Path) -> None:
     """Sanity: hand-rolled bad FCPXML must trip the validator. Catches
     helper regressions (e.g. xmllint flags wrong / DTD path silently

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1031,36 +1031,60 @@ def test_match_fcpxml_overlay_skips_into_media_when_head_trimmed(tmp_path: Path)
     assert overlay_clip.attrib["lane"] == "1"
 
 
-def test_match_fcpxml_raises_on_mixed_frame_rates(tmp_path: Path) -> None:
+def test_match_fcpxml_supports_mixed_frame_rates(tmp_path: Path) -> None:
+    """#233 -- mixed primary frame rates across stages no longer hard-
+    fail. Each asset references its own ``<format>`` so FCP conforms
+    to the timeline (taken from stage 0) at edit time. Spine timing
+    stays in sequence frame_duration units."""
     v1 = _make_video(tmp_path, "stage1.mp4")
     v2 = _make_video(tmp_path, "stage2.mp4")
     out = tmp_path / "match.fcpxml"
-    with pytest.raises(ValueError, match="mixed frame rates"):
-        generate_match_fcpxml(
-            stages=[
-                StageComposition(
-                    stage_name="stage1",
-                    video_path=v1,
-                    video=_meta_30fps(),
-                    shots=[],
-                    beep_offset_seconds=5.0,
-                    head_pad_seconds=5.0,
-                    tail_pad_seconds=5.0,
-                ),
-                StageComposition(
-                    stage_name="stage2",
-                    video_path=v2,
-                    video=_meta_2997(),
-                    shots=[],
-                    beep_offset_seconds=5.0,
-                    head_pad_seconds=5.0,
-                    tail_pad_seconds=5.0,
-                ),
-            ],
-            output_path=out,
-            project_name="match",
-            config=OutputConfig(),
-        )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=5.0,
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=_meta_2997(),
+                shots=[],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=5.0,
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    # Two distinct formats: 30/1 (stage 0) + 30000/1001 (stage 1's 29.97).
+    assert len(formats) == 2
+    frame_durations = {f.attrib["frameDuration"] for f in formats}
+    assert frame_durations == {"1/30s", "1001/30000s"}
+    # Each asset references the format matching its own rate.
+    assets = root.findall("./resources/asset")
+    asset_format_refs = [a.attrib["format"] for a in assets]
+    fid_by_fd = {f.attrib["frameDuration"]: f.attrib["id"] for f in formats}
+    assert asset_format_refs[0] == fid_by_fd["1/30s"]
+    assert asset_format_refs[1] == fid_by_fd["1001/30000s"]
+    # Sequence keeps the stage-0 format; spine asset-clips read in that
+    # frame_duration so FCP conforms each asset.
+    sequence = root.find("./library/event/project/sequence")
+    assert sequence is not None
+    assert sequence.attrib["format"] == fid_by_fd["1/30s"]
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    assert len(spine_clips) == 2
+    for clip in spine_clips:
+        assert clip.attrib["format"] == fid_by_fd["1/30s"]
 
 
 def test_match_fcpxml_raises_on_empty_stages(tmp_path: Path) -> None:
@@ -1682,10 +1706,15 @@ def test_intro_extends_sequence_duration(tmp_path: Path) -> None:
     assert duration_frames == 330 + 324 + 150
 
 
-def test_intro_with_mismatched_frame_rate_raises(tmp_path: Path) -> None:
+def test_intro_with_mismatched_frame_rate_emits_per_asset_format(
+    tmp_path: Path,
+) -> None:
+    """#233 -- intro at a different rate from the timeline no longer
+    raises. The intro asset references its own ``<format>`` so FCP
+    conforms it to the timeline at edit time."""
     primary_a, primary_b, out = _two_stage_match(tmp_path)
     stages = _basic_match_stages(primary_a, primary_b)
-    bad_intro = fcpxml_mod.IntroOutroSegment(
+    intro = fcpxml_mod.IntroOutroSegment(
         video_path=_make_video(tmp_path, "intro_60fps.mp4"),
         video=VideoMetadata(
             width=1920,
@@ -1694,16 +1723,20 @@ def test_intro_with_mismatched_frame_rate_raises(tmp_path: Path) -> None:
             frame_rate_num=60,
             frame_rate_den=1,
         ),
-        name="Bad",
+        name="Intro",
     )
-    with pytest.raises(ValueError, match="intro frame rate"):
-        generate_match_fcpxml(
-            stages=stages,
-            output_path=out,
-            project_name="match",
-            config=OutputConfig(),
-            intro=bad_intro,
-        )
+    generate_match_fcpxml(
+        stages=stages,
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+        intro=intro,
+    )
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    # Sequence format (stage 0's 30fps) + intro's 60fps.
+    durs = {f.attrib["frameDuration"] for f in formats}
+    assert "1/60s" in durs
 
 
 def test_intro_missing_file_raises_filenotfound(tmp_path: Path) -> None:

--- a/tests/test_mp4_render.py
+++ b/tests/test_mp4_render.py
@@ -486,3 +486,40 @@ def test_render_mp4_requires_at_least_one_stage(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="at least one stage"):
         mp4_render.render_mp4(comp, output_path=tmp_path / "out.mp4", work_dir=tmp_path / "work")
+
+
+def test_render_mp4_rejects_mixed_frame_rates_with_clear_message(
+    tmp_path: Path,
+) -> None:
+    """#233 -- the MP4 renderer can't conform per-asset rates without
+    re-encoding through ``fps=``. Surface a clear error naming the
+    offending stage and pointing the user at the FCPXML / FCP7
+    renderers which do conform."""
+    meta_60 = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=60,
+        frame_rate_den=1,
+    )
+    stage_a = StageComposition(
+        stage_name="A",
+        video_path=_make_video(tmp_path, "a.mp4"),
+        video=_meta_30fps(),
+        shots=[_shot(1, 1.0, 1.0)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=10.0,
+        tail_pad_seconds=20.0,
+    )
+    stage_b = StageComposition(
+        stage_name="B",
+        video_path=_make_video(tmp_path, "b.mp4"),
+        video=meta_60,
+        shots=[_shot(1, 1.0, 1.0)],
+        beep_offset_seconds=5.0,
+        head_pad_seconds=10.0,
+        tail_pad_seconds=20.0,
+    )
+    comp = composition.from_stage_compositions([stage_a, stage_b], project_name="match")
+    with pytest.raises(ValueError, match="mp4 renderer requires"):
+        mp4_render.render_mp4(comp, output_path=tmp_path / "out.mp4", work_dir=tmp_path / "work")


### PR DESCRIPTION
Closes #233.

## Summary

The match composer previously raised \`ValueError\` when stages had different frame rates -- needlessly strict for FCPXML / FCP7 XML, both of which support per-asset rates with timeline conform.

- **FCPXML**: sequence keeps stage 0's rate; each \`<asset>\` references its own \`<format>\` (allocated by a new \`_format_id_for\` helper that dedupes by rate + resolution). Spine asset-clips stay in sequence frame_duration so FCP conforms each asset at edit time. DTD-validated.
- **FCP7 XML**: \`_emit_file\` now reads \`<rate>\` + \`<duration>\` from the source's own metadata. Clipitem timing stays in sequence frames; xmeml-aware readers conform on import.
- **MP4**: keeps the restriction (the concat-demuxer pipeline can't conform per-asset rates without re-encoding through \`fps=\`). The error message now names the offenders and points at the FCPXML / FCP7 alternative.

## Tradeoffs

- Spine \`start\`/\`offset\`/\`duration\` stay in sequence frame_duration units across all renderers. Strictly speaking the asset-clip's \`start\` should be quantized to the asset's frame grid; in practice FCP / Premiere / Resolve all conform internally. If we ever see drift in a real test, we can revisit and round per-asset.
- The MP4 path *could* grow a conform mode via \`-vf fps=\`, but it requires re-encoding the whole pipeline (no more \`-c copy\` on the concat) and is real work. Filed as a follow-up implicitly via the new error message.

## Test plan

- [x] \`uv run pytest -q\` -- 920 passing (+2 new), 4 skipped
- [x] DTD validation passes for the mixed-rate FCPXML output
- [x] \`ruff check\` + \`black --check\` clean
- [ ] Manual: import the mixed-rate FCPXML into FCP and confirm the timeline plays both stages without warnings
- [ ] Manual: same for the FCP7 XML in Premiere / Resolve
- [ ] Manual: confirm the MP4 path now surfaces the named-stages error in the SPA dialog instead of the raw \"mixed frame rates\" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)