### PR TITLE
docs: SPEC + CLAUDE.md cover the compare package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,20 @@ script after adding new audited fixtures.
 The review-time variant generator ``scripts/build_ensemble_fixture.py``
 still exists for offline comparison under ``build/ensemble-review/``.
 
+## Multi-shooter comparison (`compare/` package)
+
+``splitsmith compare export <manifest>`` reads N existing single-shooter
+``MatchProject`` directories (all from the same match) and emits one
+FCPXML where each stage is a beep-aligned grid compound clip. It does
+not run detection -- it only reads finished projects' per-stage trims.
+
+Slot order is alphabetical by manifest label and stable across stages
+(missing trims become black filler, never reshuffle the grid). The
+audio-source shooter from the manifest drives the sequence frame rate
+and is the only unmuted tile. Per-module breakdown lives in SPEC.md
+under "Module responsibilities"; the example manifest is at
+``examples/compare-bromma-classifier-2026.yaml``.
+
 ## Things Claude Code should not do
 
 - Add new dependencies without asking. The dep list is small on purpose.

--- a/SPEC.md
+++ b/SPEC.md
@@ -132,6 +132,14 @@ Anomaly detection:
 - Any split >3s within the stage window → flag (likely missed shot, or just a long transition).
 - Shot count differs significantly from typical IPSC stage round counts → informational note (we don't know exact round count).
 
+**`compare/`** — Multi-shooter side-by-side FCPXML export. Reads N existing single-shooter `MatchProject` directories (all from the same match) and emits one FCPXML where each stage is a beep-aligned grid compound clip. Each shooter must already have per-stage lossless trims on disk.
+- `manifest.py`: `CompareManifest` Pydantic model + `load_manifest` YAML loader. Validates `audio_from` matches a label, label uniqueness, and resolves relative paths against the manifest's parent dir.
+- `project_loader.py`: `load_shooter` walks `MatchProject.stages`, derives the per-stage trim path via the same `_slugify` rule the per-stage exporter uses, and computes `beep_offset_in_clip = min(trim_pre_buffer_seconds, primary.beep_time)`. Stages without a primary, beep, trim, or marked `skipped` are omitted.
+- `layout.py`: pure math. `choose_grid(roster_count)` picks the smallest of `{1up, 2up-h, 2up-v, 2x2, 3x3, 4x4}` that fits the full roster (sized for the manifest, not the present subset, so slot indices stay stable across stages). `compute_layout(...)` returns a `GridLayout` with `slots_per_label` (alphabetical) and `empty_slots` for filler placement.
+- `filler.py`: `ensure_filler` shells out to ffmpeg (`-f lavfi -i color=c=black -an`) to produce a silent black mp4 sized to the longest tile in the stage. Filename encodes `(W, H, fps_num, fps_den, duration_ms)` so stages with matching geometry share one file.
+- `emitter.py`: builds the FCPXML. Sequence format from the audio-source shooter; per-tile assets dedup formats via the same `formats_by_key` pattern as `fcpxml_gen.generate_match_fcpxml`. Slot 0 (alphabetically first present label) is the spine clip; others on lanes 1..N-1; filler tiles take later lanes. Beep alignment: `delta = round((max_beep - tile_beep) / fd)` so every tile's clip-local beep coincides at the same parent timeline frame. Audio: `<adjust-volume amount="-96dB"/>` on every tile except `manifest.audio_from`. Outer spine: one `<ref-clip>` per stage with a `<marker>` named `Stage N -- <name>`.
+- `cli.py`: Typer sub-app exposing `splitsmith compare export <manifest>`.
+
 ## Data structures
 
 ```python
@@ -238,9 +246,15 @@ splitsmith fcpxml \
     --csv PATH \
     --video PATH \
     --output PATH
+
+# Multi-shooter comparison: render N shooters' beep-aligned trims as
+# a per-stage grid into one FCPXML.
+splitsmith compare export PATH/TO/manifest.yaml
 ```
 
 The `fcpxml` regeneration command matters — the user will manually fix detection errors in the CSV and want to rebuild the timeline.
+
+The `compare` command reads N existing single-shooter projects (each with per-stage lossless trims already exported) plus a manifest YAML naming them, and emits one FCPXML where each stage is a beep-aligned grid compound clip. See `compare/` under module responsibilities for the per-module breakdown and `examples/compare-bromma-classifier-2026.yaml` for an annotated manifest.
 
 ## Error handling principles
 


### PR DESCRIPTION
Fills the dev-facing doc gaps for ``splitsmith compare export`` (the multi-shooter feature merged in #261/#269/#270/#271/#272/#273).

## Summary
- SPEC.md ``Module responsibilities``: per-module breakdown of the ``compare/`` package (manifest, project_loader, layout, filler, emitter, cli) including the slot-stability rule, beep-alignment math, and audio-routing convention.
- SPEC.md ``CLI design``: lists ``splitsmith compare export <manifest>`` next to the existing subcommands and points at the example manifest.
- CLAUDE.md: short ``Multi-shooter comparison`` section so future Claude Code sessions know the feature exists, that it reads finished projects rather than running detection, and where the per-module docs live.

Pure docs. End-user facing docs (README + ``examples/compare-bromma-classifier-2026.yaml``) already shipped with the feature.

## Test plan
- [x] ``uv run pytest -q`` -- 1089 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)