### PR TITLE
mcp: trim_audit_clip tool (#211 layer 3e-1)

### DIFF
--- a/src/splitsmith/mcp/detect_tools.py
+++ b/src/splitsmith/mcp/detect_tools.py
@@ -409,3 +409,81 @@ def _atomic_write_audit_json(audit_file: Any, payload: dict[str, Any]) -> None:
             backup.unlink()
         audit_file.replace(backup)
     tmp.replace(audit_file)
+
+
+def trim_audit_clip(
+    project_root: str,
+    *,
+    stage_number: int,
+    video_id: str | None = None,
+) -> dict[str, Any]:
+    """Build (or return cached) the audit-mode short-GOP trim for a stage's
+    video.
+
+    Mirror of the trim half of ``POST /api/stages/{n}/detect-beep`` plus the
+    SPA's invalidate / re-trim flow. ``video_id=None`` targets the stage's
+    primary; pass an explicit ID to trim a secondary instead. The trim
+    window is ``[max(0, beep - pre_buffer), beep + stage_time +
+    post_buffer]``, anchored to the video's own ``beep_time``.
+
+    Idempotent: returns the cached path when source mtime + trim params
+    match. Re-runs ffmpeg on a params mismatch (beep moved, buffer
+    settings changed) without the agent having to invalidate first --
+    the helper handles cache invalidation transparently.
+
+    Preconditions: video has ``beep_time``, stage has
+    ``time_seconds > 0``, source video exists on disk. Raises
+    ``ValueError`` / ``FileNotFoundError`` otherwise. Sets
+    ``video.processed["trim"] = True`` on success and saves the project.
+    """
+    root = resolve_project_root(project_root)
+    project = MatchProject.load(root)
+    try:
+        stage = project.stage(stage_number)
+    except KeyError as exc:
+        raise ValueError(f"stage {stage_number} not found") from exc
+    if stage.time_seconds <= 0:
+        raise ValueError(
+            f"stage {stage_number} has time_seconds=0; set the stage time " "before trimming"
+        )
+    if video_id is None:
+        target = next((v for v in stage.videos if v.role == "primary"), None)
+        if target is None:
+            raise ValueError(f"stage {stage_number} has no primary video")
+    else:
+        target = next((v for v in stage.videos if v.video_id == video_id), None)
+        if target is None:
+            raise ValueError(
+                f"video {video_id} not on stage {stage_number}; "
+                f"available: {[v.video_id for v in stage.videos]}"
+            )
+    if target.beep_time is None:
+        raise ValueError(
+            f"video {target.video_id} on stage {stage_number} has no "
+            "beep_time yet; run detect_beep or set_beep_manual first"
+        )
+    source = project.resolve_video_path(root, target.path)
+    if not source.exists():
+        raise FileNotFoundError(
+            f"source video missing for stage {stage_number} " f"video {target.video_id}: {source}"
+        )
+
+    output = audio_helpers.ensure_video_audit_trim(
+        root,
+        stage_number,
+        target,
+        source,
+        target.beep_time,
+        stage.time_seconds,
+        project=project,
+    )
+    target.processed["trim"] = True
+    project.save(root)
+    return {
+        "video_id": target.video_id,
+        "role": target.role,
+        "stage_number": stage_number,
+        "beep_time": target.beep_time,
+        "stage_time_seconds": stage.time_seconds,
+        "output_path": str(output),
+    }

--- a/src/splitsmith/mcp/server.py
+++ b/src/splitsmith/mcp/server.py
@@ -255,4 +255,35 @@ def create_server(name: str = "splitsmith") -> FastMCP:
             reset=reset,
         )
 
