### PR TITLE
ingest: relink raw/ symlinks after sources move (UI + API)

### DIFF
--- a/src/splitsmith/relink.py
+++ b/src/splitsmith/relink.py
@@ -1,0 +1,247 @@
+"""Relink registered video sources after they move on disk.
+
+Project ``raw/<name>`` entries are typically symlinks to the original
+recordings; ``project.json`` stores the relative ``raw/<name>`` path.
+When the originals move (e.g. onto a network share with a different
+folder layout), nothing in ``project.json`` needs to change -- only the
+symlink targets under ``raw/``.
+
+This module provides pure helpers used by both the API and tests:
+
+- :func:`inspect_links` reports the per-video link status (ok / broken /
+  missing / not-a-symlink) for the current project.
+- :func:`index_search_root` recursively walks a folder and indexes
+  videos by lowercase basename.
+- :func:`plan_relink` matches the project's registered videos against
+  that index, defaulting to the single-candidate match when the basename
+  is unique inside the search root.
+- :func:`apply_relink` rewrites the symlinks atomically (delete + create
+  in one step, mirroring ``ln -sfn``).
+
+All functions are pure aside from :func:`apply_relink`, which is the
+single place that mutates the filesystem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from .ui.project import VIDEO_EXTENSIONS, MatchProject
+
+LinkStatus = Literal["ok", "broken", "missing_link", "not_a_symlink"]
+
+
+@dataclass(frozen=True)
+class LinkInfo:
+    """Filesystem state of one ``raw/<name>`` entry.
+
+    ``target`` is the symlink target as stored on disk (may be relative).
+    ``status`` reduces the four-state matrix to a single label the UI
+    can colour-code.
+    """
+
+    video_id: str
+    name: str
+    link_path: Path
+    target: Path | None
+    is_symlink: bool
+    target_exists: bool
+    status: LinkStatus
+
+
+@dataclass(frozen=True)
+class RelinkCandidate:
+    """One row in the relink plan: registered video + matches found in
+    the search root.
+
+    ``chosen_path`` defaults to the only candidate when exactly one was
+    found, leaves ``None`` for zero or many (the UI surfaces ambiguity).
+    """
+
+    video_id: str
+    name: str
+    link_path: Path
+    current_target: Path | None
+    current_status: LinkStatus
+    candidates: list[Path] = field(default_factory=list)
+    chosen_path: Path | None = None
+
+    @property
+    def ambiguous(self) -> bool:
+        return len(self.candidates) > 1
+
+    @property
+    def found(self) -> bool:
+        return bool(self.candidates)
+
+
+@dataclass(frozen=True)
+class AppliedRelink:
+    """Result of one applied symlink rewrite."""
+
+    video_id: str
+    name: str
+    link_path: Path
+    previous_target: Path | None
+    new_target: Path
+
+
+def _link_status(link_path: Path) -> tuple[LinkStatus, Path | None, bool, bool]:
+    """Inspect a ``raw/<name>`` entry. Returns ``(status, target,
+    is_symlink, target_exists)``.
+
+    Uses ``os.path.islink`` semantics via ``Path.is_symlink`` -- a broken
+    symlink is detected as a symlink whose target doesn't resolve.
+    """
+    if not link_path.exists() and not link_path.is_symlink():
+        return "missing_link", None, False, False
+    if link_path.is_symlink():
+        target = Path(link_path.readlink())
+        # Resolve relative targets against the link's parent so we report
+        # the actual file we're pointing at.
+        resolved = target if target.is_absolute() else (link_path.parent / target).resolve()
+        target_exists = resolved.exists()
+        return ("ok" if target_exists else "broken"), target, True, target_exists
+    # Plain file -- not a symlink. Could be a registered copy (link_mode
+    # = "copy") or a stray. Either way relinking doesn't apply.
+    return "not_a_symlink", None, False, link_path.exists()
+
+
+def inspect_links(project: MatchProject, root: Path) -> list[LinkInfo]:
+    """Report current link status for every registered video.
+
+    Stages are walked in declaration order and each video appears once;
+    if the same path is registered to multiple roles, the first
+    occurrence wins (matches :meth:`MatchProject.all_videos`).
+    """
+    raw_dir = project.raw_path(root)
+    out: list[LinkInfo] = []
+    seen: set[str] = set()
+    for video in project.all_videos():
+        link_path = (root / video.path) if not video.path.is_absolute() else video.path
+        # Project paths are stored as ``raw/<name>``; the registry only
+        # ever points inside ``raw_dir``. Resolving against root keeps
+        # the helper correct even if the user has overridden ``raw_dir``.
+        if not link_path.is_absolute():
+            link_path = raw_dir / link_path.name
+        key = str(link_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        status, target, is_symlink, target_exists = _link_status(link_path)
+        out.append(
+            LinkInfo(
+                video_id=video.video_id,
+                name=link_path.name,
+                link_path=link_path,
+                target=target,
+                is_symlink=is_symlink,
+                target_exists=target_exists,
+                status=status,
+            )
+        )
+    return out
+
+
+def index_search_root(search_root: Path) -> dict[str, list[Path]]:
+    """Recursively index video files under ``search_root`` by
+    lowercase basename.
+
+    Multiple files with the same basename in different subfolders are
+    all collected; callers surface the ambiguity to the user. Only files
+    with extensions in :data:`VIDEO_EXTENSIONS` are indexed.
+
+    Symlinks inside the search root are followed via ``rglob`` default
+    behaviour (``Path.rglob`` does not follow dir symlinks by default,
+    which is what we want -- avoids cycles on network shares).
+    """
+    if not search_root.exists():
+        raise FileNotFoundError(f"search root does not exist: {search_root}")
+    if not search_root.is_dir():
+        raise NotADirectoryError(f"search root is not a directory: {search_root}")
+    index: dict[str, list[Path]] = {}
+    for entry in search_root.rglob("*"):
+        if not entry.is_file():
+            continue
+        if entry.suffix.lower() not in VIDEO_EXTENSIONS:
+            continue
+        index.setdefault(entry.name.lower(), []).append(entry.resolve())
+    # Stable order so dry-run output is deterministic for tests.
+    for paths in index.values():
+        paths.sort()
+    return index
+
+
+def plan_relink(
+    links: list[LinkInfo],
+    index: dict[str, list[Path]],
+) -> list[RelinkCandidate]:
+    """Build a relink plan: each registered video gets the candidate
+    paths found in the search root (matched by lowercase basename).
+
+    ``chosen_path`` is filled in only when exactly one candidate exists
+    *and* it differs from the current target. The UI can override on
+    apply.
+    """
+    out: list[RelinkCandidate] = []
+    for info in links:
+        candidates = list(index.get(info.name.lower(), []))
+        chosen: Path | None = None
+        if len(candidates) == 1:
+            single = candidates[0]
+            # Skip the no-op case so the apply step doesn't re-write
+            # an already-correct symlink.
+            if info.target is None or info.target.resolve() != single:
+                chosen = single
+        out.append(
+            RelinkCandidate(
+                video_id=info.video_id,
+                name=info.name,
+                link_path=info.link_path,
+                current_target=info.target,
+                current_status=info.status,
+                candidates=candidates,
+                chosen_path=chosen,
+            )
+        )
+    return out
+
+
+def apply_relink(
+    decisions: list[tuple[Path, Path]],
+) -> list[AppliedRelink]:
+    """Rewrite each symlink to its new target (``ln -sfn`` equivalent).
+
+    ``decisions`` is a list of ``(link_path, new_target)`` pairs. The
+    new target is stored as an absolute path so the symlink survives
+    project-root moves. The previous target is captured for the
+    response so the UI can show a "was -> now" diff.
+
+    Refuses to operate on entries that exist and are not symlinks (the
+    ``not_a_symlink`` status). Callers should filter those out first.
+    """
+    applied: list[AppliedRelink] = []
+    for link_path, new_target in decisions:
+        new_target_abs = new_target if new_target.is_absolute() else new_target.resolve()
+        previous: Path | None = None
+        if link_path.is_symlink():
+            previous = Path(link_path.readlink())
+            link_path.unlink()
+        elif link_path.exists():
+            raise ValueError(
+                f"refusing to overwrite non-symlink at {link_path} (status not_a_symlink)"
+            )
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(new_target_abs)
+        applied.append(
+            AppliedRelink(
+                video_id="",  # filled in by callers that know the project
+                name=link_path.name,
+                link_path=link_path,
+                previous_target=previous,
+                new_target=new_target_abs,
+            )
+        )
+    return applied

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -10,6 +10,9 @@ Endpoints (locked v1 surface):
   POST /api/videos/scan             -- register videos (folder or explicit paths)
   POST /api/videos/auto-match       -- run video_match.py heuristic, return suggestions
   POST /api/videos/remove           -- remove a registered video + cleanup caches
+  GET  /api/videos/link-status      -- per-video raw/<name> symlink state (ok/broken/...)
+  POST /api/videos/relink/scan      -- recursive dry-run: candidates per video
+  POST /api/videos/relink/apply     -- apply chosen symlink rewrites
   GET  /api/project/cleanup/plan    -- preview disk-cleanup plan
   POST /api/project/cleanup         -- apply disk-cleanup (refuses while jobs run)
   POST /api/assignments/move        -- set role / unassign / move between stages
@@ -783,6 +786,75 @@ class ScanResponse(BaseModel):
     registered: list[str]
     auto_assigned: dict[int, str]
     skipped: list[str]
+
+
+class RelinkScanRequest(BaseModel):
+    """Body for POST /api/videos/relink/scan.
+
+    Walks ``search_root`` recursively, indexes videos by basename, and
+    matches them against the project's registered ``raw/<name>``
+    entries. Pure dry-run: never touches the filesystem.
+    """
+
+    search_root: str
+
+
+class RelinkApplyRequest(BaseModel):
+    """Body for POST /api/videos/relink/apply.
+
+    ``decisions`` maps ``video_id`` to the absolute filesystem path the
+    user picked (typically one of the candidates returned by the scan
+    endpoint, or a manually-typed override). Any video_id not listed is
+    left untouched.
+    """
+
+    decisions: dict[str, str]
+
+
+class RelinkEntryResponse(BaseModel):
+    video_id: str
+    name: str
+    link_path: str
+    current_target: str | None
+    current_status: str
+    candidates: list[str]
+    chosen_path: str | None
+    ambiguous: bool
+    found: bool
+
+
+class RelinkScanResponse(BaseModel):
+    search_root: str
+    entries: list[RelinkEntryResponse]
+
+
+class RelinkAppliedEntry(BaseModel):
+    video_id: str
+    name: str
+    link_path: str
+    previous_target: str | None
+    new_target: str
+
+
+class RelinkApplyResponse(BaseModel):
+    applied: list[RelinkAppliedEntry]
+
+
+class LinkStatusEntry(BaseModel):
+    video_id: str
+    name: str
+    link_path: str
+    current_target: str | None
+    status: str
+
+
+class LinkStatusResponse(BaseModel):
+    """Per-video filesystem status for the ``raw/<name>`` symlinks.
+    Surfaced separately from ``/api/project`` so we don't pollute the
+    persisted ``MatchProject`` model with computed fs state.
+    """
+
+    entries: list[LinkStatusEntry]
 
 
 class SettingsRequest(BaseModel):
@@ -1830,6 +1902,115 @@ def create_app(
             registered=registered,
             auto_assigned=auto_assigned,
             skipped=skipped,
+        )
+
+    @app.get("/api/videos/link-status", response_model=LinkStatusResponse)
+    def get_link_status() -> LinkStatusResponse:
+        """Per-video status of ``raw/<name>`` symlinks.
+
+        Lets the SPA badge broken / missing entries on the project page
+        without an extra walk on every project fetch.
+        """
+        from .. import relink as relink_mod
+
+        project = state.load()
+        infos = relink_mod.inspect_links(project, state.project_root)
+        return LinkStatusResponse(
+            entries=[
+                LinkStatusEntry(
+                    video_id=info.video_id,
+                    name=info.name,
+                    link_path=str(info.link_path),
+                    current_target=str(info.target) if info.target is not None else None,
+                    status=info.status,
+                )
+                for info in infos
+            ]
+        )
+
+    @app.post("/api/videos/relink/scan", response_model=RelinkScanResponse)
+    def relink_scan(req: RelinkScanRequest) -> RelinkScanResponse:
+        """Recursive dry-run: walk ``search_root`` and report per-video
+        candidates without touching the filesystem.
+        """
+        from .. import relink as relink_mod
+
+        search_root = Path(req.search_root).expanduser()
+        try:
+            index = relink_mod.index_search_root(search_root)
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        project = state.load()
+        infos = relink_mod.inspect_links(project, state.project_root)
+        plan = relink_mod.plan_relink(infos, index)
+        return RelinkScanResponse(
+            search_root=str(search_root.resolve()),
+            entries=[
+                RelinkEntryResponse(
+                    video_id=entry.video_id,
+                    name=entry.name,
+                    link_path=str(entry.link_path),
+                    current_target=(
+                        str(entry.current_target) if entry.current_target is not None else None
+                    ),
+                    current_status=entry.current_status,
+                    candidates=[str(p) for p in entry.candidates],
+                    chosen_path=str(entry.chosen_path) if entry.chosen_path is not None else None,
+                    ambiguous=entry.ambiguous,
+                    found=entry.found,
+                )
+                for entry in plan
+            ],
+        )
+
+    @app.post("/api/videos/relink/apply", response_model=RelinkApplyResponse)
+    def relink_apply(req: RelinkApplyRequest) -> RelinkApplyResponse:
+        """Apply a user-confirmed set of symlink rewrites.
+
+        ``project.json`` is not modified -- only the symlinks under
+        ``raw/`` are repointed. The video_id is preserved so the SPA
+        can match the response back to its rows.
+        """
+        from .. import relink as relink_mod
+
+        if not req.decisions:
+            raise HTTPException(status_code=400, detail="decisions must be non-empty")
+        project = state.load()
+        infos = {
+            info.video_id: info for info in relink_mod.inspect_links(project, state.project_root)
+        }
+        decisions: list[tuple[Path, Path]] = []
+        id_for_link: dict[Path, str] = {}
+        for video_id, target_str in req.decisions.items():
+            info = infos.get(video_id)
+            if info is None:
+                raise HTTPException(status_code=400, detail=f"unknown video_id: {video_id}")
+            if info.status == "not_a_symlink":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{info.name} is a regular file, not a symlink -- relink not supported",
+                )
+            target = Path(target_str).expanduser()
+            if not target.exists():
+                raise HTTPException(status_code=400, detail=f"target does not exist: {target}")
+            if not target.is_file():
+                raise HTTPException(status_code=400, detail=f"target is not a file: {target}")
+            decisions.append((info.link_path, target))
+            id_for_link[info.link_path] = video_id
+        applied = relink_mod.apply_relink(decisions)
+        return RelinkApplyResponse(
+            applied=[
+                RelinkAppliedEntry(
+                    video_id=id_for_link.get(entry.link_path, ""),
+                    name=entry.name,
+                    link_path=str(entry.link_path),
+                    previous_target=(
+                        str(entry.previous_target) if entry.previous_target is not None else None
+                    ),
+                    new_target=str(entry.new_target),
+                )
+                for entry in applied
+            ]
         )
 
     @app.post("/api/project/settings")

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -59,6 +59,14 @@ interface FolderPickerProps {
    *  includes whatever margin the caller wants (typically a couple of
    *  hours on each side to cover warm-up + drive home with the cam). */
   matchWindow?: { startEpoch: number; endEpoch: number } | null;
+  /** When true, the "Use this folder" button stays enabled even when
+   *  the current folder has no direct video children. Set by callers
+   *  that walk recursively (e.g. relink scan), where the user is
+   *  expected to pick a top-level folder whose videos live in
+   *  subdirectories. */
+  allowEmptyFolder?: boolean;
+  /** Override the action button label. Default: "Use this folder". */
+  selectLabel?: string;
 }
 
 export function FolderPicker({
@@ -68,6 +76,8 @@ export function FolderPicker({
   onCancel,
   mode = "inline",
   matchWindow = null,
+  allowEmptyFolder = false,
+  selectLabel = "Use this folder",
 }: FolderPickerProps) {
   const [listing, setListing] = useState<FsListing | null>(null);
   const [path, setPath] = useState<string | null>(initialPath ?? null);
@@ -332,16 +342,16 @@ export function FolderPicker({
           ) : (
             <Button
               type="button"
-              disabled={busy || !path || videosHere === 0}
+              disabled={busy || !path || (!allowEmptyFolder && videosHere === 0)}
               onClick={() => path && onSelect(path)}
               title={
-                videosHere === 0
+                !allowEmptyFolder && videosHere === 0
                   ? "Select a folder that contains video files, or drill in."
                   : `Use ${path}`
               }
             >
               <FolderOpen />
-              Use this folder
+              {selectLabel}
             </Button>
           )}
         </div>

--- a/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
+++ b/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
@@ -1,0 +1,414 @@
+/**
+ * Relink Sources dialog.
+ *
+ * The user picks a search root; the server walks it recursively and
+ * matches files by basename against the project's registered ``raw/``
+ * symlinks. Repeatable -- after one apply, the list of unresolved
+ * rows shrinks and the user can pick another root for the rest.
+ *
+ * Statuses (LinkStatus): ok / broken / missing_link / not_a_symlink.
+ * Only ok / broken / missing_link rows are eligible for relinking;
+ * not_a_symlink rows are surfaced read-only with an explanation.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, CheckCircle2, FolderSearch, Link2, Link2Off } from "lucide-react";
+
+import { FolderPicker } from "@/components/FolderPicker";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ApiError,
+  api,
+  type LinkStatus,
+  type LinkStatusEntry,
+  type RelinkEntry,
+} from "@/lib/api";
+
+interface RelinkDialogProps {
+  onClose: () => void;
+  onApplied?: () => void;
+}
+
+interface RowState {
+  /** From /api/videos/link-status -- always present, even before any
+   *  scan has run. */
+  link: LinkStatusEntry;
+  /** Most recent scan result for this row, if any. */
+  scan: RelinkEntry | null;
+  /** User's current pick (path). Defaults to ``scan.chosen_path`` when
+   *  the scan auto-resolved, but the user can override. */
+  picked: string | null;
+}
+
+function statusLabel(status: LinkStatus): string {
+  switch (status) {
+    case "ok":
+      return "OK";
+    case "broken":
+      return "Broken target";
+    case "missing_link":
+      return "Symlink missing";
+    case "not_a_symlink":
+      return "Plain file";
+  }
+}
+
+function statusBadgeClass(status: LinkStatus): string {
+  switch (status) {
+    case "ok":
+      return "border-status-complete/40 bg-status-complete/10 text-status-complete";
+    case "broken":
+    case "missing_link":
+      return "border-status-warning/40 bg-status-warning/10 text-status-warning";
+    case "not_a_symlink":
+      return "border-border bg-muted text-muted-foreground";
+  }
+}
+
+export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
+  const [rows, setRows] = useState<RowState[]>([]);
+  const [searchRoot, setSearchRoot] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [scannedRoots, setScannedRoots] = useState<string[]>([]);
+  const [appliedCount, setAppliedCount] = useState(0);
+
+  // Initial load: just the link status, no scan yet.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const resp = await api.getLinkStatus();
+        if (cancelled) return;
+        setRows(
+          resp.entries.map((link) => ({ link, scan: null, picked: null })),
+        );
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const counts = useMemo(() => {
+    const out = { ok: 0, broken: 0, missing: 0, plain: 0 };
+    for (const row of rows) {
+      if (row.link.status === "ok") out.ok += 1;
+      else if (row.link.status === "broken") out.broken += 1;
+      else if (row.link.status === "missing_link") out.missing += 1;
+      else out.plain += 1;
+    }
+    return out;
+  }, [rows]);
+
+  const eligibleForApply = useMemo(
+    () => rows.filter((r) => r.picked && r.link.status !== "not_a_symlink"),
+    [rows],
+  );
+
+  const runScan = async (root: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const resp = await api.relinkScan(root);
+      setRows((prev) =>
+        prev.map((row) => {
+          const found = resp.entries.find((e) => e.video_id === row.link.video_id);
+          if (!found) return row;
+          // Only auto-fill ``picked`` when the row hasn't been resolved
+          // yet by a previous scan. This way iterating across multiple
+          // search roots accumulates resolutions without clobbering them.
+          const picked =
+            row.picked ?? (found.chosen_path && !found.ambiguous ? found.chosen_path : null);
+          return { ...row, scan: found, picked };
+        }),
+      );
+      setSearchRoot(resp.search_root);
+      setScannedRoots((prev) =>
+        prev.includes(resp.search_root) ? prev : [...prev, resp.search_root],
+      );
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const applyAll = async () => {
+    if (eligibleForApply.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const decisions: Record<string, string> = {};
+      for (const row of eligibleForApply) {
+        if (row.picked) decisions[row.link.video_id] = row.picked;
+      }
+      const resp = await api.relinkApply(decisions);
+      setAppliedCount((c) => c + resp.applied.length);
+      // Refresh statuses so applied rows flip to ``ok`` and the user
+      // sees them turn green.
+      const fresh = await api.getLinkStatus();
+      setRows((prev) =>
+        fresh.entries.map((link) => {
+          const old = prev.find((r) => r.link.video_id === link.video_id);
+          return {
+            link,
+            scan: old?.scan ?? null,
+            // Once relinked, drop the pick so the row no longer counts
+            // as "to apply". A subsequent scan can repopulate it.
+            picked: link.status === "ok" ? null : old?.picked ?? null,
+          };
+        }),
+      );
+      onApplied?.();
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="relink-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-4"
+      onClick={onClose}
+    >
+      <Card
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle id="relink-dialog-title" className="flex items-center gap-2">
+            <Link2 className="size-5" />
+            Relink sources
+          </CardTitle>
+          <CardDescription>
+            Repoint the <code>raw/</code> symlinks at new locations after the
+            originals moved (e.g. onto a network share). <code>project.json</code>{" "}
+            is never modified -- only the symlinks under <code>raw/</code> are
+            rewritten.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 overflow-y-auto text-sm">
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <span className="rounded-full border border-status-complete/40 bg-status-complete/10 px-2 py-0.5 text-status-complete">
+              {counts.ok} OK
+            </span>
+            {counts.broken > 0 ? (
+              <span className="rounded-full border border-status-warning/40 bg-status-warning/10 px-2 py-0.5 text-status-warning">
+                {counts.broken} broken
+              </span>
+            ) : null}
+            {counts.missing > 0 ? (
+              <span className="rounded-full border border-status-warning/40 bg-status-warning/10 px-2 py-0.5 text-status-warning">
+                {counts.missing} missing
+              </span>
+            ) : null}
+            {counts.plain > 0 ? (
+              <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-muted-foreground">
+                {counts.plain} plain
+              </span>
+            ) : null}
+            {appliedCount > 0 ? (
+              <span className="ml-auto text-xs text-muted-foreground">
+                Repointed {appliedCount} link{appliedCount === 1 ? "" : "s"} this session.
+              </span>
+            ) : null}
+          </div>
+
+          {pickerOpen ? (
+            <div className="rounded-md border border-border p-2">
+              <FolderPicker
+                onSelect={async (path) => {
+                  setPickerOpen(false);
+                  await runScan(path);
+                }}
+                onCancel={() => setPickerOpen(false)}
+                mode="inline"
+              />
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setPickerOpen(true)}
+                disabled={busy}
+              >
+                <FolderSearch className="size-4" />
+                {scannedRoots.length === 0 ? "Pick search folder..." : "Add another folder..."}
+              </Button>
+              {scannedRoots.length > 0 ? (
+                <span className="text-xs text-muted-foreground">
+                  Scanned: {scannedRoots.join(" · ")}
+                </span>
+              ) : null}
+            </div>
+          )}
+
+          {error ? (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+              <AlertTriangle className="size-4 shrink-0" />
+              <span>{error}</span>
+            </div>
+          ) : null}
+
+          <div className="space-y-1">
+            {rows.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+                No registered videos in this project.
+              </div>
+            ) : (
+              rows.map((row) => (
+                <RelinkRow
+                  key={row.link.video_id}
+                  row={row}
+                  onPick={(path) =>
+                    setRows((prev) =>
+                      prev.map((r) =>
+                        r.link.video_id === row.link.video_id ? { ...r, picked: path } : r,
+                      ),
+                    )
+                  }
+                  disabled={busy}
+                />
+              ))
+            )}
+          </div>
+        </CardContent>
+        <div className="flex items-center justify-between gap-2 border-t border-border p-4">
+          <div className="text-xs text-muted-foreground">
+            {eligibleForApply.length === 0
+              ? searchRoot
+                ? "Pick a candidate per row to enable apply."
+                : "Pick a search folder to find candidates."
+              : `${eligibleForApply.length} row${eligibleForApply.length === 1 ? "" : "s"} ready to relink.`}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+              Close
+            </Button>
+            <Button
+              type="button"
+              onClick={applyAll}
+              disabled={busy || eligibleForApply.length === 0}
+            >
+              <Link2 className="size-4" />
+              Apply ({eligibleForApply.length})
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+interface RelinkRowProps {
+  row: RowState;
+  onPick: (path: string | null) => void;
+  disabled: boolean;
+}
+
+function RelinkRow({ row, onPick, disabled }: RelinkRowProps) {
+  const { link, scan, picked } = row;
+  const candidates = scan?.candidates ?? [];
+  const isOk = link.status === "ok";
+  const isPlain = link.status === "not_a_symlink";
+
+  return (
+    <div className="rounded-md border border-border p-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs">{link.name}</span>
+        <span
+          className={`rounded-full border px-2 py-0.5 text-xs ${statusBadgeClass(link.status)}`}
+        >
+          {statusLabel(link.status)}
+        </span>
+        {picked ? (
+          <span className="ml-auto inline-flex items-center gap-1 text-xs text-status-complete">
+            <CheckCircle2 className="size-3.5" />
+            picked
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-1 break-all text-xs text-muted-foreground">
+        {link.current_target ? (
+          <>
+            <Link2 className="mr-1 inline size-3" />
+            {link.current_target}
+          </>
+        ) : (
+          <>
+            <Link2Off className="mr-1 inline size-3" />
+            no target
+          </>
+        )}
+      </div>
+      {isPlain ? (
+        <div className="mt-2 text-xs text-muted-foreground">
+          Regular file -- not a symlink. Relink can't help here. (See the
+          ingest copy-mode work in #245.)
+        </div>
+      ) : candidates.length === 0 ? (
+        scan ? (
+          <div className="mt-2 text-xs text-muted-foreground">
+            Not found under the last search folder. Try another root.
+          </div>
+        ) : null
+      ) : candidates.length === 1 ? (
+        <div className="mt-2 flex items-start gap-2">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={picked === candidates[0]}
+            disabled={disabled || isOk}
+            onChange={(e) => onPick(e.target.checked ? candidates[0] : null)}
+          />
+          <div className="flex-1 break-all text-xs">
+            <span className="text-muted-foreground">-&gt;</span> {candidates[0]}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-2">
+          <div className="text-xs text-status-warning">
+            {candidates.length} candidates -- pick one:
+          </div>
+          <div className="mt-1 space-y-1">
+            {candidates.map((path) => (
+              <label
+                key={path}
+                className="flex cursor-pointer items-start gap-2 rounded-md border border-border p-1 hover:bg-muted/40"
+              >
+                <input
+                  type="radio"
+                  name={`pick-${link.video_id}`}
+                  className="mt-1"
+                  checked={picked === path}
+                  disabled={disabled}
+                  onChange={() => onPick(path)}
+                />
+                <span className="flex-1 break-all text-xs">{path}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
+++ b/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
@@ -240,6 +240,8 @@ export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
                 }}
                 onCancel={() => setPickerOpen(false)}
                 mode="inline"
+                allowEmptyFolder
+                selectLabel="Scan this folder"
               />
             </div>
           ) : (

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -391,6 +391,54 @@ export interface ScanResponse {
   skipped: string[];
 }
 
+/** Filesystem state of a registered ``raw/<name>`` symlink. ``ok`` =
+ *  resolves to a present file; ``broken`` = symlink with missing
+ *  target; ``missing_link`` = the symlink itself is gone;
+ *  ``not_a_symlink`` = a regular file (link_mode="copy") that the
+ *  relink flow can't help with. */
+export type LinkStatus = "ok" | "broken" | "missing_link" | "not_a_symlink";
+
+export interface LinkStatusEntry {
+  video_id: string;
+  name: string;
+  link_path: string;
+  current_target: string | null;
+  status: LinkStatus;
+}
+
+export interface LinkStatusResponse {
+  entries: LinkStatusEntry[];
+}
+
+export interface RelinkEntry {
+  video_id: string;
+  name: string;
+  link_path: string;
+  current_target: string | null;
+  current_status: LinkStatus;
+  candidates: string[];
+  chosen_path: string | null;
+  ambiguous: boolean;
+  found: boolean;
+}
+
+export interface RelinkScanResponse {
+  search_root: string;
+  entries: RelinkEntry[];
+}
+
+export interface RelinkAppliedEntry {
+  video_id: string;
+  name: string;
+  link_path: string;
+  previous_target: string | null;
+  new_target: string;
+}
+
+export interface RelinkApplyResponse {
+  applied: RelinkAppliedEntry[];
+}
+
 export type FsEntryKind = "dir" | "video" | "file";
 
 export interface FsEntry {
@@ -1185,6 +1233,28 @@ export const api = {
     request<ScanResponse>("/api/videos/scan", {
       method: "POST",
       json: { source_paths: sourcePaths, auto_assign_primary: autoAssignPrimary },
+    }),
+
+  /** Per-video filesystem status of the ``raw/<name>`` symlinks. The
+   *  Project page polls this so it can badge broken/missing entries
+   *  outside the relink dialog. */
+  getLinkStatus: () => request<LinkStatusResponse>("/api/videos/link-status"),
+
+  /** Recursive dry-run: walk ``searchRoot`` and report per-video
+   *  candidates by basename. Pure -- no filesystem mutations. */
+  relinkScan: (searchRoot: string) =>
+    request<RelinkScanResponse>("/api/videos/relink/scan", {
+      method: "POST",
+      json: { search_root: searchRoot },
+    }),
+
+  /** Apply a confirmed set of symlink rewrites. ``decisions`` maps
+   *  ``video_id`` -> absolute target path. Any video_id not listed is
+   *  left untouched. */
+  relinkApply: (decisions: Record<string, string>) =>
+    request<RelinkApplyResponse>("/api/videos/relink/apply", {
+      method: "POST",
+      json: { decisions },
     }),
 
   updateSettings: (patch: ProjectSettingsPatch) =>

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -24,6 +24,7 @@ import {
   FolderInput,
   FolderOpen,
   HardDrive,
+  Link2,
   Monitor,
   PlayCircle,
   RefreshCw,
@@ -38,6 +39,7 @@ import {
 
 import { BeepSection } from "@/components/BeepSection";
 import { CleanupDialog } from "@/components/CleanupDialog";
+import { RelinkDialog } from "@/components/RelinkDialog";
 import { FolderPicker } from "@/components/FolderPicker";
 import { HitlQueuePanel } from "@/components/HitlQueuePanel";
 import { MountSelect } from "@/components/MountSelect";
@@ -1539,6 +1541,7 @@ function SettingsSection({
 }) {
   const [expanded, setExpanded] = useState(false);
   const [cleanupOpen, setCleanupOpen] = useState(false);
+  const [relinkOpen, setRelinkOpen] = useState(false);
   const [pickerFor, setPickerFor] = useState<
     null | "raw" | "audio" | "trimmed" | "exports" | "probes" | "thumbs"
   >(null);
@@ -1708,6 +1711,26 @@ function SettingsSection({
           />
           <div className="flex items-center justify-between border-t border-border pt-3">
             <div className="text-sm">
+              <div className="font-medium">Relink sources</div>
+              <div className="text-xs text-muted-foreground">
+                Repoint <code>raw/</code> symlinks after the originals moved
+                (e.g. onto a network share). Walks the picked folder
+                recursively and matches by filename.
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => setRelinkOpen(true)}
+            >
+              <Link2 className="size-4" />
+              Relink sources...
+            </Button>
+          </div>
+          <div className="flex items-center justify-between border-t border-border pt-3">
+            <div className="text-sm">
               <div className="font-medium">Reclaim disk space</div>
               <div className="text-xs text-muted-foreground">
                 Delete generated artifacts (caches, exports, trimmed clips). Sources are never touched.
@@ -1727,6 +1750,7 @@ function SettingsSection({
         </CardContent>
       ) : null}
       {cleanupOpen ? <CleanupDialog onClose={() => setCleanupOpen(false)} /> : null}
+      {relinkOpen ? <RelinkDialog onClose={() => setRelinkOpen(false)} /> : null}
     </Card>
   );
 }

--- a/tests/test_relink.py
+++ b/tests/test_relink.py
@@ -1,0 +1,179 @@
+"""Tests for ``splitsmith.relink``: filesystem inspection, recursive
+basename indexing, plan building, and apply-time symlink rewriting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.relink import (
+    apply_relink,
+    index_search_root,
+    inspect_links,
+    plan_relink,
+)
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _project_with_videos(root: Path, names: list[str]) -> MatchProject:
+    """Init a project with one stage and a symlinked entry per name.
+
+    Each ``raw/<name>`` symlink targets a stub file under
+    ``root.parent/originals/`` so :func:`inspect_links` reports
+    ``status=ok``.
+    """
+    project = MatchProject.init(root, name="relink-test")
+    raw = project.raw_path(root)
+    raw.mkdir(parents=True, exist_ok=True)
+    originals = root.parent / "originals"
+    originals.mkdir(parents=True, exist_ok=True)
+    videos: list[StageVideo] = []
+    for name in names:
+        original = originals / name
+        original.write_bytes(b"\x00")
+        link = raw / name
+        link.symlink_to(original)
+        videos.append(StageVideo(path=Path("raw") / name, role="primary"))
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)
+    ]
+    project.save(root)
+    return project
+
+
+def test_inspect_links_reports_ok_when_target_exists(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    [info] = inspect_links(project, root)
+    assert info.status == "ok"
+    assert info.is_symlink
+    assert info.target_exists
+
+
+def test_inspect_links_reports_broken_when_target_gone(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    (tmp_path / "originals" / "a.mp4").unlink()
+    [info] = inspect_links(project, root)
+    assert info.status == "broken"
+    assert info.is_symlink
+    assert not info.target_exists
+
+
+def test_inspect_links_reports_missing_when_link_gone(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    (project.raw_path(root) / "a.mp4").unlink()
+    [info] = inspect_links(project, root)
+    assert info.status == "missing_link"
+    assert info.target is None
+
+
+def test_inspect_links_reports_not_a_symlink_for_regular_files(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    raw = project.raw_path(root)
+    (raw / "a.mp4").unlink()
+    (raw / "a.mp4").write_bytes(b"copied")
+    [info] = inspect_links(project, root)
+    assert info.status == "not_a_symlink"
+
+
+def test_index_search_root_walks_recursively_and_groups_basenames(tmp_path: Path) -> None:
+    root = tmp_path / "share"
+    (root / "headcams").mkdir(parents=True)
+    (root / "handhelds").mkdir(parents=True)
+    (root / "ignore-me.txt").write_text("not a video")
+    (root / "headcams" / "IMG_3131.MOV").write_bytes(b"")
+    (root / "handhelds" / "IMG_3131.MOV").write_bytes(b"")  # same name, different dir
+    (root / "handhelds" / "VID_001.mp4").write_bytes(b"")
+    index = index_search_root(root)
+    assert set(index.keys()) == {"img_3131.mov", "vid_001.mp4"}
+    assert len(index["img_3131.mov"]) == 2
+    assert len(index["vid_001.mp4"]) == 1
+
+
+def test_plan_relink_auto_chooses_unique_candidate(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    # Move the original to a "share" dir so the auto-pick has somewhere to go.
+    share = tmp_path / "share" / "headcams"
+    share.mkdir(parents=True)
+    (share / "a.mp4").write_bytes(b"new home")
+    links = inspect_links(project, root)
+    plan = plan_relink(links, index_search_root(tmp_path / "share"))
+    [entry] = plan
+    assert entry.chosen_path == (share / "a.mp4").resolve()
+    assert not entry.ambiguous
+
+
+def test_plan_relink_leaves_chosen_none_when_ambiguous(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    share = tmp_path / "share"
+    (share / "x").mkdir(parents=True)
+    (share / "y").mkdir(parents=True)
+    (share / "x" / "a.mp4").write_bytes(b"")
+    (share / "y" / "a.mp4").write_bytes(b"")
+    plan = plan_relink(inspect_links(project, root), index_search_root(share))
+    [entry] = plan
+    assert entry.ambiguous
+    assert entry.chosen_path is None
+    assert len(entry.candidates) == 2
+
+
+def test_plan_relink_skips_already_correct_targets(tmp_path: Path) -> None:
+    """If the symlink already points at the only candidate found in the
+    search root, the plan should not propose rewriting it."""
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    # The only candidate in the search root is the existing target.
+    share = tmp_path / "originals"
+    plan = plan_relink(inspect_links(project, root), index_search_root(share))
+    [entry] = plan
+    assert entry.candidates == [(share / "a.mp4").resolve()]
+    assert entry.chosen_path is None
+
+
+def test_apply_relink_rewrites_symlink_and_records_previous_target(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    raw = project.raw_path(root)
+    new_target = tmp_path / "share" / "subdir" / "a.mp4"
+    new_target.parent.mkdir(parents=True)
+    new_target.write_bytes(b"new")
+    [applied] = apply_relink([(raw / "a.mp4", new_target)])
+    assert applied.previous_target == tmp_path / "originals" / "a.mp4"
+    assert applied.new_target == new_target.resolve()
+    # And the link now resolves to the new target.
+    assert (raw / "a.mp4").resolve() == new_target.resolve()
+
+
+def test_apply_relink_refuses_to_overwrite_regular_file(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    raw = project.raw_path(root)
+    (raw / "a.mp4").unlink()
+    (raw / "a.mp4").write_bytes(b"copied, not symlinked")
+    new_target = tmp_path / "share" / "a.mp4"
+    new_target.parent.mkdir()
+    new_target.write_bytes(b"")
+    with pytest.raises(ValueError, match="not_a_symlink"):
+        apply_relink([(raw / "a.mp4", new_target)])
+
+
+def test_apply_relink_creates_link_when_missing(tmp_path: Path) -> None:
+    """``missing_link`` entries -- the symlink itself was deleted --
+    should still be relinkable."""
+    root = tmp_path / "match"
+    project = _project_with_videos(root, ["a.mp4"])
+    raw = project.raw_path(root)
+    (raw / "a.mp4").unlink()
+    new_target = tmp_path / "share" / "a.mp4"
+    new_target.parent.mkdir()
+    new_target.write_bytes(b"")
+    [applied] = apply_relink([(raw / "a.mp4", new_target)])
+    assert applied.previous_target is None
+    assert (raw / "a.mp4").is_symlink()

--- a/tests/test_relink_api.py
+++ b/tests/test_relink_api.py
@@ -1,0 +1,143 @@
+"""End-to-end tests for the relink API endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+from splitsmith.ui.server import create_app
+
+
+@pytest.fixture(autouse=True)
+def _disable_auto_beep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPLITSMITH_AUTO_BEEP_DISABLED", "1")
+
+
+def _setup_project(tmp_path: Path, names: list[str]) -> tuple[Path, dict[str, str]]:
+    """Init a project with one stage and a symlinked entry per name.
+
+    Returns ``(project_root, video_id_by_name)`` so tests can address the
+    relink endpoint by ``video_id``.
+    """
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="relink-api")
+    raw = project.raw_path(root)
+    raw.mkdir(parents=True, exist_ok=True)
+    originals = tmp_path / "originals"
+    originals.mkdir(parents=True, exist_ok=True)
+    videos: list[StageVideo] = []
+    ids: dict[str, str] = {}
+    for name in names:
+        original = originals / name
+        original.write_bytes(b"\x00")
+        link = raw / name
+        link.symlink_to(original)
+        sv = StageVideo(path=Path("raw") / name, role="primary")
+        videos.append(sv)
+        ids[name] = sv.video_id
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)
+    ]
+    project.save(root)
+    return root, ids
+
+
+def test_link_status_reports_ok_for_intact_links(tmp_path: Path) -> None:
+    root, ids = _setup_project(tmp_path, ["a.mp4"])
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.get("/api/videos/link-status")
+    assert resp.status_code == 200
+    [entry] = resp.json()["entries"]
+    assert entry["video_id"] == ids["a.mp4"]
+    assert entry["status"] == "ok"
+    assert entry["current_target"] == str(tmp_path / "originals" / "a.mp4")
+
+
+def test_link_status_reports_broken_after_target_removed(tmp_path: Path) -> None:
+    root, _ = _setup_project(tmp_path, ["a.mp4"])
+    (tmp_path / "originals" / "a.mp4").unlink()
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    [entry] = client.get("/api/videos/link-status").json()["entries"]
+    assert entry["status"] == "broken"
+
+
+def test_relink_scan_reports_unique_candidate(tmp_path: Path) -> None:
+    root, ids = _setup_project(tmp_path, ["a.mp4"])
+    share = tmp_path / "share" / "headcams"
+    share.mkdir(parents=True)
+    (share / "a.mp4").write_bytes(b"")
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.post("/api/videos/relink/scan", json={"search_root": str(tmp_path / "share")})
+    assert resp.status_code == 200
+    body = resp.json()
+    [entry] = body["entries"]
+    assert entry["video_id"] == ids["a.mp4"]
+    assert entry["found"]
+    assert not entry["ambiguous"]
+    assert entry["chosen_path"] == str((share / "a.mp4").resolve())
+
+
+def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
+    root, _ = _setup_project(tmp_path, ["a.mp4"])
+    share = tmp_path / "share"
+    (share / "x").mkdir(parents=True)
+    (share / "y").mkdir(parents=True)
+    (share / "x" / "a.mp4").write_bytes(b"")
+    (share / "y" / "a.mp4").write_bytes(b"")
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    [entry] = client.post("/api/videos/relink/scan", json={"search_root": str(share)}).json()[
+        "entries"
+    ]
+    assert entry["ambiguous"]
+    assert entry["chosen_path"] is None
+    assert len(entry["candidates"]) == 2
+
+
+def test_relink_scan_400_on_missing_root(tmp_path: Path) -> None:
+    root, _ = _setup_project(tmp_path, ["a.mp4"])
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.post("/api/videos/relink/scan", json={"search_root": str(tmp_path / "nope")})
+    assert resp.status_code == 400
+
+
+def test_relink_apply_rewrites_symlinks(tmp_path: Path) -> None:
+    root, ids = _setup_project(tmp_path, ["a.mp4"])
+    new_target = tmp_path / "share" / "subdir" / "a.mp4"
+    new_target.parent.mkdir(parents=True)
+    new_target.write_bytes(b"")
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.post(
+        "/api/videos/relink/apply",
+        json={"decisions": {ids["a.mp4"]: str(new_target)}},
+    )
+    assert resp.status_code == 200
+    [applied] = resp.json()["applied"]
+    assert applied["video_id"] == ids["a.mp4"]
+    assert applied["new_target"] == str(new_target.resolve())
+    # And the link on disk now resolves to the new target.
+    link = root / "raw" / "a.mp4"
+    assert link.resolve() == new_target.resolve()
+
+
+def test_relink_apply_rejects_missing_target(tmp_path: Path) -> None:
+    root, ids = _setup_project(tmp_path, ["a.mp4"])
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.post(
+        "/api/videos/relink/apply",
+        json={"decisions": {ids["a.mp4"]: str(tmp_path / "nope.mp4")}},
+    )
+    assert resp.status_code == 400
+
+
+def test_relink_apply_rejects_unknown_video_id(tmp_path: Path) -> None:
+    root, _ = _setup_project(tmp_path, ["a.mp4"])
+    target = tmp_path / "originals" / "a.mp4"
+    client = TestClient(create_app(project_root=root, project_name="x"))
+    resp = client.post(
+        "/api/videos/relink/apply",
+        json={"decisions": {"deadbeefcafe": str(target)}},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- New "Relink sources..." dialog on the Ingest page: folder picker walks the chosen root recursively, matches by basename, lets the user pick a candidate when ambiguous, and rewrites the `raw/` symlinks. Repeatable -- each scan accumulates resolutions across multiple roots so a project split across `headcam/`, `handheld/`, etc. only takes one or two picks.
- `GET /api/videos/link-status` surfaces per-video link state (ok / broken / missing_link / not_a_symlink) so the SPA can badge problems before the user opens the dialog.
- Filed #245 to track the future ingest-time copy mode + smart folder structures (so the relink path becomes optional).

## Test plan
- [x] `uv run pytest` -- 943 passed, 1 skipped
- [x] `pnpm build` -- clean
- [x] `pnpm tsc --noEmit` -- clean
- [ ] Manual: move tallmilan-2026 sources onto the network share, open Ingest -> Relink sources, point at the share root, verify all rows resolve and apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)