### PR TITLE
fcpxml: cap cam duration + match asset-clip format to asset (#236)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -1300,7 +1300,10 @@ def generate_match_fcpxml(
                 "ref": plan.primary_id,
                 "offset": _frame_aligned_str(cumulative_offset_frames, fd_num, fd_den),
                 "name": stage.stage_name,
-                "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                # ``start`` is the offset into the asset's own media -- emit
+                # in the primary's frame grid so FCP doesn't treat it as
+                # off-grid (#236).
+                "start": _asset_grid_str(head_trim_seconds, stage.video),
                 "duration": eff_duration_str,
                 # Asset-clip format references the asset's own format
                 # (#236). For all-30p stages this still equals the
@@ -1356,7 +1359,11 @@ def generate_match_fcpxml(
                     "lane": str(lane_idx),
                     "offset": _frame_aligned_str(sec_offset_frames, fd_num, fd_den),
                     "name": sec.label,
-                    "start": _frame_aligned_str(sec_start_frames, fd_num, fd_den),
+                    # ``start`` is into the cam's source media -- must
+                    # be quantized to the cam's frame grid (#236). Emit
+                    # in the cam's denominator so FCP doesn't treat
+                    # off-grid values as malformed and drop transforms.
+                    "start": _asset_grid_str(sec_start_frames * fd_seconds, sec.video),
                     "duration": _frame_aligned_str(sec_visible_frames, fd_num, fd_den),
                     # Asset-clip format must match the asset's actual
                     # format, not the sequence's. When they diverge (mixed
@@ -1367,6 +1374,12 @@ def generate_match_fcpxml(
                     "format": sec_format_id,
                 },
             )
+            # Mute the cam's audio on the timeline (#236). The asset
+            # itself keeps ``hasAudio="1"`` (the file does), but the
+            # match flow uses only the primary's audio; the cams ride
+            # for video alignment alone. -96 dB is FCP's "effectively
+            # silent" sentinel.
+            ET.SubElement(sec_clip, "adjust-volume", {"amount": "-96dB"})
             _attach_pip_transform(
                 sec_clip,
                 sec.pip,
@@ -1383,6 +1396,11 @@ def generate_match_fcpxml(
             # primary's visible start instead of head_trim seconds earlier.
             head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
             assert plan.overlay_format_id is not None  # set whenever overlay_asset_id is
+            overlay_meta = (
+                plan.stage.overlay_video
+                if plan.stage.overlay_video is not None
+                else plan.stage.video
+            )
             ET.SubElement(
                 primary_clip,
                 "asset-clip",
@@ -1391,7 +1409,9 @@ def generate_match_fcpxml(
                     "lane": str(overlay_lane),
                     "offset": head_trim_str,
                     "name": "Splitsmith overlay",
-                    "start": head_trim_str,
+                    # ``start`` is on the overlay asset's grid; emit in
+                    # the overlay's frame_duration units (#236).
+                    "start": _asset_grid_str(head_trim_seconds, overlay_meta),
                     "duration": eff_duration_str,
                     # Match the asset's actual format (#236). Same
                     # rationale as the cam asset-clips above.
@@ -1576,6 +1596,24 @@ def _frame_aligned_str(frames: int, fd_num: int, fd_den: int) -> str:
     if fd_den == 1:
         return f"{num}s"
     return f"{num}/{fd_den}s"
+
+
+def _asset_grid_str(seconds: float, meta: VideoMetadata) -> str:
+    """Format ``seconds`` quantized to the asset's frame grid + emit
+    with the asset's frame_duration denominator (#236).
+
+    ``<asset-clip start>`` is in the *asset's* timebase; emitting with
+    the sequence's denominator (when source rate differs from
+    sequence) makes FCP treat the value as off-grid and silently drop
+    overrides applied to the clip -- including ``<adjust-transform>``
+    for PiP placement. The wall-clock time is the same; the
+    representation has to match the asset's frameDuration.
+    """
+    fd_num = meta.frame_rate_den
+    fd_den = meta.frame_rate_num
+    fd_seconds = fd_num / fd_den
+    frames = round(seconds / fd_seconds)
+    return _frame_aligned_str(frames, fd_num, fd_den)
 
 
 def _overlay_format_differs(primary: VideoMetadata, overlay: VideoMetadata) -> bool:

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -1244,6 +1244,7 @@ def generate_match_fcpxml(
 
     # Intro segment (issue #173): plays first, full duration.
     if intro_asset_id is not None and intro is not None:
+        assert intro_format_id is not None
         intro_clip = ET.SubElement(
             spine,
             "asset-clip",
@@ -1253,7 +1254,7 @@ def generate_match_fcpxml(
                 "name": intro.name or intro.video_path.stem,
                 "start": "0s",
                 "duration": _frame_aligned_str(intro_duration_frames, fd_num, fd_den),
-                "format": format_id,
+                "format": intro_format_id,
             },
         )
         if chapter_markers:
@@ -1301,7 +1302,12 @@ def generate_match_fcpxml(
                 "name": stage.stage_name,
                 "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
                 "duration": eff_duration_str,
-                "format": format_id,
+                # Asset-clip format references the asset's own format
+                # (#236). For all-30p stages this still equals the
+                # sequence format; for mixed-rate stages (#233) it
+                # matches the primary's true format so FCP doesn't
+                # silently drop overrides applied to this clip.
+                "format": plan.primary_format_id,
             },
         )
 
@@ -1314,7 +1320,7 @@ def generate_match_fcpxml(
         # follows from delta = (beep_offset - head_trim) - sec_beep in
         # frames; a non-negative delta places the cam later in the parent's
         # local time, a negative delta skips into the cam's own media.
-        for lane_idx, (sec, sec_id, _sec_format_id, sec_dur_in_parent_frames) in enumerate(
+        for lane_idx, (sec, sec_id, sec_format_id, sec_dur_in_parent_frames) in enumerate(
             plan.usable_secondaries, start=1
         ):
             delta_frames = round(
@@ -1327,6 +1333,21 @@ def generate_match_fcpxml(
             else:
                 sec_offset_frames = plan.head_trim_frames
                 sec_start_frames = -delta_frames
+            # Cap the cam's visible duration to the parent's remaining
+            # visible window (#236). Without the cap a long cam clip
+            # extends past the primary's right edge in FCP, which the
+            # user reads as "trim not applied". Mirrors the MP4 renderer's
+            # ``min(cam_total - seek, effective - spine_start)`` math.
+            parent_visible_end = plan.head_trim_frames + plan.effective_duration_frames
+            cam_remaining = sec_dur_in_parent_frames - sec_start_frames
+            cam_room = parent_visible_end - sec_offset_frames
+            sec_visible_frames = max(0, min(cam_remaining, cam_room))
+            if sec_visible_frames == 0:
+                # Nothing of the cam fits in the parent's visible window
+                # (timing pushed it entirely past the right edge). Skip
+                # emitting the clip rather than producing a zero-length
+                # asset-clip the DTD rejects.
+                continue
             sec_clip = ET.SubElement(
                 primary_clip,
                 "asset-clip",
@@ -1336,8 +1357,14 @@ def generate_match_fcpxml(
                     "offset": _frame_aligned_str(sec_offset_frames, fd_num, fd_den),
                     "name": sec.label,
                     "start": _frame_aligned_str(sec_start_frames, fd_num, fd_den),
-                    "duration": _frame_aligned_str(sec_dur_in_parent_frames, fd_num, fd_den),
-                    "format": format_id,
+                    "duration": _frame_aligned_str(sec_visible_frames, fd_num, fd_den),
+                    # Asset-clip format must match the asset's actual
+                    # format, not the sequence's. When they diverge (mixed
+                    # rates after #233) FCP can drop transforms applied
+                    # to the clip -- including <adjust-transform> for
+                    # PiP. Using sec_format_id makes the format consistent
+                    # so PiP renders. (#236)
+                    "format": sec_format_id,
                 },
             )
             _attach_pip_transform(
@@ -1355,6 +1382,7 @@ def generate_match_fcpxml(
             # of the parent's visible start) so the overlay anchors at the
             # primary's visible start instead of head_trim seconds earlier.
             head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
+            assert plan.overlay_format_id is not None  # set whenever overlay_asset_id is
             ET.SubElement(
                 primary_clip,
                 "asset-clip",
@@ -1365,7 +1393,9 @@ def generate_match_fcpxml(
                     "name": "Splitsmith overlay",
                     "start": head_trim_str,
                     "duration": eff_duration_str,
-                    "format": format_id,
+                    # Match the asset's actual format (#236). Same
+                    # rationale as the cam asset-clips above.
+                    "format": plan.overlay_format_id,
                 },
             )
 
@@ -1458,6 +1488,7 @@ def generate_match_fcpxml(
 
     # Outro segment (issue #173): plays after the last stage's primary.
     if outro_asset_id is not None and outro is not None:
+        assert outro_format_id is not None
         outro_clip = ET.SubElement(
             spine,
             "asset-clip",
@@ -1467,7 +1498,7 @@ def generate_match_fcpxml(
                 "name": outro.name or outro.video_path.stem,
                 "start": "0s",
                 "duration": _frame_aligned_str(outro_duration_frames, fd_num, fd_den),
-                "format": format_id,
+                "format": outro_format_id,
             },
         )
         if chapter_markers:

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1146,6 +1146,99 @@ def test_match_fcpxml_caps_cam_duration_to_parent_visible_window(
     assert cam_dur_frames <= 90
 
 
+def test_match_fcpxml_cam_clip_mutes_audio(tmp_path: Path) -> None:
+    """#236 -- cam audio shouldn't compete with the primary's on the
+    timeline. Emit ``<adjust-volume amount=\"-96dB\"/>`` on every cam
+    asset-clip so FCP imports the cam silent."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=20.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="mute",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    primary_clip = root.find("./library/event/project/sequence/spine/asset-clip")
+    assert primary_clip is not None
+    cam_clip = primary_clip.find("asset-clip")
+    assert cam_clip is not None
+    volume = cam_clip.find("adjust-volume")
+    assert volume is not None
+    assert volume.attrib["amount"] == "-96dB"
+
+
+def test_match_fcpxml_cam_start_uses_cam_frame_grid(tmp_path: Path) -> None:
+    """#236 -- cam asset-clip's ``start`` is in the cam's own
+    frame_duration; emitting it with the sequence's denominator (when
+    cam rate differs) makes FCP treat the value as off-grid and silently
+    drop overrides applied to the clip."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    cam_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        # 60p source on a 30p timeline -- the case from the user's report.
+        frame_rate_num=60,
+        frame_rate_den=1,
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=8.0,
+                head_pad_seconds=2.0,  # head_trim = 6s
+                tail_pad_seconds=20.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=cam_meta,
+                        beep_offset_seconds=10.0,  # cam beep is later -> seek into cam
+                        label="Cam",
+                        pip=PipPlacement(corner="top-right"),
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="grid",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    primary_clip = root.find("./library/event/project/sequence/spine/asset-clip")
+    assert primary_clip is not None
+    cam_clip = primary_clip.find("asset-clip")
+    assert cam_clip is not None
+    # delta = (8 - 6) - 10 = -8s -> seek 8s into cam media. At 60p that's 480
+    # cam frames, expressed as 480/60s. Crucially the denominator is 60 (cam
+    # frame rate), not 30000 (sequence's frame_duration denominator).
+    assert cam_clip.attrib["start"] == "480/60s"
+
+
 def test_match_fcpxml_cam_asset_clip_format_matches_cam_format(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -25,6 +25,8 @@ from splitsmith.config import (
 )
 from splitsmith.fcpxml_gen import (
     FFprobeError,
+    PipPlacement,
+    SecondaryClip,
     StageComposition,
     generate_fcpxml,
     generate_match_fcpxml,
@@ -1076,15 +1078,126 @@ def test_match_fcpxml_supports_mixed_frame_rates(tmp_path: Path) -> None:
     fid_by_fd = {f.attrib["frameDuration"]: f.attrib["id"] for f in formats}
     assert asset_format_refs[0] == fid_by_fd["1/30s"]
     assert asset_format_refs[1] == fid_by_fd["1001/30000s"]
-    # Sequence keeps the stage-0 format; spine asset-clips read in that
-    # frame_duration so FCP conforms each asset.
+    # Sequence keeps the stage-0 format; each spine asset-clip
+    # references the format of its underlying asset (#236) so FCP
+    # doesn't drop overrides applied to the clip.
     sequence = root.find("./library/event/project/sequence")
     assert sequence is not None
     assert sequence.attrib["format"] == fid_by_fd["1/30s"]
     spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
     assert len(spine_clips) == 2
-    for clip in spine_clips:
-        assert clip.attrib["format"] == fid_by_fd["1/30s"]
+    assert spine_clips[0].attrib["format"] == fid_by_fd["1/30s"]
+    assert spine_clips[1].attrib["format"] == fid_by_fd["1001/30000s"]
+
+
+def test_match_fcpxml_caps_cam_duration_to_parent_visible_window(
+    tmp_path: Path,
+) -> None:
+    """#236 -- a cam whose source duration exceeds the parent's visible
+    window must be capped to the window. Without the cap FCP renders
+    the cam past the primary's right edge ("trim not applied")."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    cam_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        # 30s of cam vs a 20s primary that gets trimmed to ~5s on the spine.
+        duration_seconds=30.0,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),  # 20s @ 30p
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=1.0,  # head_trim = 4s
+                tail_pad_seconds=1.0,  # tail_trim = 13s; effective = 3s
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=cam_meta,
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                        pip=PipPlacement(corner="top-right"),
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="cap",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    primary_clip = root.find("./library/event/project/sequence/spine/asset-clip")
+    assert primary_clip is not None
+    cam_clip = primary_clip.find("asset-clip")
+    assert cam_clip is not None
+    # Parent visible window is head_trim_frames + effective_duration_frames =
+    # 120 + 90 = 210 frames at 30p, in source coords. Cam offset (parent
+    # source-time) starts at head_trim_frames = 120; cam_room = 210 - 120 = 90.
+    # Cap should yield duration <= 90 frames (3s).
+    cam_dur = cam_clip.attrib["duration"]
+    cam_dur_frames = int(cam_dur.split("/")[0])
+    assert cam_dur_frames <= 90
+
+
+def test_match_fcpxml_cam_asset_clip_format_matches_cam_format(
+    tmp_path: Path,
+) -> None:
+    """#236 -- the cam asset-clip's ``format`` attribute must reference
+    the cam's own format, not the sequence's. When they differ FCP
+    can drop overrides applied to the clip (PiP transforms, etc.)."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    cam_meta = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=60,
+        frame_rate_den=1,
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=20.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=cam_meta,
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                        pip=PipPlacement(corner="top-right"),
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="format-match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    fid_by_fd = {f.attrib["frameDuration"]: f.attrib["id"] for f in formats}
+    primary_clip = root.find("./library/event/project/sequence/spine/asset-clip")
+    assert primary_clip is not None
+    cam_clip = primary_clip.find("asset-clip")
+    assert cam_clip is not None
+    # Cam is 60p; its asset-clip must reference the 60p format id.
+    assert cam_clip.attrib["format"] == fid_by_fd["1/60s"]
+    # And the PiP transform is in place.
+    assert cam_clip.find("adjust-transform") is not None
 
 
 def test_match_fcpxml_raises_on_empty_stages(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #236.

Found in tallmilan-2026 match export -- mixed-rate stages (60p head-cam, 30p primary) produced two coupled symptoms.

## Bug 1 -- cam duration overflows parent

Cam connected-clip \`duration\` was the cam's full source duration, not capped against the parent primary's remaining visible window. FCP rendered the cam past the primary's right edge, which the user reads as \"secondary trim isn't working.\"

Fix mirrors the MP4 renderer's cap:

\`\`\`
sec_visible = min(cam_total - sec_start, parent_visible_end - sec_offset)
\`\`\`

Cams that don't intersect the visible window at all are skipped rather than emitted as zero-length clips.

## Bug 2 -- PiP transform present but not applied

The \`<adjust-transform>\` was emitted, but FCP played the cam at full frame anyway. Root cause: every asset-clip carried \`format=\"r1\"\` (the sequence) while the underlying asset referenced its own per-source \`<format>\` (\`r3\`, \`r7\`, ...). FCP can drop overrides applied to clips when the asset-clip's format doesn't match its asset.

Fix: each asset-clip now uses the asset's own format id. Applied to:
- Primary spine asset-clip (\`plan.primary_format_id\`)
- Cam connected asset-clips (\`sec_format_id\`)
- Overlay connected asset-clips (\`plan.overlay_format_id\`)
- Intro / outro spine asset-clips (\`intro_format_id\` / \`outro_format_id\`)

For all-same-rate exports nothing changes; the asset's format equals the sequence's.

## Out of scope

\`generate_fcpxml\` (single-stage) has the same latent pattern. Filed separately if the user hits it on a per-stage export.

## Test plan

- [x] \`uv run pytest -q\` -- 930 passing (+2 new), 4 skipped
- [x] \`ruff check\` + \`black --check\` clean
- [x] DTD validation continues to pass
- [ ] Manual: re-export the tallmilan-2026 match; confirm cams render in their PiP corners and end at the primary's right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)