### PR TITLE
audit: free primary <video> buffers on stage change

### DIFF
--- a/src/splitsmith/ui_static/src/components/VideoPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/VideoPanel.tsx
@@ -26,7 +26,7 @@
  * never flash the spinner.
  */
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import { AlertCircle, LayoutGrid, LayoutList, Loader2 } from "lucide-react";
 
 import { cn, useReleaseMediaOnUnmount } from "@/lib/utils";
@@ -175,9 +175,30 @@ export const VideoPanel = forwardRef<HTMLVideoElement, VideoPanelProps>(
     },
     ref,
   ) {
+    // Callback ref so we can (a) forward to the parent's ref AND (b) release
+    // demux/decoded-frame buffers on the OLD <video> when `key={videoSrc}`
+    // forces a remount on stage change. useReleaseMediaOnUnmount only fires
+    // on component unmount, not on per-element replacement, so we'd otherwise
+    // leak the prior stage's buffers and wedge the new element's first play.
     const internalRef = useRef<HTMLVideoElement | null>(null);
-    useImperativeHandle(ref, () => internalRef.current as HTMLVideoElement, []);
-    useReleaseMediaOnUnmount(internalRef);
+    const setVideoEl = useCallback(
+      (el: HTMLVideoElement | null) => {
+        const prev = internalRef.current;
+        if (prev && prev !== el) {
+          try {
+            prev.pause();
+            prev.removeAttribute("src");
+            prev.load();
+          } catch {
+            /* element already detached */
+          }
+        }
+        internalRef.current = el;
+        if (typeof ref === "function") ref(el);
+        else if (ref) ref.current = el;
+      },
+      [ref],
+    );
 
     const [status, setStatus] = useState<LoadStatus>("idle");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -324,7 +345,8 @@ export const VideoPanel = forwardRef<HTMLVideoElement, VideoPanelProps>(
               </div>
             ) : null}
             <video
-              ref={internalRef}
+              key={videoSrc}
+              ref={setVideoEl}
               src={videoSrc}
               preload="metadata"
               playsInline


### PR DESCRIPTION
## Summary
- Force a fresh primary `<video>` element per source via `key={videoSrc}` so stage switches don't reuse the prior session's media state.
- Replace `useImperativeHandle` + `useReleaseMediaOnUnmount` on the primary with a callback ref that forwards to the parent and runs `pause()` / `removeAttribute('src')` / `load()` on the outgoing element.

## Why
Heavy use on one stage (scrubbing, repeated play/pause, marking) would wedge the primary `<video>` into a permanent buffering state on the *next* stage -- spacebar would not play, scrubbing was dead, only a full page reload recovered it.

The primary element was never unmounted across stages: `VideoPanel` stays mounted and React just swaps `src` on the same node. Chrome retained demux + decoded-frame state from the prior stage, and `useReleaseMediaOnUnmount` (added in #280) couldn't free it because the hook only fires on component unmount.

Forcing a fresh element on src change drops that state; the callback ref preserves the proactive buffer release just at element granularity instead of component granularity, and keeps `videoRef.current` pointing at the live element (the old `useImperativeHandle(..., [])` would have left it pinned to the detached one after the remount).

`SecondarySlot` is unchanged -- it was already keyed by `path`, so its `useReleaseMediaOnUnmount` fired correctly per stage.

## Test plan
- [ ] Open Audit on a stage, zoom in, play with space bar, mark/unmark candidates while scrubbing until end of clip.
- [ ] Pick a different stage from the dropdown, zoom in, press space -- playback starts and scrubbing works without reloading.
- [ ] Repeat back and forth between stages a few times; no buffering wedge.
- [ ] Grid mode on/off across the same flow.
- [ ] Navigate away from Audit and back; no leaked playback state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)