### PR TITLE
compare: black filler renderer

### DIFF
--- a/src/splitsmith/compare/filler.py
+++ b/src/splitsmith/compare/filler.py
@@ -1,0 +1,101 @@
+"""Black filler video for empty grid tiles in compare exports."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class FillerRenderError(RuntimeError):
+    """ffmpeg refused to render the black filler clip."""
+
+
+def filler_filename(
+    *, width: int, height: int, frame_rate_num: int, frame_rate_den: int, duration_seconds: float
+) -> str:
+    """Deterministic filename so two stages with matching geometry reuse the same file.
+
+    Encodes ``(W, H, fps_num, fps_den, duration_ms)``; duration is rounded
+    to milliseconds because the same compound clip should resolve to the
+    same filler file across runs even when the source duration differs by
+    sub-millisecond rounding.
+    """
+    duration_ms = int(round(duration_seconds * 1000))
+    return (
+        f"_compare_filler_{width}x{height}_{frame_rate_num}-{frame_rate_den}"
+        f"_{duration_ms}ms.mp4"
+    )
+
+
+def ensure_filler(
+    *,
+    width: int,
+    height: int,
+    frame_rate_num: int,
+    frame_rate_den: int,
+    duration_seconds: float,
+    output_dir: Path,
+    ffmpeg_binary: str = "ffmpeg",
+    runner: Runner = subprocess.run,
+) -> Path:
+    """Render (or reuse) a silent black filler video.
+
+    Idempotent: the filename encodes geometry + duration, so a second call
+    with matching arguments returns the existing file without re-running
+    ffmpeg. ``output_dir`` is created if needed.
+
+    The clip has no audio (``-an``) so the emitter doesn't need to mute it
+    explicitly. ``libx264 -pix_fmt yuv420p`` is used for cross-platform
+    reproducibility -- this stays predictable in CI / Linux even though
+    the rest of the pipeline can use VideoToolbox locally.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"width/height must be positive, got {width}x{height}")
+    if frame_rate_num <= 0 or frame_rate_den <= 0:
+        raise ValueError(f"frame rate must be positive, got {frame_rate_num}/{frame_rate_den}")
+    if duration_seconds <= 0.0:
+        raise ValueError(f"duration_seconds must be positive, got {duration_seconds}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / filler_filename(
+        width=width,
+        height=height,
+        frame_rate_num=frame_rate_num,
+        frame_rate_den=frame_rate_den,
+        duration_seconds=duration_seconds,
+    )
+    if target.exists():
+        return target
+
+    fps = frame_rate_num / frame_rate_den
+    cmd = [
+        ffmpeg_binary,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=black:s={width}x{height}:r={fps:.6f}",
+        "-t",
+        f"{duration_seconds:.3f}",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-an",
+        str(target),
+    ]
+    try:
+        runner(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise FillerRenderError(f"ffmpeg binary not found: {ffmpeg_binary}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise FillerRenderError(
+            f"ffmpeg failed rendering filler ({exc.returncode}): " f"{exc.stderr or exc.stdout!r}"
+        ) from exc
+    return target

--- a/tests/test_compare_filler.py
+++ b/tests/test_compare_filler.py
@@ -1,0 +1,171 @@
+"""Tests for the black-filler renderer in compare/filler.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from splitsmith.compare.filler import (
+    FillerRenderError,
+    ensure_filler,
+    filler_filename,
+)
+
+
+def _stub_runner_factory() -> tuple[list[list[str]], Any]:
+    """Returns (calls list, stub callable) -- the stub creates its output file."""
+    calls: list[list[str]] = []
+
+    def stub(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        calls.append(list(cmd))
+        # ffmpeg writes its output to the last positional arg
+        Path(cmd[-1]).write_bytes(b"")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    return calls, stub
+
+
+def test_filler_filename_is_deterministic() -> None:
+    name = filler_filename(
+        width=1920,
+        height=1080,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+        duration_seconds=12.345,
+    )
+    again = filler_filename(
+        width=1920,
+        height=1080,
+        frame_rate_num=30000,
+        frame_rate_den=1001,
+        duration_seconds=12.345,
+    )
+    assert name == again
+    # Geometry / fps / duration are visible in the name -- so different
+    # callers see different names for different inputs.
+    assert "1920x1080" in name
+    assert "30000-1001" in name
+    assert name.endswith(".mp4")
+
+
+def test_ensure_filler_invokes_ffmpeg_with_lavfi(tmp_path: Path) -> None:
+    calls, stub = _stub_runner_factory()
+    out = ensure_filler(
+        width=1920,
+        height=1080,
+        frame_rate_num=30,
+        frame_rate_den=1,
+        duration_seconds=10.0,
+        output_dir=tmp_path,
+        runner=stub,
+    )
+    assert out.parent == tmp_path
+    assert out.exists()
+    assert len(calls) == 1
+    cmd = calls[0]
+    # Argument order matters for ffmpeg: -f lavfi must precede -i.
+    assert cmd[0] == "ffmpeg"
+    f_idx = cmd.index("-f")
+    i_idx = cmd.index("-i")
+    assert f_idx < i_idx
+    assert cmd[f_idx + 1] == "lavfi"
+    assert cmd[i_idx + 1].startswith("color=c=black:s=1920x1080:r=")
+    assert "-an" in cmd
+    assert "-c:v" in cmd
+    cv = cmd[cmd.index("-c:v") + 1]
+    assert cv == "libx264"
+    assert cmd[-1] == str(out)
+
+
+def test_ensure_filler_idempotent_skips_ffmpeg(tmp_path: Path) -> None:
+    calls, stub = _stub_runner_factory()
+    args = {
+        "width": 1280,
+        "height": 720,
+        "frame_rate_num": 60,
+        "frame_rate_den": 1,
+        "duration_seconds": 5.0,
+        "output_dir": tmp_path,
+        "runner": stub,
+    }
+    first = ensure_filler(**args)  # type: ignore[arg-type]
+    second = ensure_filler(**args)  # type: ignore[arg-type]
+    assert first == second
+    assert len(calls) == 1  # second call returns the cached file
+
+
+def test_ensure_filler_creates_output_dir(tmp_path: Path) -> None:
+    _calls, stub = _stub_runner_factory()
+    nested = tmp_path / "a" / "b" / "fillers"
+    out = ensure_filler(
+        width=640,
+        height=480,
+        frame_rate_num=30,
+        frame_rate_den=1,
+        duration_seconds=1.0,
+        output_dir=nested,
+        runner=stub,
+    )
+    assert nested.is_dir()
+    assert out.parent == nested
+
+
+def test_ensure_filler_rejects_invalid_geometry(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="width/height"):
+        ensure_filler(
+            width=0,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=lambda *a, **k: None,  # type: ignore[arg-type]
+        )
+
+
+def test_ensure_filler_rejects_invalid_duration(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="duration"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=0.0,
+            output_dir=tmp_path,
+            runner=lambda *a, **k: None,  # type: ignore[arg-type]
+        )
+
+
+def test_ffmpeg_missing_raises(tmp_path: Path) -> None:
+    def stub(_cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        raise FileNotFoundError("ffmpeg")
+
+    with pytest.raises(FillerRenderError, match="not found"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=stub,
+        )
+
+
+def test_ffmpeg_failure_propagates(tmp_path: Path) -> None:
+    def stub(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="boom")
+
+    with pytest.raises(FillerRenderError, match="boom"):
+        ensure_filler(
+            width=1920,
+            height=1080,
+            frame_rate_num=30,
+            frame_rate_den=1,
+            duration_seconds=1.0,
+            output_dir=tmp_path,
+            runner=stub,
+        )


### PR DESCRIPTION
Closes #257.

Black filler video for empty grid tiles in compare exports.

## Summary
- ``ensure_filler(...)`` renders (or reuses) a silent black mp4 via ``ffmpeg -f lavfi -i color=c=black:s=WxH:r=FPS -t DUR -c:v libx264 -pix_fmt yuv420p -an``.
- Filename encodes ``(W, H, fps_num, fps_den, duration_ms)`` so stages with matching geometry share one file across the export and across runs.
- ``runner`` injection mirrors ``splitsmith.trim.trim_video``.
- ``FillerRenderError`` wraps ffmpeg-missing / non-zero-exit cases.

## Test plan
- [x] ``uv run pytest tests/test_compare_filler.py`` -- 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)