### PR TITLE
compare: example manifest + README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,33 @@ uv run splitsmith lab rescore --universe build/lab/runs/latest.json --consensus 
 uv run splitsmith lab promote --audit-json <project>/audit/stage4.json --audit-wav <project>/audio/stage4_audit.wav --slug stage-shots-myclub-2026-stage4
 ```
 
+### `compare` -- multi-shooter side-by-side FCPXML
+
+Render one FCPXML where each stage is a beep-aligned grid of N shooters' trims. Tile slots are alphabetical by label and stay fixed across every stage so a shooter who's missing a stage gets a black filler tile rather than reshuffling the grid. Audio comes from a single nominated shooter; everyone else is muted.
+
+Each shooter must already have per-stage lossless trims on disk (i.e., you've run the per-stage exporter for each project). The comparison emitter reads `<project>/exports/stage<N>_<slug>_trimmed.mp4` for every stage of every shooter.
+
+Manifest YAML:
+
+```yaml
+output: bromma-classifier-2026.fcpxml
+audio_from: Mathias        # must match a label below
+layout_2up: horizontal     # horizontal | vertical, only used when N == 2
+shooters:
+  - project: ~/splitsmith/projects/mathias-bromma-classifier-2026
+    label: Mathias
+  - project: ~/splitsmith/projects/anders-bromma-classifier-2026
+    label: Anders
+```
+
+Render:
+
+```bash
+uv run splitsmith compare export examples/compare-bromma-classifier-2026.yaml
+```
+
+Smallest-fits grid: 1 shooter -> 1up; 2 -> 2up (horizontal or vertical); 3-4 -> 2x2; 5-9 -> 3x3; 10-16 -> 4x4. Empty slots in the chosen grid become black filler tiles for the duration of that stage. Sequence frame rate / size come from the audio-source shooter's first stage; mismatched cam rates / sizes get their own `<format>` resource and ride on FCP's edit-time conform.
+
 ### `review` -- audit a fixture in a local web UI
 
 Open a single-page browser UI for reviewing detected shots against the fixture's audio (and optional video). Marker pins on the waveform: click to toggle keep/reject, drag to fine-tune time, double-click empty waveform space to add a manual marker. Save (`Cmd+S`) writes back to the fixture JSON's `shots[]`.

--- a/examples/compare-bromma-classifier-2026.yaml
+++ b/examples/compare-bromma-classifier-2026.yaml
@@ -1,0 +1,30 @@
+# Multi-shooter comparison manifest. Renders one FCPXML where every
+# stage from each project is laid out as a beep-aligned grid of tiles.
+#
+# Run:
+#   splitsmith compare export examples/compare-bromma-classifier-2026.yaml
+#
+# Each shooter's project must already have per-stage trims on disk
+# (run the per-stage exporter for each project first).
+
+# Where to write the FCPXML. Relative paths resolve against this
+# manifest's parent directory.
+output: bromma-classifier-2026.fcpxml
+
+# Whose audio plays. Must match one of the labels below. Every other
+# tile is muted at -96 dB.
+audio_from: Mathias
+
+# Layout for the 2-shooter case only. ``horizontal`` = side-by-side,
+# ``vertical`` = stacked. Ignored when there are 3+ shooters
+# (smallest-fits grid is 2x2 / 3x3 / 4x4).
+layout_2up: horizontal
+
+# Tile slots are alphabetical by label and stay fixed across every
+# stage in the export -- if a shooter is missing a stage's trim, that
+# slot becomes a black filler tile so the grid layout doesn't shift.
+shooters:
+  - project: ~/splitsmith/projects/mathias-bromma-classifier-2026
+    label: Mathias
+  - project: ~/splitsmith/projects/anders-bromma-classifier-2026
+    label: Anders


### PR DESCRIPTION
Closes #260.

Docs + example for the multi-shooter comparison feature.

## Summary
- ``examples/compare-bromma-classifier-2026.yaml`` -- complete annotated manifest matching the locked schema.
- README ``compare`` subcommand section -- tile-ordering / slot-stability rules, smallest-fits grid table, sequence-format derivation, pointer to the example.

## Test plan
- [x] CI parity green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)