### PR TITLE
fcpxml: update Basic Title UID for FCP 12.x layout (#240)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -665,11 +665,16 @@ _TRANSITION_NAMES: dict[TransitionKind, str] = {
 
 TitleStyle = Literal["slate", "lower-third"]
 
-# FCP's "Basic Title" generator. Stable across FCP versions and the
-# safest cross-installation pick; templates that require non-default
-# Motion library availability are intentionally avoided.
+# FCP's "Basic Title" generator. Apple changed the bundle layout
+# between FCP 11 and 12: in 12.x the file lives at
+# ``PETemplates.localized/Titles.localized/Bumper:Opener.localized/
+# Basic Title.localized/Basic Title.moti`` (note ``.moti`` extension
+# and the ``Bumper:Opener`` parent that didn't exist in 10.x/11.x).
+# We target the 12.x path because that's what current FCP versions
+# ship; older installations will surface a missing-effect warning on
+# import (the user can re-pick the title manually). #240.
 _BASIC_TITLE_EFFECT_UID = (
-    ".../Generators.localized/Titles.localized/" "Basic Title.localized/Basic Title.motn"
+    ".../Titles.localized/Bumper:Opener.localized/" "Basic Title.localized/Basic Title.moti"
 )
 
 

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -2051,7 +2051,7 @@ def test_match_with_slate_title_emits_basic_title_effect(tmp_path: Path) -> None
     effects = root.findall("./resources/effect")
     assert len(effects) == 1
     assert effects[0].attrib["name"] == "Basic Title"
-    assert effects[0].attrib["uid"].endswith("Basic Title.motn")
+    assert effects[0].attrib["uid"].endswith("Basic Title.moti")
 
 
 def test_slate_title_lands_on_spine_before_primary(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #240.

FCP 12.2 failed to import the match export with:

\`\`\`
The item could not be read. (uid=\".../Generators.localized/Titles.localized/Basic Title.localized/Basic Title.motn\")
\`\`\`

Apple changed the bundled-generator layout between FCP 11 and 12:

| FCP version | Path |
|---|---|
| 10.x / 11.x | \`PETemplates.localized/Generators.localized/Titles.localized/Basic Title.localized/Basic Title.motn\` |
| 12.x | \`PETemplates.localized/Titles.localized/Bumper:Opener.localized/Basic Title.localized/Basic Title.moti\` |

Two changes: dropped the \`Generators.localized\` parent, added \`Bumper:Opener.localized\`, and the file extension is now \`.moti\` (not \`.motn\`).

The DTD didn't catch this -- it only validates structure, not UID resolution.

## Tradeoff

Older FCP installations (10.x / 11.x) will surface a missing-effect warning after this fix. With one user on FCP 12.2 and no others on the path today, the like-for-like swap is the simplest move. A future improvement would be to fall back across UIDs or to switch to \"Essential Title\" (the modern Apple-recommended title generator), but that's a larger change because the parameter set differs.

## Re-test

Re-export the match after this lands and confirm the import goes through. If PiP also renders correctly (#239 should have fixed that), we can move on to the transition black-video issue (#238).

🤖 Generated with [Claude Code](https://claude.com/claude-code)