### PR TITLE
compare: FCPXML compound-clip emitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Default ``branches: [main]`` skips PRs whose base is a feature
+    # branch (stacked PRs). Match every base so each stacked PR also
+    # runs CI.
+    branches: ["**"]
 
 jobs:
   test:

--- a/src/splitsmith/compare/__init__.py
+++ b/src/splitsmith/compare/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-shooter comparison FCPXML export.
+
+A "compare" pulls per-stage trims from N existing single-shooter
+:class:`~splitsmith.ui.project.MatchProject` directories and arranges
+them as a beep-aligned grid in one FCPXML timeline. See ``manifest.py``
+for the YAML schema and ``emitter.py`` for the FCPXML structure.
+"""

--- a/src/splitsmith/compare/emitter.py
+++ b/src/splitsmith/compare/emitter.py
@@ -1,0 +1,463 @@
+"""FCPXML emission for multi-shooter comparison exports.
+
+Builds one FCPXML where each stage is a compound clip (``<media>``)
+arranging the shooters' beep-aligned trims in a grid. The outer
+``<sequence>`` stitches the per-stage compound clips back-to-back via
+``<ref-clip>`` and drops a marker per stage.
+
+Reuses the helpers from :mod:`splitsmith.fcpxml_gen` so frame
+quantization, format-name conventions, and the source-application
+xattr stay consistent with the per-stage / per-match exporters.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from ..config import OutputConfig
+from ..fcpxml_gen import (
+    VideoMetadata,
+    _asset_grid_str,
+    _format_name,
+    _frame_aligned_str,
+    _tag_source_application,
+)
+from .filler import Runner as FillerRunner
+from .filler import ensure_filler
+from .layout import GridSlot, compute_layout
+from .manifest import CompareManifest
+from .project_loader import CompareShooterBundle, CompareStageBundle
+
+ProbeFn = Callable[[Path], VideoMetadata]
+MUTE_VOLUME = "-96dB"
+
+
+@dataclass(frozen=True)
+class _AssetEntry:
+    """One emitted ``<asset>``: id + format id + duration in sequence frames."""
+
+    asset_id: str
+    format_id: str
+    duration_seq_frames: int
+    metadata: VideoMetadata
+
+
+def _grid_transform_attrs(
+    slot: GridSlot, *, sequence_width: int, sequence_height: int
+) -> dict[str, str]:
+    """``<adjust-transform>`` attrs for a grid slot.
+
+    Mirrors :func:`splitsmith.fcpxml_gen._pip_transform_attrs`'s normalised
+    convention -- one position unit equals ``sequence_height / 100`` px so
+    the same emit reads correctly on 1080p and 4K timelines (#236).
+    """
+    unit_per_px = 100.0 / sequence_height
+    x = slot.position_px[0] * unit_per_px
+    y = slot.position_px[1] * unit_per_px
+    return {
+        "scale": f"{slot.scale:g} {slot.scale:g}",
+        "position": f"{x:g} {y:g}",
+    }
+
+
+def _seq_frames(seconds: float, fd_seconds: float) -> int:
+    return int(round(seconds / fd_seconds))
+
+
+def emit_compare_fcpxml(
+    *,
+    manifest: CompareManifest,
+    shooters: list[CompareShooterBundle],
+    output_path: Path,
+    config: OutputConfig | None = None,
+    probe: ProbeFn | None = None,
+    runner: FillerRunner = subprocess.run,
+    project_name: str | None = None,
+) -> None:
+    """Write a multi-shooter comparison FCPXML to ``output_path``.
+
+    ``shooters`` is in manifest order; the alphabetical slot ordering is
+    derived internally from ``CompareShooterBundle.label``.
+
+    The audio-source shooter (``manifest.audio_from``) determines the
+    sequence's frame rate and pixel size; tiles whose underlying assets
+    have a different rate/size get their own ``<format>`` resource and
+    rely on FCP's edit-time conform.
+
+    Stages are unioned across shooters by ``stage_number``. A stage with
+    no present shooters is omitted from the timeline.
+    """
+    if config is None:
+        config = OutputConfig()
+    del probe  # the loaders already probed; emit-time probing is unused
+
+    bundles_by_label = {s.label: s for s in shooters}
+    if manifest.audio_from not in bundles_by_label:
+        raise ValueError(
+            f"audio_from={manifest.audio_from!r} not found among loaded shooters "
+            f"({sorted(bundles_by_label)})"
+        )
+    sorted_labels = sorted(bundles_by_label)
+    audio_bundle = bundles_by_label[manifest.audio_from]
+    if not audio_bundle.stages_by_number:
+        raise ValueError(
+            f"audio_from shooter {manifest.audio_from!r} has no stages with trims; "
+            "the sequence frame rate / size cannot be derived"
+        )
+
+    # Sequence format = first stage of the audio-source shooter.
+    seq_seed = next(iter(sorted(audio_bundle.stages_by_number)))
+    seq_meta = audio_bundle.stages_by_number[seq_seed].metadata
+    fd_num = seq_meta.frame_rate_den
+    fd_den = seq_meta.frame_rate_num
+    fd_seconds = float(Fraction(fd_num, fd_den))
+    seq_width = seq_meta.width
+    seq_height = seq_meta.height
+
+    fcpxml = ET.Element("fcpxml", {"version": config.fcpxml_version})
+    resources = ET.SubElement(fcpxml, "resources")
+    seq_format_id = "r1"
+    ET.SubElement(
+        resources,
+        "format",
+        {
+            "id": seq_format_id,
+            "name": _format_name(seq_meta),
+            "frameDuration": _frame_aligned_str(1, fd_num, fd_den),
+            "width": str(seq_width),
+            "height": str(seq_height),
+            "colorSpace": "1-1-1 (Rec. 709)",
+        },
+    )
+
+    counter = {"n": 1}
+
+    def _next_id() -> str:
+        counter["n"] += 1
+        return f"r{counter['n']}"
+
+    formats_by_key: dict[tuple[int, int, int, int], str] = {
+        (seq_meta.frame_rate_num, seq_meta.frame_rate_den, seq_width, seq_height): seq_format_id
+    }
+
+    def _format_id_for(meta: VideoMetadata) -> str:
+        key = (meta.frame_rate_num, meta.frame_rate_den, meta.width, meta.height)
+        existing = formats_by_key.get(key)
+        if existing is not None:
+            return existing
+        new_id = _next_id()
+        formats_by_key[key] = new_id
+        meta_fd_num = meta.frame_rate_den
+        meta_fd_den = meta.frame_rate_num
+        ET.SubElement(
+            resources,
+            "format",
+            {
+                "id": new_id,
+                "name": _format_name(meta),
+                "frameDuration": _frame_aligned_str(1, meta_fd_num, meta_fd_den),
+                "width": str(meta.width),
+                "height": str(meta.height),
+                "colorSpace": "1-1-1 (Rec. 709)",
+            },
+        )
+        return new_id
+
+    # Emit one <asset> per (label, stage_number) trim that's actually present.
+    assets: dict[tuple[str, int], _AssetEntry] = {}
+    for label in sorted_labels:
+        bundle = bundles_by_label[label]
+        for stage_number in sorted(bundle.stages_by_number):
+            stage_bundle = bundle.stages_by_number[stage_number]
+            meta = stage_bundle.metadata
+            asset_id = _next_id()
+            format_id = _format_id_for(meta)
+            duration_frames = _seq_frames(stage_bundle.duration_seconds, fd_seconds)
+            asset = ET.SubElement(
+                resources,
+                "asset",
+                {
+                    "id": asset_id,
+                    "name": stage_bundle.trim_path.stem,
+                    "start": "0s",
+                    "duration": _frame_aligned_str(duration_frames, fd_num, fd_den),
+                    "hasVideo": "1",
+                    "hasAudio": "1",
+                    "format": format_id,
+                    "videoSources": "1",
+                    "audioSources": "1",
+                    "audioChannels": "2",
+                },
+            )
+            ET.SubElement(
+                asset,
+                "media-rep",
+                {
+                    "kind": "original-media",
+                    "src": stage_bundle.trim_path.resolve().as_uri(),
+                },
+            )
+            assets[(label, stage_number)] = _AssetEntry(
+                asset_id=asset_id,
+                format_id=format_id,
+                duration_seq_frames=duration_frames,
+                metadata=meta,
+            )
+
+    # Stage union, in numeric order. Stages with no present shooters at all are skipped.
+    all_stage_numbers = sorted({n for b in shooters for n in b.stages_by_number})
+
+    # Pre-render fillers as needed; cache by (W, H, fps, dur_frames).
+    filler_cache: dict[tuple[int, int, int, int, int], _AssetEntry] = {}
+    filler_dir = output_path.parent / "_compare_fillers"
+
+    def _filler_asset(*, duration_frames: int) -> _AssetEntry:
+        key = (
+            seq_width,
+            seq_height,
+            seq_meta.frame_rate_num,
+            seq_meta.frame_rate_den,
+            duration_frames,
+        )
+        cached = filler_cache.get(key)
+        if cached is not None:
+            return cached
+        duration_seconds = duration_frames * fd_seconds
+        path = ensure_filler(
+            width=seq_width,
+            height=seq_height,
+            frame_rate_num=seq_meta.frame_rate_num,
+            frame_rate_den=seq_meta.frame_rate_den,
+            duration_seconds=duration_seconds,
+            output_dir=filler_dir,
+            runner=runner,
+        )
+        format_id = _format_id_for(seq_meta)  # shares the sequence format
+        asset_id = _next_id()
+        asset_el = ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": asset_id,
+                "name": path.stem,
+                "start": "0s",
+                "duration": _frame_aligned_str(duration_frames, fd_num, fd_den),
+                "hasVideo": "1",
+                "hasAudio": "0",
+                "format": format_id,
+                "videoSources": "1",
+            },
+        )
+        ET.SubElement(
+            asset_el,
+            "media-rep",
+            {"kind": "original-media", "src": path.resolve().as_uri()},
+        )
+        entry = _AssetEntry(
+            asset_id=asset_id,
+            format_id=format_id,
+            duration_seq_frames=duration_frames,
+            metadata=seq_meta,
+        )
+        filler_cache[key] = entry
+        return entry
+
+    # Build per-stage <media> compound clips first (resources), then the
+    # outer <sequence> referencing them via <ref-clip>.
+    stage_compound_ids: list[tuple[int, str, str, int]] = []
+    # (stage_number, media_id, stage_name, compound_duration_frames_seq)
+
+    for stage_number in all_stage_numbers:
+        present_labels = {label for label in sorted_labels if (label, stage_number) in assets}
+        if not present_labels:
+            continue
+
+        # Stage name: prefer the audio-source shooter's name if they have
+        # this stage; else the alphabetically-first present shooter.
+        ordered_present = [lab for lab in sorted_labels if lab in present_labels]
+        if stage_number in audio_bundle.stages_by_number:
+            stage_name = audio_bundle.stages_by_number[stage_number].stage_name
+        else:
+            stage_name = (
+                bundles_by_label[ordered_present[0]].stages_by_number[stage_number].stage_name
+            )
+
+        # Layout uses native pixel dims of the first present shooter for
+        # the letterbox scale. All tiles get the same scale per slot --
+        # callers can mix non-matching cam sizes; FCP conforms each tile
+        # via per-asset format references.
+        first_bundle = bundles_by_label[ordered_present[0]].stages_by_number[stage_number]
+        layout = compute_layout(
+            sorted_labels=sorted_labels,
+            present_labels=present_labels,
+            sequence_width=seq_width,
+            sequence_height=seq_height,
+            cam_width=first_bundle.width,
+            cam_height=first_bundle.height,
+            layout_2up=manifest.layout_2up,
+        )
+
+        # Beep alignment: every tile's beep should land at the same parent
+        # timeline frame. Use the max beep across present tiles as the
+        # zero -- shooters with smaller clip-local beeps get a positive
+        # offset; the max-beep tile starts at 0.
+        present_stages: dict[str, CompareStageBundle] = {
+            lab: bundles_by_label[lab].stages_by_number[stage_number] for lab in present_labels
+        }
+        max_beep = max(s.beep_offset_in_clip for s in present_stages.values())
+        tile_durations_in_parent_frames: dict[str, int] = {}
+        tile_offsets_frames: dict[str, int] = {}
+        tile_starts_frames: dict[str, int] = {}
+        for lab, stage_bundle in present_stages.items():
+            delta_frames = round((max_beep - stage_bundle.beep_offset_in_clip) / fd_seconds)
+            if delta_frames >= 0:
+                offset_frames = delta_frames
+                start_frames = 0
+            else:
+                offset_frames = 0
+                start_frames = -delta_frames
+            tile_offsets_frames[lab] = offset_frames
+            tile_starts_frames[lab] = start_frames
+            available_seconds = stage_bundle.duration_seconds - (start_frames * fd_seconds)
+            avail_parent_frames = max(0, _seq_frames(available_seconds, fd_seconds))
+            tile_durations_in_parent_frames[lab] = avail_parent_frames
+
+        # Compound duration: longest tile-end across present labels.
+        compound_frames = max(
+            tile_offsets_frames[lab] + tile_durations_in_parent_frames[lab]
+            for lab in present_labels
+        )
+
+        media_id = _next_id()
+        media_el = ET.SubElement(
+            resources,
+            "media",
+            {"id": media_id, "name": f"stage{stage_number}-grid"},
+        )
+        compound_seq = ET.SubElement(
+            media_el,
+            "sequence",
+            {
+                "format": seq_format_id,
+                "duration": _frame_aligned_str(compound_frames, fd_num, fd_den),
+                "tcStart": "0s",
+                "tcFormat": "NDF",
+                "audioLayout": "stereo",
+                "audioRate": "48k",
+            },
+        )
+        compound_spine = ET.SubElement(compound_seq, "spine")
+
+        # Slot 0 (alphabetically first present label) is the spine clip;
+        # later slots ride as connected clips on lanes 1..N-1. Filler
+        # tiles take lanes after that.
+        spine_label = ordered_present[0]
+        for slot_idx, lab in enumerate(ordered_present):
+            asset = assets[(lab, stage_number)]
+            attrs = {
+                "ref": asset.asset_id,
+                "offset": _frame_aligned_str(tile_offsets_frames[lab], fd_num, fd_den),
+                "name": lab,
+                "start": _asset_grid_str(
+                    tile_starts_frames[lab] * fd_seconds,
+                    asset.metadata,
+                ),
+                "duration": _frame_aligned_str(
+                    tile_durations_in_parent_frames[lab], fd_num, fd_den
+                ),
+                "format": asset.format_id,
+            }
+            if lab != spine_label:
+                attrs["lane"] = str(slot_idx)
+            clip_el = ET.SubElement(compound_spine, "asset-clip", attrs)
+            slot = layout.slots_per_label[lab]
+            transform_attrs = _grid_transform_attrs(
+                slot, sequence_width=seq_width, sequence_height=seq_height
+            )
+            ET.SubElement(clip_el, "adjust-transform", transform_attrs)
+            if lab != manifest.audio_from:
+                ET.SubElement(
+                    clip_el,
+                    "adjust-volume",
+                    {"amount": MUTE_VOLUME},
+                )
+
+        # Filler tiles: one asset-clip per empty slot, spanning the full
+        # compound duration so the tile is visible for the entire stage.
+        next_lane = len(ordered_present)
+        for slot in layout.empty_slots:
+            asset_entry = _filler_asset(duration_frames=compound_frames)
+            attrs = {
+                "ref": asset_entry.asset_id,
+                "lane": str(next_lane),
+                "offset": "0s",
+                "name": "filler",
+                "start": "0s",
+                "duration": _frame_aligned_str(compound_frames, fd_num, fd_den),
+                "format": asset_entry.format_id,
+            }
+            filler_clip = ET.SubElement(compound_spine, "asset-clip", attrs)
+            transform_attrs = _grid_transform_attrs(
+                slot, sequence_width=seq_width, sequence_height=seq_height
+            )
+            ET.SubElement(filler_clip, "adjust-transform", transform_attrs)
+            next_lane += 1
+
+        stage_compound_ids.append((stage_number, media_id, stage_name, compound_frames))
+
+    # Outer <sequence>: stitch the compound clips together with markers.
+    library = ET.SubElement(fcpxml, "library")
+    event = ET.SubElement(library, "event", {"name": "splitsmith"})
+    project_name_str = project_name or output_path.stem
+    project_el = ET.SubElement(event, "project", {"name": project_name_str})
+    total_frames = sum(c[3] for c in stage_compound_ids)
+    outer_seq = ET.SubElement(
+        project_el,
+        "sequence",
+        {
+            "format": seq_format_id,
+            "duration": _frame_aligned_str(total_frames, fd_num, fd_den),
+            "tcStart": "0s",
+            "tcFormat": "NDF",
+            "audioLayout": "stereo",
+            "audioRate": "48k",
+        },
+    )
+    outer_spine = ET.SubElement(outer_seq, "spine")
+    cumulative_frames = 0
+    for stage_number, media_id, stage_name, frames in stage_compound_ids:
+        ref_clip = ET.SubElement(
+            outer_spine,
+            "ref-clip",
+            {
+                "ref": media_id,
+                "offset": _frame_aligned_str(cumulative_frames, fd_num, fd_den),
+                "name": f"Stage {stage_number} -- {stage_name}",
+                "start": "0s",
+                "duration": _frame_aligned_str(frames, fd_num, fd_den),
+                "srcEnable": "all",
+            },
+        )
+        ET.SubElement(
+            ref_clip,
+            "marker",
+            {
+                "start": "0s",
+                "duration": _frame_aligned_str(1, fd_num, fd_den),
+                "value": f"Stage {stage_number} -- {stage_name}",
+            },
+        )
+        cumulative_frames += frames
+
+    ET.indent(fcpxml, space="    ")
+    tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
+    decl_end = tree_bytes.index(b"?>") + 2
+    output_path.write_bytes(
+        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
+    )
+    _tag_source_application(output_path)

