### PR TITLE
compare: manifest schema + per-shooter project loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Default ``branches: [main]`` skips PRs whose base is a feature
+    # branch (stacked PRs). Match every base so each stacked PR also
+    # runs CI.
+    branches: ["**"]
 
 jobs:
   test:

--- a/src/splitsmith/compare/__init__.py
+++ b/src/splitsmith/compare/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-shooter comparison FCPXML export.
+
+A "compare" pulls per-stage trims from N existing single-shooter
+:class:`~splitsmith.ui.project.MatchProject` directories and arranges
+them as a beep-aligned grid in one FCPXML timeline. See ``manifest.py``
+for the YAML schema and ``emitter.py`` for the FCPXML structure.
+"""

--- a/src/splitsmith/compare/manifest.py
+++ b/src/splitsmith/compare/manifest.py
@@ -1,0 +1,94 @@
+"""Pydantic schema + YAML loader for compare-export manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class CompareShooter(BaseModel):
+    """One shooter contributing tiles to the comparison."""
+
+    project: Path
+    label: str = Field(min_length=1)
+
+    @field_validator("project", mode="before")
+    @classmethod
+    def _expand(cls, value: object) -> object:
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        if isinstance(value, Path):
+            return value.expanduser()
+        return value
+
+
+class CompareManifest(BaseModel):
+    """A compare-export manifest loaded from YAML.
+
+    Path resolution: ``output`` and shooter ``project`` paths in the
+    YAML are taken verbatim. ``~`` is expanded; relative paths are NOT
+    rewritten here -- :func:`load_manifest` does the manifest-dir
+    resolution because it's the only caller that knows where the
+    manifest lives on disk.
+    """
+
+    output: Path
+    audio_from: str = Field(min_length=1)
+    layout_2up: Literal["horizontal", "vertical"] = "horizontal"
+    shooters: list[CompareShooter] = Field(min_length=1)
+
+    @field_validator("output", mode="before")
+    @classmethod
+    def _expand_output(cls, value: object) -> object:
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        if isinstance(value, Path):
+            return value.expanduser()
+        return value
+
+    @model_validator(mode="after")
+    def _labels_unique(self) -> CompareManifest:
+        labels = [s.label for s in self.shooters]
+        if len(set(labels)) != len(labels):
+            dupes = sorted({lab for lab in labels if labels.count(lab) > 1})
+            raise ValueError(f"duplicate shooter labels: {dupes}")
+        return self
+
+    @model_validator(mode="after")
+    def _audio_from_matches(self) -> CompareManifest:
+        labels = {s.label for s in self.shooters}
+        if self.audio_from not in labels:
+            raise ValueError(
+                f"audio_from={self.audio_from!r} does not match any shooter label "
+                f"({sorted(labels)})"
+            )
+        return self
+
+
+def load_manifest(path: Path) -> CompareManifest:
+    """Read ``path`` and return a validated :class:`CompareManifest`.
+
+    Resolves the manifest's ``output`` path against the manifest's
+    parent directory when it's relative, and rewrites each shooter's
+    ``project`` path against the same base when relative -- so a
+    manifest is portable as long as the YAML and the project roots
+    move together.
+    """
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"manifest {path} must be a YAML mapping at the top level")
+    manifest = CompareManifest.model_validate(raw)
+    base = path.parent
+    if not manifest.output.is_absolute():
+        manifest = manifest.model_copy(update={"output": (base / manifest.output).resolve()})
+
+    def _resolve(p: Path) -> Path:
+        return p if p.is_absolute() else (base / p).resolve()
+
+    resolved_shooters = [
+        s.model_copy(update={"project": _resolve(s.project)}) for s in manifest.shooters
+    ]
+    return manifest.model_copy(update={"shooters": resolved_shooters})

