### PR TITLE
mcp: detect_beep tool (#211 layer 3c)

### DIFF
--- a/src/splitsmith/mcp/detect_tools.py
+++ b/src/splitsmith/mcp/detect_tools.py
@@ -1,0 +1,167 @@
+"""Detection MCP tools (issue #211 layer 3c).
+
+Wraps the heavy detection stages (beep detection now; shot detection
+in a later PR) as synchronous MCP tools. The agent flow expects to
+call these and get a result back; the underlying functions take a
+few seconds (audio extraction + 4th-order Butterworth + Hilbert) so
+running them inline is acceptable for the typical MCP client. If
+end-to-end latency becomes a problem we'd graduate to a job-runner
+abstraction matched to the HTTP server's; the synchronous shape is
+the right starting point.
+
+Detection mutates project state:
+
+* Persists the BeepDetection result onto ``StageVideo`` (time, source,
+  candidates, peak, duration, confidence, auto-detect-failed).
+* Honours the auto-trust gate (#219): when the resolved
+  ``automation.beep_low_confidence_threshold`` is met,
+  ``beep_reviewed`` flips to True so an external auto-trim chain
+  fires; below it the beep stays unreviewed and lands in the HITL
+  queue.
+* Does NOT run trim or shot detection. Those are the next layers'
+  jobs (and the HTTP daemon does them inline today).
+* Cross-correlation alignment for secondaries is also deferred.
+  ``detect_beep`` on a secondary marks ``beep_auto_detect_failed``
+  if the in-stream detector finds nothing; the SPA's existing
+  align flow handles those cases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .. import automation as automation_module
+from .. import beep_detect
+from ..ui import audio as audio_helpers
+from ..ui.project import MatchProject
+from .sandbox import resolve_project_root
+from .write_tools import _resolve_stage_video
+
+
+def detect_beep_for_video(
+    project_root: str,
+    *,
+    stage_number: int,
+    video_id: str,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Run ``beep_detect.detect_beep`` against ``video``'s cached audio
+    and persist the result on the project.
+
+    Skips when the video already has a beep recorded unless ``force``
+    is True -- re-detecting a clean beep is wasteful and would clear
+    a manual override or a reviewed pick.
+
+    Returns a summary dict with the detected time, confidence, source
+    (always ``"auto"`` here), the auto-trust gate decision, and the
+    candidate list so the agent can immediately drive
+    ``select_beep_candidate`` if it disagrees with the winner.
+    """
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    _stage, video = _resolve_stage_video(project, stage_number=stage_number, video_id=video_id)
+    if video.role == "ignored":
+        raise ValueError(
+            f"video {video_id} on stage {stage_number} is ignored; "
+            "assign it as primary or secondary first"
+        )
+    if not force and video.beep_time is not None and video.beep_source == "manual":
+        # Manual entries are explicit user intent; never overwrite
+        # without ``force=True``. Auto-detected beeps are eligible for
+        # re-detection because the detector itself may have improved.
+        return _summary(video, gate_threshold=None)
+    if not force and video.processed.get("beep") and video.beep_source == "auto":
+        return _summary(video, gate_threshold=None)
+
+    source = project.resolve_video_path(root, video.path)
+    if not source.exists():
+        raise FileNotFoundError(
+            f"source video missing for stage {stage_number} video {video_id}: {source}"
+        )
+
+    try:
+        beep = audio_helpers.detect_video_beep(
+            root,
+            stage_number,
+            video,
+            source,
+            project=project,
+        )
+    except beep_detect.BeepNotFoundError:
+        _apply_beep_not_found(video)
+        project.save(root)
+        return _summary(video, gate_threshold=None, error="not_found")
+
+    resolved_auto = automation_module.resolve_automation(
+        project_override=project.automation,
+    )
+    threshold = resolved_auto.settings.beep_low_confidence_threshold
+    _apply_detected_beep(video, beep, threshold=threshold)
+    project.save(root)
+    return _summary(video, gate_threshold=threshold)
+
+
+def _apply_detected_beep(video: Any, beep: Any, *, threshold: float) -> None:
+    """Persist a successful detection onto ``video``.
+
+    Mirrors the logic in ``server.py:_run_detect_beep_for_video`` but
+    skipped pieces (cross-align, audit-trim chain, shot-detect chain)
+    so the MCP-driven flow stays synchronous and predictable.
+    """
+    video.beep_time = beep.time
+    video.beep_source = "auto"
+    video.beep_peak_amplitude = beep.peak_amplitude
+    video.beep_duration_ms = beep.duration_ms
+    video.beep_confidence = beep.confidence
+    video.beep_candidates = list(beep.candidates)
+    video.beep_auto_detect_failed = False
+    video.beep_alignment_confidence = None
+    video.beep_alignment_delta_ms = None
+    video.processed["beep"] = True
+    # Audit trim is anchored to beep_time; a fresh detection invalidates
+    # any cached clip. The MCP doesn't run the trim job itself, so we
+    # leave the flag False -- the SPA / a future tool re-trims on next
+    # view.
+    video.processed["trim"] = False
+    # Auto-trust gate (#219): high-confidence detections skip the
+    # review pill; below-threshold land in the HITL queue.
+    video.beep_reviewed = beep.confidence >= threshold
+    if video.role == "primary":
+        video.processed["shot_detect"] = False
+
+
+def _apply_beep_not_found(video: Any) -> None:
+    """Persist a no-candidate result so the HITL queue can surface it."""
+    video.beep_time = None
+    video.beep_source = "auto"
+    video.beep_peak_amplitude = None
+    video.beep_duration_ms = None
+    video.beep_confidence = None
+    video.beep_candidates = []
+    video.beep_auto_detect_failed = True
+    video.beep_alignment_confidence = None
+    video.beep_alignment_delta_ms = None
+    video.processed["beep"] = True
+    video.processed["trim"] = False
+    video.beep_reviewed = False
+    if video.role == "primary":
+        video.processed["shot_detect"] = False
+
+
+def _summary(
+    video: Any, *, gate_threshold: float | None, error: str | None = None
+) -> dict[str, Any]:
+    """Compact response shape -- enough for the agent to decide what
+    to do next without a separate get_project round-trip."""
+    return {
+        "video_id": video.video_id,
+        "beep_time": video.beep_time,
+        "beep_source": video.beep_source,
+        "beep_confidence": video.beep_confidence,
+        "beep_reviewed": video.beep_reviewed,
+        "beep_auto_detect_failed": video.beep_auto_detect_failed,
+        "candidate_count": len(video.beep_candidates),
+        "candidates": [c.model_dump(mode="json") for c in video.beep_candidates],
+        "auto_trust_threshold": gate_threshold,
+        "error": error,
+    }

--- a/src/splitsmith/mcp/server.py
+++ b/src/splitsmith/mcp/server.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from . import tools, write_tools
+from . import detect_tools, tools, write_tools
 
 
 def create_server(name: str = "splitsmith") -> FastMCP:
@@ -185,6 +185,42 @@ def create_server(name: str = "splitsmith") -> FastMCP:
             stage_number=stage_number,
             video_id=video_id,
             reviewed=reviewed,
+        )
+
+    # ----------------------------------------------------------------
+    # Detection tools (layer 3c). Synchronous -- the call returns when
+    # the detector finishes. Beep detection takes ~5 s on a 100 s
+    # primary clip; the agent waits inline. Shot detection (heavier;
+    # CLAP / GBDT / PANN) lands in a future layer.
+    # ----------------------------------------------------------------
+
+    @mcp.tool()
+    def detect_beep(
+        project_root: str,
+        stage_number: int,
+        video_id: str,
+        force: bool = False,
+    ) -> dict:
+        """Run beep detection against a stage's video; persist the
+        result on the project.
+
+        Returns the detected ``beep_time``, calibrated ``confidence``,
+        and the ranked candidate list. Honours the
+        ``automation.beep_low_confidence_threshold`` auto-trust gate
+        (#219): detections at or above the threshold flip
+        ``beep_reviewed=True`` so the downstream chain can fire;
+        below it the beep lands in the HITL queue.
+
+        Skips when the video already has a beep unless ``force=True``.
+        Manual entries (``beep_source="manual"``) are NEVER auto-
+        rerun -- the agent must clear them via ``set_beep_manual``
+        with ``time_seconds=None`` first.
+        """
+        return detect_tools.detect_beep_for_video(
+            project_root,
+            stage_number=stage_number,
+            video_id=video_id,
+            force=force,
         )
 
     return mcp

