### PR TITLE
compare: grid layout math

### DIFF
--- a/src/splitsmith/compare/layout.py
+++ b/src/splitsmith/compare/layout.py
@@ -1,0 +1,164 @@
+"""Grid-tile placement math for compare exports.
+
+Pure functions: no I/O, no FCPXML. Slot positions are returned in
+sequence-frame pixels (centre-of-tile, sequence-centre origin, +Y up);
+the FCPXML emitter converts them to FCP's normalised units using the
+same ``unit_per_px = 100.0 / sequence_height`` rule
+:func:`splitsmith.fcpxml_gen._pip_transform_attrs` uses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+GridKind = Literal["1up", "2up-h", "2up-v", "2x2", "3x3", "4x4"]
+Layout2Up = Literal["horizontal", "vertical"]
+
+# (rows, cols) per grid kind. ``2up-h`` is one row of two; ``2up-v`` is
+# two stacked rows. Bigger grids are square.
+_GRID_SHAPE: dict[GridKind, tuple[int, int]] = {
+    "1up": (1, 1),
+    "2up-h": (1, 2),
+    "2up-v": (2, 1),
+    "2x2": (2, 2),
+    "3x3": (3, 3),
+    "4x4": (4, 4),
+}
+
+
+@dataclass(frozen=True)
+class GridSlot:
+    """One tile's transform inside the sequence frame."""
+
+    scale: float
+    """Uniform letterbox factor vs. native cam size (``1.0`` == native)."""
+
+    position_px: tuple[float, float]
+    """Centre-of-tile pixel offset from the sequence centre, +Y up."""
+
+
+@dataclass(frozen=True)
+class GridLayout:
+    """A resolved grid for one stage of one compare export."""
+
+    kind: GridKind
+    slots_per_label: dict[str, GridSlot]
+    """Slot keyed by label, in alphabetical order. Only labels actually
+    present in this stage appear; missing-tile labels are absent."""
+
+    empty_slots: list[GridSlot]
+    """Filler-tile slots for cells the chosen grid leaves empty."""
+
+
+def choose_grid(roster_count: int, *, layout_2up: Layout2Up = "horizontal") -> GridKind:
+    """Smallest grid whose capacity is ``>= roster_count``.
+
+    Sized for the *full* manifest roster, not the per-stage present
+    subset, so slot indices stay stable across stages of one export
+    (a label always lands in the same tile; missing tiles become
+    filler). 1 -> ``1up``; 2 -> ``2up-h`` or ``2up-v`` per
+    ``layout_2up``; 3..4 -> ``2x2``; 5..9 -> ``3x3``; 10..16 ->
+    ``4x4``. Counts of 0 or above 16 raise :class:`ValueError`.
+    """
+    if roster_count <= 0:
+        raise ValueError(f"roster_count must be >= 1, got {roster_count}")
+    if roster_count == 1:
+        return "1up"
+    if roster_count == 2:
+        return "2up-h" if layout_2up == "horizontal" else "2up-v"
+    if roster_count <= 4:
+        return "2x2"
+    if roster_count <= 9:
+        return "3x3"
+    if roster_count <= 16:
+        return "4x4"
+    raise ValueError(f"roster_count={roster_count} exceeds the largest supported grid (16)")
+
+
+def _slot_for_index(
+    *,
+    index: int,
+    rows: int,
+    cols: int,
+    sequence_width: int,
+    sequence_height: int,
+    cam_width: int,
+    cam_height: int,
+) -> GridSlot:
+    """Compute the transform for tile ``index`` (0-based, row-major)."""
+    row = index // cols
+    col = index % cols
+    cell_w = sequence_width / cols
+    cell_h = sequence_height / rows
+    scale = min(cell_w / cam_width, cell_h / cam_height)
+    # Centre of cell (col, row) in the same +Y-up convention the emitter
+    # uses (row 0 sits at the top of the frame, so y is positive).
+    centre_x = (col + 0.5) * cell_w - sequence_width / 2.0
+    centre_y = sequence_height / 2.0 - (row + 0.5) * cell_h
+    return GridSlot(scale=scale, position_px=(centre_x, centre_y))
+
+
+def compute_layout(
+    *,
+    sorted_labels: list[str],
+    present_labels: set[str],
+    sequence_width: int,
+    sequence_height: int,
+    cam_width: int,
+    cam_height: int,
+    layout_2up: Layout2Up = "horizontal",
+) -> GridLayout:
+    """Resolve per-tile transforms for one stage.
+
+    ``sorted_labels`` is the alphabetically-sorted list of every label
+    in the manifest (the full roster -- ``len(sorted_labels)`` drives
+    the chosen grid kind). Slot indices follow that order so a label
+    always lands in the same tile across every stage of the export,
+    regardless of who's missing. Missing labels leave their cell empty
+    for the filler; remaining unused cells in the chosen grid (when
+    the roster doesn't fill it perfectly) also go into ``empty_slots``.
+    """
+    if not sorted_labels:
+        raise ValueError("sorted_labels must not be empty")
+    if not present_labels:
+        raise ValueError("present_labels must not be empty")
+    unknown = present_labels - set(sorted_labels)
+    if unknown:
+        raise ValueError(f"present_labels has unknown labels: {sorted(unknown)}")
+
+    kind = choose_grid(len(sorted_labels), layout_2up=layout_2up)
+    rows, cols = _GRID_SHAPE[kind]
+    capacity = rows * cols
+
+    # Slot index = position in sorted_labels. Stable across stages even
+    # when a different shooter is missing each stage.
+    slots_per_label: dict[str, GridSlot] = {}
+    used_indices: set[int] = set()
+    for index, label in enumerate(sorted_labels):
+        if label in present_labels:
+            slots_per_label[label] = _slot_for_index(
+                index=index,
+                rows=rows,
+                cols=cols,
+                sequence_width=sequence_width,
+                sequence_height=sequence_height,
+                cam_width=cam_width,
+                cam_height=cam_height,
+            )
+            used_indices.add(index)
+
+    empty_slots = [
+        _slot_for_index(
+            index=i,
+            rows=rows,
+            cols=cols,
+            sequence_width=sequence_width,
+            sequence_height=sequence_height,
+            cam_width=cam_width,
+            cam_height=cam_height,
+        )
+        for i in range(capacity)
+        if i not in used_indices
+    ]
+    return GridLayout(kind=kind, slots_per_label=slots_per_label, empty_slots=empty_slots)

