### PR TITLE
mcp: write tools (#211 layer 3b)

### DIFF
--- a/src/splitsmith/mcp/server.py
+++ b/src/splitsmith/mcp/server.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from . import tools
+from . import tools, write_tools
 
 
 def create_server(name: str = "splitsmith") -> FastMCP:
@@ -88,5 +88,103 @@ def create_server(name: str = "splitsmith") -> FastMCP:
         without a separate read.
         """
         return tools.get_hitl_queue(project_root)
+
+    # ----------------------------------------------------------------
+    # Mutating tools (layer 3b). Each one loads the project, applies
+    # a focused change, and saves. No background-job triggering --
+    # that's the HTTP daemon's job runner or a future detection tool.
+    # ----------------------------------------------------------------
+
+    @mcp.tool()
+    def assign_video(
+        project_root: str,
+        video_path: str,
+        stage_number: int | None = None,
+        role: str = "secondary",
+    ) -> dict:
+        """Assign a registered video to a stage (or back to unassigned).
+
+        Equivalent to ``POST /api/assignments/move``. ``stage_number=
+        None`` returns the video to the unassigned tray; otherwise
+        ``role`` is one of ``primary | secondary | ignored``. A
+        ``primary`` assignment demotes any existing primary on the
+        target stage. A ``secondary`` assignment to a stage with no
+        primary yet auto-upgrades to primary (matches the SPA's
+        first-video-on-stage semantics).
+
+        Returns ``{video_id, role, stage_number}`` so the agent can
+        reference the placed video without re-reading the project.
+        """
+        return write_tools.assign_video(
+            project_root,
+            video_path,
+            stage_number=stage_number,
+            role=role,
+        )
+
+    @mcp.tool()
+    def set_beep_manual(
+        project_root: str,
+        stage_number: int,
+        video_id: str,
+        time_seconds: float | None,
+    ) -> dict:
+        """Manually pin (or clear) a video's beep timestamp.
+
+        ``time_seconds=None`` clears any existing beep. Otherwise the
+        value is stored with ``beep_source="manual"`` and confidence
+        pinned at 1.0 -- the auto-trust gate (#219) opens
+        immediately. Cached audit trim is invalidated either way.
+        """
+        return write_tools.set_beep_manual(
+            project_root,
+            stage_number=stage_number,
+            video_id=video_id,
+            time_seconds=time_seconds,
+        )
+
+    @mcp.tool()
+    def select_beep_candidate(
+        project_root: str,
+        stage_number: int,
+        video_id: str,
+        time_seconds: float,
+    ) -> dict:
+        """Promote one of ``video.beep_candidates`` (matched within 1
+        ms of ``time_seconds``) as the authoritative beep.
+
+        Mirror of ``POST /api/stages/{n}/videos/{vid}/beep/select``.
+        Keeps ``beep_source="auto"`` since the time still came from
+        the detector; resets ``beep_reviewed`` so the new pick needs
+        its own confirmation. Audit trim cache is invalidated.
+        """
+        return write_tools.select_beep_candidate(
+            project_root,
+            stage_number=stage_number,
+            video_id=video_id,
+            time_seconds=time_seconds,
+        )
+
+    @mcp.tool()
+    def mark_beep_reviewed(
+        project_root: str,
+        stage_number: int,
+        video_id: str,
+        reviewed: bool = True,
+    ) -> dict:
+        """Flip ``video.beep_reviewed`` (issue #71).
+
+        Setting True requires ``beep_time`` to be present. The
+        downstream chain (auto-trim + shot-detect when
+        ``automation.shot_detect_on_beep_verified`` is on) fires on
+        the HTTP server's job runner -- this tool only flips the
+        flag.
+        """
+        return write_tools.mark_beep_reviewed(
+            project_root,
+            stage_number=stage_number,
+            video_id=video_id,
+            reviewed=reviewed,
+        )
 
     return mcp

--- a/src/splitsmith/mcp/write_tools.py
+++ b/src/splitsmith/mcp/write_tools.py
@@ -1,0 +1,268 @@
+"""Mutating MCP tools (issue #211 layer 3b).
+
+Each tool follows the same load -> mutate -> save pattern: open the
+project, apply a focused change, persist back to ``project.json``.
+The mutations mirror the corresponding HTTP endpoints in
+:mod:`splitsmith.ui.server` so an agent driving the MCP and a user
+driving the SPA produce identical project state.
+
+What's deliberately NOT here:
+
+* Background-job triggers (auto-trim, auto-shot-detect, auto-beep
+  on assignment). Those are the HTTP server's job runner; the MCP
+  surface is project-state only. A user with the splitsmith UI
+  daemon running concurrently still gets the chained jobs because
+  the server watches ``project.json`` mtime; an agent running
+  without the daemon can call the future ``trim`` / ``detect_*``
+  tools (layer 3c) explicitly.
+* Audio cache invalidation is included for the beep tools because
+  it's a synchronous filesystem operation that the agent expects
+  to "just happen" -- otherwise a stale audit clip survives the
+  beep change and silently mis-aligns the next viewing session.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..ui import audio as audio_helpers
+from ..ui.project import MatchProject, StageVideo
+from .sandbox import resolve_project_root
+
+# Roles the assign tool accepts. Mirror of
+# :data:`splitsmith.ui.project.VideoRole` -- spelled out here so the
+# MCP error message tells the agent what valid values look like.
+ALLOWED_ROLES = ("primary", "secondary", "ignored")
+
+
+def assign_video(
+    project_root: str,
+    video_path: str,
+    *,
+    stage_number: int | None,
+    role: str = "secondary",
+) -> dict[str, Any]:
+    """Assign a registered video to a stage (or back to unassigned).
+
+    ``stage_number=None`` moves the video to the project's
+    ``unassigned_videos`` tray regardless of ``role``. With a stage
+    number, ``role`` is one of ``primary | secondary | ignored``;
+    ``primary`` demotes any existing primary to ``secondary``, and
+    ``secondary`` auto-upgrades to primary on a stage that has none
+    (matches the SPA's drag-and-drop semantics for first-video
+    placement).
+
+    Returns ``{video_id, role, stage_number}`` so the agent can
+    reference the placed video in subsequent tool calls without a
+    second ``get_project`` round-trip.
+    """
+    if role not in ALLOWED_ROLES:
+        raise ValueError(f"role must be one of {', '.join(ALLOWED_ROLES)}; got {role!r}")
+    root = resolve_project_root(project_root)
+    # ``video_path`` is a project-internal identifier (the project
+    # stores paths as strings relative to the project root, and
+    # ``find_video`` does string equality). Sandboxing + absolute
+    # resolution here breaks the lookup. The path was registered
+    # via a separate tool (the future scan/register tool) where
+    # sandbox enforcement applies; here we just move the label.
+    project = MatchProject.load(root)
+    placed = project.assign_video(
+        Path(video_path),
+        to_stage_number=stage_number,
+        role=role,  # type: ignore[arg-type]
+    )
+    project.save(root)
+    return {
+        "video_id": placed.video_id,
+        "role": placed.role,
+        "stage_number": stage_number,
+    }
+
+
+def set_beep_manual(
+    project_root: str,
+    *,
+    stage_number: int,
+    video_id: str,
+    time_seconds: float | None,
+) -> dict[str, Any]:
+    """Manually pin (or clear) ``video``'s beep timestamp.
+
+    ``time_seconds=None`` clears any existing beep back to "no beep
+    yet" (resets review, processed flags, candidate list). Otherwise
+    the value is stored with ``beep_source="manual"`` and confidence
+    pinned at 1.0 (the user told us where the beep is, so the
+    auto-trust gate (#219) opens immediately). The cached audit trim
+    is invalidated either way so the next viewing rebuilds with the
+    new offset.
+
+    Returns ``{beep_time, beep_source, beep_confidence,
+    beep_reviewed, beep_auto_detect_failed}`` for the updated video.
+    """
+    if time_seconds is not None and time_seconds < 0:
+        raise ValueError(f"time_seconds must be >= 0 or None; got {time_seconds}")
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    stage, video = _resolve_stage_video(project, stage_number=stage_number, video_id=video_id)
+    if time_seconds is None:
+        _apply_beep_clear(video)
+    else:
+        _apply_beep_manual(video, float(time_seconds))
+    audio_helpers.invalidate_video_audit_trim(root, stage_number, video, project=project)
+    project.save(root)
+    return _beep_state_summary(video)
+
+
+def select_beep_candidate(
+    project_root: str,
+    *,
+    stage_number: int,
+    video_id: str,
+    time_seconds: float,
+) -> dict[str, Any]:
+    """Promote one of ``video.beep_candidates`` (matched within 1 ms of
+    ``time_seconds``) as the authoritative beep.
+
+    Mirror of ``POST /api/stages/{n}/videos/{vid}/beep/select`` --
+    keeps ``beep_source="auto"`` because the time still came from the
+    detector, but copies the chosen candidate's diagnostic fields
+    (peak amplitude, duration, confidence) onto the video so the
+    HITL queue + UI render the right values. Resets ``beep_reviewed``
+    to False so a subsequent ``mark_beep_reviewed`` call confirms
+    the *new* pick rather than carrying over approval of the
+    previous one. Audit trim cache is invalidated.
+
+    Raises ``ValueError`` if the candidate list is empty or no
+    candidate is within 1 ms of ``time_seconds``.
+    """
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    stage, video = _resolve_stage_video(project, stage_number=stage_number, video_id=video_id)
+    if not video.beep_candidates:
+        raise ValueError(f"video {video_id} has no candidate list yet; run detect_beep first")
+    match_eps = 1e-3
+    chosen = next(
+        (c for c in video.beep_candidates if abs(c.time - time_seconds) <= match_eps),
+        None,
+    )
+    if chosen is None:
+        available = ", ".join(f"{c.time:.3f}" for c in video.beep_candidates)
+        raise ValueError(
+            f"no candidate within {match_eps * 1000:.0f} ms of "
+            f"{time_seconds:.3f}s; available: [{available}]"
+        )
+    video.beep_time = chosen.time
+    video.beep_source = "auto"
+    video.beep_peak_amplitude = chosen.peak_amplitude
+    video.beep_duration_ms = chosen.duration_ms
+    video.beep_confidence = chosen.confidence
+    video.beep_auto_detect_failed = False
+    video.beep_alignment_confidence = None
+    video.beep_alignment_delta_ms = None
+    video.processed["beep"] = True
+    video.processed["trim"] = False
+    # Switching candidate is a fresh claim; the user (or another
+    # agent) should re-confirm before the auto-trust gate opens.
+    video.beep_reviewed = False
+    if video.role == "primary":
+        video.processed["shot_detect"] = False
+    audio_helpers.invalidate_video_audit_trim(root, stage_number, video, project=project)
+    project.save(root)
+    return _beep_state_summary(video)
+
+
+def mark_beep_reviewed(
+    project_root: str,
+    *,
+    stage_number: int,
+    video_id: str,
+    reviewed: bool = True,
+) -> dict[str, Any]:
+    """Flip ``video.beep_reviewed`` (issue #71).
+
+    Setting True requires ``beep_time`` to be present; setting False
+    is always allowed (e.g. agent wants the user to re-pick). This
+    is the explicit handoff between detect-stage and shot-detect:
+    when the SPA's user (or an agent) confirms a beep, downstream
+    detection chains can fire. The MCP write tool only updates the
+    flag -- the chain itself runs on the HTTP server's job runner
+    or via a future ``detect_shots`` MCP tool (layer 3c).
+    """
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    _stage, video = _resolve_stage_video(project, stage_number=stage_number, video_id=video_id)
+    if reviewed and video.beep_time is None:
+        raise ValueError("cannot mark a beep reviewed before one has been detected")
+    video.beep_reviewed = bool(reviewed)
+    project.save(root)
+    return _beep_state_summary(video)
+
+
+def _resolve_stage_video(
+    project: MatchProject, *, stage_number: int, video_id: str
+) -> tuple[Any, StageVideo]:
+    try:
+        stage = project.stage(stage_number)
+    except KeyError as exc:
+        raise ValueError(f"stage {stage_number} not found") from exc
+    video = stage.find_video_by_id(video_id) if hasattr(stage, "find_video_by_id") else None
+    if video is None:
+        # Older code paths don't have ``find_video_by_id``; scan manually.
+        video = next((v for v in stage.videos if v.video_id == video_id), None)
+    if video is None:
+        raise ValueError(
+            f"video {video_id} not on stage {stage_number}; "
+            f"available: {[v.video_id for v in stage.videos]}"
+        )
+    return stage, video
+
+
+def _apply_beep_manual(video: StageVideo, time_seconds: float) -> None:
+    video.beep_time = time_seconds
+    video.beep_source = "manual"
+    video.beep_peak_amplitude = None
+    video.beep_duration_ms = None
+    # Manual entry pins confidence at 1.0 so the auto-trust gate
+    # (#219) opens immediately.
+    video.beep_confidence = 1.0
+    video.beep_candidates = []
+    video.beep_auto_detect_failed = False
+    video.beep_alignment_confidence = None
+    video.beep_alignment_delta_ms = None
+    video.processed["beep"] = True
+    video.processed["trim"] = False
+    # Manual entry implies the user / agent looked at the waveform;
+    # skip the review pill (#71).
+    video.beep_reviewed = True
+    if video.role == "primary":
+        video.processed["shot_detect"] = False
+
+
+def _apply_beep_clear(video: StageVideo) -> None:
+    video.beep_time = None
+    video.beep_source = None
+    video.beep_peak_amplitude = None
+    video.beep_duration_ms = None
+    video.beep_confidence = None
+    video.beep_candidates = []
+    video.beep_auto_detect_failed = False
+    video.beep_alignment_confidence = None
+    video.beep_alignment_delta_ms = None
+    video.processed["beep"] = False
+    video.processed["trim"] = False
+    video.beep_reviewed = False
+    if video.role == "primary":
+        video.processed["shot_detect"] = False
+
+
+def _beep_state_summary(video: StageVideo) -> dict[str, Any]:
+    return {
+        "video_id": video.video_id,
+        "beep_time": video.beep_time,
+        "beep_source": video.beep_source,
+        "beep_confidence": video.beep_confidence,
+        "beep_reviewed": video.beep_reviewed,
+        "beep_auto_detect_failed": video.beep_auto_detect_failed,
+        "processed": dict(video.processed),
+    }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -19,15 +19,31 @@ def _list_tool_names() -> set[str]:
     return {t.name for t in tools}
 
 
+READ_ONLY_TOOLS = {
+    "probe_video",
+    "discover_videos",
+    "get_project",
+    "list_stages",
+    "get_hitl_queue",
+}
+
+WRITE_TOOLS = {
+    "assign_video",
+    "set_beep_manual",
+    "select_beep_candidate",
+    "mark_beep_reviewed",
+}
+
+
 def test_server_registers_read_only_tools() -> None:
     names = _list_tool_names()
-    assert {
-        "probe_video",
-        "discover_videos",
-        "get_project",
-        "list_stages",
-        "get_hitl_queue",
-    } <= names
+    assert READ_ONLY_TOOLS <= names
+
+
+def test_server_registers_write_tools() -> None:
+    """Layer 3b adds the four mutating tools alongside the read-only set."""
+    names = _list_tool_names()
+    assert WRITE_TOOLS <= names
 
 
 def test_server_tools_have_descriptions() -> None:
@@ -41,15 +57,7 @@ def test_server_tools_have_descriptions() -> None:
 
 
 def test_server_has_no_unexpected_tools() -> None:
-    """Layer 1 only ships the read-only surface. A new tool landing
-    here without an updated test signals a missing layering decision
-    -- bump this set when adding to the server, don't silently extend.
-    """
-    expected = {
-        "probe_video",
-        "discover_videos",
-        "get_project",
-        "list_stages",
-        "get_hitl_queue",
-    }
+    """Bump this set when a new layer adds tools -- silent extension
+    would skip the design conversation about the new surface."""
+    expected = READ_ONLY_TOOLS | WRITE_TOOLS
     assert _list_tool_names() == expected

--- a/tests/test_mcp_write_tools.py
+++ b/tests/test_mcp_write_tools.py
@@ -1,0 +1,351 @@
+"""Tests for the mutating MCP tools (issue #211 layer 3b)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from splitsmith.config import BeepCandidate
+from splitsmith.mcp import write_tools
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _build_project(
+    root: Path,
+    *,
+    stages: list[StageEntry] | None = None,
+) -> MatchProject:
+    project = MatchProject.init(root, name="MCP Write Test")
+    if stages is not None:
+        project.stages = stages
+    project.save(root)
+    return project
+
+
+def _stage_with_primary(
+    *,
+    stage_number: int = 1,
+    primary_path: Path = Path("raw/p.mp4"),
+    primary_kwargs: dict | None = None,
+) -> StageEntry:
+    """Helper: build a stage with one primary video."""
+    primary = StageVideo(
+        path=primary_path,
+        role="primary",
+        **(primary_kwargs or {}),
+    )
+    return StageEntry(
+        stage_number=stage_number,
+        stage_name=f"Stage {stage_number}",
+        time_seconds=12.0,
+        videos=[primary],
+    )
+
+
+# ---------------------------------------------------------------------------
+# assign_video
+# ---------------------------------------------------------------------------
+
+
+def test_assign_video_moves_unassigned_video_to_stage(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(stage_number=1, stage_name="One", time_seconds=12.0, videos=[]),
+        ],
+    )
+    project.unassigned_videos = [StageVideo(path=Path("raw/v.mp4"), role="secondary")]
+    project.save(root)
+
+    result = write_tools.assign_video(str(root), "raw/v.mp4", stage_number=1, role="secondary")
+    # Reload to confirm persistence.
+    after = MatchProject.load(root)
+    assert len(after.unassigned_videos) == 0
+    assert len(after.stages[0].videos) == 1
+    # First-video-on-stage auto-upgrade: secondary -> primary.
+    assert after.stages[0].videos[0].role == "primary"
+    assert result["role"] == "primary"
+    assert result["stage_number"] == 1
+
+
+def test_assign_video_unassigns(tmp_path: Path) -> None:
+    """``stage_number=None`` returns the video to the unassigned tray."""
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+
+    result = write_tools.assign_video(str(root), "raw/p.mp4", stage_number=None, role="secondary")
+    after = MatchProject.load(root)
+    assert len(after.stages[0].videos) == 0
+    assert len(after.unassigned_videos) == 1
+    assert result["stage_number"] is None
+
+
+def test_assign_video_rejects_unknown_role(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root)
+    with pytest.raises(ValueError, match="role must be one of"):
+        write_tools.assign_video(str(root), "raw/v.mp4", stage_number=1, role="bogus")
+
+
+def test_assign_video_demotes_existing_primary(tmp_path: Path) -> None:
+    """Promoting a second video to primary demotes the first."""
+    root = tmp_path / "match"
+    stage = StageEntry(
+        stage_number=1,
+        stage_name="Demote",
+        time_seconds=12.0,
+        videos=[
+            StageVideo(path=Path("raw/old.mp4"), role="primary"),
+            StageVideo(path=Path("raw/new.mp4"), role="secondary"),
+        ],
+    )
+    _build_project(root, stages=[stage])
+    write_tools.assign_video(str(root), "raw/new.mp4", stage_number=1, role="primary")
+    after = MatchProject.load(root)
+    roles = {str(v.path): v.role for v in after.stages[0].videos}
+    assert roles["raw/new.mp4"] == "primary"
+    assert roles["raw/old.mp4"] == "secondary"
+
+
+# ---------------------------------------------------------------------------
+# set_beep_manual
+# ---------------------------------------------------------------------------
+
+
+def test_set_beep_manual_pins_time_and_clamps_confidence(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
+        result = write_tools.set_beep_manual(
+            str(root), stage_number=1, video_id=primary_id, time_seconds=4.5
+        )
+    after = MatchProject.load(root)
+    primary = after.stages[0].videos[0]
+    assert primary.beep_time == 4.5
+    assert primary.beep_source == "manual"
+    assert primary.beep_confidence == 1.0
+    assert primary.beep_reviewed is True
+    assert result["beep_confidence"] == 1.0
+
+
+def test_set_beep_manual_clear_resets_state(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                primary_kwargs={
+                    "beep_time": 5.0,
+                    "beep_source": "auto",
+                    "beep_confidence": 0.85,
+                    "beep_reviewed": True,
+                    "processed": {"beep": True, "shot_detect": False, "trim": True},
+                }
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
+        write_tools.set_beep_manual(
+            str(root), stage_number=1, video_id=primary_id, time_seconds=None
+        )
+    primary = MatchProject.load(root).stages[0].videos[0]
+    assert primary.beep_time is None
+    assert primary.beep_source is None
+    assert primary.beep_confidence is None
+    assert primary.beep_reviewed is False
+    assert primary.processed["beep"] is False
+    assert primary.processed["trim"] is False
+
+
+def test_set_beep_manual_invalidates_audit_trim(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch(
+        "splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"
+    ) as mock_invalidate:
+        write_tools.set_beep_manual(
+            str(root), stage_number=1, video_id=primary_id, time_seconds=4.5
+        )
+    assert mock_invalidate.call_count == 1
+
+
+def test_set_beep_manual_rejects_negative_time(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with pytest.raises(ValueError, match=">= 0"):
+        write_tools.set_beep_manual(
+            str(root), stage_number=1, video_id=primary_id, time_seconds=-0.5
+        )
+
+
+def test_set_beep_manual_unknown_stage_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root)
+    with pytest.raises(ValueError, match="stage 99 not found"):
+        write_tools.set_beep_manual(str(root), stage_number=99, video_id="abc", time_seconds=1.0)
+
+
+def test_set_beep_manual_unknown_video_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    with pytest.raises(ValueError, match="not on stage"):
+        write_tools.set_beep_manual(str(root), stage_number=1, video_id="missing", time_seconds=1.0)
+
+
+# ---------------------------------------------------------------------------
+# select_beep_candidate
+# ---------------------------------------------------------------------------
+
+
+def test_select_beep_candidate_promotes_match(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    candidates = [
+        BeepCandidate(
+            time=4.500,
+            score=10.0,
+            peak_amplitude=0.42,
+            duration_ms=350.0,
+            silence_score=8.0,
+            tonal_score=0.95,
+            confidence=0.88,
+        ),
+        BeepCandidate(
+            time=7.250,
+            score=5.0,
+            peak_amplitude=0.30,
+            duration_ms=180.0,
+            silence_score=6.0,
+            tonal_score=0.70,
+            confidence=0.45,
+        ),
+    ]
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                primary_kwargs={
+                    "beep_time": 4.5,
+                    "beep_source": "auto",
+                    "beep_candidates": candidates,
+                    "beep_reviewed": True,
+                    "beep_confidence": 0.88,
+                }
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
+        result = write_tools.select_beep_candidate(
+            str(root), stage_number=1, video_id=primary_id, time_seconds=7.250
+        )
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_time == pytest.approx(7.250)
+    assert after.beep_source == "auto"
+    assert after.beep_confidence == pytest.approx(0.45)
+    # Switching candidate resets reviewed -- new claim needs new confirmation.
+    assert after.beep_reviewed is False
+    assert result["beep_reviewed"] is False
+
+
+def test_select_beep_candidate_no_match_within_1ms_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    candidates = [
+        BeepCandidate(
+            time=4.500,
+            score=10.0,
+            peak_amplitude=0.42,
+            duration_ms=350.0,
+            silence_score=8.0,
+            tonal_score=0.95,
+            confidence=0.88,
+        ),
+    ]
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                primary_kwargs={
+                    "beep_time": 4.5,
+                    "beep_source": "auto",
+                    "beep_candidates": candidates,
+                }
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
+        with pytest.raises(ValueError, match="no candidate within"):
+            write_tools.select_beep_candidate(
+                str(root), stage_number=1, video_id=primary_id, time_seconds=99.0
+            )
+
+
+def test_select_beep_candidate_empty_list_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
+        with pytest.raises(ValueError, match="no candidate list"):
+            write_tools.select_beep_candidate(
+                str(root), stage_number=1, video_id=primary_id, time_seconds=4.5
+            )
+
+
+# ---------------------------------------------------------------------------
+# mark_beep_reviewed
+# ---------------------------------------------------------------------------
+
+
+def test_mark_beep_reviewed_flips_flag(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                primary_kwargs={
+                    "beep_time": 4.5,
+                    "beep_source": "auto",
+                    "beep_reviewed": False,
+                }
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    result = write_tools.mark_beep_reviewed(
+        str(root), stage_number=1, video_id=primary_id, reviewed=True
+    )
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_reviewed is True
+    assert result["beep_reviewed"] is True
+
+
+def test_mark_beep_reviewed_rejects_when_no_beep_yet(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with pytest.raises(ValueError, match="before one has been detected"):
+        write_tools.mark_beep_reviewed(
+            str(root), stage_number=1, video_id=primary_id, reviewed=True
+        )
+
+
+def test_mark_beep_reviewed_unmark_allowed_without_beep(tmp_path: Path) -> None:
+    """Setting reviewed=False is always allowed -- no precondition."""
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary()])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    write_tools.mark_beep_reviewed(str(root), stage_number=1, video_id=primary_id, reviewed=False)
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_reviewed is False


### PR DESCRIPTION
## Summary

Adds the four mutating tools the agent flow needs to drive a stage through the beep half of the pipeline. Each mirrors the corresponding HTTP endpoint so an agent driving the MCP and a user driving the SPA produce identical project state.

| tool | mirror of |
|---|---|
| `assign_video(project_root, video_path, stage_number, role)` | `POST /api/assignments/move` |
| `set_beep_manual(project_root, stage_number, video_id, time_seconds)` | `POST /api/stages/{n}/videos/{vid}/beep` |
| `select_beep_candidate(project_root, stage_number, video_id, time_seconds)` | `POST /api/stages/{n}/videos/{vid}/beep/select` |
| `mark_beep_reviewed(project_root, stage_number, video_id, reviewed)` | `POST /api/stages/{n}/videos/{vid}/beep/review` |

`set_beep_manual` and `select_beep_candidate` invalidate the audit trim cache so the next viewing rebuilds from the new beep offset. `set_beep_manual` clamps confidence to 1.0 (manual = auto-trust gate opens immediately, per #219). `select_beep_candidate` resets `beep_reviewed=False` so the new pick needs its own confirmation.

## Out of scope

- Background-job triggers (auto-trim, auto-shot-detect on review, auto-beep on assignment). MCP surface is project-state only; chains run on the HTTP daemon's job runner when present, or via the future `trim` / `detect_*` MCP tools (layer 3c).
- Sandboxing of `video_path` in `assign_video` -- the path is a project-internal identifier (relative to project root, string-equality match), so absolute resolution breaks the lookup.

## Test plan

- [x] 47 MCP tests pass (`uv run pytest tests/test_mcp_*.py`)
- [x] 991 tests pass overall (no regressions)
- [x] `test_mcp_server.py` asserts the read-only + write tool sets are both registered
- [x] `python -m splitsmith.mcp` boots cleanly
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)