--- a/src/splitsmith/compare/project_loader.py
+++ b/src/splitsmith/compare/project_loader.py
@@ -1,0 +1,117 @@
+"""Load per-stage trim metadata from a single shooter's MatchProject."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .. import fcpxml_gen
+from ..fcpxml_gen import VideoMetadata
+from ..ui.match_exports import _slugify
+from ..ui.project import MatchProject
+
+ProbeFn = Callable[[Path], VideoMetadata]
+
+
+@dataclass(frozen=True)
+class CompareStageBundle:
+    """All the per-stage facts the emitter needs from one shooter."""
+
+    stage_number: int
+    stage_name: str
+    trim_path: Path
+    audit_path: Path
+    beep_offset_in_clip: float
+    duration_seconds: float
+    width: int
+    height: int
+    frame_rate_num: int
+    frame_rate_den: int
+
+    @property
+    def metadata(self) -> VideoMetadata:
+        return VideoMetadata(
+            width=self.width,
+            height=self.height,
+            duration_seconds=self.duration_seconds,
+            frame_rate_num=self.frame_rate_num,
+            frame_rate_den=self.frame_rate_den,
+        )
+
+
+@dataclass(frozen=True)
+class CompareShooterBundle:
+    """A shooter's project + the per-stage bundles ready for export."""
+
+    label: str
+    project_root: Path
+    project: MatchProject
+    stages_by_number: dict[int, CompareStageBundle] = field(default_factory=dict)
+
+
+def trim_path_for_stage(
+    project: MatchProject, project_root: Path, stage_number: int, stage_name: str
+) -> Path:
+    """Return the lossless-trim path the per-stage exporter would write.
+
+    Mirrors :func:`splitsmith.ui.exports.export_audit_clip`'s naming:
+    ``<exports>/stage<N>_<slug>_trimmed.mp4``.
+    """
+    base = f"stage{stage_number}_{_slugify(stage_name)}"
+    return project.exports_path(project_root) / f"{base}_trimmed.mp4"
+
+
+def audit_path_for_stage(project: MatchProject, project_root: Path, stage_number: int) -> Path:
+    return project.audit_path(project_root) / f"stage{stage_number}.json"
+
+
+def load_shooter(
+    project_root: Path,
+    label: str,
+    *,
+    probe: ProbeFn | None = None,
+) -> CompareShooterBundle:
+    """Open ``project_root`` and build per-stage bundles for ``label``.
+
+    Stages are skipped (omitted from ``stages_by_number``) when:
+      - the stage is marked ``skipped``;
+      - there is no primary video, or the primary has no ``beep_time``;
+      - the lossless trim is not on disk.
+
+    ``probe`` defaults to :func:`splitsmith.fcpxml_gen.probe_video`;
+    pass a stub in tests to avoid shelling out to ffprobe.
+    """
+    if probe is None:
+        probe = fcpxml_gen.probe_video
+    project = MatchProject.load(project_root)
+    pre_buffer = project.trim_pre_buffer_seconds
+    bundles: dict[int, CompareStageBundle] = {}
+    for stage in project.stages:
+        if stage.skipped:
+            continue
+        primary = stage.primary()
+        if primary is None or primary.beep_time is None:
+            continue
+        trim = trim_path_for_stage(project, project_root, stage.stage_number, stage.stage_name)
+        if not trim.exists():
+            continue
+        meta = probe(trim)
+        bundles[stage.stage_number] = CompareStageBundle(
+            stage_number=stage.stage_number,
+            stage_name=stage.stage_name,
+            trim_path=trim,
+            audit_path=audit_path_for_stage(project, project_root, stage.stage_number),
+            beep_offset_in_clip=min(pre_buffer, primary.beep_time),
+            duration_seconds=meta.duration_seconds,
+            width=meta.width,
+            height=meta.height,
+            frame_rate_num=meta.frame_rate_num,
+            frame_rate_den=meta.frame_rate_den,
+        )
+    return CompareShooterBundle(
+        label=label,
+        project_root=project_root,
+        project=project,
+        stages_by_number=bundles,
+    )