--- a/tests/test_mcp_detect_tools.py
+++ b/tests/test_mcp_detect_tools.py
@@ -1,0 +1,289 @@
+"""Tests for the detection MCP tools (issue #211 layer 3c)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from splitsmith.beep_detect import BeepNotFoundError
+from splitsmith.config import BeepCandidate, BeepDetection
+from splitsmith.mcp import detect_tools
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _build_project(
+    root: Path,
+    *,
+    stages: list[StageEntry] | None = None,
+) -> MatchProject:
+    project = MatchProject.init(root, name="MCP Detect Test")
+    if stages is not None:
+        project.stages = stages
+    project.save(root)
+    return project
+
+
+def _stage_with_primary(
+    root: Path,
+    *,
+    primary_kwargs: dict | None = None,
+) -> StageEntry:
+    """Stage with a primary video whose source path actually exists on
+    disk (the detector resolves + checks existence)."""
+    src = root / "raw" / "primary.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"FAKE_MP4")
+    primary = StageVideo(
+        path=Path("raw/primary.mp4"),
+        role="primary",
+        **(primary_kwargs or {}),
+    )
+    return StageEntry(
+        stage_number=1,
+        stage_name="Stage 1",
+        time_seconds=12.0,
+        videos=[primary],
+    )
+
+
+def _fake_detection(
+    *, time: float = 5.5, confidence: float = 0.9, candidates: int = 2
+) -> BeepDetection:
+    cands = [
+        BeepCandidate(
+            time=time + 0.5 * i,
+            score=10.0 - i,
+            peak_amplitude=0.4,
+            duration_ms=350.0,
+            silence_score=8.0,
+            tonal_score=0.95,
+            confidence=confidence - 0.1 * i,
+        )
+        for i in range(candidates)
+    ]
+    return BeepDetection(
+        time=time,
+        peak_amplitude=cands[0].peak_amplitude,
+        duration_ms=cands[0].duration_ms,
+        confidence=cands[0].confidence,
+        candidates=cands,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_detect_beep_persists_result_on_project(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary(root)])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    fake = _fake_detection(time=4.875, confidence=0.92)
+
+    with patch("splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep", return_value=fake):
+        result = detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_time == pytest.approx(4.875)
+    assert after.beep_source == "auto"
+    assert after.beep_confidence == pytest.approx(0.92)
+    assert len(after.beep_candidates) == 2
+    assert after.beep_auto_detect_failed is False
+    assert result["beep_time"] == pytest.approx(4.875)
+    assert result["candidate_count"] == 2
+    assert result["error"] is None
+
+
+def test_detect_beep_high_confidence_auto_trusts_into_reviewed(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary(root)])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    fake = _fake_detection(confidence=0.92)
+
+    with patch("splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep", return_value=fake):
+        result = detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_reviewed is True
+    assert result["beep_reviewed"] is True
+    # Surfacing the threshold lets the agent explain to the user
+    # WHY auto-trust opened (or didn't).
+    assert result["auto_trust_threshold"] == 0.6
+
+
+def test_detect_beep_low_confidence_lands_in_hitl(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary(root)])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    fake = _fake_detection(confidence=0.45)
+
+    with patch("splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep", return_value=fake):
+        detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_reviewed is False
+    assert after.beep_confidence == pytest.approx(0.45)
+
+
+# ---------------------------------------------------------------------------
+# Detector failure
+# ---------------------------------------------------------------------------
+
+
+def test_detect_beep_marks_auto_detect_failed_on_no_candidate(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    _build_project(root, stages=[_stage_with_primary(root)])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch(
+        "splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep",
+        side_effect=BeepNotFoundError("no candidate"),
+    ):
+        result = detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_time is None
+    assert after.beep_auto_detect_failed is True
+    assert after.processed["beep"] is True  # detection ran; just no candidate
+    assert result["error"] == "not_found"
+    assert result["beep_auto_detect_failed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Skip / force semantics
+# ---------------------------------------------------------------------------
+
+
+def test_detect_beep_skips_when_already_detected(tmp_path: Path) -> None:
+    """Default behaviour: re-detecting an already-detected video is a
+    no-op so a workflow loop ``for stage in stages: detect_beep`` is
+    idempotent."""
+    root = tmp_path / "match"
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                root,
+                primary_kwargs={
+                    "beep_time": 5.0,
+                    "beep_source": "auto",
+                    "beep_confidence": 0.85,
+                    "processed": {"beep": True, "shot_detect": False, "trim": False},
+                },
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch("splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep") as mock_detect:
+        result = detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    mock_detect.assert_not_called()
+    assert result["beep_time"] == 5.0
+
+
+def test_detect_beep_force_reruns(tmp_path: Path) -> None:
+    """``force=True`` runs the detector even when the video has a beep."""
+    root = tmp_path / "match"
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                root,
+                primary_kwargs={
+                    "beep_time": 5.0,
+                    "beep_source": "auto",
+                    "beep_confidence": 0.55,
+                    "processed": {"beep": True, "shot_detect": False, "trim": False},
+                },
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    fake = _fake_detection(time=4.5, confidence=0.92)
+
+    with patch(
+        "splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep", return_value=fake
+    ) as mock_detect:
+        detect_tools.detect_beep_for_video(
+            str(root), stage_number=1, video_id=primary_id, force=True
+        )
+
+    mock_detect.assert_called_once()
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.beep_time == pytest.approx(4.5)
+    assert after.beep_confidence == pytest.approx(0.92)
+
+
+def test_detect_beep_never_overwrites_manual_entry_without_force(tmp_path: Path) -> None:
+    """Manual beep is the user's explicit intent. Re-detection without
+    force is a no-op even though processed['beep'] is True."""
+    root = tmp_path / "match"
+    _build_project(
+        root,
+        stages=[
+            _stage_with_primary(
+                root,
+                primary_kwargs={
+                    "beep_time": 5.0,
+                    "beep_source": "manual",
+                    "beep_confidence": 1.0,
+                    "beep_reviewed": True,
+                    "processed": {"beep": True, "shot_detect": False, "trim": False},
+                },
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+
+    with patch("splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep") as mock_detect:
+        result = detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+    mock_detect.assert_not_called()
+    assert result["beep_source"] == "manual"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_detect_beep_rejects_ignored_role(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src = root / "raw" / "x.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"x")
+    stage = StageEntry(
+        stage_number=1,
+        stage_name="Ignored",
+        time_seconds=12.0,
+        videos=[
+            StageVideo(path=Path("raw/x.mp4"), role="ignored"),
+        ],
+    )
+    _build_project(root, stages=[stage])
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with pytest.raises(ValueError, match="ignored"):
+        detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+
+def test_detect_beep_missing_source_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    primary = StageVideo(path=Path("raw/missing.mp4"), role="primary")
+    _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="Missing",
+                time_seconds=12.0,
+                videos=[primary],
+            )
+        ],
+    )
+    primary_id = MatchProject.load(root).stages[0].videos[0].video_id
+    with pytest.raises(FileNotFoundError, match="source video missing"):
+        detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -34,6 +34,10 @@ WRITE_TOOLS = {
     "mark_beep_reviewed",
 }
 
+DETECT_TOOLS = {
+    "detect_beep",
+}
+
 
 def test_server_registers_read_only_tools() -> None:
     names = _list_tool_names()
@@ -44,6 +48,12 @@ def test_server_registers_write_tools() -> None:
     """Layer 3b adds the four mutating tools alongside the read-only set."""
     names = _list_tool_names()
     assert WRITE_TOOLS <= names
+
+
+def test_server_registers_detect_tools() -> None:
+    """Layer 3c adds detection tools (just detect_beep for now)."""
+    names = _list_tool_names()
+    assert DETECT_TOOLS <= names
 
 
 def test_server_tools_have_descriptions() -> None:
@@ -59,5 +69,5 @@ def test_server_tools_have_descriptions() -> None:
 def test_server_has_no_unexpected_tools() -> None:
     """Bump this set when a new layer adds tools -- silent extension
     would skip the design conversation about the new surface."""
-    expected = READ_ONLY_TOOLS | WRITE_TOOLS
+    expected = READ_ONLY_TOOLS | WRITE_TOOLS | DETECT_TOOLS
     assert _list_tool_names() == expected


### PR DESCRIPTION
## Summary

Adds the synchronous `detect_beep` MCP tool. Wraps the existing `audio_helpers.detect_video_beep` (which audit-extracts the camera's audio + runs `beep_detect.detect_beep`) and persists the result onto the project, honouring the auto-trust gate (#219). Detection takes ~5s on a typical primary clip; running inline inside the tool call is well within MCP client patience.

```python
detect_beep(project_root: str, stage_number: int, video_id: str, force: bool = False) -> dict
```

Returns the detected `beep_time`, calibrated `confidence`, the auto-trust threshold, and the full ranked candidate list so the agent can immediately follow up with `select_beep_candidate` if it disagrees with the winner.

**Skip semantics**:
- Default: idempotent. Already-detected videos return their current state.
- `force=True`: reruns even when a beep exists.
- Manual entries (`beep_source="manual"`) are NEVER overwritten without `force=True` -- the agent must clear them via `set_beep_manual(time_seconds=None)` first.

## Out of scope (future layers)

- **Trim chain**: MCP doesn't run `ensure_video_audit_trim` -- SPA / a future trim tool handles it on next view.
- **Shot detection chain** (`automation.shot_detect_on_beep_verified`): fires on the HTTP daemon's job runner; the MCP-driven flow will get its own `detect_shots` in layer 3d.
- **Cross-correlation alignment for secondaries**: marks `beep_auto_detect_failed=True` today; SPA's existing align flow handles those.

## Test plan

- [x] 57 MCP tests pass (`uv run pytest tests/test_mcp_*.py`)
- [x] 1001 tests pass overall (no regressions)
- [x] `python -m splitsmith.mcp` boots cleanly
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)