### PR TITLE
ingest: picker uses full source WAV + shot re-detect prompt on beep change

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3457,20 +3457,16 @@ def create_app(
     ) -> audio_helpers.AuditAudioResult:
         """Per-video version of :func:`_resolve_audit_audio`.
 
-        Primary delegates to the audit-audio resolver so the existing
-        cache + trim-clip preference is preserved. Non-primary returns
-        the full per-cam WAV (``stage<N>_cam_<vid>.wav``) -- there's no
-        per-secondary trim clip, and the picker needs the whole clip
-        anyway so the user can find the buzzer / first shot regardless
-        of where the current beep estimate sits.
+        Always returns the full source WAV, regardless of role. The picker
+        is where the user *questions* the current beep -- if it shows the
+        trimmed audit clip, a beep that fell outside the trim window is
+        invisible and can't be moved onto. The audit screen still reaches
+        for the trimmed clip via the per-stage `/audio` + `/peaks`
+        endpoints, which is the right consumer for that cache.
 
-        ``beep_in_clip`` mirrors the primary path: the WAV is full source
-        time, so it's just ``video.beep_time`` (no trim offset). Audit
-        callers that need clip-local time should keep using the primary
-        endpoint -- this resolver is for the per-video beep picker.
+        ``beep_in_clip`` is just ``video.beep_time``; the WAV is in source
+        time so no trim offset applies.
         """