+    @mcp.tool()
+    def trim_audit_clip(
+        project_root: str,
+        stage_number: int,
+        video_id: str | None = None,
+    ) -> dict:
+        """Build (or return cached) the audit-mode short-GOP trim
+        for a stage's video.
+
+        ``video_id=None`` targets the stage's primary; pass an
+        explicit ID to trim a secondary. The trim window is
+        anchored to the chosen video's ``beep_time`` and spans
+        ``[max(0, beep - pre_buffer), beep + stage_time +
+        post_buffer]``.
+
+        Idempotent: returns the cached output when source mtime +
+        trim params match. Re-runs ffmpeg transparently on a
+        params mismatch (beep moved, buffer settings changed) so
+        the agent doesn't have to invalidate first. Sets
+        ``processed["trim"] = True`` on the video and saves the
+        project.
+
+        Preconditions: video has ``beep_time``, stage has
+        ``time_seconds > 0``, source video exists on disk.
+        """
+        return detect_tools.trim_audit_clip(
+            project_root,
+            stage_number=stage_number,
+            video_id=video_id,
+        )
+
     return mcp

--- a/tests/test_mcp_detect_tools.py
+++ b/tests/test_mcp_detect_tools.py
@@ -573,3 +573,189 @@ def test_detect_shots_passes_expected_rounds_through_to_ensemble(tmp_path: Path)
     # silently turn voter C off the adaptive path.
     assert mock_detect.call_args.kwargs["expected_rounds"] == 7
     assert result["expected_rounds"] == 7