--- a/tests/test_compare_manifest.py
+++ b/tests/test_compare_manifest.py
@@ -1,0 +1,159 @@
+"""Manifest schema + loader tests for the compare module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from splitsmith.compare.manifest import CompareManifest, load_manifest
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def test_round_trip_minimal(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "Mathias",
+            "shooters": [
+                {"project": "./mathias", "label": "Mathias"},
+                {"project": "./anders", "label": "Anders"},
+            ],
+        },
+    )
+    m = load_manifest(src)
+    assert m.audio_from == "Mathias"
+    assert m.layout_2up == "horizontal"  # default
+    assert m.output == (tmp_path / "out.fcpxml").resolve()
+    # relative shooter paths resolve against the manifest dir
+    assert m.shooters[0].project == (tmp_path / "mathias").resolve()
+    assert m.shooters[1].project == (tmp_path / "anders").resolve()
+
+
+def test_layout_2up_vertical(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "layout_2up": "vertical",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.layout_2up == "vertical"
+
+
+def test_layout_2up_rejects_unknown(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "layout_2up": "diagonal",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    with pytest.raises(ValidationError):
+        load_manifest(src)
+
+
+def test_audio_from_must_match_a_label(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "Nobody",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    with pytest.raises(ValidationError) as exc:
+        load_manifest(src)
+    assert "audio_from" in str(exc.value)
+
+
+def test_duplicate_labels_rejected(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [
+                {"project": "/p/1", "label": "A"},
+                {"project": "/p/2", "label": "A"},
+            ],
+        },
+    )
+    with pytest.raises(ValidationError) as exc:
+        load_manifest(src)
+    assert "duplicate" in str(exc.value)
+
+
+def test_empty_shooters_rejected(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [],
+        },
+    )
+    with pytest.raises(ValidationError):
+        load_manifest(src)
+
+
+def test_tilde_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "~/projects/anders", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.shooters[0].project == fake_home / "projects" / "anders"
+
+
+def test_absolute_paths_passthrough(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "/tmp/out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "/abs/path", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.output == Path("/tmp/out.fcpxml")
+    assert m.shooters[0].project == Path("/abs/path")
+
+
+def test_top_level_must_be_mapping(tmp_path: Path) -> None:
+    src = tmp_path / "m.yaml"
+    src.write_text("- not_a_mapping\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="mapping"):
+        load_manifest(src)
+
+
+def test_validate_directly_skips_path_resolution() -> None:
+    """``CompareManifest.model_validate`` works without going through
+    :func:`load_manifest`; relative paths simply stay relative."""
+    m = CompareManifest.model_validate(
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "rel/path", "label": "A"}],
+        }
+    )
+    assert m.shooters[0].project == Path("rel/path")

--- a/tests/test_compare_project_loader.py
+++ b/tests/test_compare_project_loader.py
@@ -1,0 +1,253 @@
+"""Tests for the per-shooter project loader in compare/project_loader.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.compare.project_loader import (
+    audit_path_for_stage,
+    load_shooter,
+    trim_path_for_stage,
+)
+from splitsmith.fcpxml_gen import VideoMetadata
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _meta(duration: float = 30.0) -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=duration,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _build_project(
+    root: Path,
+    *,
+    name: str = "test",
+    pre_buffer: float = 5.0,
+    stages: list[StageEntry] | None = None,
+) -> MatchProject:
+    project = MatchProject.init(root, name=name)
+    project.trim_pre_buffer_seconds = pre_buffer
+    project.stages = stages or []
+    project.save(root)
+    return project
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
+
+
+def test_loads_present_stages_and_skips_missing(tmp_path: Path) -> None:
+    root = tmp_path / "shooter"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="Skipper",
+                time_seconds=10.0,
+                videos=[
+                    StageVideo(path=Path("raw/v1.mp4"), role="primary", beep_time=12.5),
+                ],
+            ),
+            StageEntry(
+                stage_number=2,
+                stage_name="No Trim Yet",
+                time_seconds=10.0,
+                videos=[
+                    StageVideo(path=Path("raw/v2.mp4"), role="primary", beep_time=8.0),
+                ],
+            ),
+        ],
+    )
+
+    # Stage 1's trim exists; stage 2's does not.
+    trim1 = trim_path_for_stage(project, root, 1, "Skipper")
+    _touch(trim1)
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert set(bundle.stages_by_number) == {1}
+    s1 = bundle.stages_by_number[1]
+    assert s1.trim_path == trim1
+    assert s1.audit_path == audit_path_for_stage(project, root, 1)
+    # beep_time > pre_buffer so beep_offset_in_clip == pre_buffer
+    assert s1.beep_offset_in_clip == 5.0
+
+
+def test_short_head_clamps_beep_offset(tmp_path: Path) -> None:
+    root = tmp_path / "short-head"
+    project = _build_project(
+        root,
+        pre_buffer=5.0,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="Tight",
+                time_seconds=10.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=2.5)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "Tight"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    # primary.beep_time < pre_buffer -> short head, clip-local beep equals beep_time
+    assert bundle.stages_by_number[1].beep_offset_in_clip == 2.5
+
+
+def test_skipped_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "skipped"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                skipped=True,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_no_primary_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "noprim"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="secondary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_no_beep_time_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "nobeep"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_probe_metadata_propagates(tmp_path: Path) -> None:
+    root = tmp_path / "meta"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    trim = _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    custom = VideoMetadata(
+        width=3840,
+        height=2160,
+        duration_seconds=42.0,
+        frame_rate_num=60000,
+        frame_rate_den=1001,
+    )
+
+    captured: list[Path] = []
+
+    def probe(p: Path) -> VideoMetadata:
+        captured.append(p)
+        return custom
+
+    bundle = load_shooter(root, "M", probe=probe)
+    assert captured == [trim]
+    s1 = bundle.stages_by_number[1]
+    assert s1.duration_seconds == 42.0
+    assert s1.width == 3840
+    assert s1.height == 2160
+    assert s1.frame_rate_num == 60000
+    assert s1.frame_rate_den == 1001
+    # convenience accessor reconstructs a VideoMetadata
+    assert isinstance(s1.metadata, VideoMetadata)
+    assert s1.metadata.frame_rate_num == 60000
+
+
+def test_slug_drives_trim_filename(tmp_path: Path) -> None:
+    """Stage with a complex name resolves through ``_slugify`` for the filename."""
+    root = tmp_path / "slug"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=4,
+                stage_name="Per told me to do it!",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=2.0)],
+            )
+        ],
+    )
+    expected = project.exports_path(root) / "stage4_per-told-me-to-do-it_trimmed.mp4"
+    _touch(expected)
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number[4].trim_path == expected
+
+
+def test_default_probe_is_fcpxml_gen(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When ``probe`` is omitted, :func:`fcpxml_gen.probe_video` is used."""
+    root = tmp_path / "defaultprobe"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    calls: list[Path] = []
+
+    def fake_probe(p: Path) -> VideoMetadata:
+        calls.append(p)
+        return _meta()
+
+    import splitsmith.fcpxml_gen as fg
+
+    monkeypatch.setattr(fg, "probe_video", fake_probe)
+    bundle = load_shooter(root, "M")  # no probe= -> module default
+    assert len(calls) == 1
+    assert bundle.stages_by_number[1].duration_seconds == 30.0


### PR DESCRIPTION
Closes #255.

First slice of the multi-shooter comparison feature. Foundation only -- no FCPXML emission yet.

## Summary
- New ``src/splitsmith/compare/`` package with ``manifest.py`` (Pydantic schema + YAML loader) and ``project_loader.py`` (per-shooter discovery of trim paths + beep offsets).
- ``CompareManifest`` validators: ``audio_from`` must match a label; labels unique; ``~`` expansion; relative ``output`` and shooter ``project`` paths resolve against the manifest's parent dir.
- ``load_shooter`` walks ``MatchProject.stages``, derives the trim path via the same ``_slugify`` rule the per-stage exporter uses (``stage{N}_{slug}_trimmed.mp4``), and computes ``beep_offset_in_clip`` = ``min(trim_pre_buffer_seconds, primary.beep_time)`` to match ``ui/exports.py``'s short-head clamp.
- Stage skipping mirrors the per-stage exporter: missing primary, no ``beep_time``, ``skipped=True``, or missing trim on disk all drop the stage.

## Test plan
- [x] ``uv run pytest tests/test_compare_manifest.py tests/test_compare_project_loader.py`` -- 18/18 pass
- [ ] Manual: load a real project's manifest once #258 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)