### PR TITLE
cache: key audit WAV / trim MP4 per-video for every role

### DIFF
--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -2,17 +2,22 @@
 
 The CLI does this inline in ``cli.py:_extract_or_load_audio`` (caching the WAV
 next to the source video). The production UI prefers project-local caching so
-the project directory stays self-contained:
+the project directory stays self-contained. Cache filenames are keyed by the
+video's ``video_id`` for every role, so swapping the primary on a stage can
+never serve a different video's audio under the new primary's name:
 
-  <project>/audio/stage<N>_primary.wav            -- primary WAV (legacy name)
-  <project>/audio/stage<N>_cam_<video_id>.wav     -- non-primary WAV (per video)
-  <project>/audio/stage<N>_audit.wav              -- primary's audit WAV
-  <project>/audio/stage<N>_cam_<video_id>_audit.wav -- secondary's audit WAV
+  <project>/audio/stage<N>_cam_<video_id>.wav        -- full source WAV
+  <project>/audio/stage<N>_cam_<video_id>_audit.wav  -- audit WAV (post-trim)
+  <project>/trimmed/stage<N>_cam_<video_id>_trimmed.mp4 -- short-GOP audit MP4
 
 The audit screen (#15) prefers the audit WAV when a trimmed clip exists,
 falling back to the full WAV. Caches are invalidated when their source's
-mtime changes. Per-video keys live alongside the legacy primary names so
-existing primary caches survive the rollout to multi-camera ingest.
+mtime changes.
+
+Projects created before schema v2 used role-based legacy names
+(``stage<N>_primary.wav`` etc.) which couldn't distinguish primaries across
+reassignment. The v1->v2 migration in ``project.py`` deletes those files on
+open so the next access re-extracts under the new naming.
 """
 
 from __future__ import annotations
@@ -63,14 +68,10 @@ def video_audio_path(
 ) -> Path:
     """Resolve the cached audio-WAV path for ``video`` on ``stage_number``.
 
-    Filename rules:
-      - primary -> ``stage<N>_primary.wav`` (legacy; preserved so existing
-        caches survive the introduction of multi-cam beep workflows)
-      - non-primary -> ``stage<N>_cam_<video_id>.wav`` (per-video)
+    Always keyed by ``video_id`` so swapping the stage's primary cannot
+    alias to a previous primary's cached audio.
     """
     audio_dir = project.audio_path(project_root) if project else project_root / "audio"
-    if video.role == "primary":
-        return audio_dir / f"stage{stage_number}_primary.wav"
     return audio_dir / f"stage{stage_number}_cam_{video.video_id}.wav"
 
 
@@ -78,16 +79,19 @@ def primary_audio_path(
     project_root: Path,
     stage_number: int,
     *,
-    project: MatchProject | None = None,
+    project: MatchProject,
 ) -> Path:
-    """Resolve the cached primary-audio path for a stage.
+    """Resolve the cached audio path for ``stage_number``'s current primary.
 
-    When ``project`` is provided, its configured ``audio_dir`` (issue #23) is
-    honoured. When omitted, defaults to ``<project_root>/audio/`` for backwards
-    compatibility with callers that don't have the project model handy.
+    Convenience wrapper: looks up the primary ``StageVideo`` on the stage
+    and returns ``video_audio_path`` for it. Raises ``KeyError`` when the
+    stage doesn't exist or has no primary -- callers must gate on a real
+    primary before using this.
     """
-    audio_dir = project.audio_path(project_root) if project else project_root / "audio"
-    return audio_dir / f"stage{stage_number}_primary.wav"
+    primary = project.stage(stage_number).primary()
+    if primary is None:
+        raise KeyError(f"stage {stage_number} has no primary video")
+    return video_audio_path(project_root, stage_number, primary, project=project)
 
 
 def ensure_primary_audio(
@@ -97,50 +101,27 @@ def ensure_primary_audio(
     *,
     sample_rate: int = 48000,
     ffmpeg_binary: str = "ffmpeg",
-    project: MatchProject | None = None,
+    project: MatchProject,
 ) -> Path:
-    """Extract a mono WAV from ``source_video`` if not already cached.
+    """Extract a mono WAV for the stage's primary video if not already cached.
 
-    Cache location is ``<audio_dir>/stage<N>_primary.wav`` where ``audio_dir``
-    comes from the project's configured ``audio_dir`` override (issue #23) or
-    defaults to ``<project_root>/audio/``. Re-extracts when the source mtime
-    is newer than the cached file's. Returns the path to the cached WAV.
+    Thin wrapper around :func:`ensure_video_audio` that resolves the stage's
+    primary ``StageVideo`` and routes through the per-video cache key. Kept
+    as a named entry point so monkeypatch surfaces and existing call-sites
+    keep working without threading the ``StageVideo`` through.
     """
-    audio_path = primary_audio_path(project_root, stage_number, project=project)
-    audio_path.parent.mkdir(parents=True, exist_ok=True)
-
-    src_resolved = source_video.resolve()
-    if not src_resolved.exists():
-        raise FileNotFoundError(f"primary video missing on disk: {src_resolved}")
-
-    if audio_path.exists() and audio_path.stat().st_mtime >= src_resolved.stat().st_mtime:
-        return audio_path
-
-    if not shutil.which(ffmpeg_binary):
-        raise AudioExtractionError(f"ffmpeg binary not found: {ffmpeg_binary}")
-
-    cmd = [
-        ffmpeg_binary,
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        "-y",
-        "-i",
-        str(src_resolved),
-        "-ac",
-        "1",
-        "-ar",
-        str(sample_rate),
-        "-vn",
-        str(audio_path),
-    ]
-    try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-    except subprocess.CalledProcessError as exc:
-        raise AudioExtractionError(
-            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
-    return audio_path
+    primary = project.stage(stage_number).primary()
+    if primary is None:
+        raise KeyError(f"stage {stage_number} has no primary video")
+    return ensure_video_audio(
+        project_root,
+        stage_number,
+        primary,
+        source_video,
+        sample_rate=sample_rate,
+        ffmpeg_binary=ffmpeg_binary,
+        project=project,
+    )
 
 
 def ensure_video_audio(
@@ -155,21 +136,9 @@ def ensure_video_audio(
 ) -> Path:
     """Extract a mono WAV for ``video`` if not already cached.
 
-    For the primary, delegates to :func:`ensure_primary_audio` so the
-    legacy ``stage<N>_primary.wav`` cache + monkeypatch points keep
-    working. Non-primary cameras land at
-    ``<audio_dir>/stage<N>_cam_<video_id>.wav`` and run their own
-    extraction. Re-extracts when the source mtime is newer than cache.
+    Cache lands at ``<audio_dir>/stage<N>_cam_<video_id>.wav`` regardless of
+    role. Re-extracts when the source mtime is newer than the cache.
     """
-    if video.role == "primary":
-        return ensure_primary_audio(
-            project_root,
-            stage_number,
-            source_video,
-            sample_rate=sample_rate,
-            ffmpeg_binary=ffmpeg_binary,
-            project=project,
-        )
     audio_path = video_audio_path(project_root, stage_number, video, project=project)
     audio_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -216,12 +185,9 @@ def trimmed_video_path(
 ) -> Path:
     """Resolve the cached audit-mode short-GOP MP4 for ``video`` on a stage.
 
-    Primary keeps the legacy ``stage<N>_trimmed.mp4`` filename; non-primary
-    cameras get ``stage<N>_cam_<video_id>_trimmed.mp4`` so each angle has its
-    own scrub clip cut around its own beep.
+    Keyed by ``video_id`` for every role so each angle has its own scrub
+    clip cut around its own beep.
     """
-    if video.role == "primary":
-        return project.trimmed_path(project_root) / f"stage{stage_number}_trimmed.mp4"
     return (
         project.trimmed_path(project_root) / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
     )
@@ -229,18 +195,10 @@ def trimmed_video_path(
 
 def trimmed_primary_path(project_root: Path, stage_number: int, *, project: MatchProject) -> Path:
     """Resolve the cached short-GOP trimmed MP4 path for a stage's primary."""
-    return project.trimmed_path(project_root) / f"stage{stage_number}_trimmed.mp4"
-
-
-def audit_audio_path(
-    project_root: Path,
-    stage_number: int,
-    *,
-    project: MatchProject,
-) -> Path:
-    """Cache path for the primary's audit WAV (extracted from the trimmed MP4)."""
-    audio_dir = project.audio_path(project_root)
-    return audio_dir / f"stage{stage_number}_audit.wav"
+    primary = project.stage(stage_number).primary()
+    if primary is None:
+        raise KeyError(f"stage {stage_number} has no primary video")
+    return trimmed_video_path(project_root, stage_number, primary, project=project)
 
 
 def video_audit_audio_path(
@@ -251,10 +209,21 @@ def video_audit_audio_path(
     project: MatchProject,
 ) -> Path:
     """Cache path for ``video``'s audit WAV (extracted from its trimmed MP4)."""
-    if video.role == "primary":
-        return audit_audio_path(project_root, stage_number, project=project)
     audio_dir = project.audio_path(project_root)
     return audio_dir / f"stage{stage_number}_cam_{video.video_id}_audit.wav"
+
+
+def audit_audio_path(
+    project_root: Path,
+    stage_number: int,
+    *,
+    project: MatchProject,
+) -> Path:
+    """Cache path for the current primary's audit WAV on ``stage_number``."""
+    primary = project.stage(stage_number).primary()
+    if primary is None:
+        raise KeyError(f"stage {stage_number} has no primary video")
+    return video_audit_audio_path(project_root, stage_number, primary, project=project)
 
 
 def ensure_audit_audio(
@@ -388,21 +357,6 @@ def invalidate_video_audit_trim(
             pass
 
 
-def invalidate_audit_trim(project_root: Path, stage_number: int, *, project: MatchProject) -> None:
-    """Backward-compat shim: invalidate the primary's audit trim.
-
-    Equivalent to :func:`invalidate_video_audit_trim` with the stage's
-    primary. Synthesizes a primary-role ``StageVideo`` so the legacy code
-    path in callers that don't have the live model handy still works.
-    """
-    invalidate_video_audit_trim(
-        project_root,
-        stage_number,
-        StageVideo(path=Path("primary"), role="primary"),
-        project=project,
-    )
-
-
 def ensure_video_audit_trim(
     project_root: Path,
     stage_number: int,
@@ -417,27 +371,12 @@ def ensure_video_audit_trim(
 ) -> Path:
     """Produce the audit-mode short-GOP trim for ``video`` if not cached.
 
-    Generic over role: primary delegates to :func:`ensure_audit_trim` so
-    legacy filename caching + monkeypatch surfaces keep working;
-    secondaries run the same trim pipeline against their per-video output
-    path. The trim window is ``[max(0, beep - pre_buffer), beep +
-    stage_time + post_buffer]`` -- same shape for both roles.
-
-    Cache key is the source mtime *and* a sidecar params JSON; when the
-    beep, stage time, or buffer settings change, the next call sees a
-    params mismatch and re-trims even though the source file is untouched.
+    The trim window is ``[max(0, beep - pre_buffer), beep + stage_time +
+    post_buffer]``. Cache key is the source mtime *and* a sidecar params
+    JSON; when the beep, stage time, or buffer settings change, the next
+    call sees a params mismatch and re-trims even though the source file
+    is untouched.
     """
-    if video.role == "primary":
-        return ensure_audit_trim(
-            project_root,
-            stage_number,
-            source,
-            beep_time,
-            stage_time_seconds,
-            project=project,
-            ffmpeg_binary=ffmpeg_binary,
-            runner=runner,
-        )
     from .. import trim as trim_module
 
     output = trimmed_video_path(project_root, stage_number, video, project=project)
@@ -517,84 +456,25 @@ def ensure_audit_trim(
     ffmpeg_binary: str = "ffmpeg",
     runner: object | None = None,
 ) -> Path:
-    """Produce ``stage<N>_trimmed.mp4`` for the audit screen if not cached.
+    """Produce the audit-mode trimmed MP4 for the stage's primary if not cached.
 
-    Re-encodes the primary's source with a short GOP (Sub 5 / #16 audit
-    mode) so the audit screen scrubs frame-accurately. The trim window is
-    ``[max(0, beep - pre_buffer), beep + stage_time + post_buffer]``.
-
-    Cache key is the source mtime *and* a sidecar params JSON: when the
-    beep, stage time, or buffer settings change, the next call sees a
-    params mismatch and re-trims even though the source file is
-    untouched. Without that the user could fix a wrong beep, click "Trim
-    now", and still get the old trim served back.
-
-    Returns the path to the trimmed MP4. Raises ``AudioExtractionError``
-    on ffmpeg failure (kept under the same error type the audio helpers
-    already raise so the endpoint can map them with one ``except``).
+    Thin wrapper around :func:`ensure_video_audit_trim` that resolves the
+    stage's primary and routes through the per-video cache key.
     """
-    from .. import trim as trim_module
-
-    output = trimmed_primary_path(project_root, stage_number, project=project)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    partial = output.with_name(f"{output.stem}.partial{output.suffix}")
-    params_file = trim_params_path(output)
-    current_params = _current_trim_params(
-        primary_beep_time=primary_beep_time,
-        stage_time_seconds=stage_time_seconds,
+    primary = project.stage(stage_number).primary()
+    if primary is None:
+        raise KeyError(f"stage {stage_number} has no primary video")
+    return ensure_video_audit_trim(
+        project_root,
+        stage_number,
+        primary,
+        primary_source,
+        primary_beep_time,
+        stage_time_seconds,
         project=project,
+        ffmpeg_binary=ffmpeg_binary,
+        runner=runner,
     )
-
-    src_resolved = primary_source.resolve()
-    if not src_resolved.exists():
-        raise FileNotFoundError(f"primary video missing on disk: {src_resolved}")
-
-    cache_hit = (
-        output.exists()
-        and output.stat().st_mtime >= src_resolved.stat().st_mtime
-        and params_file.exists()
-    )
-    if cache_hit:
-        try:
-            existing_params = json.loads(params_file.read_text(encoding="utf-8"))
-            if existing_params == current_params:
-                if partial.exists():
-                    partial.unlink()
-                return output
-        except (OSError, ValueError):
-            pass
-
-    for p in (output, partial, params_file):
-        if p.exists():
-            p.unlink()
-
-    encoder = trim_module.select_audit_encoder(
-        project.trim_audit_encoder, ffmpeg_binary=ffmpeg_binary
-    )
-    trim_kwargs: dict[str, object] = {
-        "input_path": src_resolved,
-        "output_path": partial,
-        "beep_time": primary_beep_time,
-        "stage_time": stage_time_seconds,
-        "pre_buffer_seconds": project.trim_pre_buffer_seconds,
-        "post_buffer_seconds": project.trim_post_buffer_seconds,
-        "mode": "audit",
-        "video_encoder": encoder,
-        "ffmpeg_binary": ffmpeg_binary,
-        "overwrite": True,
-    }
-    if runner is not None:
-        trim_kwargs["runner"] = runner
-    try:
-        trim_module.trim_video(**trim_kwargs)
-    except trim_module.FFmpegError as exc:
-        if partial.exists():
-            partial.unlink()
-        raise AudioExtractionError(str(exc)) from exc
-
-    partial.replace(output)
-    params_file.write_text(json.dumps(current_params, indent=2) + "\n", encoding="utf-8")
-    return output
 
 
 def detect_primary_beep(

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -751,10 +751,11 @@ class MatchProject(BaseModel):
                 if primary is not None
                 else None
             )
+            audit_trim_exists = audit_trim_p is not None and audit_trim_p.exists()
             trimmed_p = (
                 lossless_trim_p
                 if lossless_trim_p.exists()
-                else (audit_trim_p if audit_trim_p is not None and audit_trim_p.exists() else lossless_trim_p)
+                else (audit_trim_p if audit_trim_exists else lossless_trim_p)
             )
 
             csv_exists = csv_p.exists()
@@ -1513,9 +1514,7 @@ class MatchProject(BaseModel):
         if stage_number is not None:
             vid = video.video_id
             audio_cache = self.audio_path(root) / f"stage{stage_number}_cam_{vid}.wav"
-            trimmed_cache = (
-                self.trimmed_path(root) / f"stage{stage_number}_cam_{vid}_trimmed.mp4"
-            )
+            trimmed_cache = self.trimmed_path(root) / f"stage{stage_number}_cam_{vid}_trimmed.mp4"
 
         audit_path: Path | None = None
         audit_reset = False

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -38,6 +39,8 @@ from .. import video_match
 from ..automation import AutomationOverride
 from ..config import BeepCandidate, StageData, StageRounds, VideoMatchConfig
 from ..video_match import match_videos_to_stages
+
+logger = logging.getLogger(__name__)
 
 # Camera-make heuristic for the default ``StageVideo.camera_mount``
 # (issue #143). The fixture schema's full ``CameraMount`` enum is much
@@ -130,7 +133,66 @@ PROJECT_FILE = "project.json"
 SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard", "probes", "thumbs")
 
 # Bumped when the on-disk schema changes in a backwards-incompatible way.
-SCHEMA_VERSION = 1
+#
+# Version history:
+#   1 -- initial.
+#   2 -- audio/trim caches keyed per-video (``stage<N>_cam_<video_id>.*``)
+#        for every role. v1 projects had role-based legacy names
+#        (``stage<N>_primary.wav`` / ``_audit.wav`` / ``_trimmed.mp4``)
+#        which could alias to a previous primary's audio after a reassignment.
+#        Migration deletes the legacy files so the next access re-extracts
+#        under the new naming.
+SCHEMA_VERSION = 2
+
+
+def _migrate_v1_to_v2(root: Path, project: MatchProject) -> None:
+    """Delete v1 legacy role-named caches so v2's per-video keys take over.
+
+    v1 cached the primary's audio/trim under role-based names
+    (``stage<N>_primary.wav``, ``stage<N>_audit.wav``,
+    ``stage<N>_trimmed.mp4``) plus the matching ``.peaks-*.json`` and
+    ``.params.json`` sidecars. After a primary swap or stage move those
+    files could hold a previous primary's data with no way to tell from
+    mtime alone, so we delete them outright and let the next access
+    re-extract under ``stage<N>_cam_<video_id>.*``.
+
+    Idempotent: missing files are ignored. Logs a one-line summary on
+    completion so the upgrade is visible in the server log.
+    """
+    audio_dir = project.audio_path(root)
+    trimmed_dir = project.trimmed_path(root)
+
+    removed = 0
+    patterns: list[tuple[Path, str]] = [
+        (audio_dir, "stage*_primary.wav"),
+        (audio_dir, "stage*_primary.peaks-*.json"),
+        (audio_dir, "stage*_audit.wav"),
+        (audio_dir, "stage*_audit.peaks-*.json"),
+        (trimmed_dir, "stage*_trimmed.mp4"),
+        (trimmed_dir, "stage*_trimmed.params.json"),
+        (trimmed_dir, "stage*_trimmed.partial.mp4"),
+    ]
+    for directory, pattern in patterns:
+        if not directory.exists():
+            continue
+        for victim in directory.glob(pattern):
+            # The new naming uses ``stage<N>_cam_<id>_trimmed.mp4`` /
+            # ``..._audit.wav``. The legacy globs above happen to also
+            # match those (``stage*_trimmed.mp4`` matches per-cam too),
+            # so guard against deleting the new artifacts.
+            if "_cam_" in victim.name:
+                continue
+            try:
+                victim.unlink()
+                removed += 1
+            except OSError:
+                continue
+
+    logger.info(
+        "schema migration v1->v2 on %s: removed %d legacy audio/trim cache file(s)",
+        project.name,
+        removed,
+    )
 
 
 VideoRole = Literal["primary", "secondary", "ignored"]
@@ -559,12 +621,24 @@ class MatchProject(BaseModel):
 
     @classmethod
     def load(cls, root: Path) -> MatchProject:
-        """Load the project from ``root``. Raises ``FileNotFoundError`` if missing."""
+        """Load the project from ``root``. Raises ``FileNotFoundError`` if missing.
+
+        Runs forward-only schema migrations when the on-disk
+        ``schema_version`` lags :data:`SCHEMA_VERSION`. The project file is
+        rewritten with the new version after a successful migration so the
+        upgrade is a one-shot cost on first open.
+        """
         path = root / PROJECT_FILE
         if not path.exists():
             raise FileNotFoundError(f"no project.json in {root}")
         data = json.loads(path.read_text(encoding="utf-8"))
-        return cls.model_validate(data)
+        on_disk_version = int(data.get("schema_version", 1))
+        project = cls.model_validate(data)
+        if on_disk_version < 2:
+            _migrate_v1_to_v2(root, project)
+            project.schema_version = 2
+            project.save(root)
+        return project
 
     def save(self, root: Path) -> None:
         """Atomically persist the project to ``root/project.json``."""
@@ -672,11 +746,15 @@ class MatchProject(BaseModel):
             # Reference trimmed_dir only when the lossless one is missing
             # so the row at least shows the user *something* trimmed.
             lossless_trim_p = exports_dir / f"{base}_trimmed.mp4"
-            audit_trim_p = trimmed_dir / f"stage{stage.stage_number}_trimmed.mp4"
+            audit_trim_p: Path | None = (
+                trimmed_dir / f"stage{stage.stage_number}_cam_{primary.video_id}_trimmed.mp4"
+                if primary is not None
+                else None
+            )
             trimmed_p = (
                 lossless_trim_p
                 if lossless_trim_p.exists()
-                else (audit_trim_p if audit_trim_p.exists() else lossless_trim_p)
+                else (audit_trim_p if audit_trim_p is not None and audit_trim_p.exists() else lossless_trim_p)
             )
 
             csv_exists = csv_p.exists()
@@ -1428,23 +1506,16 @@ class MatchProject(BaseModel):
 
         raw_link = self.resolve_video_path(root, video.path)
 
-        # Cache files are keyed on role: primary keeps the legacy
-        # ``stage<N>_primary.wav`` / ``stage<N>_trimmed.mp4`` filenames;
-        # non-primary cameras live under ``stage<N>_cam_<video_id>.*`` so
-        # each angle has its own slot. Either way the removal plan points
-        # at the per-video files so the endpoint sweeps them on disk.
+        # Cache files are keyed per-video for every role (stage<N>_cam_<id>.*)
+        # so swapping a primary cannot alias to a previous primary's cache.
         audio_cache: Path | None = None
         trimmed_cache: Path | None = None
         if stage_number is not None:
-            if was_primary:
-                audio_cache = self.audio_path(root) / f"stage{stage_number}_primary.wav"
-                trimmed_cache = self.trimmed_path(root) / f"stage{stage_number}_trimmed.mp4"
-            else:
-                vid = video.video_id
-                audio_cache = self.audio_path(root) / f"stage{stage_number}_cam_{vid}.wav"
-                trimmed_cache = (
-                    self.trimmed_path(root) / f"stage{stage_number}_cam_{vid}_trimmed.mp4"
-                )
+            vid = video.video_id
+            audio_cache = self.audio_path(root) / f"stage{stage_number}_cam_{vid}.wav"
+            trimmed_cache = (
+                self.trimmed_path(root) / f"stage{stage_number}_cam_{vid}_trimmed.mp4"
+            )
 
         audit_path: Path | None = None
         audit_reset = False

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3555,9 +3555,9 @@ def create_app(
     def stage_audio(stage_number: int) -> FileResponse:
         """Serve the audit-clip WAV for ``stage_number``.
 
-        Prefers ``stage<N>_audit.wav`` (extracted from the short-GOP trimmed
+        Prefers the primary's audit WAV (extracted from the short-GOP trimmed
         MP4 produced by Sub 5 / #16) so the waveform timeline matches what
-        the user is auditing. Falls back to the full ``stage<N>_primary.wav``
+        the user is auditing. Falls back to the primary's full source WAV
         when no trimmed clip exists yet -- the SPA surfaces this with a
         "trim required" hint.
         """
@@ -4151,8 +4151,8 @@ def create_app(
         """Serve a registered video file with HTTP Range support.
 
         For the primary of a stage, prefers the short-GOP trimmed MP4
-        produced by Sub 5 / #16 (``<trimmed>/stage<N>_trimmed.mp4``). The
-        re-encoded clip seeks frame-accurately, which is what makes the
+        produced by Sub 5 / #16 (``<trimmed>/stage<N>_cam_<video_id>_trimmed.mp4``).
+        The re-encoded clip seeks frame-accurately, which is what makes the
         audit screen's drag-scrubbing feel responsive. Secondaries fall
         through to their source file -- per-video trim runs aren't wired
         through the production UI yet.

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -141,10 +141,13 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
     )
 
     # Place a non-empty file at the trimmed-clip path so the helper
-    # detects "trim exists" without running ffmpeg.
+    # detects "trim exists" without running ffmpeg. Path is per-video in v2.
     trimmed_dir = project.trimmed_path(root)
     trimmed_dir.mkdir(parents=True, exist_ok=True)
-    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"not really a video, but non-empty")
+    primary_id = project.stages[0].videos[0].video_id
+    (trimmed_dir / f"stage1_cam_{primary_id}_trimmed.mp4").write_bytes(
+        b"not really a video, but non-empty"
+    )
 
     app = create_app(project_root=root, project_name="Trimmed Match")
     client = TestClient(app)

--- a/tests/test_lab_promote.py
+++ b/tests/test_lab_promote.py
@@ -202,17 +202,19 @@ def _setup_promote_endpoint_project(
     project.save(root)
     # Drop a primary stub + trimmed MP4 stub + audit WAV stub so
     # ``_resolve_audit_audio`` finds the trimmed-video branch and skips
-    # ffmpeg re-extraction (audit WAV mtime newer than trim).
+    # ffmpeg re-extraction (audit WAV mtime newer than trim). Caches are
+    # keyed per-video in v2 so derive the names from the primary's id.
     raw = root / "raw"
     raw.mkdir(exist_ok=True)
     (raw / "v.mp4").write_bytes(b"\x00" * 16)
+    primary_id = project.stages[0].videos[0].video_id
     trimmed = root / "trimmed"
     trimmed.mkdir(exist_ok=True)
-    trim_path = trimmed / "stage1_trimmed.mp4"
+    trim_path = trimmed / f"stage1_cam_{primary_id}_trimmed.mp4"
     trim_path.write_bytes(b"\x00" * 16)
     audio = root / "audio"
     audio.mkdir(exist_ok=True)
-    audit_wav = audio / "stage1_audit.wav"
+    audit_wav = audio / f"stage1_cam_{primary_id}_audit.wav"
     audit_wav.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake")
     # Make audit WAV newer than the trimmed MP4 so ffmpeg-extract is skipped.
     future = time.time() + 10

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -56,6 +56,62 @@ def test_init_creates_layout(tmp_path: Path) -> None:
         assert (tmp_path / "match-a" / sub).is_dir()
 
 
+def test_load_migrates_v1_caches_to_v2(tmp_path: Path) -> None:
+    """Opening a v1 project deletes the legacy role-named cache files so
+    the new per-video naming can take over without serving stale audio.
+
+    Regression for the bug where a primary swap silently reused
+    ``stage<N>_primary.wav`` content from the previous primary.
+    """
+    root = tmp_path / "legacy-match"
+    # Bootstrap a project, then forge an on-disk v1 representation so the
+    # load() migration path runs against it.
+    project = MatchProject.init(root, name="Legacy")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+        )
+    ]
+    project.save(root)
+    data = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    data["schema_version"] = 1
+    (root / PROJECT_FILE).write_text(json.dumps(data), encoding="utf-8")
+
+    audio = root / "audio"
+    audio.mkdir(exist_ok=True)
+    legacy_full = audio / "stage1_primary.wav"
+    legacy_full.write_bytes(b"OLD")
+    legacy_audit = audio / "stage1_audit.wav"
+    legacy_audit.write_bytes(b"OLD")
+    legacy_peaks = audio / "stage1_primary.peaks-1200.json"
+    legacy_peaks.write_bytes(b"[]")
+    trimmed = root / "trimmed"
+    trimmed.mkdir(exist_ok=True)
+    legacy_trim = trimmed / "stage1_trimmed.mp4"
+    legacy_trim.write_bytes(b"OLD")
+    legacy_params = trimmed / "stage1_trimmed.params.json"
+    legacy_params.write_bytes(b"{}")
+    # A pre-existing v2 cam-cache must survive the migration untouched.
+    survivor = audio / "stage1_cam_abc123_audit.wav"
+    survivor.write_bytes(b"KEEP")
+
+    reloaded = MatchProject.load(root)
+
+    assert reloaded.schema_version == 2
+    assert not legacy_full.exists()
+    assert not legacy_audit.exists()
+    assert not legacy_peaks.exists()
+    assert not legacy_trim.exists()
+    assert not legacy_params.exists()
+    assert survivor.exists()
+    # And the version bump is persisted, so a second load is a no-op.
+    persisted = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    assert persisted["schema_version"] == 2
+
+
 def test_init_is_idempotent(tmp_path: Path) -> None:
     root = tmp_path / "match-b"
     first = MatchProject.init(root, name="Match B")
@@ -713,12 +769,14 @@ def test_remove_primary_includes_audio_and_trimmed_paths(tmp_path: Path) -> None
     project.assign_video(video.path, to_stage_number=1, role="primary")
     project.stages[0].videos[0].processed = {"beep": True, "shot_detect": True, "trim": True}
 
+    vid = project.stages[0].videos[0].video_id
+
     plan = project.remove_video(video.path, root)
 
     assert plan.was_primary is True
     assert plan.stage_number == 1
-    assert plan.audio_cache_path == (root / "audio" / "stage1_primary.wav")
-    assert plan.trimmed_cache_path == (root / "trimmed" / "stage1_trimmed.mp4")
+    assert plan.audio_cache_path == (root / "audio" / f"stage1_cam_{vid}.wav")
+    assert plan.trimmed_cache_path == (root / "trimmed" / f"stage1_cam_{vid}_trimmed.mp4")
     assert plan.audit_path is None  # default: preserve audit
     assert plan.audit_reset is False
     assert project.stages[0].videos == []

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -64,7 +64,7 @@ def test_health_returns_project_info(tmp_path: Path) -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert body["project_name"] == "Test Match"
-    assert body["schema_version"] == 1
+    assert body["schema_version"] == 2
 
 
 def test_get_project_returns_full_dump(tmp_path: Path) -> None:
@@ -903,6 +903,26 @@ def test_scan_persists_last_scanned_dir(tmp_path: Path) -> None:
     assert project["last_scanned_dir"] == str(src_dir.resolve())
 
 
+def _primary_cache_paths(project_root: Path, stage_number: int = 1) -> tuple[Path, Path, Path]:
+    """Schema v2 cache paths for the stage's primary.
+
+    Returns ``(full_wav, audit_wav, trimmed_mp4)`` keyed by the primary's
+    ``video_id`` so tests don't have to hard-code the legacy
+    ``stage<N>_primary.wav`` filename (which was retired in v2).
+    """
+    project = MatchProject.load(project_root)
+    primary = project.stage(stage_number).primary()
+    assert primary is not None, f"stage {stage_number} has no primary"
+    vid = primary.video_id
+    audio_dir = project_root / "audio"
+    trimmed_dir = project_root / "trimmed"
+    return (
+        audio_dir / f"stage{stage_number}_cam_{vid}.wav",
+        audio_dir / f"stage{stage_number}_cam_{vid}_audit.wav",
+        trimmed_dir / f"stage{stage_number}_cam_{vid}_trimmed.mp4",
+    )
+
+
 def _seed_project_with_primary(tmp_path: Path) -> tuple[TestClient, Path]:
     """Boot a server with one stage and a primary video assigned. Returns
     ``(client, video_source_path)`` so the caller can mutate the source if
@@ -1248,7 +1268,7 @@ def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
 
     project_root = tmp_path / "match"
-    fake_wav = project_root / "audio" / "stage1_primary.wav"
+    fake_wav, _audit, _trim = _primary_cache_paths(project_root)
     fake_wav.parent.mkdir(parents=True, exist_ok=True)
     # Minimal RIFF header + tiny data chunk; the test only checks that bytes flow.
     fake_wav.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00" + b"\x00" * 16)
@@ -1437,13 +1457,13 @@ def test_peaks_endpoint_uses_trimmed_audio_when_present(tmp_path: Path, monkeypa
     # Create a fake "trimmed" mp4 placeholder so the existence check passes.
     trimmed_dir = project_root / "trimmed"
     trimmed_dir.mkdir(parents=True, exist_ok=True)
-    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"\x00fake_mp4")
+    _full, audit_wav, trimmed_mp4 = _primary_cache_paths(project_root)
+    trimmed_mp4.write_bytes(b"\x00fake_mp4")
 
     # Stub _extract_audio so we don't actually shell out; drop a known WAV
     # at the audit-cache path.
     audio_dir = project_root / "audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
-    audit_wav = audio_dir / "stage1_audit.wav"
     audio = np.zeros(48_000, dtype="float32")
     audio[20_000:21_000] = 0.7
     sf.write(audit_wav, audio, 48_000)
@@ -1557,14 +1577,13 @@ def test_video_peaks_endpoint_serves_primary_full_wav_even_when_trimmed_exists(
     # Cache both the trimmed audit WAV (short) and the full primary WAV
     # (long). If the picker mistakenly uses the audit clip the response
     # duration will be 1s; with the fix it's 2s.
-    audit_wav = audio_dir / "stage1_audit.wav"
+    primary_wav, audit_wav, trimmed_mp4 = _primary_cache_paths(project_root)
     sf.write(audit_wav, np.zeros(48_000, dtype="float32"), 48_000)
-    primary_wav = audio_dir / "stage1_primary.wav"
     sf.write(primary_wav, np.zeros(96_000, dtype="float32"), 48_000)
 
     trimmed_dir = project_root / "trimmed"
     trimmed_dir.mkdir(parents=True, exist_ok=True)
-    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"\x00fake_mp4")
+    trimmed_mp4.write_bytes(b"\x00fake_mp4")
 
     from splitsmith.ui import audio as audio_helpers
 
@@ -1598,7 +1617,7 @@ def test_peaks_endpoint_falls_back_to_full_when_no_trim(tmp_path: Path, monkeypa
     project_root = tmp_path / "match"
     audio_dir = project_root / "audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
-    wav = audio_dir / "stage1_primary.wav"
+    wav, _audit, _trim = _primary_cache_paths(project_root)
     audio = np.zeros(24_000, dtype="float32")
     audio[5_000:6_000] = 0.3
     sf.write(wav, audio, 48_000)
@@ -1631,7 +1650,8 @@ def test_stream_video_serves_trimmed_for_primary(tmp_path: Path) -> None:
 
     trimmed_dir = project_root / "trimmed"
     trimmed_dir.mkdir(parents=True, exist_ok=True)
-    (trimmed_dir / "stage1_trimmed.mp4").write_bytes(b"TRIMMED_MP4")
+    _full, _audit, trimmed_mp4 = _primary_cache_paths(project_root)
+    trimmed_mp4.write_bytes(b"TRIMMED_MP4")
 
     resp = client.get(f"/api/videos/stream?path={primary.path}")
     assert resp.status_code == 200
@@ -1651,7 +1671,7 @@ def test_peaks_endpoint_returns_normalized_bins(tmp_path: Path, monkeypatch) -> 
     project_root = tmp_path / "match"
     audio_dir = project_root / "audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
-    wav = audio_dir / "stage1_primary.wav"
+    wav, _audit, _trim = _primary_cache_paths(project_root)
     audio = np.zeros(48_000, dtype="float32")
     audio[10_000:11_000] = 0.5
     sf.write(wav, audio, 48_000)
@@ -1733,7 +1753,8 @@ def test_detect_beep_auto_trims(tmp_path: Path, monkeypatch) -> None:
     project_after = client.get("/api/project").json()
     assert project_after["stages"][0]["videos"][0]["beep_time"] == pytest.approx(6.5)
     assert project_after["stages"][0]["videos"][0]["processed"]["trim"] is True
-    assert (project_root / "trimmed" / "stage1_trimmed.mp4").exists()
+    _full, _audit, expected_trim = _primary_cache_paths(project_root)
+    assert expected_trim.exists()
     assert len(trim_calls) == 1
     assert trim_calls[0]["mode"] == "audit"
     assert trim_calls[0]["beep_time"] == pytest.approx(6.5)
@@ -1899,7 +1920,8 @@ def test_post_trim_endpoint_produces_clip(tmp_path: Path, monkeypatch) -> None:
     assert final["status"] == "succeeded", final
     project_after = client.get("/api/project").json()
     assert project_after["stages"][0]["videos"][0]["processed"]["trim"] is True
-    assert (project_root / "trimmed" / "stage1_trimmed.mp4").exists()
+    _full, _audit, expected_trim = _primary_cache_paths(project_root)
+    assert expected_trim.exists()
 
 
 def test_trim_invalidates_when_beep_changes(tmp_path: Path, monkeypatch) -> None:
@@ -3239,11 +3261,11 @@ def test_remove_primary_clears_caches_and_keeps_audit(tmp_path: Path) -> None:
     )
     project = MatchProject.load(root)
     project.assign_video(Path("raw/clip.mp4"), to_stage_number=1, role="primary")
+    project.save(root)
     # Simulate processed state: write fake cached files audit/audio/trimmed.
-    audio_cache = root / "audio" / "stage1_primary.wav"
+    audio_cache, _audit_wav, trimmed_cache = _primary_cache_paths(root)
     audio_cache.parent.mkdir(parents=True, exist_ok=True)
     audio_cache.write_bytes(b"wav")
-    trimmed_cache = root / "trimmed" / "stage1_trimmed.mp4"
     trimmed_cache.parent.mkdir(parents=True, exist_ok=True)
     trimmed_cache.write_bytes(b"mp4")
     audit = root / "audit" / "stage1.json"


### PR DESCRIPTION
## Summary

- Drops the role branch in `audio.py` path helpers so every cache file (full WAV, audit WAV, trimmed MP4) lands at `stage<N>_cam_<video_id>.*` regardless of role. The `primary_audio_path` / `trimmed_primary_path` / `audit_audio_path` / `ensure_primary_audio` / `ensure_audit_trim` wrappers stay as thin shims that resolve the stage's primary and delegate, preserving call-site + monkeypatch surfaces.
- Bumps `SCHEMA_VERSION` 1 -> 2. `MatchProject.load` runs a forward-only migration that deletes legacy role-named cache files (`stage<N>_primary.wav` / `_audit.wav` / `_trimmed.mp4` + matching `.peaks-*.json` / `.params.json` / `.partial.mp4`) so the next audit access re-extracts under the new naming. A `_cam_` guard in the globs protects v2 artifacts. One-line `INFO` log summarises the upgrade.
- Test helper `_primary_cache_paths` in `tests/test_ui_server.py` plus a v1 -> v2 migration regression in `tests/test_ui_project.py`. Existing tests updated for the new naming.

## Why

In `/Users/mathias/matches/blacksmith-handgun-2026-anton`, two stages' `stage<N>_primary.wav` files were bit-identical (MD5 `218203...`) but pointed to different primary videos in `project.json`. The cause: `stage<N>_primary.wav` is a slot keyed only by stage+role, and the mtime cache check can't tell "this is the new primary's audio" from "this is the previous primary's audio." `/api/assignments/move` (and the auto-upgrade inside `assign_video`) never invalidated those caches, so the audit waveform drifted out of sync with the video after a reassignment. Per-video keying makes the bug class impossible.

## Test plan

- [x] `uv run pytest` — 1108 passed, 4 skipped
- [x] New `test_load_migrates_v1_caches_to_v2` regression
- [x] Smoke-tested migration on the affected project: 33 stale legacy cache files removed, `project.json` now `schema_version: 2`, surviving `stage4_cam_<id>.*` files preserved
- [ ] Open audit view on a migrated project; confirm waveform matches the current primary on each stage (manual)
- [ ] Reorder videos / move a video between stages; confirm the new primary's waveform appears without restarting the server (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)