### PR TITLE
fcpxml: rotate PiP corner cycle clockwise from top-left

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -34,11 +34,13 @@ from .config import OutputConfig, Shot, SplitColorThresholds, VideoMetadata
 PipCorner = Literal["top-right", "top-left", "bottom-right", "bottom-left"]
 
 # Corner cycle order when PiP is requested without an explicit per-cam corner.
-# Top-right first because that's where the user typically wants the headcam-
-# vs-handheld layout to land for an IPSC stage view.
+# Top-left first, then clockwise -- the natural reading order for the user
+# scanning a stitched match: first cam takes the top-left, the next wraps
+# around to the right, then bottom-right, then bottom-left. This is the
+# default until per-cam corner overrides land in a layout-template feature.
 _PIP_CORNER_CYCLE: tuple[PipCorner, ...] = (
-    "top-right",
     "top-left",
+    "top-right",
     "bottom-right",
     "bottom-left",
 )

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1516,8 +1516,10 @@ def test_pip_position_is_resolution_independent(tmp_path: Path) -> None:
 
 
 def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:
-    """Multiple cams without explicit pip get TR -> TL -> BR -> BL when
-    ``apply_pip_corner_cycle`` is asked to inject a default."""
+    """Multiple cams without explicit pip get TL -> TR -> BR -> BL
+    (clockwise from the top-left) when ``apply_pip_corner_cycle`` is
+    asked to inject a default. The order matches reading flow so the
+    first cam is most prominent at the top-left."""
     secs = tuple(
         fcpxml_mod.SecondaryClip(
             video_path=Path(f"cam{i}.mp4"),
@@ -1531,7 +1533,7 @@ def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:
         secs, default=fcpxml_mod.PipPlacement(scale=0.3, margin_pct=1.5)
     )
     corners = [s.pip.corner for s in laid_out]  # type: ignore[union-attr]
-    assert corners == ["top-right", "top-left", "bottom-right", "bottom-left"]
+    assert corners == ["top-left", "top-right", "bottom-right", "bottom-left"]
     # Default scale / margin propagate; corner is the only override.
     for s in laid_out:
         assert s.pip is not None
@@ -1560,7 +1562,7 @@ def test_apply_pip_corner_cycle_preserves_explicit() -> None:
     )
     assert laid_out[0] is explicit  # untouched
     assert laid_out[1].pip is not None
-    assert laid_out[1].pip.corner == "top-right"  # cycle starts at TR
+    assert laid_out[1].pip.corner == "top-left"  # cycle starts at TL
 
 
 def test_apply_pip_corner_cycle_default_none_is_noop() -> None:


### PR DESCRIPTION
Small reorder of the auto-cycle for stages without explicit per-cam corners. Today's order TR -> TL -> BR -> BL puts the first cam in the same corner where the stage name overlay sits; switching to clockwise-from-top-left (TL -> TR -> BR -> BL) keeps the first cam visually distinct and matches Western reading flow.

Default until layout templates land. Tests updated to the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)