### PR TITLE
compare: CLI verb wiring (splitsmith compare export)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "PTH"]
 # warning is a false positive for Typer-based CLIs.
 "src/splitsmith/cli.py" = ["B008"]
 "src/splitsmith/lab_cli.py" = ["B008"]
+"src/splitsmith/compare/cli.py" = ["B008"]
 # Scoreboard models intentionally mirror the documented `/api/v1/` wire shape
 # verbatim, which is mixed snake_case + camelCase. Translation to splitsmith's
 # snake_case happens in adapters, not in the parsed-response models.

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -56,9 +56,11 @@ app = typer.Typer(
 )
 console = Console()
 
+from .compare.cli import compare_app  # noqa: E402
 from .lab_cli import app as _lab_app  # noqa: E402
 
 app.add_typer(_lab_app, name="lab")
+app.add_typer(compare_app, name="compare")
 
 
 # ---------------------------------------------------------------------------

--- a/src/splitsmith/compare/cli.py
+++ b/src/splitsmith/compare/cli.py
@@ -1,0 +1,41 @@
+"""Typer sub-app for ``splitsmith compare ...``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from . import emitter as emitter_mod
+from . import manifest as manifest_mod
+from . import project_loader
+
+compare_app = typer.Typer(
+    name="compare",
+    help="Multi-shooter comparison FCPXML.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+console = Console()
+
+
+@compare_app.command("export")
+def export(
+    manifest_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to a comparison manifest YAML.",
+    ),
+) -> None:
+    """Render a multi-shooter comparison FCPXML from MANIFEST_PATH."""
+    manifest = manifest_mod.load_manifest(manifest_path)
+    shooters = [project_loader.load_shooter(s.project, s.label) for s in manifest.shooters]
+    emitter_mod.emit_compare_fcpxml(
+        manifest=manifest,
+        shooters=shooters,
+        output_path=manifest.output,
+    )
+    console.print(f"[green]Wrote[/] {manifest.output}")

--- a/tests/test_compare_cli.py
+++ b/tests/test_compare_cli.py
@@ -1,0 +1,107 @@
+"""End-to-end smoke test for ``splitsmith compare export <manifest>``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from splitsmith.cli import app
+from splitsmith.fcpxml_gen import VideoMetadata
+from splitsmith.ui.match_exports import _slugify
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+def _ffmpeg_stub_factory() -> Any:
+    def stub(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        Path(cmd[-1]).write_bytes(b"")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    return stub
+
+
+def _seed_shooter(root: Path, *, name: str, stage_name: str = "Skipper") -> Path:
+    project = MatchProject.init(root, name=name)
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name=stage_name,
+            time_seconds=10.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=5.0)],
+        )
+    ]
+    project.save(root)
+    trim = project.exports_path(root) / f"stage1_{_slugify(stage_name)}_trimmed.mp4"
+    trim.parent.mkdir(parents=True, exist_ok=True)
+    trim.write_bytes(b"")
+    return root
+
+
+def test_export_writes_fcpxml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    a_root = _seed_shooter(tmp_path / "a", name="a")
+    b_root = _seed_shooter(tmp_path / "b", name="b")
+
+    manifest_path = tmp_path / "compare.yaml"
+    output = tmp_path / "out.fcpxml"
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                "output": str(output),
+                "audio_from": "Mathias",
+                "shooters": [
+                    {"project": str(a_root), "label": "Anders"},
+                    {"project": str(b_root), "label": "Mathias"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Stub ffprobe (used by the project loader) and ffmpeg (used by the
+    # filler renderer) so the test doesn't depend on either binary.
+    def fake_probe(_p: Path) -> VideoMetadata:
+        return VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=30.0,
+            frame_rate_num=30,
+            frame_rate_den=1,
+        )
+
+    import splitsmith.compare.emitter as em_mod
+    import splitsmith.compare.project_loader as pl_mod
+
+    monkeypatch.setattr(pl_mod.fcpxml_gen, "probe_video", fake_probe)
+    monkeypatch.setattr(em_mod.subprocess, "run", _ffmpeg_stub_factory())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["compare", "export", str(manifest_path)])
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+
+
+def test_missing_manifest_errors(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["compare", "export", str(tmp_path / "missing.yaml")])
+    assert result.exit_code != 0
+
+
+def test_audio_from_mismatch_surfaces_validation_error(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                "output": str(tmp_path / "out.fcpxml"),
+                "audio_from": "NotPresent",
+                "shooters": [{"project": str(tmp_path / "p"), "label": "Real"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["compare", "export", str(manifest_path)])
+    assert result.exit_code != 0


### PR DESCRIPTION
Closes #259.

End-to-end CLI for the multi-shooter comparison feature.

## Summary
- New ``src/splitsmith/compare/cli.py`` with ``compare_app`` Typer sub-app exposing one verb: ``export <manifest>``.
- Mounted in ``src/splitsmith/cli.py`` next to the existing ``lab`` sub-app.
- ``pyproject.toml``: adds ``compare/cli.py`` to the per-file B008 ignore.

## Test plan
- [x] ``uv run pytest tests/test_compare_cli.py`` -- 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)