### PR TITLE
fcpxml: PiP defaults to bottom-left CCW at 30% to clear overlay

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -34,15 +34,17 @@ from .config import OutputConfig, Shot, SplitColorThresholds, VideoMetadata
 PipCorner = Literal["top-right", "top-left", "bottom-right", "bottom-left"]
 
 # Corner cycle order when PiP is requested without an explicit per-cam corner.
-# Top-left first, then clockwise -- the natural reading order for the user
-# scanning a stitched match: first cam takes the top-left, the next wraps
-# around to the right, then bottom-right, then bottom-left. This is the
-# default until per-cam corner overrides land in a layout-template feature.
+# Bottom-left first, then counter-clockwise: BL -> BR -> TR -> TL. The
+# overlay (shot counter top-left, timer top-right) collides with PiPs at
+# the top corners, so the bottom corners are filled first; CCW keeps the
+# 1-cam common case anchored to the bottom-left away from the running
+# timer. Per-cam corner overrides land in a layout-template feature
+# follow-up.
 _PIP_CORNER_CYCLE: tuple[PipCorner, ...] = (
-    "top-left",
-    "top-right",
-    "bottom-right",
     "bottom-left",
+    "bottom-right",
+    "top-right",
+    "top-left",
 )
 
 
@@ -57,8 +59,8 @@ class PipPlacement:
     sequence width / height (so it scales sensibly across resolutions).
     """
 
-    corner: PipCorner = "top-right"
-    scale: float = 0.25
+    corner: PipCorner = "bottom-left"
+    scale: float = 0.30
     margin_pct: float = 2.0
 
     def resolve(

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -92,7 +92,9 @@ class MatchExportRequestData:
     # Issue #193. ``"stacked"`` keeps today's full-frame stacked layout
     # (every secondary covers the one below). ``"pip-corners"`` adds an
     # ``<adjust-transform>`` to each secondary so they land in rotating
-    # corners (TR -> TL -> BR -> BL) at 25% scale with a 2% inset.
+    # corners (BL -> BR -> TR -> TL, counter-clockwise from bottom-left
+    # so the 1-cam case stays clear of the overlay's top-corner widgets)
+    # at 30% scale with a 2% inset.
     pip_layout: PipLayout = "stacked"
     # Issue #197. Renderer chosen for this export.
     output_format: OutputFormat = "fcpxml"

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -173,12 +173,12 @@ def test_from_stage_compositions_resolves_pip_against_sequence_dims(tmp_path: Pa
     comp = composition.from_stage_compositions([stage_comp], project_name="match")
     sec = comp.stages[0].secondaries[0]
     assert sec.transform is not None
-    # 1920x1080 sequence, scale=0.25, margin_pct=2.0:
-    # half_w=960, clip_half_w=240, margin_x=38.4 -> x = 960 - 240 - 38.4 = 681.6
-    # half_h=540, clip_half_h=135, margin_y=21.6 -> y = 540 - 135 - 21.6 = 383.4
-    assert sec.transform.scale == pytest.approx(0.25)
-    assert sec.transform.position[0] == pytest.approx(681.6)
-    assert sec.transform.position[1] == pytest.approx(383.4)
+    # 1920x1080 sequence, default scale=0.30, margin_pct=2.0:
+    # half_w=960, clip_half_w=288, margin_x=38.4 -> x = 960 - 288 - 38.4 = 633.6
+    # half_h=540, clip_half_h=162, margin_y=21.6 -> y = 540 - 162 - 21.6 = 356.4
+    assert sec.transform.scale == pytest.approx(0.30)
+    assert sec.transform.position[0] == pytest.approx(633.6)
+    assert sec.transform.position[1] == pytest.approx(356.4)
     assert sec.beep_offset_seconds == 5.0
     assert sec.role == "cam"
 

--- a/tests/test_fcp7xml_render.py
+++ b/tests/test_fcp7xml_render.py
@@ -400,15 +400,15 @@ def test_pip_emits_basic_motion_filter(tmp_path: Path) -> None:
     assert effect is not None
     assert effect.findtext("effectid") == "basic"
     params = {p.findtext("parameterid"): p for p in effect.findall("parameter")}
-    assert params["scale"].findtext("value") == "25"  # 0.25 * 100
-    # 1080p sequence, scale=0.25, margin=2.0%:
-    # IR position = (681.6, 383.4) (FCPXML coords, +Y up)
-    # FCP7 horiz = 681.6 / 960 = 0.71 (rounded)
-    # FCP7 vert = -383.4 / 540 = -0.71 (FCP7 +Y down -> sign flips)
+    assert params["scale"].findtext("value") == "30"  # 0.30 * 100
+    # 1080p sequence, default scale=0.30, margin=2.0%:
+    # IR position = (633.6, 356.4) (FCPXML coords, +Y up)
+    # FCP7 horiz = 633.6 / 960 = 0.66 (rounded)
+    # FCP7 vert = -356.4 / 540 = -0.66 (FCP7 +Y down -> sign flips)
     horiz = float(params["center"].find("value/horiz").text)  # type: ignore[arg-type, union-attr]
     vert = float(params["center"].find("value/vert").text)  # type: ignore[arg-type, union-attr]
-    assert horiz == pytest.approx(0.71, abs=0.01)
-    assert vert == pytest.approx(-0.71, abs=0.01)
+    assert horiz == pytest.approx(0.66, abs=0.01)
+    assert vert == pytest.approx(-0.66, abs=0.01)
 
 
 def test_pip_y_axis_flips_for_bottom_corners(tmp_path: Path) -> None:

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1555,16 +1555,16 @@ def test_secondary_with_pip_emits_corner_transform(corner: str, tmp_path: Path) 
     assert transform is not None
     assert list(cam_clip)[0] is transform  # transform must precede markers / nested clips
     expected = _expected_pip_attrs(
-        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner=corner
+        seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner=corner
     )
     assert transform.attrib == expected
 
 
 def test_pip_position_is_resolution_independent(tmp_path: Path) -> None:
     """#236 -- FCPXML position is in normalized "100 == sequence_height"
