### PR TITLE
beep: raise auto-trust threshold default 0.6 -> 0.95

### DIFF
--- a/src/splitsmith/automation.py
+++ b/src/splitsmith/automation.py
@@ -69,7 +69,7 @@ class AutomationSettings(BaseSettings):
     shot_detect_on_beep_verified: bool = True
     """When the user marks a beep reviewed, fire shot detection."""
 
-    beep_low_confidence_threshold: float = 0.6
+    beep_low_confidence_threshold: float = 0.95
     """Minimum auto-detector confidence in [0, 1] required to auto-trust a beep.
 
     Joins issue #219: an auto-detected beep with confidence at or above
@@ -79,11 +79,13 @@ class AutomationSettings(BaseSettings):
     queue and the user (or an agent driving the workflow) is asked to
     pick the right candidate from the ranked list.
 
-    Empirically the labelled fixture set has ~95% top-1 precision in the
-    ``confidence >= 0.7`` band; 0.6 is the conservative default that
-    keeps a few ambiguous cases in HITL rather than wasting CLAP / GBDT
-    / PANN cycles on a beep the agent will end up correcting. Manual
-    entries always clamp confidence to 1.0 and bypass this gate.
+    Manual entries always clamp confidence to 1.0 and bypass this gate.
+
+    History: the original default was 0.6, calibrated against the
+    labelled fixture set (~95% top-1 precision in the ``>= 0.7`` band).
+    Field use surfaced too many incorrectly-auto-trusted beeps on
+    recursive-scan ingests, so the default was raised to 0.95 pending
+    a re-calibration with more data.
     """
 
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2414,14 +2414,15 @@ def create_app(
                 v_fresh.processed["trim"] = True
             fresh.save(state.project_root)
         if trimmed_ok and video.role == "primary" and video.beep_reviewed:
-            # Shot detection is primary-only AND gated on the user
-            # confirming the beep (#71). Auto-detect always leaves
-            # ``beep_reviewed=False`` so this branch only fires for
-            # manual-override paths or after the user explicitly clicked
-            # "Mark reviewed" (which re-triggers chaining via
-            # ``set_beep_reviewed``). Saves the heavy CLAP / GBDT / PANN
-            # ensemble work when the beep timestamp is wrong, since
-            # everything downstream of it would be garbage anyway.
+            # Shot detection is primary-only AND gated on
+            # ``beep_reviewed`` (#71). That flag is True either because
+            # the user explicitly clicked "Mark reviewed" (which
+            # re-triggers chaining via ``set_beep_reviewed``) or because
+            # the auto-trust gate cleared (#219 layer 3b: confidence at
+            # or above ``beep_low_confidence_threshold``). Saves the
+            # heavy CLAP / GBDT / PANN ensemble work when the beep
+            # timestamp is wrong, since everything downstream of it
+            # would be garbage anyway.
             #
             # Layered automation gate (#215): users can disable the
             # auto-trigger globally or per project. ``cli_override`` is

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5069,7 +5069,7 @@ def test_get_automation_returns_resolved_settings_and_provenance(tmp_path: Path)
     body = resp.json()
     assert body["settings"] == {
         "shot_detect_on_beep_verified": True,
-        "beep_low_confidence_threshold": 0.6,
+        "beep_low_confidence_threshold": 0.95,
     }
     prov = body["provenance"]["shot_detect_on_beep_verified"]
     assert prov["source"] == "global"
@@ -5078,7 +5078,7 @@ def test_get_automation_returns_resolved_settings_and_provenance(tmp_path: Path)
     assert prov["cli_value"] is None
     threshold_prov = body["provenance"]["beep_low_confidence_threshold"]
     assert threshold_prov["source"] == "global"
-    assert threshold_prov["global_value"] == 0.6
+    assert threshold_prov["global_value"] == 0.95
 
 
 def test_get_automation_reports_project_provenance_when_overridden(


### PR DESCRIPTION
## Summary
- Auto-detected beeps were being marked reviewed too aggressively. With the 0.6 default, recursive-scan ingests were chaining straight into shot detection on videos whose beeps had not actually been verified, defeating the HITL review step.
- Bumps `automation.beep_low_confidence_threshold` default from 0.6 to 0.95 so practically every ingested video requires an explicit "Mark reviewed" click before shot detection fires. Once we have more labelled data we can drop this back down or rebuild the calibration.
- Also fixes a stale comment in `_run_detect_beep_for_video` that claimed auto-detect always leaves `beep_reviewed=False` -- that hasn't been true since #232.

## Test plan
- [x] `uv run pytest tests/test_ui_server.py -k automation`
- [ ] Ingest a fresh stage in the UI and confirm videos land unreviewed and stay out of the shot-detect chain until a click

🤖 Generated with [Claude Code](https://claude.com/claude-code)