### PR TITLE
ingest: scan picker recurses into subfolders

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1840,8 +1840,14 @@ def create_app(
                 raise HTTPException(status_code=400, detail=f"source dir not found: {source}")
             if not source.is_dir():
                 raise HTTPException(status_code=400, detail=f"not a directory: {source}")
-            for entry in sorted(source.iterdir()):
-                if entry.is_dir() or entry.suffix.lower() not in VIDEO_EXTENSIONS:
+            # Walk recursively so the picker can accept a top-level folder
+            # whose videos live in subdirectories (mirrors the relink
+            # scanner's behaviour). ``rglob`` does not follow directory
+            # symlinks by default, which avoids cycles on network shares.
+            for entry in sorted(source.rglob("*")):
+                if not entry.is_file():
+                    continue
+                if entry.suffix.lower() not in VIDEO_EXTENSIONS:
                     continue
                 candidates.append(entry)
             last_dir = source.resolve()

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -1514,6 +1514,8 @@ function ScanSection({
               onScanFiles(files.map((f) => f.path));
             }}
             onCancel={() => setOpen(false)}
+            allowEmptyFolder
+            selectLabel="Scan this folder"
           />
         )}
         {disabled ? (

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3076,6 +3076,33 @@ def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
     assert project["last_scanned_dir"] == str(src_dir.resolve())
 
 
+def test_scan_videos_walks_subdirectories(tmp_path: Path) -> None:
+    """source_dir recurses into subfolders so users can point at a parent
+    folder whose videos live inside dated/per-card subdirectories
+    (mirrors the relink scanner's behaviour)."""
+    project_root = tmp_path / "match"
+    app = create_app(project_root=project_root, project_name="x")
+    client = TestClient(app)
+
+    src_dir = tmp_path / "videos"
+    (src_dir / "card-a").mkdir(parents=True)
+    (src_dir / "card-b" / "nested").mkdir(parents=True)
+    nested_a = src_dir / "card-a" / "A.mp4"
+    nested_b = src_dir / "card-b" / "nested" / "B.mp4"
+    nested_a.write_bytes(b"")
+    nested_b.write_bytes(b"")
+    # Non-video sibling at root should be ignored.
+    (src_dir / "notes.txt").write_text("hi")
+
+    resp = client.post(
+        "/api/videos/scan",
+        json={"source_dir": str(src_dir), "auto_assign_primary": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert sorted(body["registered"]) == ["raw/A.mp4", "raw/B.mp4"]
+
+
 def test_scan_400_when_neither_source_dir_nor_paths(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- `/api/videos/scan` (`source_dir` mode) now walks recursively via `rglob`, matching the relink scanner's behaviour
- The ingest `FolderPicker` accepts a folder with no direct video children (`allowEmptyFolder`, label "Scan this folder"), so pointing at a parent of dated/per-card subdirectories Just Works
- Added a regression test covering nested-folder discovery

## Test plan
- [x] `uv run pytest tests/test_ui_server.py -k scan_videos` (4 passing, including the new `test_scan_videos_walks_subdirectories`)
- [x] `npx tsc --noEmit` clean in `ui_static/`
- [ ] Manual: pick a folder with no direct videos, confirm scan finds nested clips

🤖 Generated with [Claude Code](https://claude.com/claude-code)