### PR TITLE
fcpxml: visible frame around PiP cams via Simple Border (#243)

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -677,6 +677,16 @@ _BASIC_TITLE_EFFECT_UID = (
     ".../Titles.localized/Bumper:Opener.localized/" "Basic Title.localized/Basic Title.moti"
 )
 
+# FCP's "Simple Border" video effect under Stylize (#243). Adds a thin
+# coloured outline around any clip; lives in ``PETemplates`` alongside
+# Basic Title. Used to make PiP cams visually distinct from the primary
+# at corner placements. The user can edit the border's colour /
+# thickness in FCP after import; we ship with the bundled defaults to
+# keep the XML small.
+_PIP_FRAME_EFFECT_UID = (
+    ".../Effects.localized/Stylize.localized/" "Simple Border.localized/Simple Border.moef"
+)
+
 
 @dataclass(frozen=True)
 class StageTitle:
@@ -1182,6 +1192,30 @@ def generate_match_fcpxml(
             },
         )
 
+    # PiP frame effect resource (#243). One Simple Border effect
+    # referenced by every cam asset-clip with a PiP transform; the
+    # frame defaults (thin white outline) come from the bundled
+    # effect's parameters and stay editable in FCP. Skip emission
+    # when no cam has PiP -- the cam covers the timeline at full
+    # frame and a frame would be a no-op visual.
+    pip_frame_effect_id: str | None = None
+    if any(
+        sec.pip is not None
+        for plan in plans
+        for sec, _sec_id, _sec_format_id, _sec_dur in plan.usable_secondaries
+    ):
+        resource_counter += 1
+        pip_frame_effect_id = f"r{resource_counter}"
+        ET.SubElement(
+            resources,
+            "effect",
+            {
+                "id": pip_frame_effect_id,
+                "name": "Simple Border",
+                "uid": _PIP_FRAME_EFFECT_UID,
+            },
+        )
+
     titles_by_index: dict[int, StageTitle] = {ti.stage_index: ti for ti in titles}
     slate_frames_by_index: dict[int, int] = {
         idx: round(ti.duration_seconds / fd_seconds)
@@ -1411,6 +1445,15 @@ def generate_match_fcpxml(
                 sequence_width=base.width,
                 sequence_height=base.height,
             )
+            # Visible frame around the PiP cam (#243). Only when the
+            # cam is corner-positioned (sec.pip is set); a stacked
+            # full-frame cam doesn't need it.
+            if sec.pip is not None and pip_frame_effect_id is not None:
+                ET.SubElement(
+                    sec_clip,
+                    "filter-video",
+                    {"ref": pip_frame_effect_id, "name": "Simple Border"},
+                )
 
         if plan.overlay_asset_id is not None:
             overlay_lane = len(plan.usable_secondaries) + 1

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1146,6 +1146,95 @@ def test_match_fcpxml_caps_cam_duration_to_parent_visible_window(
     assert cam_dur_frames <= 90
 
 
+def test_match_fcpxml_cam_with_pip_gets_simple_border_filter(
+    tmp_path: Path,
+) -> None:
+    """#243 -- cams with a PiP transform also get a Simple Border
+    ``<filter-video>`` so the corner inset has a visible frame.
+    The effect resource is allocated once and shared across cams."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=20.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                        pip=PipPlacement(corner="top-right"),
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="frame",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    effects = root.findall("./resources/effect")
+    border_effects = [e for e in effects if e.attrib.get("name") == "Simple Border"]
+    assert len(border_effects) == 1
+    border = border_effects[0]
+    assert border.attrib["uid"].endswith("Simple Border.moef")
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    filters = cam_clip.findall("filter-video")
+    assert len(filters) == 1
+    assert filters[0].attrib["ref"] == border.attrib["id"]
+
+
+def test_match_fcpxml_stacked_cam_has_no_frame_filter(tmp_path: Path) -> None:
+    """Stacked (full-frame) cams don't get the frame filter -- the
+    border would be a no-op visual since the cam already covers the
+    sequence. The effect resource is also skipped to keep the XML
+    tidy when no cam needs it."""
+    primary_path = _make_video(tmp_path, "stage1.mp4")
+    cam_path = _make_video(tmp_path, "stage1_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=primary_path,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=20.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam_path,
+                        video=_meta_30fps(),
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="no-frame",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    border_effects = [
+        e for e in root.findall("./resources/effect") if e.attrib.get("name") == "Simple Border"
+    ]
+    assert len(border_effects) == 0
+    cam_clip = root.find(".//spine/asset-clip/asset-clip")
+    assert cam_clip is not None
+    assert cam_clip.find("filter-video") is None
+
+
 def test_match_fcpxml_cam_clip_mutes_audio(tmp_path: Path) -> None:
     """#236 -- cam audio shouldn't compete with the primary's on the
     timeline. Emit ``<adjust-volume amount=\"-96dB\"/>`` on every cam


### PR DESCRIPTION
Closes #243.

Cams in their corner inset (PiP) blended into the primary's content because they had no visible boundary. Reference FCP's bundled \"Simple Border\" effect via \`<filter-video>\` on each cam asset-clip — same idiom as the title and transition effects.

UID points at the FCP 12.x bundle layout (alongside the Basic Title path in #240):

\`\`\`
.../Effects.localized/Stylize.localized/Simple Border.localized/Simple Border.moef
\`\`\`

Default colour and thickness come from the bundled effect; the user can edit per-cam in FCP's Effect inspector after import. Stacked (full-frame) cams skip the frame -- a border on a clip that covers the sequence is a no-op.

## Tradeoff

UID resolver fragility, same as Basic Title (#240). If Apple moves or renames Simple Border in a future FCP version, FCP will surface a missing-effect warning and the user re-picks. Trade accepted for the same reasons -- baking the frame into the cam render would force a re-encode of every cam at trim time, which is much heavier.

## Test plan

- [x] \`uv run pytest -q\` -- 934 passing (+2 new), 4 skipped
- [x] DTD validation passes
- [x] \`ruff check\` + \`black --check\` clean
- [ ] Manual: re-export the match and confirm each PiP cam shows a visible Simple Border in FCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)