### PR TITLE
audit: rebuild trim on re-detect + watchdog clears stuck buffering

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2750,6 +2750,43 @@ def create_app(
             )
         source = proj.resolve_video_path(state.project_root, prim.path)
 
+        # Re-detect-all on an old project (and the v1->v2 cache migration in
+        # #298) leaves stages with no trimmed MP4 cached. Without that file,
+        # ensure_audit_audio falls back to the full source WAV -- shot
+        # detection still works, but the audit page then streams the raw
+        # source clip into <video>, where long-GOP 4K MOVs wedge in buffering
+        # on first play. Force the trim here so every shot-detect run leaves
+        # the audit cache in the same state the beep-detect path would have.
+        handle.update(progress=0.05, message="Ensuring audit trim...")
+        try:
+            audio_helpers.ensure_video_audit_trim(
+                state.project_root,
+                stage_number,
+                prim,
+                source,
+                prim.beep_time,
+                stg.time_seconds,
+                project=proj,
+                runner=_cancellable_runner(handle),
+            )
+            trim_fresh = state.load()
+            try:
+                v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
+            except KeyError:
+                v_fresh = None
+            if v_fresh is not None and not v_fresh.processed.get("trim"):
+                v_fresh.processed["trim"] = True
+                trim_fresh.save(state.project_root)
+        except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
+            # Soft failure: detection can still proceed against the source
+            # WAV. ensure_audit_audio's fallback handles the missing trim,
+            # so we log and continue rather than abort the whole job.
+            logger.warning(
+                "shot_detect could not (re)build trim for stage %d: %s",
+                stage_number,
+                exc,
+            )
+
         handle.update(progress=0.1, message="Preparing audio...")
         audit = audio_helpers.ensure_audit_audio(
             state.project_root,

--- a/src/splitsmith/ui_static/src/components/VideoPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/VideoPanel.tsx
@@ -33,6 +33,12 @@ import { cn, useReleaseMediaOnUnmount } from "@/lib/utils";
 import type { StageVideo } from "@/lib/api";
 
 const BUFFER_FLASH_DELAY_MS = 150;
+// Cadence for the buffering-state watchdog. Some browsers (Chrome on a
+// long-GOP source served with Range requests) drop `canplay`/`playing`
+// after a stall recovers, leaving the overlay stuck until reload. We
+// poll `readyState` + `currentTime` and clear the state ourselves when
+// the element is demonstrably playable again.
+const BUFFER_WATCHDOG_INTERVAL_MS = 500;
 
 type LoadStatus = "idle" | "loading" | "buffering" | "ready" | "error";
 
@@ -97,6 +103,31 @@ function SecondarySlot({ label, src, onRef, onBuffering }: SecondarySlotProps) {
     }
     setShowBufferIndicator(false);
     return undefined;
+  }, [status]);
+
+  // Watchdog: when stuck in "buffering", poll readyState / currentTime so
+  // we can recover even if the browser doesn't emit a clearing event.
+  useEffect(() => {
+    if (status !== "buffering") return undefined;
+    const startTime = internalRef.current?.currentTime ?? 0;
+    let lastTime = startTime;
+    const id = window.setInterval(() => {
+      const el = internalRef.current;
+      if (!el) return;
+      // HAVE_FUTURE_DATA (3) or better is enough to play.
+      if (el.readyState >= 3) {
+        setStatus("ready");
+        onBufferingLatest.current(false);
+        return;
+      }
+      if (!el.paused && el.currentTime !== lastTime) {
+        setStatus("ready");
+        onBufferingLatest.current(false);
+        return;
+      }
+      lastTime = el.currentTime;
+    }, BUFFER_WATCHDOG_INTERVAL_MS);
+    return () => window.clearInterval(id);
   }, [status]);
 
   const handleWaiting = useCallback(() => {
@@ -227,6 +258,32 @@ export const VideoPanel = forwardRef<HTMLVideoElement, VideoPanelProps>(
       }
       setShowBufferIndicator(false);
       return undefined;
+    }, [status]);
+
+    // Watchdog: when the element is stuck in "buffering", poll
+    // readyState / currentTime so the overlay can clear even if the
+    // browser swallows the canplay / playing / seeked event. Without
+    // this, a single onWaiting against a long-GOP 4K source (the
+    // fallback path when the audit trim is missing) wedges the spinner
+    // until a full page reload.
+    useEffect(() => {
+      if (status !== "buffering") return undefined;
+      const startVideo = internalRef.current;
+      let lastTime = startVideo?.currentTime ?? 0;
+      const id = window.setInterval(() => {
+        const el = internalRef.current;
+        if (!el) return;
+        if (el.readyState >= 3) {
+          setStatus("ready");
+          return;
+        }
+        if (!el.paused && el.currentTime !== lastTime) {
+          setStatus("ready");
+          return;
+        }
+        lastTime = el.currentTime;
+      }, BUFFER_WATCHDOG_INTERVAL_MS);
+      return () => window.clearInterval(id);
     }, [status]);
 
     if (videos.length === 0) {

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2229,6 +2229,73 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     assert proj_after["stages"][0]["videos"][0]["processed"]["shot_detect"] is True
 
 
+def test_shot_detect_endpoint_ensures_trim_before_detection(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Re-detect on a project whose trims were wiped (e.g. by the v1->v2
+    cache migration in #298) must rebuild the trimmed MP4. Without this
+    the audit page falls through to streaming the raw source clip and
+    long-GOP MOVs wedge in <video> buffering on first play."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.stages[0].time_seconds = 10.0
+    project.save(project_root)
+    project.resolve_video_path(project_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = project_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    wav = audio_dir / "stage1_audit.wav"
+    sf.write(wav, np.zeros(48_000, dtype="float32"), 48_000)
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        audio_path = wav
+        beep_in_clip = 5.0
+        trimmed = True
+
+    trim_calls: list[tuple] = []
+
+    def fake_trim(root, stage_n, video, source, beep, stage_t, **kwargs):
+        trim_calls.append((stage_n, video.video_id, beep, stage_t))
+        return None
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", fake_trim)
+    monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
+    monkeypatch.setattr(
+        ensemble_module,
+        "detect_shots_ensemble",
+        lambda *a, **kw: _fake_ensemble_result([]),
+    )
+
+    resp = client.post("/api/stages/1/shot-detect")
+    assert resp.status_code == 200
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
+
+    # Trim was invoked once with the right (stage, video, beep, stage_time).
+    assert len(trim_calls) == 1
+    stage_n, video_id, beep, stage_t = trim_calls[0]
+    assert stage_n == 1
+    assert video_id == primary.video_id
+    assert beep == pytest.approx(5.0)
+    assert stage_t == pytest.approx(10.0)
+
+    # processed.trim flips on the primary so the SPA reflects the rebuilt cache.
+    proj_after = client.get("/api/project").json()
+    assert proj_after["stages"][0]["videos"][0]["processed"].get("trim") is True
+
+
 def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -2268,6 +2335,7 @@ def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
         trimmed = True
 
     monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
     monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
 
     captured: dict = {}
@@ -2320,6 +2388,7 @@ def test_shot_detect_endpoint_passes_default_class_when_mount_missing(
         trimmed = True
 
     monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
     monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
 
     captured: dict = {}
@@ -2398,6 +2467,7 @@ def test_shot_detect_all_endpoint_submits_per_eligible_stage(tmp_path: Path, mon
             self.trimmed = True
 
     monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda root, n, *a, **kw: FakeAudit(n))
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
     monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
     monkeypatch.setattr(
         ensemble_module,
@@ -2461,6 +2531,7 @@ def test_shot_detect_endpoint_writes_stage_rounds_into_audit_json(
         trimmed = True
 
     monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
     monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
 
     captured: dict = {}
@@ -2550,6 +2621,7 @@ def test_shot_detect_endpoint_dedupes_active_jobs(tmp_path: Path, monkeypatch) -
         trimmed = True
 
     monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
     monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: None)
 
     proceed = threading.Event()

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2229,9 +2229,7 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     assert proj_after["stages"][0]["videos"][0]["processed"]["shot_detect"] is True
 
 
-def test_shot_detect_endpoint_ensures_trim_before_detection(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_shot_detect_endpoint_ensures_trim_before_detection(tmp_path: Path, monkeypatch) -> None:
     """Re-detect on a project whose trims were wiped (e.g. by the v1->v2
     cache migration in #298) must rebuild the trimmed MP4. Without this
     the audit page falls through to streaming the raw source clip and


### PR DESCRIPTION
## Summary

Two regressions surfaced when opening an old project whose `raw/` symlinks were relinked to new source locations (compounded by the v1->v2 cache migration in #298, which deleted every legacy role-named trim MP4):

- **Re-detect all + reset never rebuilt trims.** The bulk endpoint only enqueued `shot_detect` jobs; the trim step lives in `_run_detect_beep_for_video`. With no cached trim, `/api/videos/stream` fell through to the raw long-GOP source and audit waveform/audio paths walked the slow source-WAV fallback.
- **Pressing Space wedged \"Buffering...\".** On long-GOP 4K sources, `onWaiting` fires and Chrome sometimes drops the subsequent `canplay`/`playing` once the stall recovers; the overlay then stayed up until a full page reload.

Fixes:
1. `_run_shot_detect` now calls `ensure_video_audit_trim` for the primary before `ensure_audit_audio`, so re-detect-all (and every other shot-detect entry point) leaves the trim cache in the same state the beep-detect path would have. Soft failure if ffmpeg can't reach the source -- detection continues against the source WAV.
2. `VideoPanel` and `SecondarySlot` gained a 500ms `readyState`/`currentTime` watchdog while `status === \"buffering\"`. When the element is demonstrably playable again (HAVE_FUTURE_DATA, or currentTime advancing while unpaused) the overlay clears even if the browser swallowed the clearing event.

No change to the source files or the negative-training pipeline: trims always wrote to `trimmed/` and never touched the source MOVs, and mined-negative training reads source audio outside the stage window via the fixture pipeline, not the per-project audit cache.

## Test plan

- [x] `pytest tests/test_ui_server.py` -- 198 passed (incl. new `test_shot_detect_endpoint_ensures_trim_before_detection`)
- [x] `pytest tests/test_mcp_detect_tools.py` -- still green
- [x] `npx tsc --noEmit` + `npm run build` on the SPA
- [ ] Manual: open the old project, hit \"Re-detect all + reset\" on Ingest, confirm trims appear in `trimmed/` and each audit page opens with a fast (trimmed) waveform on first load
- [ ] Manual: on a stage where the trim is intentionally deleted, press Space and confirm the buffering overlay clears within ~1s once playback actually starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)