### PR TITLE
lab: surface the ensemble-sweep dashboard inside the Lab page

### DIFF
--- a/src/splitsmith/lab/sweeps.py
+++ b/src/splitsmith/lab/sweeps.py
@@ -1,0 +1,241 @@
+"""Read-only access to the ensemble sweep dashboard for the Lab UI.
+
+The CLI in ``scripts/run_sweep.py`` writes ``build/sweeps/runs.parquet``
+(every parameter combo x fixture row) and ``scripts/plot_sweep.py``
+emits a per-run directory with rendered PNGs + ``report.md``. This
+module wraps those artifacts in Pydantic shapes the FastAPI server
+can hand to the SPA without re-implementing parquet parsing
+client-side.
+
+No write APIs: launching new sweeps stays on the CLI for now. The UI
+just consumes what's on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+from pydantic import BaseModel, Field
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SWEEPS_DIR = REPO_ROOT / "build" / "sweeps"
+RUNS_PARQUET = SWEEPS_DIR / "runs.parquet"
+
+PNG_FILENAMES = {"overview", "per_fixture_bars"}  # filename whitelist for the static endpoint
+
+
+class SweepRunSummary(BaseModel):
+    """One row per ``run_id`` -- header info for the Sweeps list."""
+
+    run_id: str
+    signals_build_id: str
+    swept_keys: list[str] = Field(
+        description="Names of parameters that actually varied across this run."
+    )
+    n_combos: int
+    n_fixtures: int
+    best_f1: float
+    best_precision: float
+    best_recall: float
+    best_kept: int
+    best_true_pos: int
+    best_false_pos: int
+    best_false_neg: int
+    best_combo_idx: int
+
+
+class SweepFixtureRow(BaseModel):
+    """One (combo, fixture) datapoint in a sweep."""
+
+    fixture: str
+    camera_class: str
+    n_candidates: int
+    n_positives: int
+    n_kept: int
+    true_pos: int
+    false_pos: int
+    false_neg: int
+    precision: float
+    recall: float
+    f1: float
+
+
+class SweepComboRow(BaseModel):
+    """One parameter combination + its aggregate metrics."""
+
+    combo_idx: int
+    params: dict[str, Any]
+    aggregate: SweepFixtureRow
+    per_class: list[SweepFixtureRow]
+    per_fixture: list[SweepFixtureRow]
+
+
+class SweepRunDetail(BaseModel):
+    """Full payload for one run_id: summary + every combo."""
+
+    summary: SweepRunSummary
+    combos: list[SweepComboRow]
+    available_plots: list[str] = Field(
+        description=(
+            "Plot stems present in build/sweeps/<run_id>/ that the UI "
+            "can request via the static endpoint. Only the composite "
+            "overview + per-fixture bars are guaranteed; metric heatmaps "
+            "or line plots depend on whether the sweep was 1D / 2D."
+        ),
+    )
+
+
+def _row_to_fixture(row: dict[str, Any]) -> SweepFixtureRow:
+    return SweepFixtureRow(
+        fixture=row["fixture"],
+        camera_class=row["camera_class"] or "__agg__",
+        n_candidates=int(row["n_candidates"]),
+        n_positives=int(row["n_positives"]),
+        n_kept=int(row["n_kept"]),
+        true_pos=int(row["true_pos"]),
+        false_pos=int(row["false_pos"]),
+        false_neg=int(row["false_neg"]),
+        precision=float(row["precision"]),
+        recall=float(row["recall"]),
+        f1=float(row["f1"]),
+    )
+
+
+def _load_all_rows() -> list[dict[str, Any]]:
+    if not RUNS_PARQUET.exists():
+        return []
+    return pq.read_table(RUNS_PARQUET).to_pylist()
+
+
+def _params_for(combo_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Extract the ``param_*`` columns from any row of the combo."""
+    return {
+        k.removeprefix("param_"): v
+        for k, v in combo_rows[0].items()
+        if k.startswith("param_")
+    }
+
+
+def _swept_keys_for(rows: list[dict[str, Any]]) -> list[str]:
+    """Filter the declared sweep keys to those that actually vary."""
+    if not rows:
+        return []
+    declared = [k for k in (rows[0].get("swept_keys") or "").split(",") if k]
+    agg = [r for r in rows if r["fixture"] == "__all__"]
+    out: list[str] = []
+    for k in declared:
+        seen = {r[f"param_{k}"] for r in agg}
+        if len(seen) > 1:
+            out.append(k)
+    return out
+
+
+def list_runs() -> list[SweepRunSummary]:
+    """Return one summary per ``run_id``, newest first.
+
+    Newest is approximated by sorting on the run_id prefix (ISO
+    timestamp), which is how ``run_sweep.py`` constructs the id.
+    """
+    rows = _load_all_rows()
+    by_run: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        by_run.setdefault(r["run_id"], []).append(r)
+
+    summaries: list[SweepRunSummary] = []
+    for run_id, run_rows in by_run.items():
+        agg = [r for r in run_rows if r["fixture"] == "__all__"]
+        if not agg:
+            continue
+        best = max(agg, key=lambda r: r["f1"])
+        fixtures = {r["fixture"] for r in run_rows if not r["fixture"].startswith("__")}
+        summaries.append(
+            SweepRunSummary(
+                run_id=run_id,
+                signals_build_id=run_rows[0]["signals_build_id"],
+                swept_keys=_swept_keys_for(run_rows),
+                n_combos=len({r["combo_idx"] for r in run_rows}),
+                n_fixtures=len(fixtures),
+                best_f1=float(best["f1"]),
+                best_precision=float(best["precision"]),
+                best_recall=float(best["recall"]),
+                best_kept=int(best["n_kept"]),
+                best_true_pos=int(best["true_pos"]),
+                best_false_pos=int(best["false_pos"]),
+                best_false_neg=int(best["false_neg"]),
+                best_combo_idx=int(best["combo_idx"]),
+            )
+        )
+    summaries.sort(key=lambda s: s.run_id, reverse=True)
+    return summaries
+
+
+def get_run(run_id: str) -> SweepRunDetail | None:
+    """Return the full payload for ``run_id``, or None if absent."""
+    rows = [r for r in _load_all_rows() if r["run_id"] == run_id]
+    if not rows:
+        return None
+    summaries = [s for s in list_runs() if s.run_id == run_id]
+    if not summaries:
+        return None
+    summary = summaries[0]
+
+    by_combo: dict[int, list[dict[str, Any]]] = {}
+    for r in rows:
+        by_combo.setdefault(int(r["combo_idx"]), []).append(r)
+
+    combos: list[SweepComboRow] = []
+    for idx in sorted(by_combo.keys()):
+        combo_rows = by_combo[idx]
+        agg = next(r for r in combo_rows if r["fixture"] == "__all__")
+        per_class = [
+            _row_to_fixture({**r, "camera_class": r["fixture"].removeprefix("__class_")})
+            for r in combo_rows
+            if r["fixture"].startswith("__class_")
+        ]
+        per_fixture = [
+            _row_to_fixture(r)
+            for r in combo_rows
+            if not r["fixture"].startswith("__")
+        ]
+        combos.append(
+            SweepComboRow(
+                combo_idx=idx,
+                params=_params_for(combo_rows),
+                aggregate=_row_to_fixture(agg),
+                per_class=per_class,
+                per_fixture=per_fixture,
+            )
+        )
+
+    run_dir = SWEEPS_DIR / run_id
+    available_plots: list[str] = []
+    if run_dir.is_dir():
+        for p in sorted(run_dir.glob("*.png")):
+            available_plots.append(p.stem)
+
+    return SweepRunDetail(
+        summary=summary,
+        combos=combos,
+        available_plots=available_plots,
+    )
+
+
+def plot_path(run_id: str, plot_name: str) -> Path | None:
+    """Resolve ``build/sweeps/<run_id>/<plot_name>.png`` if it exists.
+
+    Used by the FastAPI route to serve images without exposing the
+    rest of ``build/`` to the SPA. The plot_name is constrained to
+    alnum / underscore by the caller.
+    """
+    if not plot_name.replace("_", "").isalnum():
+        return None
+    candidate = SWEEPS_DIR / run_id / f"{plot_name}.png"
+    try:
+        candidate.relative_to(SWEEPS_DIR)
+    except ValueError:
+        return None
+    if not candidate.is_file():
+        return None
+    return candidate

