### PR TITLE
ingest: scope BeepSection busy state per section

### DIFF
--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -63,9 +63,7 @@ interface Props {
    *  per-video API endpoints carry ``video.video_id`` so jobs and caches
    *  stay scoped to one camera at a time. */
   video: StageVideo;
-  busy: boolean;
   onProjectUpdate: (next: MatchProject) => void;
-  setBusy: (b: boolean) => void;
   setError: (msg: string | null) => void;
   /** Drop the section's own border/background when nested inside a video
    *  panel that already provides the single visual frame. */
@@ -75,12 +73,18 @@ interface Props {
 export function BeepSection({
   stageNumber,
   video,
-  busy,
   onProjectUpdate,
-  setBusy,
   setError,
   bare = false,
 }: Props) {
+  // Section-local busy. Each video's beep section runs its own
+  // independent jobs (auto-queued on assignment, or user-initiated via
+  // Detect / Save / Clear), so disabling controls page-wide while one
+  // section's job is in flight blocks unrelated work like assigning the
+  // next video from the unassigned tray. Keeping busy local means each
+  // section disables only its own buttons; the JobsPanel still surfaces
+  // the running job globally.
+  const [busy, setBusy] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(video.beep_time?.toFixed(3) ?? "");
   // Brief background highlight on the draft input whenever its value is
@@ -157,7 +161,7 @@ export function BeepSection({
     return () => {
       cancelled = true;
     };
-  }, [stageNumber, videoId, onProjectUpdate, setBusy, setError]);
+  }, [stageNumber, videoId, onProjectUpdate, setError]);
 
   const detect = async (force: boolean) => {
     setBusy(true);

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -2690,8 +2690,6 @@ function StageCard({
               stageNumber={stage.stage_number}
               video={primary}
               bare
-              busy={busy}
-              setBusy={setBusy}
               setError={setError}
               onProjectUpdate={onProjectUpdate}
             />
@@ -2728,8 +2726,6 @@ function StageCard({
               stageNumber={stage.stage_number}
               video={v}
               bare
-              busy={busy}
-              setBusy={setBusy}
               setError={setError}
               onProjectUpdate={onProjectUpdate}
             />


### PR DESCRIPTION
## Summary
- Assigning a video from the unassigned tray (e.g. clicking `→ S1`) auto-queues a `detect_beep` job. The freshly-mounted `BeepSection` for the new video had a resume-poll effect that called the **page-level** `setBusy(true)` and awaited the job to completion — so the unassigned tray's `→ S1/S2/...` buttons stayed greyed out for the entire beep+trim run, then re-enabled the moment shot-detect was submitted.
- The `/api/assignments/move` request itself only takes ~9 ms; the block was purely on the SPA side.
- The whole point of the job queue (`ThreadPoolExecutor(max_workers=2)`) is to let the user keep working while detection runs. Now `BeepSection` manages its own `busy` locally — its own controls (Detect, Set manually, Save, Clear, Use cross-align, Use this candidate, Mark reviewed) still disable while its job is in flight, but the rest of the page stays interactive. `JobsPanel` still surfaces the running job globally.

## Test plan
- [ ] In a fresh project, drop several videos into the unassigned tray.
- [ ] Click `→ S1` on one video. Confirm a `detect_beep` job appears in `JobsPanel`.
- [ ] Immediately click `→ S2` on a second video while the first job is still running. The button should be enabled and the second assignment should succeed (server runs up to 2 jobs in parallel; further assignments queue).
- [ ] Confirm that the BeepSection of the *currently-running* video still has its `Detect beep` / `Set manually` buttons disabled (so the user doesn't double-fire the same job).
- [ ] Verify `tsc -b --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)