--- a/src/splitsmith/compare/filler.py
+++ b/src/splitsmith/compare/filler.py
@@ -1,0 +1,101 @@
+"""Black filler video for empty grid tiles in compare exports."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class FillerRenderError(RuntimeError):
+    """ffmpeg refused to render the black filler clip."""
+
+
+def filler_filename(
+    *, width: int, height: int, frame_rate_num: int, frame_rate_den: int, duration_seconds: float
+) -> str:
+    """Deterministic filename so two stages with matching geometry reuse the same file.
+
+    Encodes ``(W, H, fps_num, fps_den, duration_ms)``; duration is rounded
+    to milliseconds because the same compound clip should resolve to the
+    same filler file across runs even when the source duration differs by
+    sub-millisecond rounding.
+    """
+    duration_ms = int(round(duration_seconds * 1000))
+    return (
+        f"_compare_filler_{width}x{height}_{frame_rate_num}-{frame_rate_den}"
+        f"_{duration_ms}ms.mp4"
+    )
+
+
+def ensure_filler(
+    *,
+    width: int,
+    height: int,
+    frame_rate_num: int,
+    frame_rate_den: int,
+    duration_seconds: float,
+    output_dir: Path,
+    ffmpeg_binary: str = "ffmpeg",
+    runner: Runner = subprocess.run,
+) -> Path:
+    """Render (or reuse) a silent black filler video.
+
+    Idempotent: the filename encodes geometry + duration, so a second call
+    with matching arguments returns the existing file without re-running
+    ffmpeg. ``output_dir`` is created if needed.
+
+    The clip has no audio (``-an``) so the emitter doesn't need to mute it
+    explicitly. ``libx264 -pix_fmt yuv420p`` is used for cross-platform
+    reproducibility -- this stays predictable in CI / Linux even though
+    the rest of the pipeline can use VideoToolbox locally.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"width/height must be positive, got {width}x{height}")
+    if frame_rate_num <= 0 or frame_rate_den <= 0:
+        raise ValueError(f"frame rate must be positive, got {frame_rate_num}/{frame_rate_den}")
+    if duration_seconds <= 0.0:
+        raise ValueError(f"duration_seconds must be positive, got {duration_seconds}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / filler_filename(
+        width=width,
+        height=height,
+        frame_rate_num=frame_rate_num,
+        frame_rate_den=frame_rate_den,
+        duration_seconds=duration_seconds,
+    )
+    if target.exists():
+        return target
+
+    fps = frame_rate_num / frame_rate_den
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=black:s={width}x{height}:r={fps:.6f}",
+        "-t",
+        f"{duration_seconds:.3f}",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-an",
+        str(target),
+    ]
+    try:
+        runner(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise FillerRenderError(f"ffmpeg binary not found: {ffmpeg_binary}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise FillerRenderError(
+            f"ffmpeg failed rendering filler ({exc.returncode}): " f"{exc.stderr or exc.stdout!r}"
+        ) from exc
+    return target

--- a/src/splitsmith/compare/layout.py
+++ b/src/splitsmith/compare/layout.py
@@ -1,0 +1,164 @@
+"""Grid-tile placement math for compare exports.
+
+Pure functions: no I/O, no FCPXML. Slot positions are returned in
+sequence-frame pixels (centre-of-tile, sequence-centre origin, +Y up);
+the FCPXML emitter converts them to FCP's normalised units using the
+same ``unit_per_px = 100.0 / sequence_height`` rule
+:func:`splitsmith.fcpxml_gen._pip_transform_attrs` uses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+GridKind = Literal["1up", "2up-h", "2up-v", "2x2", "3x3", "4x4"]
+Layout2Up = Literal["horizontal", "vertical"]
+
+# (rows, cols) per grid kind. ``2up-h`` is one row of two; ``2up-v`` is
+# two stacked rows. Bigger grids are square.
+_GRID_SHAPE: dict[GridKind, tuple[int, int]] = {
+    "1up": (1, 1),
+    "2up-h": (1, 2),
+    "2up-v": (2, 1),
+    "2x2": (2, 2),
+    "3x3": (3, 3),
+    "4x4": (4, 4),
+}
+
+
+@dataclass(frozen=True)
+class GridSlot:
+    """One tile's transform inside the sequence frame."""
+
+    scale: float
+    """Uniform letterbox factor vs. native cam size (``1.0`` == native)."""
+
+    position_px: tuple[float, float]
+    """Centre-of-tile pixel offset from the sequence centre, +Y up."""
+
+
+@dataclass(frozen=True)
+class GridLayout:
+    """A resolved grid for one stage of one compare export."""
+
+    kind: GridKind
+    slots_per_label: dict[str, GridSlot]
+    """Slot keyed by label, in alphabetical order. Only labels actually
+    present in this stage appear; missing-tile labels are absent."""
+
+    empty_slots: list[GridSlot]
+    """Filler-tile slots for cells the chosen grid leaves empty."""
+
+
+def choose_grid(roster_count: int, *, layout_2up: Layout2Up = "horizontal") -> GridKind:
+    """Smallest grid whose capacity is ``>= roster_count``.
+
+    Sized for the *full* manifest roster, not the per-stage present
+    subset, so slot indices stay stable across stages of one export
+    (a label always lands in the same tile; missing tiles become
+    filler). 1 -> ``1up``; 2 -> ``2up-h`` or ``2up-v`` per
+    ``layout_2up``; 3..4 -> ``2x2``; 5..9 -> ``3x3``; 10..16 ->
+    ``4x4``. Counts of 0 or above 16 raise :class:`ValueError`.
+    """
+    if roster_count <= 0:
+        raise ValueError(f"roster_count must be >= 1, got {roster_count}")
+    if roster_count == 1:
+        return "1up"
+    if roster_count == 2:
+        return "2up-h" if layout_2up == "horizontal" else "2up-v"
+    if roster_count <= 4:
+        return "2x2"
+    if roster_count <= 9:
+        return "3x3"
+    if roster_count <= 16:
+        return "4x4"
+    raise ValueError(f"roster_count={roster_count} exceeds the largest supported grid (16)")
+
+
+def _slot_for_index(
+    *,
+    index: int,
+    rows: int,
+    cols: int,
+    sequence_width: int,
+    sequence_height: int,
+    cam_width: int,
+    cam_height: int,
+) -> GridSlot:
+    """Compute the transform for tile ``index`` (0-based, row-major)."""
+    row = index // cols
+    col = index % cols
+    cell_w = sequence_width / cols
+    cell_h = sequence_height / rows
+    scale = min(cell_w / cam_width, cell_h / cam_height)
+    # Centre of cell (col, row) in the same +Y-up convention the emitter
+    # uses (row 0 sits at the top of the frame, so y is positive).
+    centre_x = (col + 0.5) * cell_w - sequence_width / 2.0
+    centre_y = sequence_height / 2.0 - (row + 0.5) * cell_h
+    return GridSlot(scale=scale, position_px=(centre_x, centre_y))
+
+
+def compute_layout(
+    *,
+    sorted_labels: list[str],
+    present_labels: set[str],
+    sequence_width: int,
+    sequence_height: int,
+    cam_width: int,
+    cam_height: int,
+    layout_2up: Layout2Up = "horizontal",
+) -> GridLayout:
+    """Resolve per-tile transforms for one stage.
+
+    ``sorted_labels`` is the alphabetically-sorted list of every label
+    in the manifest (the full roster -- ``len(sorted_labels)`` drives
+    the chosen grid kind). Slot indices follow that order so a label
+    always lands in the same tile across every stage of the export,
+    regardless of who's missing. Missing labels leave their cell empty
+    for the filler; remaining unused cells in the chosen grid (when
+    the roster doesn't fill it perfectly) also go into ``empty_slots``.
+    """
+    if not sorted_labels:
+        raise ValueError("sorted_labels must not be empty")
+    if not present_labels:
+        raise ValueError("present_labels must not be empty")
+    unknown = present_labels - set(sorted_labels)
+    if unknown:
+        raise ValueError(f"present_labels has unknown labels: {sorted(unknown)}")
+
+    kind = choose_grid(len(sorted_labels), layout_2up=layout_2up)
+    rows, cols = _GRID_SHAPE[kind]
+    capacity = rows * cols
+
+    # Slot index = position in sorted_labels. Stable across stages even
+    # when a different shooter is missing each stage.
+    slots_per_label: dict[str, GridSlot] = {}
+    used_indices: set[int] = set()
+    for index, label in enumerate(sorted_labels):
+        if label in present_labels:
+            slots_per_label[label] = _slot_for_index(
+                index=index,
+                rows=rows,
+                cols=cols,
+                sequence_width=sequence_width,
+                sequence_height=sequence_height,
+                cam_width=cam_width,
+                cam_height=cam_height,
+            )
+            used_indices.add(index)
+
+    empty_slots = [
+        _slot_for_index(
+            index=i,
+            rows=rows,
+            cols=cols,
+            sequence_width=sequence_width,
+            sequence_height=sequence_height,
+            cam_width=cam_width,
+            cam_height=cam_height,
+        )
+        for i in range(capacity)
+        if i not in used_indices
+    ]
+    return GridLayout(kind=kind, slots_per_label=slots_per_label, empty_slots=empty_slots)

--- a/src/splitsmith/compare/manifest.py
+++ b/src/splitsmith/compare/manifest.py
@@ -1,0 +1,94 @@
+"""Pydantic schema + YAML loader for compare-export manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class CompareShooter(BaseModel):
+    """One shooter contributing tiles to the comparison."""
+
+    project: Path
+    label: str = Field(min_length=1)
+
+    @field_validator("project", mode="before")
+    @classmethod
+    def _expand(cls, value: object) -> object:
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        if isinstance(value, Path):
+            return value.expanduser()
+        return value
+
+
+class CompareManifest(BaseModel):
+    """A compare-export manifest loaded from YAML.
+
+    Path resolution: ``output`` and shooter ``project`` paths in the
+    YAML are taken verbatim. ``~`` is expanded; relative paths are NOT
+    rewritten here -- :func:`load_manifest` does the manifest-dir
+    resolution because it's the only caller that knows where the
+    manifest lives on disk.
+    """
+
+    output: Path
+    audio_from: str = Field(min_length=1)
+    layout_2up: Literal["horizontal", "vertical"] = "horizontal"
+    shooters: list[CompareShooter] = Field(min_length=1)
+
+    @field_validator("output", mode="before")
+    @classmethod
+    def _expand_output(cls, value: object) -> object:
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        if isinstance(value, Path):
+            return value.expanduser()
+        return value
+
+    @model_validator(mode="after")
+    def _labels_unique(self) -> CompareManifest:
+        labels = [s.label for s in self.shooters]
+        if len(set(labels)) != len(labels):
+            dupes = sorted({lab for lab in labels if labels.count(lab) > 1})
+            raise ValueError(f"duplicate shooter labels: {dupes}")
+        return self
+
+    @model_validator(mode="after")
+    def _audio_from_matches(self) -> CompareManifest:
+        labels = {s.label for s in self.shooters}
+        if self.audio_from not in labels:
+            raise ValueError(
+                f"audio_from={self.audio_from!r} does not match any shooter label "
+                f"({sorted(labels)})"
+            )
+        return self
+
+
+def load_manifest(path: Path) -> CompareManifest:
+    """Read ``path`` and return a validated :class:`CompareManifest`.
+
+    Resolves the manifest's ``output`` path against the manifest's
+    parent directory when it's relative, and rewrites each shooter's
+    ``project`` path against the same base when relative -- so a
+    manifest is portable as long as the YAML and the project roots
+    move together.
+    """
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"manifest {path} must be a YAML mapping at the top level")
+    manifest = CompareManifest.model_validate(raw)
+    base = path.parent
+    if not manifest.output.is_absolute():
+        manifest = manifest.model_copy(update={"output": (base / manifest.output).resolve()})
+
+    def _resolve(p: Path) -> Path:
+        return p if p.is_absolute() else (base / p).resolve()
+
+    resolved_shooters = [
+        s.model_copy(update={"project": _resolve(s.project)}) for s in manifest.shooters
+    ]
+    return manifest.model_copy(update={"shooters": resolved_shooters})

--- a/src/splitsmith/compare/project_loader.py
+++ b/src/splitsmith/compare/project_loader.py
@@ -1,0 +1,117 @@
+"""Load per-stage trim metadata from a single shooter's MatchProject."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .. import fcpxml_gen
+from ..fcpxml_gen import VideoMetadata
+from ..ui.match_exports import _slugify
+from ..ui.project import MatchProject
+
+ProbeFn = Callable[[Path], VideoMetadata]
+
+
+@dataclass(frozen=True)
+class CompareStageBundle:
+    """All the per-stage facts the emitter needs from one shooter."""
+
+    stage_number: int
+    stage_name: str
+    trim_path: Path
+    audit_path: Path
+    beep_offset_in_clip: float
+    duration_seconds: float
+    width: int
+    height: int
+    frame_rate_num: int
+    frame_rate_den: int
+
+    @property
+    def metadata(self) -> VideoMetadata:
+        return VideoMetadata(
+            width=self.width,
+            height=self.height,
+            duration_seconds=self.duration_seconds,
+            frame_rate_num=self.frame_rate_num,
+            frame_rate_den=self.frame_rate_den,
+        )
+
+
+@dataclass(frozen=True)
+class CompareShooterBundle:
+    """A shooter's project + the per-stage bundles ready for export."""
+
+    label: str
+    project_root: Path
+    project: MatchProject
+    stages_by_number: dict[int, CompareStageBundle] = field(default_factory=dict)
+
+
+def trim_path_for_stage(
+    project: MatchProject, project_root: Path, stage_number: int, stage_name: str
+) -> Path:
+    """Return the lossless-trim path the per-stage exporter would write.
+
+    Mirrors :func:`splitsmith.ui.exports.export_audit_clip`'s naming:
+    ``<exports>/stage<N>_<slug>_trimmed.mp4``.
+    """
+    base = f"stage{stage_number}_{_slugify(stage_name)}"
+    return project.exports_path(project_root) / f"{base}_trimmed.mp4"
+
+
+def audit_path_for_stage(project: MatchProject, project_root: Path, stage_number: int) -> Path:
+    return project.audit_path(project_root) / f"stage{stage_number}.json"
+
+
+def load_shooter(
+    project_root: Path,
+    label: str,
+    *,
+    probe: ProbeFn | None = None,
+) -> CompareShooterBundle:
+    """Open ``project_root`` and build per-stage bundles for ``label``.
+
+    Stages are skipped (omitted from ``stages_by_number``) when:
+      - the stage is marked ``skipped``;
+      - there is no primary video, or the primary has no ``beep_time``;
+      - the lossless trim is not on disk.
+
+    ``probe`` defaults to :func:`splitsmith.fcpxml_gen.probe_video`;
+    pass a stub in tests to avoid shelling out to ffprobe.
+    """
+    if probe is None:
+        probe = fcpxml_gen.probe_video
+    project = MatchProject.load(project_root)
+    pre_buffer = project.trim_pre_buffer_seconds
+    bundles: dict[int, CompareStageBundle] = {}
+    for stage in project.stages:
+        if stage.skipped:
+            continue
+        primary = stage.primary()
+        if primary is None or primary.beep_time is None:
+            continue
+        trim = trim_path_for_stage(project, project_root, stage.stage_number, stage.stage_name)
+        if not trim.exists():
+            continue
+        meta = probe(trim)
+        bundles[stage.stage_number] = CompareStageBundle(
+            stage_number=stage.stage_number,
+            stage_name=stage.stage_name,
+            trim_path=trim,
+            audit_path=audit_path_for_stage(project, project_root, stage.stage_number),
+            beep_offset_in_clip=min(pre_buffer, primary.beep_time),
+            duration_seconds=meta.duration_seconds,
+            width=meta.width,
+            height=meta.height,
+            frame_rate_num=meta.frame_rate_num,
+            frame_rate_den=meta.frame_rate_den,
+        )
+    return CompareShooterBundle(
+        label=label,
+        project_root=project_root,
+        project=project,
+        stages_by_number=bundles,
+    )

--- a/tests/test_compare_emitter.py
+++ b/tests/test_compare_emitter.py
@@ -1,0 +1,427 @@
+"""Tests for the FCPXML emitter in compare/emitter.py.
+
+Mirrors the unit-test pattern from ``tests/test_fcpxml_gen.py``: synthetic
+``VideoMetadata``, empty placeholder mp4s, ffmpeg + ffprobe stubbed via
+runner injection. Asserts the emitted XML's shape rather than driving real
+FCP.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from splitsmith.compare.emitter import emit_compare_fcpxml
+from splitsmith.compare.manifest import CompareManifest, CompareShooter
+from splitsmith.compare.project_loader import CompareShooterBundle, CompareStageBundle
+from splitsmith.config import OutputConfig
+from splitsmith.ui.project import MatchProject
+from tests._dtd import fcpxml_dtd, fcpxml_dtd_path, validate_against_dtd
+
+
+def _stub_ffmpeg_runner() -> Any:
+    def stub(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        Path(cmd[-1]).write_bytes(b"")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    return stub
+
+
+def _stage(
+    *,
+    stage_number: int,
+    stage_name: str,
+    trim_path: Path,
+    beep: float = 5.0,
+    duration: float = 30.0,
+    width: int = 1920,
+    height: int = 1080,
+    fps_num: int = 30,
+    fps_den: int = 1,
+) -> CompareStageBundle:
+    trim_path.parent.mkdir(parents=True, exist_ok=True)
+    if not trim_path.exists():
+        trim_path.write_bytes(b"")
+    return CompareStageBundle(
+        stage_number=stage_number,
+        stage_name=stage_name,
+        trim_path=trim_path,
+        audit_path=trim_path.with_suffix(".json"),
+        beep_offset_in_clip=beep,
+        duration_seconds=duration,
+        width=width,
+        height=height,
+        frame_rate_num=fps_num,
+        frame_rate_den=fps_den,
+    )
+
+
+def _bundle(
+    label: str,
+    stages: list[CompareStageBundle],
+    *,
+    project_root: Path,
+    project_name: str = "p",
+) -> CompareShooterBundle:
+    proj = MatchProject.init(project_root, name=project_name)
+    return CompareShooterBundle(
+        label=label,
+        project_root=project_root,
+        project=proj,
+        stages_by_number={s.stage_number: s for s in stages},
+    )
+
+
+def _manifest(
+    output: Path,
+    audio_from: str,
+    labels: list[str],
+    layout_2up: str = "horizontal",
+) -> CompareManifest:
+    return CompareManifest(
+        output=output,
+        audio_from=audio_from,
+        layout_2up=layout_2up,
+        shooters=[CompareShooter(project=Path(f"/p/{lab}"), label=lab) for lab in labels],
+    )
+
+
+def test_two_shooters_minimal_structure(tmp_path: Path) -> None:
+    a_root = tmp_path / "a"
+    b_root = tmp_path / "b"
+    a = _bundle(
+        "Anders",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="Skipper",
+                trim_path=a_root / "exports" / "stage1_a.mp4",
+            )
+        ],
+        project_root=a_root,
+    )
+    b = _bundle(
+        "Mathias",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="Skipper",
+                trim_path=b_root / "exports" / "stage1_b.mp4",
+            )
+        ],
+        project_root=b_root,
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(
+        manifest=m,
+        shooters=[a, b],
+        output_path=out,
+        config=OutputConfig(),
+        runner=_stub_ffmpeg_runner(),
+    )
+    assert out.exists()
+    content = out.read_bytes()
+    assert content.startswith(b"<?xml")
+    assert b"<!DOCTYPE fcpxml>" in content
+    root = ET.fromstring(content)
+    assert root.tag == "fcpxml"
+    # Sequence format set from the audio-source shooter.
+    fmt = root.find("./resources/format")
+    assert fmt is not None
+    assert fmt.attrib["frameDuration"] == "1/30s"
+    assert fmt.attrib["width"] == "1920"
+    # One <media> compound clip per included stage.
+    media = root.findall("./resources/media")
+    assert len(media) == 1
+    # Outer spine has one <ref-clip> per stage.
+    ref_clips = root.findall("./library/event/project/sequence/spine/ref-clip")
+    assert len(ref_clips) == 1
+    assert "Stage 1" in ref_clips[0].attrib["name"]
+    # And each ref-clip has a marker for the stage start.
+    markers = ref_clips[0].findall("marker")
+    assert len(markers) == 1
+    assert "Skipper" in markers[0].attrib["value"]
+
+
+def test_audio_routing_only_audio_from_unmuted(tmp_path: Path) -> None:
+    a = _bundle(
+        "Anders",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "a" / "x.mp4")],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "Mathias",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "b" / "x.mp4")],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(
+        manifest=m,
+        shooters=[a, b],
+        output_path=out,
+        runner=_stub_ffmpeg_runner(),
+    )
+    root = ET.fromstring(out.read_bytes())
+    media = root.find("./resources/media")
+    assert media is not None
+    clips = media.findall("./sequence/spine/asset-clip")
+    assert len(clips) == 2
+    by_name = {c.attrib["name"]: c for c in clips}
+    # Anders is muted; Mathias is live.
+    anders_vol = by_name["Anders"].find("adjust-volume")
+    mathias_vol = by_name["Mathias"].find("adjust-volume")
+    assert anders_vol is not None and anders_vol.attrib["amount"] == "-96dB"
+    assert mathias_vol is None
+
+
+def test_alphabetical_first_present_is_spine_clip(tmp_path: Path) -> None:
+    a = _bundle(
+        "Anders",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "a" / "x.mp4")],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "Mathias",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "b" / "x.mp4")],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    root = ET.fromstring(out.read_bytes())
+    spine_clips = root.findall("./resources/media/sequence/spine/asset-clip")
+    # Anders (alphabetically first) is the spine clip with no lane attr.
+    spine_first = spine_clips[0]
+    assert spine_first.attrib["name"] == "Anders"
+    assert "lane" not in spine_first.attrib
+    # Mathias rides on lane 1.
+    assert spine_clips[1].attrib["name"] == "Mathias"
+    assert spine_clips[1].attrib["lane"] == "1"
+
+
+def test_beep_alignment_offsets_smaller_beep_later(tmp_path: Path) -> None:
+    # Anders beep at 4.0s, Mathias at 5.1s. Mathias has the larger beep
+    # so it lands at parent t=0; Anders is offset by ~33 frames @ 30fps.
+    a = _bundle(
+        "Anders",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="X",
+                trim_path=tmp_path / "a" / "x.mp4",
+                beep=4.0,
+            )
+        ],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "Mathias",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="X",
+                trim_path=tmp_path / "b" / "x.mp4",
+                beep=5.1,
+            )
+        ],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    root = ET.fromstring(out.read_bytes())
+    by_name = {
+        c.attrib["name"]: c for c in root.findall("./resources/media/sequence/spine/asset-clip")
+    }
+    # delta = round((5.1 - 4.0)/0.0333...) = 33
+    assert by_name["Anders"].attrib["offset"] == "33/30s"
+    assert by_name["Anders"].attrib["start"] == "0s"
+    assert by_name["Mathias"].attrib["offset"] == "0s"
+    assert by_name["Mathias"].attrib["start"] == "0s"
+
+
+def test_layout_2up_vertical_position_x_zero(tmp_path: Path) -> None:
+    a = _bundle(
+        "A",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "a" / "x.mp4")],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "B",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "b" / "x.mp4")],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "A", ["A", "B"], layout_2up="vertical")
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    root = ET.fromstring(out.read_bytes())
+    transforms = root.findall("./resources/media/sequence/spine/asset-clip/adjust-transform")
+    # vertical 2up: x=0 for both tiles
+    for t in transforms:
+        x_str, _y_str = t.attrib["position"].split()
+        assert float(x_str) == 0.0
+
+
+def test_filler_emitted_for_missing_tile(tmp_path: Path) -> None:
+    # Roster of 3, only 2 present in stage 1: one filler tile expected.
+    a = _bundle(
+        "A",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "a" / "x.mp4")],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "B",
+        [_stage(stage_number=1, stage_name="X", trim_path=tmp_path / "b" / "x.mp4")],
+        project_root=tmp_path / "b",
+    )
+    # C has no stage 1 trim
+    c = _bundle("C", [], project_root=tmp_path / "c")
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "A", ["A", "B", "C"])
+
+    runner_calls: list[list[str]] = []
+
+    def stub(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        runner_calls.append(list(cmd))
+        Path(cmd[-1]).write_bytes(b"")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    emit_compare_fcpxml(manifest=m, shooters=[a, b, c], output_path=out, runner=stub)
+    root = ET.fromstring(out.read_bytes())
+    clips = root.findall("./resources/media/sequence/spine/asset-clip")
+    names = [c.attrib["name"] for c in clips]
+    assert "A" in names and "B" in names
+    # Filler clips are named "filler" by the emitter; assert one is present
+    # for the missing C slot (and possibly an extra unused-cell slot).
+    assert names.count("filler") >= 1
+    # ffmpeg invoked at least once for the filler.
+    assert any("lavfi" in c for c in runner_calls)
+    # Filler's underlying asset is named with the deterministic prefix.
+    asset_names = [a.attrib["name"] for a in root.findall("./resources/asset")]
+    assert any(n.startswith("_compare_filler_") for n in asset_names)
+
+
+def test_stage_present_only_in_secondary_uses_first_present_name(tmp_path: Path) -> None:
+    # Audio-source shooter (Mathias) has no stage 2, but Anders does.
+    a = _bundle(
+        "Anders",
+        [
+            _stage(stage_number=1, stage_name="One", trim_path=tmp_path / "a" / "1.mp4"),
+            _stage(
+                stage_number=2,
+                stage_name="Anders Stage Two",
+                trim_path=tmp_path / "a" / "2.mp4",
+            ),
+        ],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "Mathias",
+        [_stage(stage_number=1, stage_name="One", trim_path=tmp_path / "b" / "1.mp4")],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    root = ET.fromstring(out.read_bytes())
+    ref_clips = root.findall("./library/event/project/sequence/spine/ref-clip")
+    assert len(ref_clips) == 2
+    assert ref_clips[0].attrib["name"] == "Stage 1 -- One"
+    assert ref_clips[1].attrib["name"] == "Stage 2 -- Anders Stage Two"
+
+
+def test_mixed_frame_rate_allocates_separate_format(tmp_path: Path) -> None:
+    a = _bundle(
+        "A",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="X",
+                trim_path=tmp_path / "a" / "x.mp4",
+                fps_num=30,
+                fps_den=1,
+            )
+        ],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "B",
+        [
+            _stage(
+                stage_number=1,
+                stage_name="X",
+                trim_path=tmp_path / "b" / "x.mp4",
+                fps_num=30000,
+                fps_den=1001,
+                width=3840,
+                height=2160,
+            )
+        ],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "A", ["A", "B"])
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    root = ET.fromstring(out.read_bytes())
+    formats = root.findall("./resources/format")
+    # Sequence format (A's 30fps 1080p) + B's 29.97 4K format.
+    assert len(formats) == 2
+    rates = sorted(f.attrib["frameDuration"] for f in formats)
+    assert rates == sorted(["1/30s", "1001/30000s"])
+
+
+def test_audio_from_not_among_shooters_raises(tmp_path: Path) -> None:
+    out = tmp_path / "out.fcpxml"
+    # Build a manifest whose audio_from doesn't match the loaded bundles.
+    # CompareManifest's own validator catches the YAML case; the emitter
+    # guards against the in-process programming-error case where the
+    # caller passed mismatched bundles.
+    manifest = CompareManifest(
+        output=out,
+        audio_from="A",
+        shooters=[CompareShooter(project=Path("/p/a"), label="A")],
+    )
+    with pytest.raises(ValueError, match="audio_from"):
+        emit_compare_fcpxml(
+            manifest=manifest,
+            shooters=[_bundle("Different", [], project_root=tmp_path / "d")],
+            output_path=out,
+            runner=_stub_ffmpeg_runner(),
+        )
+
+
+def test_audio_from_shooter_with_no_stages_raises(tmp_path: Path) -> None:
+    audio_bundle = _bundle("A", [], project_root=tmp_path / "a")
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "A", ["A"])
+    with pytest.raises(ValueError, match="no stages"):
+        emit_compare_fcpxml(
+            manifest=m,
+            shooters=[audio_bundle],
+            output_path=out,
+            runner=_stub_ffmpeg_runner(),
+        )
+
+
+@fcpxml_dtd
+def test_emitted_fcpxml_validates_against_dtd(tmp_path: Path) -> None:
+    a = _bundle(
+        "Anders",
+        [_stage(stage_number=1, stage_name="Skipper", trim_path=tmp_path / "a" / "1.mp4")],
+        project_root=tmp_path / "a",
+    )
+    b = _bundle(
+        "Mathias",
+        [_stage(stage_number=1, stage_name="Skipper", trim_path=tmp_path / "b" / "1.mp4")],
+        project_root=tmp_path / "b",
+    )
+    out = tmp_path / "out.fcpxml"
+    m = _manifest(out, "Mathias", ["Anders", "Mathias"])
+    emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
+    validate_against_dtd(out, dtd=fcpxml_dtd_path())

--- a/tests/test_compare_filler.py
+++ b/tests/test_compare_filler.py
@@ -1,0 +1,171 @@
+"""Tests for the black-filler renderer in compare/filler.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from splitsmith.compare.filler import (
+    FillerRenderError,
+    ensure_filler,
+    filler_filename,
+)
+
+
+def _stub_runner_factory() -> tuple[list[list[str]], Any]:
+    """Returns (calls list, stub callable) -- the stub creates its output file."""
+    calls: list[list[str]] = []
+
+    def stub(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        calls.append(list(cmd))
+        # ffmpeg writes its output to the last positional arg
+        Path(cmd[-1]).write_bytes(b"")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    return calls, stub
+
+
+def test_filler_filename_is_deterministic() -> None:
+    name = filler_filename(
+        width=1920,
+        height=1080,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+        duration_seconds=12.345,
+    )
+    again = filler_filename(
+        width=1920,
+        height=1080,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+        duration_seconds=12.345,
+    )
+    assert name == again
+    # Geometry / fps / duration are visible in the name -- so different
+    # callers see different names for different inputs.
+    assert "1920x1080" in name
+    assert "30000-1001" in name
+    assert name.endswith(".mp4")
+
+
+def test_ensure_filler_invokes_ffmpeg_with_lavfi(tmp_path: Path) -> None:
+    calls, stub = _stub_runner_factory()
+    out = ensure_filler(
+        width=1920,
+        height=1080,
+        frame_rate_num=30,
+        frame_rate_den=1,
+        duration_seconds=10.0,
+        output_dir=tmp_path,
+        runner=stub,
+    )
+    assert out.parent == tmp_path
+    assert out.exists()
+    assert len(calls) == 1
+    cmd = calls[0]
+    # Argument order matters for ffmpeg: -f lavfi must precede -i.
+    assert cmd[0] == "ffmpeg"
+    f_idx = cmd.index("-f")
+    i_idx = cmd.index("-i")
+    assert f_idx < i_idx
+    assert cmd[f_idx + 1] == "lavfi"
+    assert cmd[i_idx + 1].startswith("color=c=black:s=1920x1080:r=")
+    assert "-an" in cmd
+    assert "-c:v" in cmd
+    cv = cmd[cmd.index("-c:v") + 1]
+    assert cv == "libx264"
+    assert cmd[-1] == str(out)
+
+
+def test_ensure_filler_idempotent_skips_ffmpeg(tmp_path: Path) -> None:
+    calls, stub = _stub_runner_factory()
+    args = {
+        "width": 1280,
+        "height": 720,
+        "frame_rate_num": 60,
+        "frame_rate_den": 1,
+        "duration_seconds": 5.0,
+        "output_dir": tmp_path,
+        "runner": stub,
+    }
+    first = ensure_filler(**args)  # type: ignore[arg-type]
+    second = ensure_filler(**args)  # type: ignore[arg-type]
+    assert first == second
+    assert len(calls) == 1  # second call returns the cached file
+
+
+def test_ensure_filler_creates_output_dir(tmp_path: Path) -> None:
+    _calls, stub = _stub_runner_factory()
+    nested = tmp_path / "a" / "b" / "fillers"
+    out = ensure_filler(
+        width=640,
+        height=480,
+        frame_rate_num=30,
+        frame_rate_den=1,
+        duration_seconds=1.0,
+        output_dir=nested,
+        runner=stub,
+    )
+    assert nested.is_dir()
+    assert out.parent == nested
+
+
+def test_ensure_filler_rejects_invalid_geometry(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="width/height"):
+        ensure_filler(
+            width=0,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=lambda *a, **k: None,  # type: ignore[arg-type]
+        )
+
+
+def test_ensure_filler_rejects_invalid_duration(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="duration"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=0.0,
+            output_dir=tmp_path,
+            runner=lambda *a, **k: None,  # type: ignore[arg-type]
+        )
+
+
+def test_ffmpeg_missing_raises(tmp_path: Path) -> None:
+    def stub(_cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        raise FileNotFoundError("ffmpeg")
+
+    with pytest.raises(FillerRenderError, match="not found"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=stub,
+        )
+
+
+def test_ffmpeg_failure_propagates(tmp_path: Path) -> None:
+    def stub(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="boom")
+
+    with pytest.raises(FillerRenderError, match="boom"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=stub,
+        )

--- a/tests/test_compare_layout.py
+++ b/tests/test_compare_layout.py
@@ -1,0 +1,213 @@
+"""Grid layout math tests for the compare module."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+
+import pytest
+
+from splitsmith.compare.layout import (
+    GridLayout,
+    GridSlot,
+    choose_grid,
+    compute_layout,
+)
+
+
+def test_choose_grid_table() -> None:
+    assert choose_grid(1) == "1up"
+    assert choose_grid(2, layout_2up="horizontal") == "2up-h"
+    assert choose_grid(2, layout_2up="vertical") == "2up-v"
+    assert choose_grid(3) == "2x2"
+    assert choose_grid(4) == "2x2"
+    assert choose_grid(5) == "3x3"
+    assert choose_grid(9) == "3x3"
+    assert choose_grid(10) == "4x4"
+    assert choose_grid(16) == "4x4"
+
+
+def test_choose_grid_rejects_zero_and_overflow() -> None:
+    with pytest.raises(ValueError):
+        choose_grid(0)
+    with pytest.raises(ValueError):
+        choose_grid(17)
+
+
+def test_2up_horizontal_mirrored_around_x_zero() -> None:
+    layout = compute_layout(
+        sorted_labels=["A", "B"],
+        present_labels={"A", "B"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+        layout_2up="horizontal",
+    )
+    assert layout.kind == "2up-h"
+    a, b = layout.slots_per_label["A"], layout.slots_per_label["B"]
+    # cell width = 960; centres at +/- 480 px from sequence centre
+    assert a.position_px == (-480.0, 0.0)
+    assert b.position_px == (480.0, 0.0)
+    # letterbox: 1920-wide cam in a 960-wide cell -> 0.5 scale
+    assert math.isclose(a.scale, 0.5)
+    assert math.isclose(b.scale, 0.5)
+    assert layout.empty_slots == []
+
+
+def test_2up_vertical_stacks_with_x_zero() -> None:
+    layout = compute_layout(
+        sorted_labels=["A", "B"],
+        present_labels={"A", "B"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+        layout_2up="vertical",
+    )
+    assert layout.kind == "2up-v"
+    # Two rows, one col: cell h = 540; +Y up so row 0 lives at +270
+    assert layout.slots_per_label["A"].position_px == (0.0, 270.0)
+    assert layout.slots_per_label["B"].position_px == (0.0, -270.0)
+
+
+def test_alphabetical_slot_assignment_is_stable_across_stages() -> None:
+    """A label always lands in the same cell, regardless of who's missing."""
+    sorted_labels = ["Anders", "Mathias", "Per"]
+
+    full = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Anders", "Mathias", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    # roster of 3 -> 2x2 grid; alphabetical assignment fills cells 0,1,2
+    # (top-left, top-right, bottom-left), leaving cell 3 empty.
+    assert full.kind == "2x2"
+    a_pos = full.slots_per_label["Anders"].position_px
+    m_pos = full.slots_per_label["Mathias"].position_px
+    p_pos = full.slots_per_label["Per"].position_px
+    assert len(full.empty_slots) == 1
+
+    # Drop Anders for one stage: Mathias and Per stay in cells 1 and 2;
+    # cell 0 (where Anders normally lives) becomes a filler slot.
+    no_anders = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Mathias", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert no_anders.kind == "2x2"
+    assert no_anders.slots_per_label["Mathias"].position_px == m_pos
+    assert no_anders.slots_per_label["Per"].position_px == p_pos
+    assert "Anders" not in no_anders.slots_per_label
+    assert len(no_anders.empty_slots) == 2  # cell 0 (Anders) + cell 3 (unused)
+    anders_filler = next(s for s in no_anders.empty_slots if s.position_px == a_pos)
+    assert anders_filler.position_px == a_pos
+
+    # Drop Mathias instead: Anders stays at cell 0, Per stays at cell 2.
+    no_mathias = compute_layout(
+        sorted_labels=sorted_labels,
+        present_labels={"Anders", "Per"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert no_mathias.slots_per_label["Anders"].position_px == a_pos
+    assert no_mathias.slots_per_label["Per"].position_px == p_pos
+    assert any(s.position_px == m_pos for s in no_mathias.empty_slots)
+
+
+def test_present_labels_must_be_subset_of_sorted_labels() -> None:
+    with pytest.raises(ValueError, match="unknown"):
+        compute_layout(
+            sorted_labels=["A"],
+            present_labels={"B"},
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_empty_inputs_rejected() -> None:
+    with pytest.raises(ValueError):
+        compute_layout(
+            sorted_labels=[],
+            present_labels=set(),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+    with pytest.raises(ValueError):
+        compute_layout(
+            sorted_labels=["A"],
+            present_labels=set(),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_oversized_roster_raises() -> None:
+    sorted_labels = [f"L{i:02d}" for i in range(17)]
+    with pytest.raises(ValueError, match="exceeds"):
+        compute_layout(
+            sorted_labels=sorted_labels,
+            present_labels=set(sorted_labels),
+            sequence_width=1920,
+            sequence_height=1080,
+            cam_width=1920,
+            cam_height=1080,
+        )
+
+
+def test_3x3_full_grid_empty_slots_are_empty() -> None:
+    labels = [chr(ord("A") + i) for i in range(9)]
+    layout = compute_layout(
+        sorted_labels=labels,
+        present_labels=set(labels),
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1920,
+        cam_height=1080,
+    )
+    assert layout.kind == "3x3"
+    assert layout.empty_slots == []
+    # Centre cell is at the sequence centre.
+    assert layout.slots_per_label["E"].position_px == (0.0, 0.0)
+
+
+def test_letterbox_scale_for_non_matching_aspect() -> None:
+    # 4:3 cam in a 16:9 cell at 2x2 -> scale clamped by height (cell_h/cam_h)
+    layout = compute_layout(
+        sorted_labels=["A", "B", "C", "D"],
+        present_labels={"A", "B", "C", "D"},
+        sequence_width=1920,
+        sequence_height=1080,
+        cam_width=1440,
+        cam_height=1080,
+        layout_2up="horizontal",
+    )
+    cell_w, cell_h = 960, 540
+    expected = min(cell_w / 1440, cell_h / 1080)
+    for slot in layout.slots_per_label.values():
+        assert math.isclose(slot.scale, expected)
+
+
+def test_dataclasses_are_hashable_and_immutable() -> None:
+    slot = GridSlot(scale=0.5, position_px=(1.0, 2.0))
+    layout = GridLayout(kind="1up", slots_per_label={"A": slot}, empty_slots=[])
+    assert isinstance(slot.position_px, tuple)
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        slot.scale = 0.25  # type: ignore[misc]
+    # GridLayout has a dict field, so it isn't hashable, but slots are.
+    assert hash(slot) is not None
+    assert layout.kind == "1up"

--- a/tests/test_compare_manifest.py
+++ b/tests/test_compare_manifest.py
@@ -1,0 +1,159 @@
+"""Manifest schema + loader tests for the compare module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from splitsmith.compare.manifest import CompareManifest, load_manifest
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def test_round_trip_minimal(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "Mathias",
+            "shooters": [
+                {"project": "./mathias", "label": "Mathias"},
+                {"project": "./anders", "label": "Anders"},
+            ],
+        },
+    )
+    m = load_manifest(src)
+    assert m.audio_from == "Mathias"
+    assert m.layout_2up == "horizontal"  # default
+    assert m.output == (tmp_path / "out.fcpxml").resolve()
+    # relative shooter paths resolve against the manifest dir
+    assert m.shooters[0].project == (tmp_path / "mathias").resolve()
+    assert m.shooters[1].project == (tmp_path / "anders").resolve()
+
+
+def test_layout_2up_vertical(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "layout_2up": "vertical",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.layout_2up == "vertical"
+
+
+def test_layout_2up_rejects_unknown(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "layout_2up": "diagonal",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    with pytest.raises(ValidationError):
+        load_manifest(src)
+
+
+def test_audio_from_must_match_a_label(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "Nobody",
+            "shooters": [{"project": "/p/a", "label": "A"}],
+        },
+    )
+    with pytest.raises(ValidationError) as exc:
+        load_manifest(src)
+    assert "audio_from" in str(exc.value)
+
+
+def test_duplicate_labels_rejected(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [
+                {"project": "/p/1", "label": "A"},
+                {"project": "/p/2", "label": "A"},
+            ],
+        },
+    )
+    with pytest.raises(ValidationError) as exc:
+        load_manifest(src)
+    assert "duplicate" in str(exc.value)
+
+
+def test_empty_shooters_rejected(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [],
+        },
+    )
+    with pytest.raises(ValidationError):
+        load_manifest(src)
+
+
+def test_tilde_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "~/projects/anders", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.shooters[0].project == fake_home / "projects" / "anders"
+
+
+def test_absolute_paths_passthrough(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "m.yaml",
+        {
+            "output": "/tmp/out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "/abs/path", "label": "A"}],
+        },
+    )
+    m = load_manifest(src)
+    assert m.output == Path("/tmp/out.fcpxml")
+    assert m.shooters[0].project == Path("/abs/path")
+
+
+def test_top_level_must_be_mapping(tmp_path: Path) -> None:
+    src = tmp_path / "m.yaml"
+    src.write_text("- not_a_mapping\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="mapping"):
+        load_manifest(src)
+
+
+def test_validate_directly_skips_path_resolution() -> None:
+    """``CompareManifest.model_validate`` works without going through
+    :func:`load_manifest`; relative paths simply stay relative."""
+    m = CompareManifest.model_validate(
+        {
+            "output": "out.fcpxml",
+            "audio_from": "A",
+            "shooters": [{"project": "rel/path", "label": "A"}],
+        }
+    )
+    assert m.shooters[0].project == Path("rel/path")

--- a/tests/test_compare_project_loader.py
+++ b/tests/test_compare_project_loader.py
@@ -1,0 +1,253 @@
+"""Tests for the per-shooter project loader in compare/project_loader.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.compare.project_loader import (
+    audit_path_for_stage,
+    load_shooter,
+    trim_path_for_stage,
+)
+from splitsmith.fcpxml_gen import VideoMetadata
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _meta(duration: float = 30.0) -> VideoMetadata:
+    return VideoMetadata(
+        width=1920,
+        height=1080,
+        duration_seconds=duration,
+        frame_rate_num=30,
+        frame_rate_den=1,
+    )
+
+
+def _build_project(
+    root: Path,
+    *,
+    name: str = "test",
+    pre_buffer: float = 5.0,
+    stages: list[StageEntry] | None = None,
+) -> MatchProject:
+    project = MatchProject.init(root, name=name)
+    project.trim_pre_buffer_seconds = pre_buffer
+    project.stages = stages or []
+    project.save(root)
+    return project
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
+
+
+def test_loads_present_stages_and_skips_missing(tmp_path: Path) -> None:
+    root = tmp_path / "shooter"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="Skipper",
+                time_seconds=10.0,
+                videos=[
+                    StageVideo(path=Path("raw/v1.mp4"), role="primary", beep_time=12.5),
+                ],
+            ),
+            StageEntry(
+                stage_number=2,
+                stage_name="No Trim Yet",
+                time_seconds=10.0,
+                videos=[
+                    StageVideo(path=Path("raw/v2.mp4"), role="primary", beep_time=8.0),
+                ],
+            ),
+        ],
+    )
+
+    # Stage 1's trim exists; stage 2's does not.
+    trim1 = trim_path_for_stage(project, root, 1, "Skipper")
+    _touch(trim1)
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert set(bundle.stages_by_number) == {1}
+    s1 = bundle.stages_by_number[1]
+    assert s1.trim_path == trim1
+    assert s1.audit_path == audit_path_for_stage(project, root, 1)
+    # beep_time > pre_buffer so beep_offset_in_clip == pre_buffer
+    assert s1.beep_offset_in_clip == 5.0
+
+
+def test_short_head_clamps_beep_offset(tmp_path: Path) -> None:
+    root = tmp_path / "short-head"
+    project = _build_project(
+        root,
+        pre_buffer=5.0,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="Tight",
+                time_seconds=10.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=2.5)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "Tight"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    # primary.beep_time < pre_buffer -> short head, clip-local beep equals beep_time
+    assert bundle.stages_by_number[1].beep_offset_in_clip == 2.5
+
+
+def test_skipped_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "skipped"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                skipped=True,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_no_primary_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "noprim"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="secondary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_no_beep_time_stage_is_omitted(tmp_path: Path) -> None:
+    root = tmp_path / "nobeep"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number == {}
+
+
+def test_probe_metadata_propagates(tmp_path: Path) -> None:
+    root = tmp_path / "meta"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    trim = _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    custom = VideoMetadata(
+        width=3840,
+        height=2160,
+        duration_seconds=42.0,
+        frame_rate_num=60000,
+        frame_rate_den=1001,
+    )
+
+    captured: list[Path] = []
+
+    def probe(p: Path) -> VideoMetadata:
+        captured.append(p)
+        return custom
+
+    bundle = load_shooter(root, "M", probe=probe)
+    assert captured == [trim]
+    s1 = bundle.stages_by_number[1]
+    assert s1.duration_seconds == 42.0
+    assert s1.width == 3840
+    assert s1.height == 2160
+    assert s1.frame_rate_num == 60000
+    assert s1.frame_rate_den == 1001
+    # convenience accessor reconstructs a VideoMetadata
+    assert isinstance(s1.metadata, VideoMetadata)
+    assert s1.metadata.frame_rate_num == 60000
+
+
+def test_slug_drives_trim_filename(tmp_path: Path) -> None:
+    """Stage with a complex name resolves through ``_slugify`` for the filename."""
+    root = tmp_path / "slug"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=4,
+                stage_name="Per told me to do it!",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=2.0)],
+            )
+        ],
+    )
+    expected = project.exports_path(root) / "stage4_per-told-me-to-do-it_trimmed.mp4"
+    _touch(expected)
+    bundle = load_shooter(root, "M", probe=lambda _p: _meta())
+    assert bundle.stages_by_number[4].trim_path == expected
+
+
+def test_default_probe_is_fcpxml_gen(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When ``probe`` is omitted, :func:`fcpxml_gen.probe_video` is used."""
+    root = tmp_path / "defaultprobe"
+    project = _build_project(
+        root,
+        stages=[
+            StageEntry(
+                stage_number=1,
+                stage_name="X",
+                time_seconds=0.0,
+                videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.0)],
+            )
+        ],
+    )
+    _touch(trim_path_for_stage(project, root, 1, "X"))
+
+    calls: list[Path] = []
+
+    def fake_probe(p: Path) -> VideoMetadata:
+        calls.append(p)
+        return _meta()
+
+    import splitsmith.fcpxml_gen as fg
+
+    monkeypatch.setattr(fg, "probe_video", fake_probe)
+    bundle = load_shooter(root, "M")  # no probe= -> module default
+    assert len(calls) == 1
+    assert bundle.stages_by_number[1].duration_seconds == 30.0


### PR DESCRIPTION
Closes #258. Stacked on top of #263 (filler), #262 (layout), #261 (loader).

The core of the multi-shooter comparison feature. Builds one FCPXML where each stage is a compound clip arranging per-shooter trims in a beep-aligned grid, stitched back-to-back via ``<ref-clip>``.

## Summary
- Sequence format from the audio-source shooter; per-tile assets dedup formats via the same ``formats_by_key`` pattern as ``generate_match_fcpxml`` (#233).
- Slot 0 (alphabetically first present label) is the spine clip; others on lanes 1..N-1. Filler tiles take later lanes.
- ``<adjust-volume amount="-96dB"/>`` mutes every tile except ``manifest.audio_from``.
- ``<adjust-transform>`` uses the normalised ``unit_per_px = 100/sequence_height`` convention (#236).
- Beep alignment: ``delta = round((max_beep - tile_beep) / fd)`` -> tile ``offset`` / ``start`` so every clip-local beep lands on the same parent frame (mirrors ``generate_fcpxml``'s secondary-cam logic).
- Outer spine: one ``<ref-clip>`` per stage with a marker; stage name prefers the audio-source shooter, falls back to alphabetically-first present shooter.
- Filler clips share an on-disk file via ``ensure_filler``; reused across stages with matching compound duration.

## Test plan
- [x] ``uv run pytest tests/test_compare_emitter.py`` -- 11/11 pass.
- [x] DTD validation under ``@fcpxml_dtd``.
- [x] Full suite: ``uv run pytest -q`` -- 1002 passed, 4 skipped.
- [x] Lint + format clean.

## Defaults applied
- Stage name when shooters disagree: audio-source shooter's name wins; falls back to alphabetically-first present shooter.
- Compound's inner ``<sequence format>`` references the sequence-level format (``r1``); per-tile size handled by ``<adjust-transform>``.
- Quantization: outer ``<ref-clip duration>`` and compound ``<sequence duration>`` quantize to sequence frame rate; per-tile ``<asset-clip start>`` quantizes to the tile's own asset rate via ``_asset_grid_str``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)