--- a/src/splitsmith/lab/sweeps.py
+++ b/src/splitsmith/lab/sweeps.py
@@ -111,11 +111,7 @@ def _load_all_rows() -> list[dict[str, Any]]:
 
 def _params_for(combo_rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Extract the ``param_*`` columns from any row of the combo."""
-    return {
-        k.removeprefix("param_"): v
-        for k, v in combo_rows[0].items()
-        if k.startswith("param_")
-    }
+    return {k.removeprefix("param_"): v for k, v in combo_rows[0].items() if k.startswith("param_")}
 
 
 def _swept_keys_for(rows: list[dict[str, Any]]) -> list[str]:
@@ -194,11 +190,7 @@ def get_run(run_id: str) -> SweepRunDetail | None:
             for r in combo_rows
             if r["fixture"].startswith("__class_")
         ]
-        per_fixture = [
-            _row_to_fixture(r)
-            for r in combo_rows
-            if not r["fixture"].startswith("__")
-        ]
+        per_fixture = [_row_to_fixture(r) for r in combo_rows if not r["fixture"].startswith("__")]
         combos.append(
             SweepComboRow(
                 combo_idx=idx,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6305,9 +6305,7 @@ def create_app(
         @app.get("/api/lab/sweeps")
         def lab_sweeps_list() -> JSONResponse:
             """List one row per ``run_id`` with best-F1 highlights."""
-            return JSONResponse(
-                [s.model_dump(mode="json") for s in _sweeps_module.list_runs()]
-            )
+            return JSONResponse([s.model_dump(mode="json") for s in _sweeps_module.list_runs()])
 
         @app.get("/api/lab/sweeps/{run_id}")
         def lab_sweeps_detail(run_id: str) -> JSONResponse:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6291,6 +6291,46 @@ def create_app(
                 }
             )
 
+        # ------------------------------------------------------------------
+        # Lab: ensemble parameter sweeps (read-only dashboard)
+        # ------------------------------------------------------------------
+        #
+        # Backed by ``build/sweeps/runs.parquet`` + ``build/sweeps/<run_id>/``
+        # written by ``scripts/run_sweep.py`` + ``scripts/plot_sweep.py``.
+        # No launch endpoint yet -- sweeps stay on the CLI for now.
+
+        from .. import lab as _lab_module_for_sweeps  # noqa: F401  (silences mypy)
+        from ..lab import sweeps as _sweeps_module
+
+        @app.get("/api/lab/sweeps")
+        def lab_sweeps_list() -> JSONResponse:
+            """List one row per ``run_id`` with best-F1 highlights."""
+            return JSONResponse(
+                [s.model_dump(mode="json") for s in _sweeps_module.list_runs()]
+            )
+
+        @app.get("/api/lab/sweeps/{run_id}")
+        def lab_sweeps_detail(run_id: str) -> JSONResponse:
+            """Return the full payload for one run: every combo + per-fixture rows."""
+            detail = _sweeps_module.get_run(run_id)
+            if detail is None:
+                raise HTTPException(status_code=404, detail=f"no sweep run {run_id!r}")
+            return JSONResponse(detail.model_dump(mode="json"))
+
+        @app.get("/api/lab/sweeps/{run_id}/plot/{plot_name}.png")
+        def lab_sweeps_plot(run_id: str, plot_name: str) -> FileResponse:
+            """Serve one PNG from ``build/sweeps/<run_id>/``.
+
+            The plot_name is restricted to alnum + underscore by the
+            ``sweeps`` helper so a malicious caller can't traverse
+            outside the run dir. Returns 404 when the plot doesn't
+            exist (e.g. a 2D plot requested for a 1D sweep).
+            """
+            path = _sweeps_module.plot_path(run_id, plot_name)
+            if path is None:
+                raise HTTPException(status_code=404, detail="plot not found")
+            return FileResponse(path, media_type="image/png", filename=path.name)
+
     if lab_enabled:
         _setup_lab()
 

--- a/src/splitsmith/ui_static/src/components/SweepsCard.tsx
+++ b/src/splitsmith/ui_static/src/components/SweepsCard.tsx
@@ -1,0 +1,379 @@
+/**
+ * SweepsCard: read-only browser for the ensemble-sweep dashboard.
+ *
+ * Backend: ``/api/lab/sweeps`` (lists run_ids), ``/api/lab/sweeps/<id>``
+ * (per-combo + per-fixture rows), ``/api/lab/sweeps/<id>/plot/<name>.png``
+ * (rendered matplotlib output served from ``build/sweeps/<id>/``).
+ *
+ * No launch UI yet -- sweeps are produced by ``scripts/run_sweep.py``;
+ * the card just surfaces what's on disk so the Lab page can show the
+ * actionable view without context-switching to a terminal.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, BarChart3, Loader2, LineChart, RefreshCw } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  api,
+  type SweepRunDetail,
+  type SweepRunSummary,
+} from "@/lib/api";
+
+function pct(v: number): string {
+  return (v * 100).toFixed(1) + "%";
+}
+
+function ShortFixture({ name }: { name: string }) {
+  // Match the Python plotter's _short_fixture helper so labels look the
+  // same in the UI as in the rendered PNGs.
+  const compact = name.replace(/^stage-shots-/, "");
+  return <span className="font-mono text-[10px]">{compact}</span>;
+}
+
+function MetricCell({ value }: { value: number }) {
+  return (
+    <span className="tabular-nums">{pct(value)}</span>
+  );
+}
+
+export function SweepsCard() {
+  const [runs, setRuns] = useState<SweepRunSummary[] | null>(null);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SweepRunDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = () => {
+    setLoading(true);
+    setError(null);
+    api
+      .listSweepRuns()
+      .then((rs) => {
+        setRuns(rs);
+        if (rs.length && !selectedRunId) {
+          setSelectedRunId(rs[0].run_id);
+        }
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    reload();
+    // run-on-mount only; manual refresh covers re-fetches
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRunId) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    api
+      .getSweepRun(selectedRunId)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRunId]);
+
+  const bestCombo = useMemo(() => {
+    if (!detail) return null;
+    return detail.combos.find(
+      (c) => c.combo_idx === detail.summary.best_combo_idx,
+    );
+  }, [detail]);
+
+  const swept = detail?.summary.swept_keys ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <LineChart className="size-4 text-primary" />
+            Parameter sweeps
+          </CardTitle>
+          <CardDescription>
+            Read-only dashboard of past <code>scripts/run_sweep.py</code> runs.
+            Backed by <code>build/sweeps/runs.parquet</code>.
+          </CardDescription>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={reload}
+          disabled={loading}
+          aria-label="Refresh sweep list"
+        >
+          {loading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <RefreshCw className="size-4" />
+          )}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+            <AlertCircle className="size-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {runs && runs.length === 0 && (
+          <div className="flex items-start gap-2 rounded-md border border-muted bg-muted/30 p-3 text-xs text-muted-foreground">
+            <BarChart3 className="size-4 shrink-0" />
+            <span>
+              No sweeps yet. Produce one with{" "}
+              <code>
+                uv run python scripts/run_sweep.py --grid scripts/sweep_grids/voter_c_slack_fine.yaml
+              </code>{" "}
+              then click refresh.
+            </span>
+          </div>
+        )}
+
+        {runs && runs.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Runs ({runs.length})
+            </p>
+            <div className="grid gap-2">
+              {runs.map((r) => {
+                const active = r.run_id === selectedRunId;
+                return (
+                  <button
+                    key={r.run_id}
+                    type="button"
+                    onClick={() => setSelectedRunId(r.run_id)}
+                    className={
+                      "w-full rounded-md border px-3 py-2 text-left transition " +
+                      (active
+                        ? "border-primary bg-primary/5"
+                        : "border-muted hover:border-muted-foreground/40")
+                    }
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="truncate font-mono text-[11px]">
+                        {r.run_id}
+                      </span>
+                      <Badge variant="outline" className="shrink-0 font-mono text-[10px]">
+                        F1 {r.best_f1.toFixed(3)}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                      <span>
+                        {r.n_combos} combo{r.n_combos === 1 ? "" : "s"}
+                      </span>
+                      <span>{r.n_fixtures} fixtures</span>
+                      <span>P {pct(r.best_precision)}</span>
+                      <span>R {pct(r.best_recall)}</span>
+                      {r.swept_keys.length > 0 ? (
+                        <span className="font-mono">
+                          swept: {r.swept_keys.join(" x ")}
+                        </span>
+                      ) : (
+                        <span className="italic">defaults snapshot</span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {detail && bestCombo && (
+          <div className="space-y-4 border-t pt-4">
+            <div className="flex flex-wrap items-baseline gap-2">
+              <p className="text-sm font-semibold">Best aggregate</p>
+              <Badge variant="outline" className="font-mono text-[10px]">
+                combo_idx {bestCombo.combo_idx}
+              </Badge>
+              <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+                F1 <span className="font-semibold text-foreground">{detail.summary.best_f1.toFixed(4)}</span>
+                {"  "}P {pct(detail.summary.best_precision)} R {pct(detail.summary.best_recall)}{"  "}
+                kept {detail.summary.best_kept} (TP {detail.summary.best_true_pos}, FP{" "}
+                {detail.summary.best_false_pos}, FN {detail.summary.best_false_neg})
+              </span>
+            </div>
+
+            {swept.length > 0 && (
+              <details>
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  Best-combo parameters ({Object.keys(bestCombo.params).length})
+                </summary>
+                <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] sm:grid-cols-3">
+                  {Object.entries(bestCombo.params)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([k, v]) => {
+                      const isSwept = swept.includes(k);
+                      return (
+                        <div key={k} className="flex items-center justify-between gap-2">
+                          <code
+                            className={
+                              isSwept
+                                ? "text-foreground font-semibold"
+                                : "text-muted-foreground"
+                            }
+                          >
+                            {k}
+                          </code>
+                          <span className="font-mono tabular-nums">{String(v)}</span>
+                        </div>
+                      );
+                    })}
+                </div>
+              </details>
+            )}
+
+            {detail.available_plots.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Plots
+                </p>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {/* Show the composite overview large; everything else as smaller thumbs */}
+                  {detail.available_plots.includes("overview") && (
+                    <a
+                      key="overview"
+                      href={api.sweepPlotUrl(detail.summary.run_id, "overview")}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="col-span-full block rounded-md border bg-muted/30 p-2"
+                    >
+                      <img
+                        src={api.sweepPlotUrl(detail.summary.run_id, "overview")}
+                        alt="sweep overview"
+                        className="mx-auto w-full"
+                        loading="lazy"
+                      />
+                    </a>
+                  )}
+                  {detail.available_plots
+                    .filter((p) => p !== "overview")
+                    .map((p) => (
+                      <a
+                        key={p}
+                        href={api.sweepPlotUrl(detail.summary.run_id, p)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="block rounded-md border bg-muted/30 p-2"
+                      >
+                        <p className="mb-1 truncate font-mono text-[10px] text-muted-foreground">
+                          {p}
+                        </p>
+                        <img
+                          src={api.sweepPlotUrl(detail.summary.run_id, p)}
+                          alt={p}
+                          className="mx-auto w-full"
+                          loading="lazy"
+                        />
+                      </a>
+                    ))}
+                </div>
+              </div>
+            )}
+
+            {bestCombo.per_fixture.length > 0 && (
+              <details>
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  Per-fixture (best combo, {bestCombo.per_fixture.length} rows)
+                </summary>
+                <div className="mt-2 max-h-[420px] overflow-auto rounded-md border">
+                  <table className="w-full text-[11px]">
+                    <thead className="sticky top-0 bg-muted/60">
+                      <tr>
+                        <th className="px-2 py-1 text-left">fixture</th>
+                        <th className="px-2 py-1 text-left">camera</th>
+                        <th className="px-2 py-1 text-right">kept</th>
+                        <th className="px-2 py-1 text-right">TP</th>
+                        <th className="px-2 py-1 text-right">FP</th>
+                        <th className="px-2 py-1 text-right">FN</th>
+                        <th className="px-2 py-1 text-right">P</th>
+                        <th className="px-2 py-1 text-right">R</th>
+                        <th className="px-2 py-1 text-right">F1</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[...bestCombo.per_fixture]
+                        .sort((a, b) => b.f1 - a.f1)
+                        .map((r) => (
+                          <tr key={r.fixture} className="border-t">
+                            <td className="px-2 py-1">
+                              <ShortFixture name={r.fixture} />
+                            </td>
+                            <td className="px-2 py-1 text-muted-foreground">
+                              {r.camera_class}
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums">
+                              {r.n_kept}
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums">
+                              {r.true_pos}
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums text-destructive">
+                              {r.false_pos}
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums text-orange-600">
+                              {r.false_neg}
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums">
+                              <MetricCell value={r.precision} />
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums">
+                              <MetricCell value={r.recall} />
+                            </td>
+                            <td className="px-2 py-1 text-right tabular-nums font-semibold">
+                              <MetricCell value={r.f1} />
+                            </td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </table>
+                </div>
+              </details>
+            )}
+
+            {bestCombo.per_class.length > 0 && (
+              <details>
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  Per camera class (best combo)
+                </summary>
+                <div className="mt-2 grid gap-1 text-[11px]">
+                  {bestCombo.per_class.map((r) => (
+                    <div
+                      key={r.camera_class}
+                      className="flex items-center justify-between rounded border px-2 py-1"
+                    >
+                      <span className="font-mono">{r.camera_class}</span>
+                      <span className="text-muted-foreground tabular-nums">
+                        kept {r.n_kept}, P {pct(r.precision)}, R {pct(r.recall)}, F1 {r.f1.toFixed(3)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1904,6 +1904,20 @@ export const api = {
       { method: "DELETE" },
     ),
 
+  /** Ensemble parameter-sweep dashboard (read-only). Backed by
+   *  ``build/sweeps/runs.parquet`` written by ``scripts/run_sweep.py``. */
+  listSweepRuns: () => request<SweepRunSummary[]>("/api/lab/sweeps"),
+
+  /** Full per-combo + per-fixture detail for one sweep run. */
+  getSweepRun: (runId: string) =>
+    request<SweepRunDetail>(`/api/lab/sweeps/${encodeURIComponent(runId)}`),
+
+  /** Build a URL the SPA can drop into an ``<img src>`` -- request goes
+   *  through FastAPI so the gitignored build/ tree is never directly
+   *  exposed. ``plotName`` is the file stem without ``.png``. */
+  sweepPlotUrl: (runId: string, plotName: string): string =>
+    `/api/lab/sweeps/${encodeURIComponent(runId)}/plot/${encodeURIComponent(plotName)}.png`,
+
   promoteSecondary: (
     stageNumber: number,
     videoId: string,
@@ -2151,6 +2165,56 @@ export interface LabEvalRun {
   universe: LabEvalUniverse;
   config_hash: string;
   built_at: string;
+}
+
+/**
+ * Ensemble parameter-sweep types. Mirrors ``src/splitsmith/lab/sweeps.py``.
+ * Sweeps are produced by ``scripts/run_sweep.py`` and lurk in
+ * ``build/sweeps/runs.parquet``; the Lab tab reads them through
+ * ``/api/lab/sweeps``.
+ */
+export interface SweepFixtureRow {
+  fixture: string;
+  camera_class: string;
+  n_candidates: number;
+  n_positives: number;
+  n_kept: number;
+  true_pos: number;
+  false_pos: number;
+  false_neg: number;
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+export interface SweepComboRow {
+  combo_idx: number;
+  params: Record<string, unknown>;
+  aggregate: SweepFixtureRow;
+  per_class: SweepFixtureRow[];
+  per_fixture: SweepFixtureRow[];
+}
+
+export interface SweepRunSummary {
+  run_id: string;
+  signals_build_id: string;
+  swept_keys: string[];
+  n_combos: number;
+  n_fixtures: number;
+  best_f1: number;
+  best_precision: number;
+  best_recall: number;
+  best_kept: number;
+  best_true_pos: number;
+  best_false_pos: number;
+  best_false_neg: number;
+  best_combo_idx: number;
+}
+
+export interface SweepRunDetail {
+  summary: SweepRunSummary;
+  combos: SweepComboRow[];
+  available_plots: string[];
 }
 
 export { ApiError };

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -37,6 +37,7 @@ import {
   Trash2,
 } from "lucide-react";
 
+import { SweepsCard } from "@/components/SweepsCard";
 import { Waveform } from "@/components/Waveform";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -259,6 +260,8 @@ export function Lab() {
           evalLoading={evalLoading}
         />
       ) : null}
+
+      <SweepsCard />
     </div>
   );
 }

--- a/tests/test_lab_sweeps.py
+++ b/tests/test_lab_sweeps.py
@@ -131,7 +131,9 @@ def test_plot_path_rejects_traversal_segments(synthetic_runs_parquet: Path) -> N
     assert sweeps_module.plot_path("runA", "../runA/overview") is None
     assert sweeps_module.plot_path("runA", "..") is None
     assert sweeps_module.plot_path("runA", "a/b") is None
-    assert sweeps_module.plot_path("runA", "overview.png") is None  # extension already added by helper
+    # plot_path appends ``.png`` itself; passing it leaves a stray dot
+    # that fails the alnum + underscore filter.
+    assert sweeps_module.plot_path("runA", "overview.png") is None
 
 
 def test_plot_path_missing_file_returns_none(synthetic_runs_parquet: Path) -> None:

--- a/tests/test_lab_sweeps.py
+++ b/tests/test_lab_sweeps.py
@@ -1,0 +1,144 @@
+"""Lab sweeps dashboard: parquet -> Pydantic + path-traversal guard.
+
+The sweep endpoints are read-only: the only complexity worth pinning
+is (a) the parquet -> Pydantic transform on a synthetic runs.parquet
+and (b) the plot_path filename guard that prevents an attacker from
+walking out of ``build/sweeps/<run_id>/`` via ``..`` segments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from splitsmith.lab import sweeps as sweeps_module
+
+
+def _make_row(
+    run_id: str,
+    fixture: str,
+    combo_idx: int,
+    *,
+    f1: float,
+    precision: float = 0.9,
+    recall: float = 0.95,
+    swept_keys: str = "consensus",
+    consensus: int = 3,
+) -> dict:
+    return {
+        "run_id": run_id,
+        "combo_idx": combo_idx,
+        "signals_build_id": "2026-05-11T00-00-00Z_abc1234",
+        "fixture": fixture,
+        "camera_class": "__agg__" if fixture.startswith("__") else "headcam",
+        "n_candidates": 100,
+        "n_positives": 20,
+        "n_kept": 21,
+        "true_pos": 19,
+        "false_pos": 2,
+        "false_neg": 1,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "disagreement_1_count": 0,
+        "disagreement_1_pos": 0,
+        "solo_a": 0,
+        "solo_b": 0,
+        "solo_c": 0,
+        "solo_d": 0,
+        "solo_e": 0,
+        "voter_a_floor_eff": 0.018,
+        "voter_b_threshold_eff": 0.05,
+        "voter_c_threshold_eff": 0.1,
+        "voter_d_threshold_eff": 0.05,
+        "voter_e_threshold_eff": None,
+        "swept_keys": swept_keys,
+        "param_consensus": consensus,
+        "param_apriori_boost": 1.0,
+        "param_c_required": True,
+    }
+
+
+@pytest.fixture
+def synthetic_runs_parquet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Plant a small runs.parquet + plot file the sweeps module can read."""
+    sweeps_dir = tmp_path / "sweeps"
+    sweeps_dir.mkdir()
+    monkeypatch.setattr(sweeps_module, "SWEEPS_DIR", sweeps_dir)
+    monkeypatch.setattr(sweeps_module, "RUNS_PARQUET", sweeps_dir / "runs.parquet")
+
+    rows = [
+        # Run A: 2 combos x (1 fixture + agg)
+        _make_row("runA", "fixA", 0, f1=0.8, consensus=2),
+        _make_row("runA", "__all__", 0, f1=0.8, consensus=2),
+        _make_row("runA", "fixA", 1, f1=0.91, consensus=3),
+        _make_row("runA", "__all__", 1, f1=0.91, consensus=3),
+        # Run B: 1 combo
+        _make_row("runB", "fixA", 0, f1=0.7, swept_keys=""),
+        _make_row("runB", "__all__", 0, f1=0.7, swept_keys=""),
+    ]
+    pq.write_table(pa.Table.from_pylist(rows), sweeps_dir / "runs.parquet")
+
+    plot_dir = sweeps_dir / "runA"
+    plot_dir.mkdir()
+    (plot_dir / "overview.png").write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    return sweeps_dir
+
+
+def test_list_runs_orders_newest_first_and_picks_best_f1(synthetic_runs_parquet: Path) -> None:
+    runs = sweeps_module.list_runs()
+    assert [r.run_id for r in runs] == ["runB", "runA"]
+    run_a = next(r for r in runs if r.run_id == "runA")
+    assert run_a.best_f1 == pytest.approx(0.91)
+    assert run_a.best_combo_idx == 1
+    assert run_a.swept_keys == ["consensus"]
+    assert run_a.n_combos == 2
+    assert run_a.n_fixtures == 1
+
+
+def test_swept_keys_filters_singleton_values(synthetic_runs_parquet: Path) -> None:
+    run_b = next(r for r in sweeps_module.list_runs() if r.run_id == "runB")
+    # runB declares no swept keys at all
+    assert run_b.swept_keys == []
+
+
+def test_get_run_returns_combos_and_plots(synthetic_runs_parquet: Path) -> None:
+    detail = sweeps_module.get_run("runA")
+    assert detail is not None
+    assert detail.summary.run_id == "runA"
+    assert len(detail.combos) == 2
+    best = detail.combos[detail.summary.best_combo_idx]
+    assert best.aggregate.f1 == pytest.approx(0.91)
+    assert "consensus" in best.params
+    assert "overview" in detail.available_plots
+
+
+def test_get_run_missing_returns_none(synthetic_runs_parquet: Path) -> None:
+    assert sweeps_module.get_run("never-ran") is None
+
+
+def test_plot_path_returns_existing_png(synthetic_runs_parquet: Path) -> None:
+    p = sweeps_module.plot_path("runA", "overview")
+    assert p is not None
+    assert p.name == "overview.png"
+
+
+def test_plot_path_rejects_traversal_segments(synthetic_runs_parquet: Path) -> None:
+    """A plot_name containing slashes or dots must not escape SWEEPS_DIR."""
+    assert sweeps_module.plot_path("runA", "../runA/overview") is None
+    assert sweeps_module.plot_path("runA", "..") is None
+    assert sweeps_module.plot_path("runA", "a/b") is None
+    assert sweeps_module.plot_path("runA", "overview.png") is None  # extension already added by helper
+
+
+def test_plot_path_missing_file_returns_none(synthetic_runs_parquet: Path) -> None:
+    assert sweeps_module.plot_path("runA", "no_such_plot") is None
+
+
+def test_list_runs_empty_parquet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sweeps_module, "SWEEPS_DIR", tmp_path)
+    monkeypatch.setattr(sweeps_module, "RUNS_PARQUET", tmp_path / "missing.parquet")
+    assert sweeps_module.list_runs() == []


### PR DESCRIPTION
## Summary
Stacked phase 2B of the dashboard work. Adds a read-only **Parameter sweeps** card at the bottom of \`/lab\` so you can browse past sweep runs without switching to a terminal. Reuses the matplotlib PNGs the CLI already produces under \`build/sweeps/<run_id>/\`; launching new sweeps stays on the CLI for now.

## Pieces
- \`src/splitsmith/lab/sweeps.py\` — parquet -> Pydantic adapter (\`SweepRunSummary\`, \`SweepRunDetail\`, \`SweepComboRow\`, \`SweepFixtureRow\`) plus a filename-guarded \`plot_path\` helper that rejects \`..\` / slash segments.
- \`src/splitsmith/ui/server.py\` — three new endpoints under the existing \`/api/lab/*\` gate:
  - \`GET /api/lab/sweeps\` (list)
  - \`GET /api/lab/sweeps/{run_id}\` (detail)
  - \`GET /api/lab/sweeps/{run_id}/plot/{name}.png\` (serve PNG)
- \`src/splitsmith/ui_static/src/components/SweepsCard.tsx\` — new card. Lists runs with best-F1 badges, highlights swept params, shows composite + line/heatmap plots, collapsible per-fixture + per-camera-class tables.

## Test plan
- [x] \`uv run pytest -q\` — 1108 passed, 4 skipped (8 new \`test_lab_sweeps\` cases including the path-traversal guard).
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm build\` clean (684 KB JS bundle — same shape as before; warning unchanged from main)
- [x] TestClient hits all three endpoints with real \`build/sweeps/runs.parquet\`: list returns 2 runs, detail returns 11 combos + 6 plots, PNG serves \`image/png\` 206 KB, traversal attempt returns 404.
- [ ] **Not done:** visual inspection of the card in an actual browser. The build + typecheck + TestClient pass, and the card is mounted at the bottom of \`/lab\` -- worth a quick eyeball before merging.

## Out of scope
- Launching new sweeps from the UI (next iteration; needs a parameter form).
- Plotly / interactive plots (deferred per earlier discussion; PNGs work and reuse the CLI output).
- End-user (non-\`--lab\`) surfaces stay untouched.