### PR TITLE
sweep: starter grids for voters B/D/E + finding that A/B/D have no leverage

### DIFF
--- a/docs/ensemble_dashboard/findings/2026-05-11_voter_abd_have_no_leverage.md
+++ b/docs/ensemble_dashboard/findings/2026-05-11_voter_abd_have_no_leverage.md
@@ -1,0 +1,83 @@
+# Finding: voters A, B, D have no leverage under c_required=True
+
+**Date:** 2026-05-11
+**Sweep run_ids:**
+* `2026-05-11T07-10-32Z_5f36fa7_voter_a_floor_offset`
+* `2026-05-11T07-10-33Z_5f36fa7_voter_b_threshold_offset`
+* `2026-05-11T07-10-35Z_5f36fa7_voter_d_threshold_offset`
+
+## TL;DR
+
+Sweeping each of voters A, B, D's thresholds across a wide range
+(±0.05 around the calibrated value for A; +0 to +0.15 for B; +0 to
++0.10 for D) moves aggregate metrics by **0, 0, and 1 false positive
+respectively**. The production ensemble is essentially insensitive to
+A/B/D thresholds because voter C's veto (`c_required=True`) absorbs
+their work first.
+
+| voter | offset range | F1 spread | FP delta |
+|---|---|---|---|
+| A | [-0.02, +0.05] | 0.0000 | 0 |
+| B | [+0.00, +0.15] | 0.0000 | 0 |
+| D | [+0.00, +0.10] | 0.0008 | -1 |
+
+For comparison, the voter C slack sweep on the same corpus moves F1
+by 0.026 (0.945 -> 0.971) across the same kind of small parameter
+range.
+
+## Why this happens
+
+Three voters are calibrated to the lowest positive (100 % recall by
+construction):
+
+* Voter A: floor = min(confidence over labeled positives)
+* Voter B: threshold = min(clap_diff over labeled positives)
+* Voter D: threshold = min(gunshot_prob over labeled positives)
+
+So at the calibrated value, every truth shot votes yes; the only way
+sweeping their threshold can change outcomes is by *dropping* truth
+shots (going up) or by accepting candidates that all four other
+voters already either accept or reject. Voter C runs in adaptive top-
+K mode and gates every keep decision (`c_required=True`), so a
+candidate voter A/B/D would have dropped is already dropped by C, and
+a candidate they'd have kept stays kept only if C agrees.
+
+The result: A/B/D contribute **redundant recall** votes; they don't
+contribute precision.
+
+## Implications
+
+* **Tuning effort goes to voter C, full stop.** This is what we
+  found on the slack sweep -- the +0.012 F1 gain came entirely from
+  voter C, with A/B/D unchanged.
+* **Could we drop A/B/D entirely?** Probably not -- they're the
+  redundancy that makes `vote_total >= consensus` meaningful, and
+  they catch failure modes where C is wrong about a real shot. But
+  their *thresholds* don't need tuning past the lowest-positive
+  calibration.
+* **The dashboard works correctly.** It surfaces the right lesson:
+  flat curves mean "this knob doesn't matter."
+
+## Not tested here
+
+* **`c_required=False`** would re-introduce A/B/D leverage by making
+  the consensus a pure majority vote. Worth a sweep on a separate
+  branch to confirm the inverse hypothesis (A/B/D sweeps move
+  outcomes when C is not vetoing). Skipping for now because
+  `c_required=False` is known to be much worse on the 281-FP
+  calibration set (#103); the experiment is academic.
+* **Voter E** (CLIP visual probe). The shipped `signals.parquet`
+  was built with `--skip-voter-e` so its column is all NaN. Run
+  `scripts/build_sweep_signals.py` (no flag) and sweep
+  `voter_e_threshold_offset` once that column is populated.
+
+## Reproduce
+
+```bash
+uv run python scripts/run_sweep.py --grid scripts/sweep_grids/voter_a_floor_offset.yaml --append
+uv run python scripts/run_sweep.py --grid scripts/sweep_grids/voter_b_threshold_offset.yaml --append
+uv run python scripts/run_sweep.py --grid scripts/sweep_grids/voter_d_threshold_offset.yaml --append
+uv run python scripts/plot_sweep.py --run-id <one of the run_ids>
+```
+
+Plots in `build/sweeps/<run_id>/` (gitignored; render locally).

--- a/scripts/sweep_grids/voter_b_threshold_offset.yaml
+++ b/scripts/sweep_grids/voter_b_threshold_offset.yaml
@@ -1,0 +1,8 @@
+# 1D sweep: shift voter B's CLAP shot-vs-not-shot differential threshold.
+#
+# Calibration sets the threshold to the lowest clap_diff seen on an
+# audited positive -- 100 % recall by construction. Negative offsets
+# can't help (would just keep more non-positives). Positive offsets
+# trade recall for precision; a sweet spot exists only if voter B's
+# precision-veto power outweighs its recall cost relative to consensus.
+voter_b_threshold_offset: [0.0, 0.01, 0.025, 0.05, 0.075, 0.10, 0.15]

--- a/scripts/sweep_grids/voter_d_threshold_offset.yaml
+++ b/scripts/sweep_grids/voter_d_threshold_offset.yaml
@@ -1,0 +1,7 @@
+# 1D sweep: shift voter D's PANN gunshot-class probability threshold.
+#
+# Same shape as voter B: calibrated to lowest positive (100 % recall).
+# Positive offsets sacrifice recall for precision; useful for finding
+# the gunshot-prob value where real shots stop benefiting from voter D
+# and FPs start dominating.
+voter_d_threshold_offset: [0.0, 0.001, 0.005, 0.01, 0.02, 0.05, 0.10]

--- a/scripts/sweep_grids/voter_e_threshold_offset.yaml
+++ b/scripts/sweep_grids/voter_e_threshold_offset.yaml
@@ -1,0 +1,14 @@
+# 1D sweep: shift voter E's CLIP-probe P(shot) threshold.
+#
+# Requires:
+# * ``signals.parquet`` rebuilt WITHOUT ``--skip-voter-e`` (so the
+#   ``voter_e_signal`` column is populated -- the default --skip flow
+#   stores NaN and the sweep will silently no-op).
+# * Source videos still reachable for the audited fixtures (the visual
+#   probe re-extracts frames at candidate times).
+#
+# Voter E is calibrated to a TARGET RECALL (not lowest-positive) so it
+# has more headroom than B/D -- non-zero offset is a real knob.
+enable_voter_e: [true]
+e_required: [true]
+voter_e_threshold_offset: [-0.05, 0.0, 0.05, 0.10, 0.15, 0.20]


### PR DESCRIPTION
## Summary
Independent follow-up to #287. Adds 1D sweep grids for the three voters that were missing one (B, D, E threshold offsets) and documents a meta-finding the runs surfaced: under \`c_required=True\` (production default), voters A, B, D have no leverage on aggregate metrics.

## Why bother adding grids for voters with no leverage?
- (a) The dashboard is supposed to make this kind of insensitivity *visible*, not silent. Flat curves are a real result.
- (b) If we ever experiment with \`c_required=False\` (or with a per-voter veto rework), A/B/D leverage comes back and the grids are already there.
- (c) The voter E grid ships gated on \`enable_voter_e\`/\`e_required\` so it no-ops until \`signals.parquet\` is rebuilt without \`--skip-voter-e\`.

## Numbers
| voter | offset range | F1 spread | FP delta |
|---|---|---|---|
| A | [-0.02, +0.05] | 0.0000 | 0 |
| B | [+0.00, +0.15] | 0.0000 | 0 |
| D | [+0.00, +0.10] | 0.0008 | -1 |

vs the voter-C slack sweep on the same corpus: F1 spread 0.026, FP delta -18. The leverage gap is the finding.

## Full writeup
\`docs/ensemble_dashboard/findings/2026-05-11_voter_abd_have_no_leverage.md\`

## Test plan
- [x] All three grids accepted by \`run_sweep.py\` (\`--grid scripts/sweep_grids/voter_*.yaml\`)
- [x] Runs appended to \`build/sweeps/runs.parquet\`; visible in the Lab card from #287 once that merges
- [x] No code changes -- only YAML + markdown, so no test impact