### PR TITLE
ensemble: retune voter_c_confidence_override 0.75 -> 0.60 (Pareto win)

### DIFF
--- a/docs/ensemble_dashboard/findings/2026-05-11_override_lift_apriori_dead.md
+++ b/docs/ensemble_dashboard/findings/2026-05-11_override_lift_apriori_dead.md
@@ -1,0 +1,106 @@
+# Finding: voter_c_confidence_override is mis-tuned; apriori_boost is dead
+
+**Date:** 2026-05-11
+**Sweep run_ids:**
+* `2026-05-11T07-34-17Z_33a361a_voter_c_confidence_override`
+* `2026-05-11T07-34-18Z_33a361a_apriori_boost`
+
+## TL;DR
+
+Two more knobs swept from the leverage map after the
+`consensus_x_c_required` confirmation:
+
+* **`voter_c_confidence_override`** -- real lift available. Dropping
+  from the current **0.75 -> 0.60** rescues **3 truth shots on
+  handheld fixtures for free** (no extra FPs anywhere). F1:
+  0.9709 -> 0.9735 (+0.0026). Per-class consistent.
+* **`apriori_boost`** -- another dead axis. F1 is byte-identical at
+  0.9709 across the entire [0.0, 2.0] range, just like consensus and
+  A/B/D thresholds.
+
+## voter_c_confidence_override sweep (overall)
+
+| override | TP  | FP | FN | precision | recall | F1     |
+|----------|-----|----|----|-----------|--------|--------|
+| null *(disabled)* | 548 | 25 | 28 | 0.956 | 0.951 | 0.9539 |
+| 0.50     | 572 | 26 |  4 | 0.957 | 0.993 | 0.9744 |
+| **0.60** | 570 | 25 |  6 | 0.958 | 0.990 | **0.9735** |
+| 0.70     | 568 | 25 |  8 | 0.958 | 0.986 | 0.9718 |
+| **0.75** *(current)* | 567 | 25 |  9 | 0.958 | 0.984 | 0.9709 |
+| 0.80     | 567 | 25 |  9 | 0.958 | 0.984 | 0.9709 |
+| 0.85     | 564 | 25 | 12 | 0.958 | 0.979 | 0.9682 |
+| 0.90     | 559 | 25 | 17 | 0.957 | 0.971 | 0.9638 |
+| 0.95     | 552 | 25 | 24 | 0.957 | 0.958 | 0.9575 |
+
+## Per-class (handheld vs headcam)
+
+**Handheld:** override sweep matters a lot -- 0.75 -> 0.50 lifts F1
+0.9806 -> 0.9867 by recovering 4 truth shots that were being rank-
+capped despite scoring in [0.50, 0.75] on the GBDT.
+
+| override | handheld TP | handheld FP | handheld F1 |
+|----------|-------------|-------------|-------------|
+| 0.50     | 333         |  9          | 0.9867      |
+| **0.60** | 332         |  9          | 0.9852      |
+| 0.70     | 330         |  9          | 0.9821      |
+| **0.75** | 329         |  9          | 0.9806      |
+
+**Headcam:** flat in [0.60, 0.80] -- the rank cap is already accepting
+all the high-GBDT-prob real shots; the override at any value in this
+range neither helps nor hurts.
+
+| override | headcam TP | headcam FP | headcam F1 |
+|----------|------------|------------|------------|
+| 0.50     | 239        | 17         | 0.9579     |
+| **0.60** | 238        | 16         | 0.9577     |
+| **0.75** | 238        | 16         | 0.9577     |
+
+## Why I recommend 0.60 over 0.50
+
+0.50 lifts overall F1 by another +0.0009 over 0.60 -- but it does so
+by trading 1 extra FP on headcam for 1 extra recovered TP on
+handheld. That's the same lopsided FP-vs-FN UX cost we used to argue
+in favor of #286 (rejected markers are still on the audit timeline,
+one click to flip; FPs need active attention to catch). 0.60 has
+**no FP cost at all** -- strictly Pareto-better than 0.75.
+
+## apriori_boost sweep
+
+| apriori_boost | TP  | FP | FN | F1     |
+|---------------|-----|----|----|--------|
+| 0.00          | 567 | 25 |  9 | 0.9709 |
+| 0.25 .. 2.00  | 567 | 25 |  9 | 0.9709 |
+
+Completely flat. Under `c_required=True`, the boost lifts top-K
+candidates above the consensus threshold but voter C already vetoed
+everything the consensus would have caught. Same root cause as the
+consensus-axis collapse: voter C runs the precision filter.
+
+Could be ripped out entirely (`apriori_boost=0` is identical to
+`apriori_boost=2.0` on every metric), but leaving it as a knob
+costs nothing and preserves the option for a future ensemble that
+weakens `c_required`.
+
+## Updated leverage map (after five sweeps)
+
+| knob | leverage under c_required=True |
+|---|---|
+| `voter_c_slack_frac` | **High** -- retuned via #286 |
+| `voter_c_confidence_override` | **Real** -- retune candidate, see this doc |
+| `consensus` | None (1..4 identical) |
+| `apriori_boost` | None (0.0..2.0 identical) |
+| `voter_a/b_threshold_offset` | None |
+| `voter_d_threshold_offset` | None |
+| Voter E | Untested -- needs CLIP rebuild |
+
+After five sweeps the map is converging: voter C's two knobs are the
+only ones that move metrics in the production config. Voter E is the
+last unknown.
+
+## Reproduce
+
+```bash
+uv run python scripts/run_sweep.py --grid scripts/sweep_grids/voter_c_confidence_override.yaml --append
+uv run python scripts/run_sweep.py --grid scripts/sweep_grids/apriori_boost.yaml --append
+uv run python scripts/plot_sweep.py --run-id <run_id>
+```

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -113,7 +113,7 @@ DEFAULTS: dict[str, Any] = {
     "voter_c_mode": "adaptive",
     "voter_c_slack_min": 3,
     "voter_c_slack_frac": 0.10,
-    "voter_c_confidence_override": 0.75,
+    "voter_c_confidence_override": 0.60,
     "use_expected_rounds": True,
     "camera_class_filter": "all",
 }

