### PR TITLE
mcp: detect_shots tool (#211 layer 3d)

### DIFF
--- a/src/splitsmith/mcp/detect_tools.py
+++ b/src/splitsmith/mcp/detect_tools.py
@@ -28,14 +28,50 @@ Detection mutates project state:
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import threading
+from datetime import UTC, datetime
 from typing import Any
 
 from .. import automation as automation_module
 from .. import beep_detect
+from .. import ensemble as ensemble_module
 from ..ui import audio as audio_helpers
 from ..ui.project import MatchProject
 from .sandbox import resolve_project_root
 from .write_tools import _resolve_stage_video
+
+logger = logging.getLogger(__name__)
+
+# Lazy module-level cache for the ensemble runtime (CLAP / GBDT / PANN
+# weights, optionally CLIP for voter E). Loading takes ~5 s; subsequent
+# calls in the same process are free. Mirrors the HTTP server's
+# ``_get_ensemble_runtime`` so MCP clients pay the cost once per server
+# lifetime.
+_ENSEMBLE_RUNTIME: ensemble_module.EnsembleRuntime | None = None
+_ENSEMBLE_RUNTIME_LOCK = threading.Lock()
+
+
+def _get_ensemble_runtime() -> ensemble_module.EnsembleRuntime:
+    """Load + cache the ensemble runtime; thread-safe.
+
+    Test code monkeypatches this function (and
+    ``ensemble.detect_shots_ensemble``) to avoid pulling the heavy
+    model weights into the test process.
+    """
+    global _ENSEMBLE_RUNTIME
+    if _ENSEMBLE_RUNTIME is None:
+        with _ENSEMBLE_RUNTIME_LOCK:
+            if _ENSEMBLE_RUNTIME is None:
+                with_voter_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
+                _ENSEMBLE_RUNTIME = ensemble_module.load_ensemble_runtime(with_voter_e=with_voter_e)
+    return _ENSEMBLE_RUNTIME
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
 
 
 def detect_beep_for_video(
@@ -165,3 +201,211 @@ def _summary(
         "auto_trust_threshold": gate_threshold,
         "error": error,
     }
+
+
+def detect_shots_for_stage(
+    project_root: str,
+    *,
+    stage_number: int,
+    reset: bool = False,
+) -> dict[str, Any]:
+    """Run the 4-voter shot-detection ensemble on a stage's audit clip.
+
+    Mirror of ``POST /api/stages/{n}/shot-detect``: loads the audit
+    audio (preferring the trim cache, falling back to the full
+    primary WAV), runs CLAP + GBDT + PANN consensus, and writes the
+    candidate universe + seeded ``shots[]`` into
+    ``<project>/audit/stage<N>.json``. The file is the source of
+    truth for the audit UI; the SPA + MCP both read / write it.
+
+    Preconditions: stage has a primary, primary has ``beep_time``,
+    stage has ``time_seconds > 0``. Raises ``ValueError`` otherwise.
+
+    ``reset=True`` wipes the existing ``shots[]`` before seeding from
+    the new run -- useful when re-running detection after fixing a
+    wrong beep. By default ``shots[]`` is preserved if non-empty
+    (the user retains authority over the curated list).
+
+    First call in a process loads the ensemble runtime (~5 s for
+    CLAP + GBDT + PANN weights, plus first-call download if not yet
+    cached). Subsequent calls reuse it. Voter E (CLIP image
+    encoder, ~600 MB) requires ``SPLITSMITH_ENABLE_VOTER_E=1`` --
+    matches the HTTP server.
+    """
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    try:
+        stage = project.stage(stage_number)
+    except KeyError as exc:
+        raise ValueError(f"stage {stage_number} not found") from exc
+    primary = next((v for v in stage.videos if v.role == "primary"), None)
+    if primary is None:
+        raise ValueError(f"stage {stage_number} has no primary video")
+    if primary.beep_time is None:
+        raise ValueError(
+            f"stage {stage_number} primary has no beep_time yet; "
+            "run detect_beep or set_beep_manual first"
+        )
+    if stage.time_seconds <= 0:
+        raise ValueError(
+            f"stage {stage_number} has time_seconds=0; import a "
+            "scoreboard or set the stage time before running shot detection"
+        )
+    source = project.resolve_video_path(root, primary.path)
+    if not source.exists():
+        raise FileNotFoundError(f"primary source missing for stage {stage_number}: {source}")
+
+    audit = audio_helpers.ensure_audit_audio(
+        root, stage_number, source, primary.beep_time, project=project
+    )
+    beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else primary.beep_time
+
+    audit_dir = project.audit_path(root)
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_file = audit_dir / f"stage{stage_number}.json"
+    existing_json = _load_or_seed_audit_json(audit_file, stage, beep_in_clip)
+    if stage.stage_rounds is not None:
+        existing_json["stage_rounds"] = stage.stage_rounds.model_dump(
+            mode="json", exclude_none=True
+        )
+    expected_rounds = _expected_rounds_from(existing_json)
+
+    runtime = _get_ensemble_runtime()
+    audio_array, sr = beep_detect.load_audio(audit.audio_path)
+    cam_class = ensemble_module.camera_class_from_mount(primary.camera_mount)
+    enable_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
+    ensemble_cfg = ensemble_module.EnsembleConfig(enable_voter_e=enable_e)
+    result = ensemble_module.detect_shots_ensemble(
+        audio_array,
+        sr,
+        beep_in_clip,
+        stage.time_seconds,
+        runtime,
+        expected_rounds=expected_rounds,
+        ensemble_config=ensemble_cfg,
+        camera_class=cam_class,
+        video_path=source if enable_e else None,
+        source_beep_time=primary.beep_time if enable_e else None,
+    )
+
+    candidates = [_candidate_dict(c) for c in result.candidates]
+    existing_json["_candidates_pending_audit"] = {
+        "_note": (
+            "4-voter ensemble (issue #31). vote_a/b/c/d=1 means the voter "
+            "kept the candidate; ensemble_score = vote_total + apriori_boost. "
+            "shots[] is seeded from candidates with ensemble_score >= consensus."
+        ),
+        "consensus": result.consensus,
+        "expected_rounds": result.expected_rounds,
+        "candidates": candidates,
+    }
+    if reset:
+        existing_json["shots"] = []
+    seeded = False
+    if not existing_json.get("shots"):
+        kept = [c for c in result.candidates if c.kept]
+        existing_json["shots"] = [
+            {
+                "shot_number": i,
+                "candidate_number": c.candidate_number,
+                "time": c.time,
+                "ms_after_beep": c.ms_after_beep,
+                "source": "detected",
+                "ensemble_votes": c.vote_total,
+                "apriori_boost": c.apriori_boost,
+                "ensemble_score": c.ensemble_score,
+            }
+            for i, c in enumerate(kept, start=1)
+        ]
+        seeded = True
+    events = list(existing_json.get("audit_events") or [])
+    events.append(
+        {
+            "ts": _now_iso(),
+            "kind": "shot_detect_run",
+            "payload": {
+                "candidate_count": len(candidates),
+                "kept_count": sum(1 for c in result.candidates if c.kept),
+                "consensus": result.consensus,
+                "expected_rounds": result.expected_rounds,
+                "seeded_shots": seeded,
+                "source": "mcp",
+            },
+        }
+    )
+    existing_json["audit_events"] = events
+    _atomic_write_audit_json(audit_file, existing_json)
+
+    primary.processed["shot_detect"] = True
+    project.save(root)
+    return {
+        "stage_number": stage_number,
+        "candidate_count": len(candidates),
+        "kept_count": sum(1 for c in result.candidates if c.kept),
+        "consensus": result.consensus,
+        "expected_rounds": result.expected_rounds,
+        "shots_seeded": seeded,
+        "shot_count": len(existing_json.get("shots") or []),
+    }
+
+
+def _candidate_dict(cand: Any) -> dict[str, Any]:
+    return {
+        "candidate_number": cand.candidate_number,
+        "time": cand.time,
+        "ms_after_beep": cand.ms_after_beep,
+        "peak_amplitude": cand.peak_amplitude,
+        "confidence": cand.confidence,
+        "vote_a": cand.vote_a,
+        "vote_b": cand.vote_b,
+        "vote_c": cand.vote_c,
+        "vote_d": cand.vote_d,
+        "vote_e": cand.vote_e,
+        "vote_total": cand.vote_total,
+        "apriori_boost": cand.apriori_boost,
+        "ensemble_score": cand.ensemble_score,
+        "score_c": cand.score_c,
+        "clap_diff": cand.clap_diff,
+        "gunshot_prob": cand.gunshot_prob,
+        "voter_e_signal": cand.voter_e_signal,
+    }
+
+
+def _load_or_seed_audit_json(audit_file: Any, stage: Any, beep_in_clip: float) -> dict[str, Any]:
+    if audit_file.exists():
+        try:
+            return json.loads(audit_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Discarding unreadable audit JSON at %s: %s", audit_file, exc)
+    return {
+        "stage_number": stage.stage_number,
+        "stage_name": stage.stage_name,
+        "stage_time_seconds": stage.time_seconds,
+        "beep_time": round(beep_in_clip, 4),
+        "shots": [],
+    }
+
+
+def _expected_rounds_from(audit_json: dict[str, Any]) -> int | None:
+    sr_block = audit_json.get("stage_rounds")
+    if isinstance(sr_block, dict):
+        raw = sr_block.get("expected")
+        if isinstance(raw, int) and raw > 0:
+            return raw
+    return None
+
+
+def _atomic_write_audit_json(audit_file: Any, payload: dict[str, Any]) -> None:
+    """Atomic write with a ``.bak`` of the previous version.
+
+    Mirrors the SPA's ``put_stage_audit`` write semantics so a
+    concurrent SPA / MCP read sees a consistent file.
+    """
+    tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
+    backup = audit_file.with_suffix(audit_file.suffix + ".bak")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    if audit_file.exists():
+        if backup.exists():
+            backup.unlink()
+        audit_file.replace(backup)
+    tmp.replace(audit_file)

--- a/src/splitsmith/mcp/server.py
+++ b/src/splitsmith/mcp/server.py
@@ -223,4 +223,36 @@ def create_server(name: str = "splitsmith") -> FastMCP:
             force=force,
         )
 
+    @mcp.tool()
+    def detect_shots(
+        project_root: str,
+        stage_number: int,
+        reset: bool = False,
+    ) -> dict:
+        """Run the 4-voter shot-detection ensemble on a stage.
+
+        Mirror of ``POST /api/stages/{n}/shot-detect``. Loads the
+        audit clip's audio, runs CLAP + GBDT + PANN consensus, and
+        writes the candidate universe + seeded ``shots[]`` into
+        ``<project>/audit/stage<N>.json``.
+
+        Preconditions: stage has a primary, primary has
+        ``beep_time``, stage has ``time_seconds > 0``.
+
+        First call in this server lifetime loads the ensemble
+        runtime (~5 s for CLAP + GBDT + PANN, plus first-call
+        download if not yet cached locally). Subsequent calls
+        reuse the cached weights. A typical 60 s stage finishes in
+        20-40 s on CPU. Voter E (CLIP, ~600 MB) requires
+        ``SPLITSMITH_ENABLE_VOTER_E=1``.
+
+        ``reset=True`` wipes the existing ``shots[]`` before
+        seeding; default preserves curated lists.
+        """
+        return detect_tools.detect_shots_for_stage(
+            project_root,
+            stage_number=stage_number,
+            reset=reset,
+        )
+
     return mcp

--- a/tests/test_mcp_detect_tools.py
+++ b/tests/test_mcp_detect_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +12,47 @@ from splitsmith.beep_detect import BeepNotFoundError
 from splitsmith.config import BeepCandidate, BeepDetection
 from splitsmith.mcp import detect_tools
 from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _fake_ensemble_result(times: list[float], consensus: int = 3, expected_rounds=None):
+    """Build a small ``EnsembleResult`` for tests so we don't pull
+    CLAP / GBDT / PANN weights into CI.
+
+    Mirrors the helper in ``test_ui_server.py``; duplicated here so
+    these tests stay self-contained."""
+    from splitsmith.ensemble import EnsembleCandidate, EnsembleResult
+
+    cands = [
+        EnsembleCandidate(
+            candidate_number=i + 1,
+            time=t,
+            ms_after_beep=round((t - 5.0) * 1000),
+            peak_amplitude=0.5,
+            confidence=0.85,
+            vote_a=1,
+            vote_b=1,
+            vote_c=1,
+            vote_d=1,
+            vote_total=4,
+            apriori_boost=0.0,
+            ensemble_score=4.0,
+            score_c=0.9,
+            clap_diff=0.5,
+            gunshot_prob=0.7,
+            kept=True,
+        )
+        for i, t in enumerate(times)
+    ]
+    return EnsembleResult(candidates=cands, consensus=consensus, expected_rounds=expected_rounds)
+
+
+class _FakeAudit:
+    """Stub matching :class:`AuditAudioResult` -- audio_path + beep_in_clip."""
+
+    def __init__(self, audio_path: Path, beep_in_clip: float = 5.0) -> None:
+        self.audio_path = audio_path
+        self.beep_in_clip = beep_in_clip
+        self.trimmed = True
 
 
 def _build_project(
@@ -287,3 +329,247 @@ def test_detect_beep_missing_source_raises(tmp_path: Path) -> None:
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
     with pytest.raises(FileNotFoundError, match="source video missing"):
         detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id)
+
+
+# ---------------------------------------------------------------------------
+# detect_shots
+# ---------------------------------------------------------------------------
+
+
+def _seed_shot_detect_project(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a project ready for shot detection: primary with beep_time,
+    stage time_seconds > 0, source video on disk, audit WAV synthesised so
+    ``ensure_audit_audio`` can be stubbed cleanly. Returns (root, source, wav)."""
+    import numpy as np
+    import soundfile as sf
+
+    root = tmp_path / "match"
+    src = root / "raw" / "primary.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"FAKE_MP4")
+    wav = root / "audio" / "stage1_audit.wav"
+    wav.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(wav), np.zeros(48_000, dtype="float32"), 48_000)
+
+    primary = StageVideo(
+        path=Path("raw/primary.mp4"),
+        role="primary",
+        beep_time=5.0,
+        beep_source="manual",
+        beep_confidence=1.0,
+        beep_reviewed=True,
+    )
+    project = MatchProject.init(root, name="MCP Shots Test")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[primary],
+        )
+    ]
+    project.save(root)
+    return root, src, wav
+
+
+def test_detect_shots_writes_audit_json_and_seeds_shots(tmp_path: Path) -> None:
+    root, _src, wav = _seed_shot_detect_project(tmp_path)
+    fake_result = _fake_ensemble_result([5.5, 6.1, 6.9])
+
+    with (
+        patch(
+            "splitsmith.mcp.detect_tools.audio_helpers.ensure_audit_audio",
+            return_value=_FakeAudit(wav, beep_in_clip=5.0),
+        ),
+        patch("splitsmith.mcp.detect_tools._get_ensemble_runtime", return_value=None),
+        patch(
+            "splitsmith.mcp.detect_tools.ensemble_module.detect_shots_ensemble",
+            return_value=fake_result,
+        ),
+    ):
+        result = detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+    audit_file = root / "audit" / "stage1.json"
+    assert audit_file.exists()
+    payload = json.loads(audit_file.read_text())
+    assert len(payload["shots"]) == 3
+    # Source provenance lets the user filter ``audit_events`` by where a run came from.
+    last_event = payload["audit_events"][-1]
+    assert last_event["payload"]["source"] == "mcp"
+    assert result["candidate_count"] == 3
+    assert result["kept_count"] == 3
+    assert result["shots_seeded"] is True
+    # Project flag is flipped so the SPA's stage badge updates.
+    primary = MatchProject.load(root).stages[0].videos[0]
+    assert primary.processed["shot_detect"] is True
+
+
+def test_detect_shots_preserves_curated_shots_by_default(tmp_path: Path) -> None:
+    """When ``shots[]`` is already populated (user curated), default
+    behaviour must not overwrite it -- the detector run still records
+    candidates into ``_candidates_pending_audit`` for the audit UI."""
+    root, _src, wav = _seed_shot_detect_project(tmp_path)
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_file = audit_dir / "stage1.json"
+    curated = {
+        "stage_number": 1,
+        "stage_name": "One",
+        "stage_time_seconds": 12.0,
+        "beep_time": 5.0,
+        "shots": [
+            {"shot_number": 1, "time": 5.42, "source": "manual"},
+            {"shot_number": 2, "time": 5.91, "source": "manual"},
+        ],
+    }
+    audit_file.write_text(json.dumps(curated, indent=2))
+    fake_result = _fake_ensemble_result([5.5, 6.1, 6.9])
+
+    with (
+        patch(
+            "splitsmith.mcp.detect_tools.audio_helpers.ensure_audit_audio",
+            return_value=_FakeAudit(wav),
+        ),
+        patch("splitsmith.mcp.detect_tools._get_ensemble_runtime", return_value=None),
+        patch(
+            "splitsmith.mcp.detect_tools.ensemble_module.detect_shots_ensemble",
+            return_value=fake_result,
+        ),
+    ):
+        result = detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+    payload = json.loads(audit_file.read_text())
+    assert len(payload["shots"]) == 2  # curated list preserved
+    assert payload["_candidates_pending_audit"]["candidates"]
+    assert result["shots_seeded"] is False
+
+
+def test_detect_shots_reset_wipes_existing_shots(tmp_path: Path) -> None:
+    root, _src, wav = _seed_shot_detect_project(tmp_path)
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    (audit_dir / "stage1.json").write_text(
+        json.dumps(
+            {
+                "stage_number": 1,
+                "stage_name": "One",
+                "stage_time_seconds": 12.0,
+                "beep_time": 5.0,
+                "shots": [{"shot_number": 1, "time": 5.42, "source": "manual"}],
+            }
+        )
+    )
+    fake_result = _fake_ensemble_result([5.5, 6.1])
+
+    with (
+        patch(
+            "splitsmith.mcp.detect_tools.audio_helpers.ensure_audit_audio",
+            return_value=_FakeAudit(wav),
+        ),
+        patch("splitsmith.mcp.detect_tools._get_ensemble_runtime", return_value=None),
+        patch(
+            "splitsmith.mcp.detect_tools.ensemble_module.detect_shots_ensemble",
+            return_value=fake_result,
+        ),
+    ):
+        result = detect_tools.detect_shots_for_stage(str(root), stage_number=1, reset=True)
+
+    payload = json.loads((root / "audit" / "stage1.json").read_text())
+    # Reset cleared the manual shot, then seeded the 2 detected ones.
+    assert len(payload["shots"]) == 2
+    assert all(s["source"] == "detected" for s in payload["shots"])
+    assert result["shots_seeded"] is True
+
+
+def test_detect_shots_rejects_stage_without_beep_time(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src = root / "raw" / "primary.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"x")
+    project = MatchProject.init(root, name="No Beep")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[StageVideo(path=Path("raw/primary.mp4"), role="primary")],
+        )
+    ]
+    project.save(root)
+    with pytest.raises(ValueError, match="no beep_time"):
+        detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+
+def test_detect_shots_rejects_stage_without_time_seconds(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src = root / "raw" / "primary.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"x")
+    project = MatchProject.init(root, name="No Time")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=0.0,
+            videos=[
+                StageVideo(
+                    path=Path("raw/primary.mp4"),
+                    role="primary",
+                    beep_time=5.0,
+                    beep_source="manual",
+                    beep_confidence=1.0,
+                )
+            ],
+        )
+    ]
+    project.save(root)
+    with pytest.raises(ValueError, match="time_seconds"):
+        detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+
+def test_detect_shots_rejects_stage_without_primary(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    project = MatchProject.init(root, name="No Primary")
+    project.stages = [StageEntry(stage_number=1, stage_name="One", time_seconds=12.0, videos=[])]
+    project.save(root)
+    with pytest.raises(ValueError, match="no primary"):
+        detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+
+def test_detect_shots_passes_expected_rounds_through_to_ensemble(tmp_path: Path) -> None:
+    """When the audit JSON carries ``stage_rounds.expected``, the
+    ensemble's adaptive voter C + apriori boost expects to receive it."""
+    root, _src, wav = _seed_shot_detect_project(tmp_path)
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    (audit_dir / "stage1.json").write_text(
+        json.dumps(
+            {
+                "stage_number": 1,
+                "stage_name": "One",
+                "stage_time_seconds": 12.0,
+                "beep_time": 5.0,
+                "shots": [],
+                "stage_rounds": {"expected": 7},
+            }
+        )
+    )
+    fake_result = _fake_ensemble_result([5.5], expected_rounds=7)
+
+    with (
+        patch(
+            "splitsmith.mcp.detect_tools.audio_helpers.ensure_audit_audio",
+            return_value=_FakeAudit(wav),
+        ),
+        patch("splitsmith.mcp.detect_tools._get_ensemble_runtime", return_value=None),
+        patch(
+            "splitsmith.mcp.detect_tools.ensemble_module.detect_shots_ensemble",
+            return_value=fake_result,
+        ) as mock_detect,
+    ):
+        result = detect_tools.detect_shots_for_stage(str(root), stage_number=1)
+
+    # Verify the kwarg passthrough -- a regression that drops it would
+    # silently turn voter C off the adaptive path.
+    assert mock_detect.call_args.kwargs["expected_rounds"] == 7
+    assert result["expected_rounds"] == 7

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -36,6 +36,7 @@ WRITE_TOOLS = {
 
 DETECT_TOOLS = {
     "detect_beep",
+    "detect_shots",
 }
 
 


### PR DESCRIPTION
## Summary

Adds the synchronous `detect_shots` MCP tool, completing the detection surface. An agent can now drive a full stage from raw videos to audited shots without leaving the MCP.

```python
detect_shots(project_root: str, stage_number: int, reset: bool = False) -> dict
```

Mirrors `POST /api/stages/{n}/shot-detect`: loads the audit clip's audio, runs CLAP + GBDT + PANN 4-voter consensus, writes the candidate universe and seeded `shots[]` into `<project>/audit/stage<N>.json`.

**Preconditions**: stage has primary, primary has `beep_time`, stage has `time_seconds > 0`. Errors with a descriptive ValueError otherwise.

**`reset` semantics**: default preserves existing curated `shots[]` (the user retains authority); `reset=True` wipes them before seeding from the new run. The `_candidates_pending_audit.candidates` block is always overwritten so the audit UI sees the latest decision trail.

**Audit trail**: each run appends an `audit_events` row tagged `source: "mcp"` so the trail distinguishes SPA-driven from agent-driven runs.

## Implementation notes

- Module-level lazy cache for the ensemble runtime (mirror of `server.py:_get_ensemble_runtime`). First MCP call in a server lifetime pays the ~5s CLAP/GBDT/PANN load; subsequent calls reuse it. Voter E (CLIP, ~600MB) requires `SPLITSMITH_ENABLE_VOTER_E=1`.
- Atomic write with `.bak` rotation matches `put_stage_audit` so a concurrent SPA/MCP read never sees a half-written file.
- Logic deliberately duplicated from `_run_shot_detect` rather than refactored out -- the inner function is closed over `state`/`handle`. Pulling it out cleanly is the right follow-up but out of scope.

## Test plan

- [x] 64 MCP tests pass (`uv run pytest tests/test_mcp_*.py`)
- [x] 1008 tests pass overall (no regressions)
- [x] 7 new `detect_shots` tests cover happy path, curated-shots preservation, reset, all three preconditions, and `stage_rounds.expected` passthrough
- [x] Ensemble + audit-audio resolver mocked in tests; CI doesn't pull CLAP/GBDT/PANN weights
- [x] black + ruff clean

## What's left for the umbrella (#211)

- Layer 3e: trim tool, then export pipeline (`list_templates`, `apply_template`, `export_match`, `render_mp4`, `build_youtube_sidecar`)
- Layer 3f: `/splitsmith-match` skill + run-log + dry-run mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)