-        if video.role == "primary":
-            return _resolve_audit_audio(project, stage_number)
         source = project.resolve_video_path(state.project_root, video.path)
         try:
             audio_path = audio_helpers.ensure_video_audio(

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -95,6 +95,15 @@ export function BeepSection({
   // tailwind transition-colors fade; see the input className below.
   const [draftFlashing, setDraftFlashing] = useState(false);
   const [jobStatus, setJobStatus] = useState<Job | null>(null);
+  // After a beep change on a primary that already had shots detected,
+  // surface an inline banner offering to re-run shot detection. Captured
+  // from props pre-change because the override endpoint flips
+  // ``processed.shot_detect`` to false as part of clearing stale state,
+  // so the post-call shape can't tell us shots existed before.
+  const [pendingShotRedetect, setPendingShotRedetect] = useState<{
+    deltaMs: number;
+  } | null>(null);
+  const [redetecting, setRedetecting] = useState(false);
   const flashDraftInput = useCallback(() => {
     // Drop-then-set across an rAF tick so a second pick in quick
     // succession re-triggers the fade instead of being a no-op (state
@@ -195,6 +204,37 @@ export function BeepSection({
     }
   };
 
+  // Capture pre-change "had shots" so we can offer a re-detect after the
+  // override clears the flag. Primary-only: shot detection is anchored
+  // on the primary's trim, so secondaries never invalidate shots.
+  const queueShotRedetectIfNeeded = useCallback(
+    (prevBeepTime: number | null, prevHadShots: boolean, nextBeepTime: number | null) => {
+      if (!isPrimary || !prevHadShots || nextBeepTime == null) return;
+      const deltaMs = Math.round(((nextBeepTime - (prevBeepTime ?? nextBeepTime)) * 1000));
+      setPendingShotRedetect({ deltaMs });
+    },
+    [isPrimary],
+  );
+
+  const runShotRedetect = useCallback(async () => {
+    setRedetecting(true);
+    setError(null);
+    try {
+      const job = await api.detectShots(stageNumber, { reset: true });
+      const final = await api.pollJob(job.id);
+      if (final.status === "failed") {
+        setError(final.error ?? "Shot detection failed");
+      } else {
+        onProjectUpdate(await api.getProject());
+      }
+      setPendingShotRedetect(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRedetecting(false);
+    }
+  }, [stageNumber, onProjectUpdate, setError]);
+
   const save = async () => {
     const trimmed = draft.trim();
     if (!trimmed) {
@@ -206,12 +246,15 @@ export function BeepSection({
       setError("Beep time must be a non-negative number of seconds");
       return;
     }
+    const prevBeepTime = video.beep_time;
+    const prevHadShots = isPrimary && video.processed.shot_detect;
     setBusy(true);
     try {
       const updated = await api.overrideBeepForVideo(stageNumber, videoId, value);
       onProjectUpdate(updated);
       setError(null);
       setEditing(false);
+      queueShotRedetectIfNeeded(prevBeepTime, prevHadShots, value);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -234,11 +277,14 @@ export function BeepSection({
   };
 
   const selectCandidate = async (time: number) => {
+    const prevBeepTime = video.beep_time;
+    const prevHadShots = isPrimary && video.processed.shot_detect;
     setBusy(true);
     try {
       const updated = await api.selectBeepCandidateForVideo(stageNumber, videoId, time);
       onProjectUpdate(updated);
       setError(null);
+      queueShotRedetectIfNeeded(prevBeepTime, prevHadShots, time);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -424,6 +470,15 @@ export function BeepSection({
     }
   };
 
+  const shotRedetectBanner = pendingShotRedetect ? (
+    <ShotRedetectBanner
+      deltaMs={pendingShotRedetect.deltaMs}
+      busy={redetecting}
+      onRedetect={() => void runShotRedetect()}
+      onDismiss={() => setPendingShotRedetect(null)}
+    />
+  ) : null;
+
   if (collapsed) {
     return (
       <div
@@ -432,6 +487,7 @@ export function BeepSection({
           !bare && "rounded-md border border-border/60 bg-muted/20",
         )}
       >
+        {shotRedetectBanner}
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant={pillVariant} className="gap-1">
             <Check className="size-3" />
@@ -460,6 +516,7 @@ export function BeepSection({
         !bare && "rounded-md border border-border/60 bg-muted/20",
       )}
     >
+      {shotRedetectBanner}
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant={pillVariant} className="gap-1" title={pillTitle}>
           <Check className="size-3" />
@@ -534,6 +591,8 @@ export function BeepSection({
           deltaMs={deltaMs!}
           confidence={conf}
           onUseCrossAlign={async () => {
+            const prevBeepTime = video.beep_time;
+            const prevHadShots = isPrimary && video.processed.shot_detect;
             setBusy(true);
             try {
               const updated = await api.overrideBeepForVideo(
@@ -543,6 +602,7 @@ export function BeepSection({
               );
               onProjectUpdate(updated);
               setError(null);
+              queueShotRedetectIfNeeded(prevBeepTime, prevHadShots, crossAlignSuggestion);
             } catch (e) {
               setError(e instanceof Error ? e.message : String(e));
             } finally {
@@ -1277,6 +1337,49 @@ function AlignmentDisagreement({
             ariaLabel={`Cross-align preview at ${crossAlignTime.toFixed(3)}s`}
           />
         </div>
+      </div>
+    </div>
+  );
+}
+
+/** Shown after a primary's beep moves while shot detection had already
+ *  run for the stage. Shot times are anchored to the previous trim, so
+ *  the user has to decide: re-run detection now, or keep the current
+ *  list (e.g. when the change is sub-frame and won't affect anything).
+ *  Stays inline -- the user just changed a value above and the prompt
+ *  needs to be obviously connected to that action, not floated as a
+ *  toast. */
+function ShotRedetectBanner({
+  deltaMs,
+  busy,
+  onRedetect,
+  onDismiss,
+}: {
+  deltaMs: number;
+  busy: boolean;
+  onRedetect: () => void;
+  onDismiss: () => void;
+}) {
+  const absMs = Math.abs(deltaMs);
+  const direction = deltaMs > 0 ? "later" : deltaMs < 0 ? "earlier" : "unchanged";
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-2 rounded-md border border-amber-300/60 bg-amber-50 px-2 py-1.5 text-xs text-amber-950 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100"
+    >
+      <span className="font-medium">Shot times are now stale.</span>
+      <span>
+        Beep moved {absMs} ms {direction}; existing shot timestamps were
+        detected against the old trim.
+      </span>
+      <div className="ml-auto flex gap-1">
+        <Button size="sm" variant="default" onClick={onRedetect} disabled={busy}>
+          {busy ? <Loader2 className="animate-spin" /> : <Sparkles />}
+          Re-detect shots
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onDismiss} disabled={busy}>
+          Keep existing
+        </Button>
       </div>
     </div>
   );

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1532,6 +1532,54 @@ def test_video_audio_endpoint_serves_secondary_wav(tmp_path: Path, monkeypatch) 
     assert resp.content.startswith(b"RIFF")
 
 
+def test_video_peaks_endpoint_serves_primary_full_wav_even_when_trimmed_exists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The per-video picker endpoint always returns the full source WAV,
+    even for primaries that already have a trimmed audit clip cached.
+
+    Regression: the picker is where the user *questions* the current beep,
+    so a beep that fell outside the trim window must still be visible on
+    the waveform. The audit screen reaches for the trimmed clip via the
+    per-stage endpoint -- different consumer, different cache.
+    """
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary_id = primary["video_id"]
+
+    # Cache both the trimmed audit WAV (short) and the full primary WAV
+    # (long). If the picker mistakenly uses the audit clip the response
+    # duration will be 1s; with the fix it's 2s.
+    audit_wav = audio_dir / "stage1_audit.wav"
+    sf.write(audit_wav, np.zeros(48_000, dtype="float32"), 48_000)
+    primary_wav = audio_dir / "stage1_primary.wav"
+    sf.write(primary_wav, np.zeros(96_000, dtype="float32"), 48_000)
+
+    trimmed_dir = project_root / "trimmed"
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"\x00fake_mp4")
+
+    from splitsmith.ui import audio as audio_helpers
+
+    def fake_ensure_video(root, n, video, source, **kwargs):  # type: ignore[no-untyped-def]
+        return primary_wav
+
+    monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
+
+    resp = client.get(f"/api/stages/1/videos/{primary_id}/peaks?bins=64")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["trimmed"] is False
+    assert body["duration"] == pytest.approx(2.0)
+
+
 def test_video_peaks_endpoint_404_for_unknown_video(tmp_path: Path) -> None:
     """The per-video endpoint 404s when video_id isn't on the stage --
     same shape as the per-video beep endpoints."""


### PR DESCRIPTION
## Summary
- The per-video beep picker (`BeepSection`) now serves the full source WAV for primary as well as secondary, instead of falling back to the trimmed audit clip when one was cached. A beep that fell outside the old trim window was previously invisible on the waveform and impossible to snap to. The audit screen still uses the trimmed clip via the per-stage `/audio` + `/peaks` endpoints -- different consumer, different cache.
- After a primary's beep changes (Apply / candidate select / use cross-align) while shot detection had already run, an inline amber banner appears with the beep delta and two buttons: **Re-detect shots** (`POST /api/stages/{n}/shot-detect?reset=true`) or **Keep existing**. The "had shots" signal is captured pre-call because `_apply_beep_override` clears `processed.shot_detect` as part of invalidating stale state.

## Test plan
- [ ] Open the ingest screen for a stage where shot detection has run, edit the primary's beep on the waveform, click Apply -> banner appears with the delta, "Re-detect shots" submits the job and refreshes the project on success.
- [ ] On the same stage, click "Keep existing" -> banner dismisses, no job submitted.
- [ ] Edit a primary's beep before any shot-detect run -> no banner.
- [ ] Edit a secondary's beep -> no banner.
- [ ] Open the picker for a primary that has a cached `stage<N>_trimmed.mp4` and a beep deliberately set outside the trim window -> waveform shows the full clip, marker can be placed on the actual beep, snap-to-beep accepts.
- [ ] `uv run pytest tests/test_ui_server.py` (new regression test covers the picker-uses-full-WAV path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)