-    units. ``scale=0.25, margin_pct=2.0, corner="top-right"`` emits the
-    same position string on 1080p and 4K timelines (only the pixel
-    offset differs; the normalized value stays put)."""
+    units. The default PiP (scale=0.30, margin_pct=2.0, corner="top-right")
+    emits the same position string on 1080p and 4K timelines (only the
+    pixel offset differs; the normalized value stays put)."""
     video = tmp_path / "v.mp4"
     video.write_bytes(b"")
     secondary = tmp_path / "cam.mp4"
@@ -1593,22 +1593,22 @@ def test_pip_position_is_resolution_independent(tmp_path: Path) -> None:
     )
     assert transform is not None
     expected = _expected_pip_attrs(
-        seq_w=3840, seq_h=2160, scale=0.25, margin_pct=2.0, corner="top-right"
+        seq_w=3840, seq_h=2160, scale=0.30, margin_pct=2.0, corner="top-right"
     )
     assert transform.attrib == expected
     # Resolution-independent: the same PiP at 1080p emits the same
     # normalized position string.
     expected_1080 = _expected_pip_attrs(
-        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner="top-right"
+        seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner="top-right"
     )
     assert expected_1080["position"] == expected["position"]
 
 
 def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:
-    """Multiple cams without explicit pip get TL -> TR -> BR -> BL
-    (clockwise from the top-left) when ``apply_pip_corner_cycle`` is
-    asked to inject a default. The order matches reading flow so the
-    first cam is most prominent at the top-left."""
+    """Multiple cams without explicit pip get BL -> BR -> TR -> TL
+    (counter-clockwise from the bottom-left) when ``apply_pip_corner_cycle``
+    is asked to inject a default. The order keeps the 1-cam common case
+    away from the overlay (shot counter top-left, timer top-right)."""
     secs = tuple(
         fcpxml_mod.SecondaryClip(
             video_path=Path(f"cam{i}.mp4"),
@@ -1622,7 +1622,7 @@ def test_apply_pip_corner_cycle_assigns_rotating_corners() -> None:
         secs, default=fcpxml_mod.PipPlacement(scale=0.3, margin_pct=1.5)
     )
     corners = [s.pip.corner for s in laid_out]  # type: ignore[union-attr]
-    assert corners == ["top-left", "top-right", "bottom-right", "bottom-left"]
+    assert corners == ["bottom-left", "bottom-right", "top-right", "top-left"]
     # Default scale / margin propagate; corner is the only override.
     for s in laid_out:
         assert s.pip is not None
@@ -1638,7 +1638,7 @@ def test_apply_pip_corner_cycle_preserves_explicit() -> None:
         video=_meta_30fps(),
         beep_offset_seconds=5.0,
         label="Main cam",
-        pip=fcpxml_mod.PipPlacement(corner="bottom-left", scale=0.4),
+        pip=fcpxml_mod.PipPlacement(corner="top-right", scale=0.4),
     )
     auto = fcpxml_mod.SecondaryClip(
         video_path=Path("cam_aux.mp4"),
@@ -1651,7 +1651,7 @@ def test_apply_pip_corner_cycle_preserves_explicit() -> None:
     )
     assert laid_out[0] is explicit  # untouched
     assert laid_out[1].pip is not None
