### PR TITLE
fcpxml: fix mixed-rate connected-clip @offset + primary duration units

### DIFF
--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -982,10 +982,14 @@ def generate_match_fcpxml(
     plans: list[_StagePlan] = []
 
     for stage in stages:
-        stage_frame_duration = Fraction(stage.video.frame_rate_den, stage.video.frame_rate_num)
-        primary_duration_frames = int(
-            round(stage.video.duration_seconds / float(stage_frame_duration))
-        )
+        # ``primary_duration_frames`` is in *sequence* frames so it can be
+        # subtracted from ``head_trim_frames`` / ``tail_trim_frames``
+        # (which are also sequence frames) without unit-mixing. For
+        # mixed-rate stages (#233) computing this in stage-local frames
+        # produced an effective_duration_frames in nonsense units that
+        # surfaced as cams playing past the primary's right edge and
+        # primary durations way off on the spine.
+        primary_duration_frames = int(round(stage.video.duration_seconds / fd_seconds))
 
         # Determine actual head and tail available in the trimmed file.
         # head_avail = beep_offset (the trim's pre-buffer; may be < trim_buffer
@@ -1419,7 +1423,19 @@ def generate_match_fcpxml(
                 {
                     "ref": sec_id,
                     "lane": str(lane_idx),
-                    "offset": _frame_aligned_str(sec_offset_frames, fd_num, fd_den),
+                    # ``offset`` is in the *parent primary's* source
+                    # frame grid (the parent's frame_duration), not the
+                    # sequence's. When the primary's rate differs from
+                    # the sequence's (mixed-rate match exports, #233),
+                    # emitting in the sequence grid produces values
+                    # that don't land on the parent's frame boundary
+                    # and FCP rejects the import with "not on an edit
+                    # frame boundary". ``duration`` stays on the
+                    # *sequence's* grid -- it expresses how long the
+                    # connected clip occupies the timeline, which must
+                    # align with the sequence frame_duration for FCP
+                    # to render frame-by-frame.
+                    "offset": _asset_grid_str(sec_offset_frames * fd_seconds, stage.video),
                     "name": sec.label,
                     # ``start`` is into the cam's source media -- must
                     # be quantized to the cam's frame grid (#236). Emit
@@ -1465,7 +1481,12 @@ def generate_match_fcpxml(
             # stay in sync. ``offset`` is also head_trim (parent-source-time
             # of the parent's visible start) so the overlay anchors at the
             # primary's visible start instead of head_trim seconds earlier.
-            head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
+            # ``offset`` is in the parent primary's source grid (must
+            # quantize to the primary's frame_duration -- mixed-rate
+            # fix); ``duration`` stays on the sequence grid (must
+            # quantize to the sequence's frame_duration). ``start`` is
+            # in the overlay's own grid.
+            parent_offset_str = _asset_grid_str(head_trim_seconds, stage.video)
             assert plan.overlay_format_id is not None  # set whenever overlay_asset_id is
             overlay_meta = (
                 plan.stage.overlay_video
@@ -1478,7 +1499,7 @@ def generate_match_fcpxml(
                 {
                     "ref": plan.overlay_asset_id,
                     "lane": str(overlay_lane),
-                    "offset": head_trim_str,
+                    "offset": parent_offset_str,
                     "name": "Splitsmith overlay",
                     # ``start`` is on the overlay asset's grid; emit in
                     # the overlay's frame_duration units (#236).
@@ -1494,15 +1515,17 @@ def generate_match_fcpxml(
         # above secondaries + overlay so the text always sits on top.
         # ``offset`` anchors at the primary's visible head; the user
         # can drag the title later in FCP if they want it elsewhere.
+        # ``offset`` is in the parent primary's source grid (mixed-rate
+        # fix); ``duration`` stays on the sequence grid; ``start``=0s
+        # since the title generator has no source media.
         if stage_title is not None and stage_title.style == "lower-third":
             assert title_effect_id is not None
             lt_lane = len(plan.usable_secondaries) + 2
             lt_dur_frames = round(stage_title.duration_seconds / fd_seconds)
-            head_trim_str = _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den)
             _emit_title_clip(
                 primary_clip,
                 ref=title_effect_id,
-                offset_str=head_trim_str,
+                offset_str=_asset_grid_str(head_trim_seconds, stage.video),
                 start_str="0s",
                 duration_str=_frame_aligned_str(lt_dur_frames, fd_num, fd_den),
                 title=stage_title,
@@ -1513,15 +1536,16 @@ def generate_match_fcpxml(
         # Chapter marker on the visible head of the primary (#204).
         # FCP / FCP7 / Premiere all forward chapter markers into the
         # MP4 chapter atom on export, which is the upload-ready
-        # signal YouTube reads. Marker start = head_trim_frames (the
-        # in-source frame where playback starts), so it lands on the
-        # spine at the stage's beginning.
+        # signal YouTube reads. Marker start = head_trim_seconds (the
+        # in-source time where playback starts), so it lands on the
+        # spine at the stage's beginning. ``start`` is in the parent
+        # primary's grid (mixed-rate fix).
         if chapter_markers:
             ET.SubElement(
                 primary_clip,
                 "chapter-marker",
                 {
-                    "start": _frame_aligned_str(plan.head_trim_frames, fd_num, fd_den),
+                    "start": _asset_grid_str(head_trim_seconds, stage.video),
                     "duration": frame_duration_str,
                     "value": stage.stage_name,
                 },

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -1090,6 +1090,79 @@ def test_match_fcpxml_supports_mixed_frame_rates(tmp_path: Path) -> None:
     assert spine_clips[1].attrib["format"] == fid_by_fd["1001/30000s"]
 
 
+def test_match_fcpxml_connected_offsets_use_parent_grid_when_rates_differ(
+    tmp_path: Path,
+) -> None:
+    """Regression: a connected clip's ``offset`` must be expressed in the
+    *parent* primary's frame grid, not the sequence's. When stage 1's
+    primary is 60p but the sequence is 30p (taken from stage 0), the
+    cam offset 4s = ``120/30s`` (sequence grid) doesn't land on the
+    parent's 1/60s frame_duration evenly in the general case; FCP
+    rejects the import with "not on an edit frame boundary". The
+    correct emission quantizes to the parent (1/60s) -> ``240/60s``."""
+    v1 = _make_video(tmp_path, "stage1.mp4")
+    v2 = _make_video(tmp_path, "stage2.mp4")
+    cam = _make_video(tmp_path, "stage2_cam.mp4")
+    out = tmp_path / "match.fcpxml"
+    meta_60p = VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=20.0,
+        frame_rate_num=60,
+        frame_rate_den=1,
+    )
+    generate_match_fcpxml(
+        stages=[
+            StageComposition(
+                stage_name="stage1",
+                video_path=v1,
+                video=_meta_30fps(),
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=5.0,
+                tail_pad_seconds=5.0,
+            ),
+            StageComposition(
+                stage_name="stage2",
+                video_path=v2,
+                video=meta_60p,
+                shots=[_shot(1, 1.0, 1.0)],
+                beep_offset_seconds=5.0,
+                head_pad_seconds=1.0,  # head_trim = 4s
+                tail_pad_seconds=5.0,
+                secondaries=[
+                    SecondaryClip(
+                        video_path=cam,
+                        video=meta_60p,
+                        beep_offset_seconds=5.0,
+                        label="Cam",
+                        pip=PipPlacement(corner="bottom-left"),
+                    )
+                ],
+            ),
+        ],
+        output_path=out,
+        project_name="match",
+        config=OutputConfig(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./library/event/project/sequence/spine/asset-clip")
+    cam_clip = spine_clips[1].find("asset-clip")
+    assert cam_clip is not None
+    # Stage 2 primary is 60p, so the cam's parent grid is 1/60s. Offset
+    # 4s must land on that grid: 4 * 60 = 240 -> "240/60s". The buggy
+    # emission used the sequence grid (1/30s) and produced "120/30s",
+    # which doesn't line up with the parent's frame_duration in the
+    # mixed-rate case.
+    assert cam_clip.attrib["offset"] == "240/60s"
+    # ``duration`` stays on the sequence grid (1/30s) -- it expresses
+    # how long the cam occupies the sequence timeline, which must
+    # quantize to the sequence's frame_duration. Stage 2's effective
+    # window is 7s (20s source - 4s head_trim - 9s tail_trim) @ 30p
+    # = 210 sequence frames -> "210/30s".
+    assert cam_clip.attrib["duration"] == "210/30s"
+
+
 def test_match_fcpxml_caps_cam_duration_to_parent_visible_window(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Two related bugs surface together when a match has stages with different frame rates.

**1. Connected clip @offset on the wrong grid.** Cams / overlay / lower-third titles emitted their \`@offset\` in the sequence's frame grid. FCPXML requires it in the *parent primary's* source grid; when rates differ, values like \`270/60s\` (4.5s on a 60p sequence) don't land on the parent's 1001/30000s frame_duration and FCP rejects the import with \"not on an edit frame boundary\". \`@duration\` stays on the sequence grid (it spans the timeline, must quantize to sequence frame_duration).

**2. \`primary_duration_frames\` had mixed units.** Computed in stage-local frames but subtracted from head/tail trim frames (sequence frames). For mixed-rate stages this produced nonsense \`effective_duration\` -- cams played past the primary's right edge and primary spine durations were off.

## Test plan
- [x] \`uv run pytest\` -- 954 passed, 4 skipped
- [x] New regression test: 30p stage 0 + 60p stage 1 + cam, asserts cam \`@offset\` uses parent grid (1/60s) and \`@duration\` uses sequence grid (1/30s)
- [ ] Re-export \`tallmilan-2026-match\` and confirm Apple's FCPXML validator runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)