--- a/tests/test_compare_layout.py
+++ b/tests/test_compare_layout.py
@@ -1,0 +1,213 @@
+"""Grid layout math tests for the compare module."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+
+import pytest
+
+from splitsmith.compare.layout import (
+    GridLayout,
+    GridSlot,
+    choose_grid,
+    compute_layout,
+)
+
+
+def test_choose_grid_table() -> None:
+    assert choose_grid(1) == "1up"
+    assert choose_grid(2, layout_2up="horizontal") == "2up-h"
+    assert choose_grid(2, layout_2up="vertical") == "2up-v"
+    assert choose_grid(3) == "2x2"
+    assert choose_grid(4) == "2x2"
+    assert choose_grid(5) == "3x3"
+    assert choose_grid(9) == "3x3"
+    assert choose_grid(10) == "4x4"
+    assert choose_grid(16) == "4x4"
+
+
+def test_choose_grid_rejects_zero_and_overflow() -> None:
+    with pytest.raises(ValueError):
+        choose_grid(0)
+    with pytest.raises(ValueError):
+        choose_grid(17)
+
+
+def test_2up_horizontal_mirrored_around_x_zero() -> None:
+    layout = compute_layout(
+        sorted_labels=["A", "B"],
+        present_labels={"A", "B"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+        layout_2up="horizontal",
+    )
+    assert layout.kind == "2up-h"
+    a, b = layout.slots_per_label["A"], layout.slots_per_label["B"]
+    # cell width = 960; centres at +/- 480 px from sequence centre
+    assert a.position_px == (-480.0, 0.0)
+    assert b.position_px == (480.0, 0.0)
+    # letterbox: 1920-wide cam in a 960-wide cell -> 0.5 scale
+    assert math.isclose(a.scale, 0.5)
+    assert math.isclose(b.scale, 0.5)
+    assert layout.empty_slots == []
+
+
+def test_2up_vertical_stacks_with_x_zero() -> None:
+    layout = compute_layout(
+        sorted_labels=["A", "B"],
+        present_labels={"A", "B"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+        layout_2up="vertical",
+    )
+    assert layout.kind == "2up-v"
+    # Two rows, one col: cell h = 540; +Y up so row 0 lives at +270
+    assert layout.slots_per_label["A"].position_px == (0.0, 270.0)
+    assert layout.slots_per_label["B"].position_px == (0.0, -270.0)
+
+
+def test_alphabetical_slot_assignment_is_stable_across_stages() -> None:
+    """A label always lands in the same cell, regardless of who's missing."""
+    sorted_labels = ["Anders", "Mathias", "Per"]
+
+    full = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Anders", "Mathias", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    # roster of 3 -> 2x2 grid; alphabetical assignment fills cells 0,1,2
+    # (top-left, top-right, bottom-left), leaving cell 3 empty.
+    assert full.kind == "2x2"
+    a_pos = full.slots_per_label["Anders"].position_px
+    m_pos = full.slots_per_label["Mathias"].position_px
+    p_pos = full.slots_per_label["Per"].position_px
+    assert len(full.empty_slots) == 1
+
+    # Drop Anders for one stage: Mathias and Per stay in cells 1 and 2;
+    # cell 0 (where Anders normally lives) becomes a filler slot.
+    no_anders = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Mathias", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert no_anders.kind == "2x2"
+    assert no_anders.slots_per_label["Mathias"].position_px == m_pos
+    assert no_anders.slots_per_label["Per"].position_px == p_pos
+    assert "Anders" not in no_anders.slots_per_label
+    assert len(no_anders.empty_slots) == 2  # cell 0 (Anders) + cell 3 (unused)
+    anders_filler = next(s for s in no_anders.empty_slots if s.position_px == a_pos)
+    assert anders_filler.position_px == a_pos
+
+    # Drop Mathias instead: Anders stays at cell 0, Per stays at cell 2.
+    no_mathias = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Anders", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert no_mathias.slots_per_label["Anders"].position_px == a_pos
+    assert no_mathias.slots_per_label["Per"].position_px == p_pos
+    assert any(s.position_px == m_pos for s in no_mathias.empty_slots)
+
+
+def test_present_labels_must_be_subset_of_sorted_labels() -> None:
+    with pytest.raises(ValueError, match="unknown"):
+        compute_layout(
+            sorted_labels=["A"],
+            present_labels={"B"},
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_empty_inputs_rejected() -> None:
+    with pytest.raises(ValueError):
+        compute_layout(
+            sorted_labels=[],
+            present_labels=set(),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+    with pytest.raises(ValueError):
+        compute_layout(
+            sorted_labels=["A"],
+            present_labels=set(),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_oversized_roster_raises() -> None:
+    sorted_labels = [f"L{i:02d}" for i in range(17)]
+    with pytest.raises(ValueError, match="exceeds"):
+        compute_layout(
+            sorted_labels=sorted_labels,
+            present_labels=set(sorted_labels),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_3x3_full_grid_empty_slots_are_empty() -> None:
+    labels = [chr(ord("A") + i) for i in range(9)]
+    layout = compute_layout(
+        sorted_labels=labels,
+        present_labels=set(labels),
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert layout.kind == "3x3"
+    assert layout.empty_slots == []
+    # Centre cell is at the sequence centre.
+    assert layout.slots_per_label["E"].position_px == (0.0, 0.0)
+
+
+def test_letterbox_scale_for_non_matching_aspect() -> None:
+    # 4:3 cam in a 16:9 cell at 2x2 -> scale clamped by height (cell_h/cam_h)
+    layout = compute_layout(
+        sorted_labels=["A", "B", "C", "D"],
+        present_labels={"A", "B", "C", "D"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1440,
+        cam_height=1080,
+        layout_2up="horizontal",
+    )
+    cell_w, cell_h = 960, 540
+    expected = min(cell_w / 1440, cell_h / 1080)
+    for slot in layout.slots_per_label.values():
+        assert math.isclose(slot.scale, expected)
+
+
+def test_dataclasses_are_hashable_and_immutable() -> None:
+    slot = GridSlot(scale=0.5, position_px=(1.0, 2.0))
+    layout = GridLayout(kind="1up", slots_per_label={"A": slot}, empty_slots=[])
+    assert isinstance(slot.position_px, tuple)
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        slot.scale = 0.25  # type: ignore[misc]
+    # GridLayout has a dict field, so it isn't hashable, but slots are.
+    assert hash(slot) is not None
+    assert layout.kind == "1up"


### PR DESCRIPTION
Closes #256.

Pure math for tile placement in the multi-shooter comparison feature. No I/O, no FCPXML.

## Summary
- ``choose_grid(roster_count, layout_2up)`` -> one of ``{1up, 2up-h, 2up-v, 2x2, 3x3, 4x4}``. Sized for the full roster (not the per-stage present subset) so a label always lands in the same cell across every stage of the export.
- ``compute_layout(...)`` -> ``GridLayout`` with ``slots_per_label`` (alphabetical) and ``empty_slots`` (the union of missing-label cells and any unused cells the grid leaves over -- e.g. cell 3 of a 2x2 grid with a 3-shooter roster). Slot positions are in sequence-frame pixels, centre-of-tile, +Y up.
- Letterbox scale per slot: ``min(cell_w/cam_w, cell_h/cam_h)``.

## Test plan
- [x] ``uv run pytest tests/test_compare_layout.py`` -- 11/11 pass
- [x] Stable slot indices verified: same label lands in the same cell across stages even when other labels go missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)