-    assert laid_out[1].pip.corner == "top-left"  # cycle starts at TL
+    assert laid_out[1].pip.corner == "bottom-left"  # cycle starts at BL
 
 
 def test_apply_pip_corner_cycle_default_none_is_noop() -> None:
@@ -1704,7 +1704,7 @@ def test_match_fcpxml_secondary_pip_uses_sequence_dims(tmp_path: Path) -> None:
     )
     assert transform is not None
     expected = _expected_pip_attrs(
-        seq_w=1920, seq_h=1080, scale=0.25, margin_pct=2.0, corner="top-right"
+        seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner="top-right"
     )
     assert transform.attrib == expected
 

--- a/tests/test_mp4_render.py
+++ b/tests/test_mp4_render.py
@@ -217,11 +217,11 @@ def test_build_stage_command_pip_secondary(tmp_path: Path) -> None:
         plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
     )
     fg = cmd[cmd.index("-filter_complex") + 1]
-    # Cam scaled to 25% of 1920x1080 -> 480x270.
-    assert "scale=480:270" in fg
-    # ffmpeg overlay X = (1920*(1-0.25))/2 + 681.6 = 720 + 681.6 = 1401.6
-    # ffmpeg overlay Y = (1080*(1-0.25))/2 - 383.4 = 405 - 383.4 = 21.6
-    assert "overlay=x=1401.6:y=21.6" in fg
+    # Cam scaled to 30% of 1920x1080 -> 576x324.
+    assert "scale=576:324" in fg
+    # ffmpeg overlay X = (1920*(1-0.3))/2 + 633.6 = 672 + 633.6 = 1305.6
+    # ffmpeg overlay Y = (1080*(1-0.3))/2 - 356.4 = 378 - 356.4 = 21.6
+    assert "overlay=x=1305.6:y=21.6" in fg
     # ``enable`` keeps the cam visible only during its computed window.
     assert "between(t," in fg
 


### PR DESCRIPTION
## Summary
- Overlay's shot counter (top-left) and timer (top-right) collide with PiPs in the top corners
- Move the corner cycle to start at bottom-left and rotate counter-clockwise: BL -> BR -> TR -> TL
- Bump default \`PipPlacement.scale\` from 0.25 to 0.30 for a more readable inset
- Default \`PipPlacement.corner\` flips from \`top-right\` to \`bottom-left\` to match the cycle's first slot

## Test plan
- [x] \`uv run pytest\` -- 934 passed, 4 skipped
- [x] \`uv run ruff check\` / \`black --check\` -- clean
- [ ] Re-export the test match with PiP corners on and confirm no overlap with the overlay widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)