+
+
+# ---------------------------------------------------------------------------
+# trim_audit_clip
+# ---------------------------------------------------------------------------
+
+
+def _seed_trim_project(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Project ready for trim: primary with beep_time + stage time + source."""
+    root = tmp_path / "match"
+    src = root / "raw" / "primary.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"FAKE_MP4")
+    primary = StageVideo(
+        path=Path("raw/primary.mp4"),
+        role="primary",
+        beep_time=5.0,
+        beep_source="manual",
+        beep_confidence=1.0,
+        beep_reviewed=True,
+    )
+    project = MatchProject.init(root, name="MCP Trim Test")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[primary],
+        )
+    ]
+    project.save(root)
+    out = root / "trimmed" / "stage1_trimmed.mp4"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    return root, src, out
+
+
+def test_trim_audit_clip_calls_helper_and_flips_flag(tmp_path: Path) -> None:
+    root, _src, out_path = _seed_trim_project(tmp_path)
+
+    with patch(
+        "splitsmith.mcp.detect_tools.audio_helpers.ensure_video_audit_trim",
+        return_value=out_path,
+    ) as mock_trim:
+        result = detect_tools.trim_audit_clip(str(root), stage_number=1)
+
+    assert mock_trim.call_count == 1
+    # Helper should be called with the primary's beep_time + stage time.
+    kwargs = mock_trim.call_args
+    args = kwargs.args
+    # ensure_video_audit_trim signature: (root, stage_number, video, source,
+    # beep_time, stage_time_seconds, *, project=...)
+    assert args[1] == 1  # stage_number
+    assert args[4] == 5.0  # beep_time
+    assert args[5] == 12.0  # stage_time
+    after = MatchProject.load(root).stages[0].videos[0]
+    assert after.processed["trim"] is True
+    assert result["output_path"].endswith("stage1_trimmed.mp4")
+    assert result["beep_time"] == 5.0
+
+
+def test_trim_audit_clip_targets_secondary_when_video_id_given(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "match"
+    primary_src = root / "raw" / "p.mp4"
+    secondary_src = root / "raw" / "s.mp4"
+    for s in (primary_src, secondary_src):
+        s.parent.mkdir(parents=True, exist_ok=True)
+        s.write_bytes(b"x")
+    primary = StageVideo(
+        path=Path("raw/p.mp4"),
+        role="primary",
+        beep_time=5.0,
+        beep_source="manual",
+        beep_confidence=1.0,
+    )
+    secondary = StageVideo(
+        path=Path("raw/s.mp4"),
+        role="secondary",
+        beep_time=4.5,
+        beep_source="aligned",
+    )
+    project = MatchProject.init(root, name="Trim Sec")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[primary, secondary],
+        )
+    ]
+    project.save(root)
+    secondary_id = MatchProject.load(root).stages[0].videos[1].video_id
+
+    out = root / "trimmed" / f"stage1_cam_{secondary_id[:6]}_trimmed.mp4"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with patch(
+        "splitsmith.mcp.detect_tools.audio_helpers.ensure_video_audit_trim",
+        return_value=out,
+    ) as mock_trim:
+        result = detect_tools.trim_audit_clip(str(root), stage_number=1, video_id=secondary_id)
+
+    # Helper got the secondary, not the primary.
+    args = mock_trim.call_args.args
+    assert args[2].video_id == secondary_id
+    assert args[4] == 4.5  # secondary's own beep_time
+    after = MatchProject.load(root).stages[0]
+    sec_after = next(v for v in after.videos if v.video_id == secondary_id)
+    assert sec_after.processed["trim"] is True
+    # Primary's flag is untouched -- targeting one video doesn't ripple.
+    prim_after = next(v for v in after.videos if v.role == "primary")
+    assert prim_after.processed["trim"] is False
+    assert result["video_id"] == secondary_id
+
+
+def test_trim_audit_clip_rejects_video_without_beep(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src = root / "raw" / "p.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"x")
+    primary = StageVideo(path=Path("raw/p.mp4"), role="primary")
+    project = MatchProject.init(root, name="No Beep Trim")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[primary],
+        )
+    ]
+    project.save(root)
+    with pytest.raises(ValueError, match="no beep_time"):
+        detect_tools.trim_audit_clip(str(root), stage_number=1)
+
+
+def test_trim_audit_clip_rejects_zero_stage_time(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    src = root / "raw" / "p.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"x")
+    primary = StageVideo(
+        path=Path("raw/p.mp4"),
+        role="primary",
+        beep_time=5.0,
+        beep_source="manual",
+    )
+    project = MatchProject.init(root, name="No Time Trim")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=0.0,
+            videos=[primary],
+        )
+    ]
+    project.save(root)
+    with pytest.raises(ValueError, match="time_seconds=0"):
+        detect_tools.trim_audit_clip(str(root), stage_number=1)
+
+
+def test_trim_audit_clip_rejects_unknown_video_id(tmp_path: Path) -> None:
+    root, _src, _out = _seed_trim_project(tmp_path)
+    with pytest.raises(ValueError, match="not on stage"):
+        detect_tools.trim_audit_clip(str(root), stage_number=1, video_id="bogus")
+
+
+def test_trim_audit_clip_missing_source_raises(tmp_path: Path) -> None:
+    root = tmp_path / "match"
+    primary = StageVideo(
+        path=Path("raw/missing.mp4"),
+        role="primary",
+        beep_time=5.0,
+        beep_source="manual",
+    )
+    project = MatchProject.init(root, name="Missing Source Trim")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=12.0,
+            videos=[primary],
+        )
+    ]
+    project.save(root)
+    with pytest.raises(FileNotFoundError, match="source video missing"):
+        detect_tools.trim_audit_clip(str(root), stage_number=1)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -37,6 +37,7 @@ WRITE_TOOLS = {
 DETECT_TOOLS = {
     "detect_beep",
     "detect_shots",
+    "trim_audit_clip",
 }
 
 


### PR DESCRIPTION
## Summary

Smallest next slice: synchronous `trim_audit_clip` tool wrapping `audio_helpers.ensure_video_audit_trim`. Builds (or returns the cached) short-GOP audit MP4 — the prerequisite that was blocking the export pipeline (`export_match` reads the trimmed MP4).

```python
trim_audit_clip(project_root: str, stage_number: int, video_id: str | None = None) -> dict
```

`video_id=None` targets the stage's primary; pass an explicit ID to trim a secondary. Idempotent: returns cached output when source mtime + trim params match. Re-runs ffmpeg transparently on a params mismatch (beep moved, buffer settings changed). Sets `processed["trim"] = True` on success.

After this lands the agent can drive **ingest -> beep -> shots -> trim** end-to-end from MCP; the export step is still SPA-driven until the rest of layer 3e (`list_templates`, `apply_template`, `export_match`, `render_mp4`, `build_youtube_sidecar`) lands.

## Test plan

- [x] 71 MCP tests pass (`uv run pytest tests/test_mcp_*.py`)
- [x] 1014 tests pass overall (no regressions)
- [x] 6 new trim tests cover helper passthrough + flag flip, secondary-only targeting, all three preconditions (no beep, no time, missing source), unknown video id
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)