--- a/scripts/sweep_grids/apriori_boost.yaml
+++ b/scripts/sweep_grids/apriori_boost.yaml
@@ -1,0 +1,9 @@
+# 1D sweep: magnitude of the apriori boost for top-K candidates.
+#
+# When ``expected_rounds`` is provided, the top-N candidates by
+# detector confidence get ``+apriori_boost`` added to their consensus
+# score. Boost=1.0 (production) is equivalent to one extra vote;
+# boost=0.0 disables. Under c_required=True the consensus threshold
+# is already absorbed (see the consensus_x_c_required finding), so
+# this knob may also be a dead axis.
+apriori_boost: [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]

--- a/scripts/sweep_grids/voter_c_confidence_override.yaml
+++ b/scripts/sweep_grids/voter_c_confidence_override.yaml
@@ -1,0 +1,12 @@
+# 1D sweep: voter C's "high-score override" floor.
+#
+# When a candidate's GBDT prob clears ``confidence_override``, voter C
+# accepts it even when ranked outside the top-(K+slack). #103's
+# follow-up shipped 0.75 because two rank-cut FNs scored 0.80 / 0.90.
+# Sweeping reveals where the boundary actually matters on the
+# 30-fixture corpus: dropping it pulls more candidates past the
+# rank cap (recall up, precision down), raising it disables the
+# override entirely (the rank cap alone).
+#
+# null disables the override (rank cap only).
+voter_c_confidence_override: [null, 0.50, 0.60, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95]

