### PR TITLE
ui: stop browser memory drift across long sessions

### DIFF
--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -21,7 +21,14 @@
  * visible in the preview).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type VideoHTMLAttributes,
+} from "react";
 import { Link } from "react-router-dom";
 import {
   Check,
@@ -43,7 +50,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Waveform } from "@/components/Waveform";
-import { cn } from "@/lib/utils";
+import { cn, useReleaseMediaOnUnmount } from "@/lib/utils";
 import {
   ApiError,
   api,
@@ -55,6 +62,16 @@ import {
   type PeaksResult,
   type StageVideo,
 } from "@/lib/api";
+
+// Wraps a <video> with the buffer-release hook so conditional preview
+// clips don't leak decoded frames when they unmount on key/state change.
+function ReleasingPreviewVideo(
+  props: VideoHTMLAttributes<HTMLVideoElement>,
+) {
+  const ref = useRef<HTMLVideoElement | null>(null);
+  useReleaseMediaOnUnmount(ref);
+  return <video ref={ref} {...props} />;
+}
 
 interface Props {
   stageNumber: number;
@@ -683,6 +700,7 @@ function BeepWaveformPicker({
   const [snapping, setSnapping] = useState(false);
   const [proposal, setProposal] = useState<BeepSnapResult | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  useReleaseMediaOnUnmount(audioRef);
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -1010,7 +1028,7 @@ function ProposalPreview({
     );
   }
   return (
-    <video
+    <ReleasingPreviewVideo
       key={`${stageNumber}:${videoId}:${time.toFixed(3)}`}
       src={api.videoBeepPreviewUrl(stageNumber, videoId, time)}
       className="h-32 w-56 rounded-md border border-border/60 bg-black object-cover"
@@ -1120,7 +1138,7 @@ function BeepCandidates({
                   Preview unavailable (no cached clip yet)
                 </div>
               ) : (
-                <video
+                <ReleasingPreviewVideo
                   key={`${stageNumber}:${videoId}:${candidates[previewIndex].time.toFixed(3)}`}
                   src={api.videoBeepPreviewUrl(
                     stageNumber,
@@ -1236,7 +1254,7 @@ function BeepPreview({
           Preview unavailable
         </div>
       ) : (
-        <video
+        <ReleasingPreviewVideo
           key={`${stageNumber}:${videoId}:${beepTime.toFixed(3)}`}
           src={api.videoBeepPreviewUrl(stageNumber, videoId, beepTime)}
           className="h-40 w-64 rounded-md border border-border/60 bg-black object-cover"

--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -39,6 +39,10 @@ const IDLE_POLL_MS = 5000;
 // push the unread errors out of view.
 const FAILED_VISIBLE_LIMIT = 6;
 const SECTION_VISIBLE_LIMIT = 8;
+// Cap the in-memory job list. The backend retains full history; the
+// panel only renders the most-recent rows per section, so anything
+// beyond this is dead weight that grows with session length.
+const JOBS_RETENTION = 64;
 const POPOVER_ID = "jobs-panel-popover";
 
 const KIND_LABEL: Record<string, string> = {
@@ -122,11 +126,14 @@ export function JobsPanel() {
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const failedSectionRef = useRef<HTMLElement | null>(null);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (signal?: AbortSignal) => {
     try {
-      const next = await api.listJobs();
-      setJobs(next);
+      const next = await api.listJobs({ signal });
+      // Only display the most recent N; the backend may keep an
+      // unbounded history but we don't need to retain it client-side.
+      setJobs(next.slice(0, JOBS_RETENTION));
     } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") return;
       // Network blip: keep last snapshot. The next poll will retry.
       if (err instanceof ApiError) {
         // ignore
@@ -141,18 +148,18 @@ export function JobsPanel() {
   const activeRef = useRef(false);
   activeRef.current = jobs.some(isActive);
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | null = null;
     const tick = async () => {
-      if (cancelled) return;
-      await refresh();
-      if (cancelled) return;
+      if (controller.signal.aborted) return;
+      await refresh(controller.signal);
+      if (controller.signal.aborted) return;
       const interval = activeRef.current ? ACTIVE_POLL_MS : IDLE_POLL_MS;
       timer = setTimeout(tick, interval);
     };
     void tick();
     return () => {
-      cancelled = true;
+      controller.abort();
       if (timer != null) clearTimeout(timer);
     };
   }, [refresh]);

--- a/src/splitsmith/ui_static/src/components/VideoPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/VideoPanel.tsx
@@ -29,7 +29,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { AlertCircle, LayoutGrid, LayoutList, Loader2 } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn, useReleaseMediaOnUnmount } from "@/lib/utils";
 import type { StageVideo } from "@/lib/api";
 
 const BUFFER_FLASH_DELAY_MS = 150;
@@ -73,9 +73,14 @@ function SecondarySlot({ label, src, onRef, onBuffering }: SecondarySlotProps) {
   const [status, setStatus] = useState<LoadStatus>("idle");
   const [showBufferIndicator, setShowBufferIndicator] = useState(false);
 
+  // Internal ref shadows the parent's callback ref so we can free decoded
+  // buffers on unmount even after React clears the parent's reference.
+  const internalRef = useRef<HTMLVideoElement | null>(null);
   const setRef = useCallback((el: HTMLVideoElement | null) => {
+    internalRef.current = el;
     onRefLatest.current(el);
   }, []);
+  useReleaseMediaOnUnmount(internalRef);
 
   useEffect(() => {
     if (!src) {
@@ -172,6 +177,7 @@ export const VideoPanel = forwardRef<HTMLVideoElement, VideoPanelProps>(
   ) {
     const internalRef = useRef<HTMLVideoElement | null>(null);
     useImperativeHandle(ref, () => internalRef.current as HTMLVideoElement, []);
+    useReleaseMediaOnUnmount(internalRef);
 
     const [status, setStatus] = useState<LoadStatus>("idle");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1506,8 +1506,12 @@ export const api = {
   unbindProject: () =>
     request<ServerHealth>("/api/user/recent-projects/unbind", { method: "POST" }),
 
-  listJobs: () => request<Job[]>("/api/jobs"),
-  getJob: (jobId: string) => request<Job>(`/api/jobs/${encodeURIComponent(jobId)}`),
+  listJobs: (opts?: { signal?: AbortSignal }) =>
+    request<Job[]>("/api/jobs", { signal: opts?.signal }),
+  getJob: (jobId: string, opts?: { signal?: AbortSignal }) =>
+    request<Job>(`/api/jobs/${encodeURIComponent(jobId)}`, {
+      signal: opts?.signal,
+    }),
 
   /** Request cooperative cancellation. Idempotent: a finished job is returned
    *  as-is. For a running trim job the server terminates the underlying
@@ -1531,12 +1535,17 @@ export const api = {
   pollJob: async (
     jobId: string,
     onUpdate: (job: Job) => void,
-    opts: { intervalMs?: number; timeoutMs?: number } = {},
+    opts: { intervalMs?: number; timeoutMs?: number; signal?: AbortSignal } = {},
   ): Promise<Job> => {
     const interval = opts.intervalMs ?? 750;
     const deadline = Date.now() + (opts.timeoutMs ?? 10 * 60 * 1000);
+    const { signal } = opts;
     while (true) {
-      const job = await request<Job>(`/api/jobs/${encodeURIComponent(jobId)}`);
+      if (signal?.aborted) throw new DOMException("aborted", "AbortError");
+      const job = await request<Job>(
+        `/api/jobs/${encodeURIComponent(jobId)}`,
+        { signal },
+      );
       onUpdate(job);
       if (
         job.status === "succeeded" ||
@@ -1546,7 +1555,19 @@ export const api = {
       if (Date.now() > deadline) {
         throw new Error(`Timed out waiting for job ${jobId}`);
       }
-      await new Promise((r) => setTimeout(r, interval));
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, interval);
+        if (signal) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(new DOMException("aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }
+      });
     }
   },
 

--- a/src/splitsmith/ui_static/src/lib/utils.ts
+++ b/src/splitsmith/ui_static/src/lib/utils.ts
@@ -1,6 +1,44 @@
+import { useEffect, useRef, type RefObject } from "react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+// Releases decoded media buffers held by an HTMLMediaElement on unmount.
+// Why: Chrome (and others) keep demux + decoded-frame state attached to
+// the element even after React removes the node; the only reliable way
+// to free it is pause + remove src + load(). We snapshot ref.current
+// after every commit so the cleanup still has a handle even when the
+// element mounts later than the parent (conditional rendering) and even
+// after React clears the original ref during the unmount commit.
+export function useReleaseMediaOnUnmount<T extends HTMLMediaElement>(
+  ref: RefObject<T | null>,
+): void {
+  // Use a separate ref so React's commit-phase ref nulling doesn't
+  // strip our handle before the cleanup runs.
+  const lastSeen = useRef<T | null>(null);
+  // Re-snapshot on every commit so we always have the most recent
+  // mounted element (handles conditional <audio>/<video> rendering).
+  useEffect(() => {
+    if (ref.current) lastSeen.current = ref.current;
+  });
+  useEffect(() => {
+    return () => {
+      const el = lastSeen.current;
+      if (!el) return;
+      try {
+        el.pause();
+        el.removeAttribute("src");
+        el.load();
+      } catch {
+        /* element already detached */
+      }
+      lastSeen.current = null;
+    };
+    // lastSeen is stable for the lifetime of the component instance;
+    // we only want one cleanup, on unmount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -2424,9 +2424,11 @@ function PromoteAgainstFixtureButton({
   useEffect(() => {
     if (!job || job.status === "succeeded" || job.status === "failed" || job.status === "cancelled") return;
     const id = job.id;
+    const controller = new AbortController();
     const interval = setInterval(async () => {
       try {
-        const updated = await api.getJob(id);
+        const updated = await api.getJob(id, { signal: controller.signal });
+        if (controller.signal.aborted) return;
         setJob(updated);
         if (
           updated.status === "succeeded" ||
@@ -2436,10 +2438,13 @@ function PromoteAgainstFixtureButton({
           setBusy(false);
         }
       } catch {
-        // ignore -- next tick retries
+        // ignore -- next tick retries (or we've been aborted)
       }
     }, 500);
-    return () => clearInterval(interval);
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
   }, [job]);
 
   useEffect(() => {

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -116,6 +116,15 @@ export function Lab() {
       });
   }, []);
 
+  // Tear down the shared AudioContext + decoded-buffer cache when the
+  // user leaves /lab; otherwise hundreds of MB of decoded PCM survives
+  // navigation for the lifetime of the tab.
+  useEffect(() => {
+    return () => {
+      disposeLabAudio();
+    };
+  }, []);
+
   // Coalesce concurrent runEval calls. Without this, each label-save
   // fallback (when the server cache is cold) submits its own job ->
   // 12-15 labels -> 12-15 eval jobs.
@@ -2320,21 +2329,45 @@ function getAudioCtx(): AudioContext {
   return _sharedAudioCtx;
 }
 
+// Decoded AudioBuffers are big (~12 MB/min mono float32 at 48 kHz). The
+// cache uses Map insertion-order as LRU and is capped so a long Lab
+// session can't keep every fixture resident.
+const AUDIO_CACHE_MAX = 3;
 const _audioBufferCache = new Map<string, Promise<AudioBuffer>>();
 function loadAudioBuffer(url: string): Promise<AudioBuffer> {
-  let p = _audioBufferCache.get(url);
-  if (!p) {
-    const ctx = getAudioCtx();
-    p = fetch(url)
-      .then((r) => {
-        if (!r.ok) throw new Error(`audio fetch failed: ${r.status}`);
-        return r.arrayBuffer();
-      })
-      .then((buf) => ctx.decodeAudioData(buf));
-    _audioBufferCache.set(url, p);
-    p.catch(() => _audioBufferCache.delete(url));
+  const existing = _audioBufferCache.get(url);
+  if (existing) {
+    _audioBufferCache.delete(url);
+    _audioBufferCache.set(url, existing);
+    return existing;
+  }
+  const ctx = getAudioCtx();
+  const p = fetch(url)
+    .then((r) => {
+      if (!r.ok) throw new Error(`audio fetch failed: ${r.status}`);
+      return r.arrayBuffer();
+    })
+    .then((buf) => ctx.decodeAudioData(buf));
+  _audioBufferCache.set(url, p);
+  p.catch(() => _audioBufferCache.delete(url));
+  while (_audioBufferCache.size > AUDIO_CACHE_MAX) {
+    const oldest = _audioBufferCache.keys().next().value;
+    if (oldest === undefined) break;
+    _audioBufferCache.delete(oldest);
   }
   return p;
+}
+
+// Clear cached buffers and close the shared AudioContext so its audio
+// thread + scheduling state can be reclaimed. Called on Lab unmount.
+function disposeLabAudio(): void {
+  _audioBufferCache.clear();
+  if (_sharedAudioCtx) {
+    _sharedAudioCtx.close().catch(() => {
+      /* already closed */
+    });
+    _sharedAudioCtx = null;
+  }
 }
 
 function useAudioBuffer(url: string): {

--- a/src/splitsmith/ui_static/src/pages/PromoteReview.tsx
+++ b/src/splitsmith/ui_static/src/pages/PromoteReview.tsx
@@ -40,6 +40,7 @@ import {
   type PromoteReport,
   type StageAudit,
 } from "@/lib/api";
+import { useReleaseMediaOnUnmount } from "@/lib/utils";
 
 const PEAK_BINS = 1500;
 const NUDGE_MS = 5;
@@ -183,6 +184,8 @@ export function PromoteReview() {
   const [waveWidth, setWaveWidth] = useState(0);
   const anchorAudioRef = useRef<HTMLAudioElement | null>(null);
   const secondaryAudioRef = useRef<HTMLAudioElement | null>(null);
+  useReleaseMediaOnUnmount(anchorAudioRef);
+  useReleaseMediaOnUnmount(secondaryAudioRef);
 
   useEffect(() => {
     const el = waveColumnRef.current;

--- a/src/splitsmith/ui_static/src/pages/Review.tsx
+++ b/src/splitsmith/ui_static/src/pages/Review.tsx
@@ -61,6 +61,7 @@ import {
   type StageAudit,
 } from "@/lib/api";
 import { isTypingTextTarget, useBlurOnPointerClick } from "@/lib/audit-input";
+import { useReleaseMediaOnUnmount } from "@/lib/utils";
 
 const PEAK_BINS = 1500;
 const MAX_UNDO = 50;
@@ -110,6 +111,8 @@ export function Review() {
   // video at audio_t + offset (and vice versa).
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  useReleaseMediaOnUnmount(audioRef);
+  useReleaseMediaOnUnmount(videoRef);
   const [currentTime, setCurrentTime] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [loopMode, setLoopMode] = useState(false);


### PR DESCRIPTION
## Summary

A long-running browser tab kept growing in RSS without bound. The dominant causes:

- **Lab.tsx** held a module-scope `Map` of fully decoded `AudioBuffer`s (~12 MB/min mono float32 at 48 kHz) with no eviction. The shared `AudioContext` was also never closed. A session that browsed 20 fixtures could pin hundreds of MB across navigation.
- Every `<video>` and `<audio>` element retained demux + decoded-frame buffers after React removed the node from the DOM. Browsers only release them on `pause() + removeAttribute('src') + load()`.
- Polling effects (`JobsPanel`, Audit job poll) kept inflight fetches alive past unmount; their captured closures held component state until the response landed.
- `JobsPanel` kept the full `/api/jobs` payload in state but only rendered ~14 rows.

## Fixes

- `pages/Lab.tsx`: LRU-cap `_audioBufferCache` at 3 entries; new `disposeLabAudio()` clears the cache and closes the shared `AudioContext` on Lab unmount.
- `lib/utils.ts`: new `useReleaseMediaOnUnmount(ref)` hook. Snapshots the element after every commit so it survives React's commit-phase ref nulling and works for conditionally rendered media.
- Hook applied at every `<video>`/`<audio>` site: `VideoPanel` primary + `SecondarySlot`, `BeepSection` audio + three preview videos (via a small `ReleasingPreviewVideo` wrapper that handles the conditional-render case), `PromoteReview` anchor + secondary audio, `Review` video + audio.
- `lib/api.ts`: thread `AbortSignal` through `listJobs`, `getJob`, `pollJob`. `pollJob` also aborts its inter-poll sleep.
- `JobsPanel` + Audit job poll: wire `AbortController`s in effect cleanup so inflight fetches die on unmount instead of resolving against a dead component.
- `JobsPanel`: trim retained payload to `JOBS_RETENTION = 64` before `setJobs`.

## Test plan

- [ ] Open `/lab`, browse 5+ fixtures; confirm tab RSS stays bounded and falls when navigating away (DevTools → Performance → Memory).
- [ ] On `/audit`, switch stages multiple times with grid mode toggled on; confirm secondary `<video>` elements release (Chrome `chrome://media-internals` should not accumulate orphaned players).
- [ ] On `/promote-review`, navigate in/out; confirm anchor + secondary `<audio>` release.
- [ ] Trigger a long-running shot-detect job, navigate away mid-poll; confirm no `setState on unmounted component` warnings and the inflight fetch is aborted (Network tab shows status `(canceled)`).
- [ ] Heavy `JobsPanel` activity: confirm `jobs` state stays bounded at 64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)