### PR TITLE
fcpxml: emit PiP position in FCPXML normalized units (#236)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -144,8 +144,28 @@ def _pip_transform_attrs(
     sequence_width: int,
     sequence_height: int,
 ) -> dict[str, str]:
-    """Format ``<adjust-transform>`` attributes for ``pip`` in this sequence."""
-    scale, (x, y) = pip.resolve(sequence_width=sequence_width, sequence_height=sequence_height)
+    """Format ``<adjust-transform>`` attributes for ``pip`` in this sequence.
+
+    FCPXML's ``position`` is in normalized units where ``100`` equals
+    the sequence's full height in pixels (i.e. one unit equals
+    ``sequence_height / 100`` px). Discovered empirically (#236):
+    raw-pixel emit produced a ``position`` value FCP UI displayed at
+    exactly ``sequence_height / 100`` x the intended pixel offset
+    (21.6x on a 4K timeline), pushing the cam off-screen.
+
+    The value is resolution-independent in this convention -- a top-
+    right corner at scale 0.25 and 2% margin emits the same normalized
+    position on 1080p and 4K timelines.
+
+    ``scale`` stays a unit-less ratio (1.0 == native size); only
+    position needs the conversion.
+    """
+    scale, (x_px, y_px) = pip.resolve(
+        sequence_width=sequence_width, sequence_height=sequence_height
+    )
+    unit_per_px = 100.0 / sequence_height
+    x = x_px * unit_per_px
+    y = y_px * unit_per_px
     return {
         "scale": f"{scale:g} {scale:g}",
         "position": f"{x:g} {y:g}",

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -77,14 +77,18 @@ def test_sequence_format_from_video_copies_dims_and_rate() -> None:
     ["top-right", "top-left", "bottom-right", "bottom-left"],
 )
 def test_pip_placement_resolve_matches_emitter_attrs(corner: str) -> None:
-    """``PipPlacement.resolve`` is the single source of truth for both the
-    IR's ``Transform`` and the FCPXML emitter's attribute strings -- if
-    the two ever disagreed the bridge would silently drift."""
+    """``PipPlacement.resolve`` is the IR's pixel-space source of truth;
+    the FCPXML emitter scales those pixels into FCPXML's normalized
+    ``100 == sequence_height`` position units (#236). The conversion is
+    a fixed scalar for a given sequence height, so both the IR and the
+    emitter still agree on placement -- they just speak different units.
+    """
     pip = PipPlacement(corner=corner)  # type: ignore[arg-type]
-    scale, (x, y) = pip.resolve(sequence_width=1920, sequence_height=1080)
+    scale, (x_px, y_px) = pip.resolve(sequence_width=1920, sequence_height=1080)
     attrs = fcpxml_gen._pip_transform_attrs(pip, sequence_width=1920, sequence_height=1080)
     assert attrs["scale"] == f"{scale:g} {scale:g}"
-    assert attrs["position"] == f"{x:g} {y:g}"
+    unit = 100.0 / 1080
+    assert attrs["position"] == f"{x_px * unit:g} {y_px * unit:g}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1375,6 +1375,10 @@ def _expected_pip_attrs(
     margin_pct: float,
     corner: str,
 ) -> dict[str, str]:
+    """Mirror of ``_pip_transform_attrs``: pixel position from
+    ``PipPlacement.resolve`` then converted to FCPXML's normalized
+    units (100 == sequence_height in pixels). See #236 for derivation.
+    """
     half_w = seq_w / 2.0
     half_h = seq_h / 2.0
     clip_half_w = half_w * scale
@@ -1389,7 +1393,11 @@ def _expected_pip_attrs(
         y = half_h - clip_half_h - margin_y
     else:
         y = -(half_h - clip_half_h - margin_y)
-    return {"scale": f"{scale:g} {scale:g}", "position": f"{x:g} {y:g}"}
+    unit_per_px = 100.0 / seq_h
+    return {
+        "scale": f"{scale:g} {scale:g}",
+        "position": f"{x * unit_per_px:g} {y * unit_per_px:g}",
+    }
 
 
 def test_secondary_without_pip_emits_no_transform(tmp_path: Path) -> None:
@@ -1463,10 +1471,11 @@ def test_secondary_with_pip_emits_corner_transform(corner: str, tmp_path: Path) 
     assert transform.attrib == expected
 
 
-def test_pip_position_scales_with_sequence_dimensions(tmp_path: Path) -> None:
-    """At a 4K sequence with ``scale=0.25, margin_pct=2.0`` the absolute
-    pixel position is twice the 1080p value -- the clip stays anchored to
-    the same fractional corner regardless of resolution."""
+def test_pip_position_is_resolution_independent(tmp_path: Path) -> None:
+    """#236 -- FCPXML position is in normalized "100 == sequence_height"
+    units. ``scale=0.25, margin_pct=2.0, corner="top-right"`` emits the
+    same position string on 1080p and 4K timelines (only the pixel
+    offset differs; the normalized value stays put)."""
     video = tmp_path / "v.mp4"
     video.write_bytes(b"")
     secondary = tmp_path / "cam.mp4"
@@ -1498,6 +1507,12 @@ def test_pip_position_scales_with_sequence_dimensions(tmp_path: Path) -> None:
         seq_w=3840, seq_h=2160, scale=0.25, margin_pct=2.0, corner="top-right"
     )
     assert transform.attrib == expected
+    # Resolution-independent: the same PiP at 1080p emits the same
+    # normalized position string.
+    expected_1080 = _expected_pip_attrs(
+        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner="top-right"
+    )
+    assert expected_1080["position"] == expected["position"]
 
 
 def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:


### PR DESCRIPTION
Found via user inspection in FCP 12.2: cams emitted with PiP transforms were placed off-screen because their \`position\` value was 21.6x the intended pixel offset.

## Diagnosis

User opened the cam's Transform inspector and reported X=29445.1 px, Y=16562.9 px. We emit position=\"1363.2 766.8\" for top-right at scale 0.25 / margin 2% on a 4K (3840x2160) sequence. The ratio 29445.1 / 1363.2 = 21.5944 matches **2160 / 100** exactly -- pinning down the unit.

FCPXML's \`<adjust-transform position>\` is in **normalized units where 100 == sequence_height in pixels** (one unit == sequence_height / 100 px). Our emitter has been treating it as raw pixels since #193, which only happened to look right when the amplified value rounded to 0.

## Fix

\`_pip_transform_attrs\` now multiplies the resolved pixel coordinates by \`100.0 / sequence_height\` before emit. The IR continues to carry pixel-space values (\`Transform.position\` docstring already says pixel-units; only the FCPXML attribute string needs the conversion).

Side effect: the emitted position is now resolution-independent. A top-right corner at scale 0.25 + margin 2% emits the same normalized string on 1080p and 4K timelines.

## Tests

- \`_expected_pip_attrs\` helper mirrors the new conversion.
- New assertion: 1080p and 4K produce identical \`position\` strings (resolution-independence guarantee).
- \`test_pip_placement_resolve_matches_emitter_attrs\` updated to expect the unit conversion (resolve returns pixels, the emitter normalizes).

## Manual verification (asked from user)

After this lands and re-export: confirm cams render in the configured corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)