--- a/src/splitsmith/ensemble/voters.py
+++ b/src/splitsmith/ensemble/voters.py
@@ -33,7 +33,7 @@ def vote_c_adaptive(
     *,
     slack_min: int = 3,
     slack_frac: float = 0.10,
-    confidence_override: float | None = 0.75,
+    confidence_override: float | None = 0.60,
 ) -> np.ndarray:
     """Voter C in adaptive mode: keep the top-(K+slack) probabilities.
 
@@ -60,9 +60,19 @@ def vote_c_adaptive(
     candidates pass voter C regardless of rank. The K-cap can otherwise
     silence voter C even when its GBDT is very confident -- e.g. real
     shots that score 0.8-0.9 get cut off by the rank cutoff while the
-    median FP scores ~0.005. The default 0.75 was tuned on 334 labeled
-    FPs (max score 0.73, 13 / 334 ≥ 0.10) and 226 truth shots (the two
-    rank-cut FNs scored 0.80 / 0.90). Pass ``None`` to disable.
+    median FP scores ~0.005. Pass ``None`` to disable.
+
+    Default ``0.60`` retuned on the 30-fixture corpus via
+    ``docs/ensemble_dashboard/findings/2026-05-11_override_lift_apriori_dead.md``.
+    The previous value 0.75 was tuned on the smaller #103 set (334
+    FPs, max FP score 0.73). On the broader corpus the override sweep
+    plateaus in [0.60, 0.75] for headcam and rises monotonically as
+    you drop it for handheld -- lowering to 0.60 rescues 3 truth
+    shots on the handheld iPhone17pro fixtures with **zero new FPs**
+    on either class. Per-class evidence is Pareto-clean, which is why
+    we land at 0.60 rather than 0.50 (the F1-optimal value, but 0.50
+    trades 1 headcam FP for 1 headcam TP -- worse than 0.60 under
+    the FP-is-more-dangerous UX argument).
     """
     if gbdt_probs.size == 0 or expected_rounds <= 0:
         return np.zeros_like(gbdt_probs, dtype=np.int64)


### PR DESCRIPTION
## Summary
Two more sweeps off the leverage map:

- **\`voter_c_confidence_override\`** -- real lift. Dropping **0.75 -> 0.60** rescues **3 truth shots on the handheld iPhone17pro fixtures for free** (zero new FPs anywhere). F1: 0.9709 -> 0.9735 (+0.0026). Per-class strictly Pareto-clean: handheld improves, headcam unchanged in [0.60, 0.75].
- **\`apriori_boost\`** -- another dead axis. F1 byte-identical at 0.9709 across [0.0, 2.0]. Same root cause as the consensus / A/B/D collapse from #288 + #289.

## Numbers
| override | TP  | FP | FN | precision | recall | F1 |
|---|---|---|---|---|---|---|
| null *(disabled)* | 548 | 25 | 28 | 0.956 | 0.951 | 0.954 |
| 0.50 | 572 | 26 |  4 | 0.957 | 0.993 | 0.974 |
| **0.60** | 570 | 25 |  6 | 0.958 | 0.990 | **0.9735** |
| 0.70 | 568 | 25 |  8 | 0.958 | 0.986 | 0.972 |
| 0.75 *(prev)* | 567 | 25 |  9 | 0.958 | 0.984 | 0.971 |
| 0.85 | 564 | 25 | 12 | 0.958 | 0.979 | 0.968 |
| 0.95 | 552 | 25 | 24 | 0.957 | 0.958 | 0.958 |

Going to 0.50 is slightly higher F1 but loses the Pareto property (trades 1 headcam FP for 1 headcam TP). Choosing 0.60 keeps the FP-is-more-dangerous UX argument intact (same one we used in #286).

## Updated leverage map (after 5 sweeps)

| knob | leverage |
|---|---|
| \`voter_c_slack_frac\` | **High** (retuned via #286) |
| \`voter_c_confidence_override\` | **Real** (this PR) |
| \`consensus\` | None |
| \`apriori_boost\` | None |
| \`voter_a/b_threshold_offset\` | None |
| \`voter_d_threshold_offset\` | None |
| Voter E | Untested |

Voter C's two knobs are the only things that move metrics in production. Voter E is the last unknown -- needs a CLIP rebuild.

## Test plan
- [x] \`uv run pytest -q\` -- 1108 passed, 4 skipped
- [x] \`uv run ruff check src tests\` + \`uv run black --check src tests\` clean
- [x] Existing voter-C tests pass tests pass arguments explicitly so unaffected by default change
- [x] \`scripts/run_sweep.py\` DEFAULTS updated to match production