### PR TITLE
ensemble: filesystem-driven fixture registry (closes #302)

### DIFF
--- a/scripts/analyze_negatives.py
+++ b/scripts/analyze_negatives.py
@@ -28,23 +28,11 @@ import numpy as np
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble.features import _HAND_FEATURE_NAMES, compute_hand_features
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.ensemble.tta import compute_tta_agreement
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 CACHE_DIR = FIXTURES_DIR / ".cache"
 

--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -51,83 +51,19 @@ from splitsmith.ensemble.calibration import (
     DEFAULT_VOTER_E_PROBE_FILENAME,
     camera_class_from_mount,
 )
+from splitsmith.ensemble.fixtures import (
+    WRONG_CLIP_FIXTURES,
+    fixture_stems,
+)
 from splitsmith.ensemble.tta import compute_tta_agreement
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage4-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-    # Phone-cam (issue #137 / promote-secondary, PR #134). Calibration
-    # script auto-skips fixtures missing CLAP / PANN caches; run
-    # ``scripts/extract_clap_features.py`` and
-    # ``scripts/extract_audio_embeddings.py`` for these stems first to
-    # pick them up.
-    "stage-shots-tallmilan-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage4-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94-apple-iphone17pro",
-    # Phone-cam (PR #152, anchored against the blacksmith headcam fixtures
-    # to land cross-match acoustic variation -- issue #149's near-term ask).
-    "stage-shots-blacksmith-2026-stage1-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94-apple-iphone17pro",
-    # Cross-shooter headcam fixtures at the tallmilan-2026 match (PR
-    # #279). Same physical match as the s97dcec94 tallmilan set, so
-    # they carry the same bay acoustics but a different shooter's
-    # cadence -- including them lets calibration distinguish shooter
-    # drift from match acoustics. Camera info absent in the audit
-    # JSONs; ``camera_class_from_mount`` falls back to headcam.
-    "stage-shots-tallmilan-2026-stage1-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage2-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage3-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage4-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage5-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage6-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage7-s36ed6e4e",
-    # Cross-shooter handheld fixtures at the blacksmith handgun open 2026
-    # match (camera.mount=hand, bucketed as handheld). Different bay
-    # acoustics from tallmilan; same shooter token as the tallmilan-2026
-    # set above. First non-phone handheld batch -- adds bare-mic
-    # handheld variation to a class previously dominated by the
-    # iphone17pro internal-mic set.
-    "stage-shots-blacksmith-handgun-open-2026-stage1-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage2-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage3-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage4-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage5-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage6-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage7-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage8-s36ed6e4e",
-]
-
-# Fixtures whose promote-report flagged ``wrong_clip_suspected: true`` --
-# the phone clip linked to that stage is silent at the snapped shot
-# positions (probably the wrong clip / occluded mic). Keeping them in
-# repo for inspection, skipping them in calibration so they don't pull
-# the GBDT toward labelling silence as positive. See issue #154 for the
-# re-anchor plan.
-WRONG_CLIP_FIXTURES: frozenset[str] = frozenset(
-    {
-        "stage-shots-blacksmith-2026-stage6-s97dcec94-apple-iphone17pro",
-        "stage-shots-tallmilan-2026-stage4-s97dcec94-apple-iphone17pro",
-    }
-)
+# Every audited fixture; the discovery is filesystem-driven so adding a
+# new audited JSON + WAV under tests/fixtures/ picks it up automatically.
+# WRONG_CLIP_FIXTURES still applies as a Voter E exclusion -- those
+# fixtures have valid audio but mismatched video, so the audio-side
+# voters keep them while the visual probe ignores them.
+DEFAULT_FIXTURES = fixture_stems()
 FIXTURES_DIR = Path("tests/fixtures")
 FULL_DIR = FIXTURES_DIR / "full"
 CACHE_DIR = FIXTURES_DIR / ".cache"

--- a/scripts/build_ensemble_fixture.py
+++ b/scripts/build_ensemble_fixture.py
@@ -48,22 +48,10 @@ from sklearn.model_selection import StratifiedKFold
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 CACHE_DIR = FIXTURES_DIR / ".cache"
 OUTPUT_DIR = Path("build/ensemble-review")

--- a/scripts/eval_detector.py
+++ b/scripts/eval_detector.py
@@ -30,22 +30,10 @@ from pathlib import Path
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 
 

--- a/scripts/eval_ensemble.py
+++ b/scripts/eval_ensemble.py
@@ -44,23 +44,11 @@ import numpy as np
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble.features import compute_hand_features
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.ensemble.tta import compute_tta_agreement
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 CACHE_DIR = FIXTURES_DIR / ".cache"
 

--- a/scripts/eval_refinement.py
+++ b/scripts/eval_refinement.py
@@ -20,23 +20,11 @@ import numpy as np
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig, ShotRefineConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 from splitsmith.shot_refine import refine_shot_time
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 
 

--- a/scripts/extract_audio_embeddings.py
+++ b/scripts/extract_audio_embeddings.py
@@ -30,52 +30,12 @@ import numpy as np
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-    # Phone-cam fixtures (PR #134 + PR #152).
-    "stage-shots-tallmilan-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage4-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94-apple-iphone17pro",
-    # Cross-shooter headcam fixtures at tallmilan-2026 (PR #279).
-    "stage-shots-tallmilan-2026-stage1-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage2-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage3-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage4-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage5-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage6-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage7-s36ed6e4e",
-    # Cross-shooter handheld fixtures at the blacksmith handgun open 2026 match.
-    "stage-shots-blacksmith-handgun-open-2026-stage1-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage2-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage3-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage4-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage5-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage6-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage7-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage8-s36ed6e4e",
-]
+# Every audited fixture; the discovery is filesystem-driven so adding a
+# new audited JSON + WAV under tests/fixtures/ picks it up automatically.
+DEFAULT_FIXTURES = fixture_stems()
 FIXTURES_DIR = Path("tests/fixtures")
 CACHE_DIR = FIXTURES_DIR / ".cache"
 PANN_SR = 32000  # PANNs CNN14 native rate

--- a/scripts/extract_clap_features.py
+++ b/scripts/extract_clap_features.py
@@ -36,53 +36,14 @@ import numpy as np
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-    # Phone-cam fixtures (PR #134 + PR #152). Promoted from headcam
-    # anchors; shots[] inherited verbatim, camera.mount=hand.
-    "stage-shots-tallmilan-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage4-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94-apple-iphone17pro",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94-apple-iphone17pro",
-    # Cross-shooter headcam fixtures at tallmilan-2026 (PR #279).
-    "stage-shots-tallmilan-2026-stage1-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage2-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage3-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage4-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage5-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage6-s36ed6e4e",
-    "stage-shots-tallmilan-2026-stage7-s36ed6e4e",
-    # Cross-shooter handheld fixtures at the blacksmith handgun open 2026 match.
-    "stage-shots-blacksmith-handgun-open-2026-stage1-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage2-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage3-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage4-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage5-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage6-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage7-s36ed6e4e",
-    "stage-shots-blacksmith-handgun-open-2026-stage8-s36ed6e4e",
-]
+# Every audited fixture; the discovery is filesystem-driven so adding a
+# new audited JSON + WAV under tests/fixtures/ picks it up automatically.
+# See src/splitsmith/ensemble/fixtures.py for the registry that backs
+# this and (build|extract)_* siblings.
+DEFAULT_FIXTURES = fixture_stems()
 FIXTURES_DIR = Path("tests/fixtures")
 CACHE_DIR = FIXTURES_DIR / ".cache"
 CLAP_SR = 48000  # CLAP-HTSAT native sample rate

--- a/scripts/lofo_mining_experiment.py
+++ b/scripts/lofo_mining_experiment.py
@@ -32,6 +32,7 @@ from sklearn.model_selection import StratifiedKFold
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble import features as feat
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
 FIXTURES_DIR = Path("tests/fixtures")
@@ -47,20 +48,7 @@ TIME_TOL_S = 1e-3
 CONSENSUS = 3
 APRIORI_BOOST = 1.0  # only applied when expected_rounds is set; not for these fixtures
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 
 
 def _label(cand_t: list[float], truth_shots: list[dict], tol_ms: float) -> list[int]:

--- a/scripts/refresh_candidates.py
+++ b/scripts/refresh_candidates.py
@@ -21,22 +21,10 @@ from pathlib import Path
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import detect_shots
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 
 

--- a/scripts/train_classifier.py
+++ b/scripts/train_classifier.py
@@ -37,26 +37,14 @@ from sklearn.model_selection import StratifiedKFold
 
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
+from splitsmith.ensemble.fixtures import fixture_stems
 from splitsmith.shot_detect import (
     _cwt_max_envelope,
     _hf_lf_ratio,
     detect_shots,
 )
 
-DEFAULT_FIXTURES = [
-    "stage-shots-tallmilan-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage7-s97dcec94",
-    "stage-shots-blacksmith-2026-stage1-s97dcec94",
-    "stage-shots-blacksmith-2026-stage2-s97dcec94",
-    "stage-shots-blacksmith-2026-stage3-s97dcec94",
-    "stage-shots-blacksmith-2026-stage5-s97dcec94",
-    "stage-shots-blacksmith-2026-stage6-s97dcec94",
-    "stage-shots-blacksmith-2026-stage8-s97dcec94",
-    "stage-shots-tallmilan-2026-stage2-s97dcec94",
-    "stage-shots-tallmilan-2026-stage7-s97dcec94",
-    "stage-shots-tallmilan-2026-stage5-s97dcec94",
-    "stage-shots-tallmilan-2026-stage6-s97dcec94",
-]
+DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 
 FEATURE_NAMES = [

--- a/src/splitsmith/ensemble/fixtures.py
+++ b/src/splitsmith/ensemble/fixtures.py
@@ -1,0 +1,224 @@
+"""Single source of truth for the audited fixture corpus.
+
+For most of 2026 every script that touched the calibration corpus kept
+its own ``DEFAULT_FIXTURES`` literal -- 11 separate lists across
+``scripts/``, in slow drift against ``tests/fixtures/``. Symptoms:
+
+* New fixtures (e.g. shooter ``s0fe3d797``) had to be added to each list
+  by hand; missing one silently shrank that script's corpus.
+* ``build_ensemble_artifacts.py`` listed ``tallmilan-2026-stage4-s97dcec94``
+  but neither ``extract_clap_features.py`` nor ``extract_audio_embeddings.py``
+  did, so the artifact build saw a fixture whose feature cache had never
+  been generated.
+
+This module replaces those literals with on-disk discovery: every audit
+JSON under ``tests/fixtures/`` is parsed once per process and exposed as
+a ``Fixture`` with the metadata the scripts care about (mount, shooter,
+match, expected_rounds). Filters return the same set you got before
+without naming any individual fixture in code.
+
+The corpus *can* still grow without anyone updating this module -- just
+drop the audited JSON + WAV alongside the others and it shows up
+automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+FIXTURES_DIR: Path = Path(__file__).resolve().parents[3] / "tests" / "fixtures"
+
+# Fixtures excluded from Voter E (CLIP visual probe) training because the
+# extracted clip is from the wrong stage window -- audio is correct,
+# video is not. Audio-only voters (A/B/C) still see these.
+WRONG_CLIP_FIXTURES: frozenset[str] = frozenset(
+    {
+        "stage-shots-blacksmith-2026-stage6-s97dcec94-apple-iphone17pro",
+        "stage-shots-tallmilan-2026-stage4-s97dcec94-apple-iphone17pro",
+    }
+)
+
+# Files in tests/fixtures/ that look like stage-shots-*.json but are not
+# audit JSONs. Skip these in discovery.
+_NON_AUDIT_SUFFIXES = (
+    ".json.bak",
+    ".json.before-promote",
+    "-promotion-report.json",
+    "-candidates.csv",  # not a json, but defensive
+    ".peaks-1200.json",
+    ".peaks-1500.json",
+)
+
+_MATCH_STAGE_RE = re.compile(
+    r"^stage-shots-(?P<match>.+?-\d{4})-stage(?P<stage>\d+)(?:-(?P<rest>.+))?$"
+)
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """Audited fixture descriptor parsed from ``tests/fixtures/<stem>.json``."""
+
+    stem: str
+    mount: str | None
+    camera_id: str | None
+    camera_make: str | None
+    camera_model: str | None
+    shooter_id: str | None
+    match: str | None
+    stage_number: int | None
+    expected_rounds: int | None
+    n_audited_shots: int
+    has_wav: bool
+
+    @property
+    def audited(self) -> bool:
+        return self.n_audited_shots > 0
+
+    @property
+    def is_headcam(self) -> bool:
+        return self.mount == "head"
+
+    @property
+    def camera_class(self) -> str:
+        """Same mapping the ensemble runtime uses (mount=head -> headcam)."""
+        return "headcam" if self.mount == "head" else "handheld"
+
+
+def _parse_match_and_stage(stem: str) -> tuple[str | None, int | None]:
+    m = _MATCH_STAGE_RE.match(stem)
+    if not m:
+        return None, None
+    try:
+        stage = int(m.group("stage"))
+    except (TypeError, ValueError):
+        stage = None
+    return m.group("match"), stage
+
+
+def _looks_like_audit_json(path: Path) -> bool:
+    name = path.name
+    if not name.startswith("stage-shots-"):
+        return False
+    if any(name.endswith(suf) for suf in _NON_AUDIT_SUFFIXES):
+        return False
+    return path.suffix == ".json"
+
+
+_DISCOVERY_CACHE: dict[Path, tuple[Fixture, ...]] = {}
+
+
+def _scan(fixtures_dir: Path) -> Iterator[Fixture]:
+    for json_path in sorted(fixtures_dir.glob("stage-shots-*.json")):
+        if not _looks_like_audit_json(json_path):
+            continue
+        try:
+            data = json.loads(json_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if "beep_time" not in data:
+            continue
+        stem = json_path.stem
+        camera = data.get("camera") or {}
+        shooter = data.get("shooter") or {}
+        rounds = data.get("stage_rounds") or {}
+        match, stage_number = _parse_match_and_stage(stem)
+        yield Fixture(
+            stem=stem,
+            mount=camera.get("mount"),
+            camera_id=camera.get("id"),
+            camera_make=camera.get("make"),
+            camera_model=camera.get("model"),
+            shooter_id=shooter.get("id"),
+            match=match,
+            stage_number=stage_number,
+            expected_rounds=rounds.get("expected"),
+            n_audited_shots=len(data.get("shots") or []),
+            has_wav=json_path.with_suffix(".wav").exists(),
+        )
+
+
+def all_fixtures(fixtures_dir: Path | None = None) -> tuple[Fixture, ...]:
+    """Discover every audit JSON under ``fixtures_dir`` and return descriptors.
+
+    When ``fixtures_dir`` is ``None`` the module-level :data:`FIXTURES_DIR`
+    is resolved at call time -- this is what lets tests monkeypatch the
+    directory.
+
+    Results are cached per resolved directory. Tests that drop a new
+    fixture on disk should call :func:`all_fixtures.cache_clear` to force
+    rediscovery.
+
+    Files are skipped silently when:
+
+    * the name matches a non-audit pattern (``*.json.bak``, promotion
+      reports, peaks summaries);
+    * the JSON fails to parse;
+    * the JSON has no ``beep_time`` field (a cheap proxy for "is this
+      really an audit JSON?").
+
+    Returned tuple is sorted by ``stem`` for a stable iteration order.
+    """
+    dir_ = fixtures_dir if fixtures_dir is not None else FIXTURES_DIR
+    if dir_ not in _DISCOVERY_CACHE:
+        _DISCOVERY_CACHE[dir_] = tuple(_scan(dir_))
+    return _DISCOVERY_CACHE[dir_]
+
+
+def _cache_clear() -> None:
+    _DISCOVERY_CACHE.clear()
+
+
+# Mirror ``functools.cache``'s interface so call sites that expect
+# ``all_fixtures.cache_clear()`` keep working.
+all_fixtures.cache_clear = _cache_clear  # type: ignore[attr-defined]
+
+
+def audited(
+    *,
+    mount: str | None = None,
+    shooter_id: str | None = None,
+    match: str | None = None,
+    exclude_wrong_clip: bool = False,
+) -> list[Fixture]:
+    """Return audited fixtures (``n_audited_shots > 0``), optionally filtered.
+
+    All filter args are AND-combined. Unfiltered ``audited()`` returns
+    every fixture with at least one verified shot.
+    """
+    items = [f for f in all_fixtures() if f.audited]
+    if mount is not None:
+        items = [f for f in items if f.mount == mount]
+    if shooter_id is not None:
+        items = [f for f in items if f.shooter_id == shooter_id]
+    if match is not None:
+        items = [f for f in items if f.match == match]
+    if exclude_wrong_clip:
+        items = [f for f in items if f.stem not in WRONG_CLIP_FIXTURES]
+    return items
+
+
+def fixture_stems(
+    *,
+    mount: str | None = None,
+    shooter_id: str | None = None,
+    match: str | None = None,
+    exclude_wrong_clip: bool = False,
+) -> list[str]:
+    """Drop-in replacement for the old ``DEFAULT_FIXTURES`` literals.
+
+    Same filter args as :func:`audited`; returns just the stems in stable
+    sorted order.
+    """
+    return [
+        f.stem
+        for f in audited(
+            mount=mount,
+            shooter_id=shooter_id,
+            match=match,
+            exclude_wrong_clip=exclude_wrong_clip,
+        )
+    ]

--- a/tests/test_fixtures_registry.py
+++ b/tests/test_fixtures_registry.py
@@ -1,0 +1,181 @@
+"""Tests for the auto-discovered fixture registry.
+
+These exercise discovery against a temp dir so the tests are independent
+of how the real ``tests/fixtures/`` corpus grows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from splitsmith.ensemble import fixtures as registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    """``all_fixtures`` is process-cached; reset it before every test."""
+    registry.all_fixtures.cache_clear()
+    yield
+    registry.all_fixtures.cache_clear()
+
+
+def _write_audit(
+    dir_: Path,
+    stem: str,
+    *,
+    mount: str = "head",
+    shooter_id: str = "s00000000",
+    n_shots: int = 5,
+    expected_rounds: int | None = 5,
+    make: str | None = "Insta360",
+    model: str | None = "GO 3S",
+    write_wav: bool = True,
+) -> None:
+    payload = {
+        "beep_time": 0.5,
+        "stage_time_seconds": 30.0,
+        "shots": [{"shot_number": i + 1, "time": 1.0 + i * 0.3} for i in range(n_shots)],
+        "camera": {"mount": mount, "id": "go3s", "make": make, "model": model, "position": "shooter"},
+        "shooter": {"id": shooter_id},
+        "stage_rounds": {"expected": expected_rounds} if expected_rounds is not None else {},
+    }
+    (dir_ / f"{stem}.json").write_text(json.dumps(payload))
+    if write_wav:
+        (dir_ / f"{stem}.wav").write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+
+
+def test_discovery_finds_audit_jsons_and_parses_metadata(tmp_path: Path) -> None:
+    _write_audit(tmp_path, "stage-shots-foo-2026-stage1-s12345678", shooter_id="s12345678")
+    _write_audit(
+        tmp_path,
+        "stage-shots-bar-2026-stage7-s00000000",
+        mount="hand",
+        expected_rounds=12,
+        n_shots=12,
+        make=None,
+        model=None,
+    )
+
+    fx = registry.all_fixtures(tmp_path)
+    assert len(fx) == 2
+    by_stem = {f.stem: f for f in fx}
+    foo = by_stem["stage-shots-foo-2026-stage1-s12345678"]
+    assert foo.mount == "head"
+    assert foo.shooter_id == "s12345678"
+    assert foo.match == "foo-2026"
+    assert foo.stage_number == 1
+    assert foo.expected_rounds == 5
+    assert foo.n_audited_shots == 5
+    assert foo.audited
+    assert foo.is_headcam
+    assert foo.camera_class == "headcam"
+
+    bar = by_stem["stage-shots-bar-2026-stage7-s00000000"]
+    assert bar.mount == "hand"
+    assert bar.match == "bar-2026"
+    assert bar.stage_number == 7
+    assert bar.camera_class == "handheld"
+    assert bar.camera_make is None  # missing metadata propagates as None
+
+
+def test_discovery_skips_non_audit_json_files(tmp_path: Path) -> None:
+    _write_audit(tmp_path, "stage-shots-foo-2026-stage1-s12345678")
+    # Non-audit lookalikes that must be ignored.
+    (tmp_path / "stage-shots-foo-2026-stage1.json.bak").write_text("{}")
+    (tmp_path / "stage-shots-foo-2026-stage1-s12345678-promotion-report.json").write_text("{}")
+    (tmp_path / "stage-shots-foo-2026-stage1.peaks-1200.json").write_text("{}")
+    (tmp_path / "stage-shots-foo-2026-stage1.json.before-promote").write_text("{}")
+    # A real .json that's not an audit (missing beep_time).
+    (tmp_path / "stage-shots-bogus-2026-stage1.json").write_text(json.dumps({"shots": []}))
+    fx = registry.all_fixtures(tmp_path)
+    assert [f.stem for f in fx] == ["stage-shots-foo-2026-stage1-s12345678"]
+
+
+def test_audited_filter_drops_zero_shot_fixtures(tmp_path: Path) -> None:
+    _write_audit(tmp_path, "stage-shots-foo-2026-stage1-s12345678", n_shots=3)
+    _write_audit(tmp_path, "stage-shots-foo-2026-stage2-s12345678", n_shots=0)
+    fx_all = registry.all_fixtures(tmp_path)
+    assert len(fx_all) == 2  # both discovered
+    # ``audited`` uses module-level FIXTURES_DIR by default; we have to
+    # monkeypatch the discovery to point at the temp dir for the helper
+    # to filter against the right set. Easiest: reuse all_fixtures(dir).
+    audited = [f for f in registry.all_fixtures(tmp_path) if f.audited]
+    assert [f.stem for f in audited] == ["stage-shots-foo-2026-stage1-s12345678"]
+
+
+def test_filters_by_mount_and_shooter(tmp_path: Path, monkeypatch) -> None:
+    _write_audit(tmp_path, "stage-shots-m-2026-stage1-saaaa1111", mount="head", shooter_id="saaaa1111")
+    _write_audit(tmp_path, "stage-shots-m-2026-stage2-saaaa1111", mount="hand", shooter_id="saaaa1111")
+    _write_audit(tmp_path, "stage-shots-m-2026-stage3-sbbbb2222", mount="head", shooter_id="sbbbb2222")
+    monkeypatch.setattr(registry, "FIXTURES_DIR", tmp_path)
+    registry.all_fixtures.cache_clear()
+
+    head_a = registry.audited(mount="head", shooter_id="saaaa1111")
+    assert [f.stem for f in head_a] == ["stage-shots-m-2026-stage1-saaaa1111"]
+
+    head_all = registry.fixture_stems(mount="head")
+    assert head_all == [
+        "stage-shots-m-2026-stage1-saaaa1111",
+        "stage-shots-m-2026-stage3-sbbbb2222",
+    ]
+
+
+def test_exclude_wrong_clip_strips_known_bad_video_fixtures(
+    tmp_path: Path, monkeypatch
+) -> None:
+    bad = next(iter(registry.WRONG_CLIP_FIXTURES))
+    good = "stage-shots-good-2026-stage1-s12345678"
+    _write_audit(tmp_path, bad)
+    _write_audit(tmp_path, good)
+    monkeypatch.setattr(registry, "FIXTURES_DIR", tmp_path)
+    registry.all_fixtures.cache_clear()
+
+    without_filter = registry.fixture_stems()
+    assert bad in without_filter and good in without_filter
+    with_filter = registry.fixture_stems(exclude_wrong_clip=True)
+    assert bad not in with_filter and good in with_filter
+
+
+def test_fixture_stems_is_sorted_for_stable_iteration(tmp_path: Path, monkeypatch) -> None:
+    """Discovery returns stems in lexicographic order so downstream code
+    that depends on iteration order (folds, train/test splits) gets the
+    same answer regardless of filesystem walk order."""
+    for stem in (
+        "stage-shots-foo-2026-stage3-s12345678",
+        "stage-shots-foo-2026-stage1-s12345678",
+        "stage-shots-foo-2026-stage2-s12345678",
+    ):
+        _write_audit(tmp_path, stem)
+    monkeypatch.setattr(registry, "FIXTURES_DIR", tmp_path)
+    registry.all_fixtures.cache_clear()
+    stems = registry.fixture_stems()
+    assert stems == sorted(stems)
+
+
+def test_real_corpus_has_audited_headcam_fixtures() -> None:
+    """Anchor test against the actual ``tests/fixtures/`` corpus -- catches
+    a regression where discovery silently returns an empty list (e.g.
+    if FIXTURES_DIR resolves to the wrong path after a refactor).
+
+    The exact count grows over time, so we only assert lower bounds and
+    invariants. The corpus had 13 audited headcam fixtures from shooter
+    s97dcec94 at the time this registry shipped (#302)."""
+    head_s97 = registry.audited(mount="head", shooter_id="s97dcec94")
+    assert len(head_s97) >= 13
+    assert all(f.is_headcam for f in head_s97)
+    assert all(f.audited for f in head_s97)
+    # Every discovered headcam fixture must have a stage number parsed
+    # out of its stem -- if this fails the regex needs widening.
+    assert all(f.stage_number is not None for f in head_s97)
+
+
+def test_real_corpus_camera_classes_partition_audited() -> None:
+    """Every audited fixture maps to one of the two known camera classes."""
+    audited = [f for f in registry.all_fixtures() if f.audited]
+    classes = {f.camera_class for f in audited}
+    assert classes <= {"headcam", "handheld"}
+    # No audited fixture should be missing a mount.
+    assert all(f.mount in {"head", "hand"} for f in audited)


### PR DESCRIPTION
## Summary

- New \`splitsmith.ensemble.fixtures\` module discovers audit JSONs under \`tests/fixtures/\` at first call. \`Fixture\` descriptors expose mount / shooter / match / expected_rounds / camera_class; filter helpers (\`audited()\`, \`fixture_stems()\`) replace the per-script literal lists.
- Migrates 11 scripts that each kept their own \`DEFAULT_FIXTURES\`. The drift this caused is on display in the diff: 8 \"small-12\" scripts grow to 13 because \`tallmilan-2026-stage4-s97dcec94\` was missing from the hand-maintained set; the 3 \"all-audited\" scripts converge to 40 (extracts previously had 39, build_ensemble_artifacts had 40 -- the source of #302).
- \`WRONG_CLIP_FIXTURES\` (Voter E video exclusion) lifted from \`build_ensemble_artifacts.py\` into the registry so every caller sees the same copy.

## Why this is auto-discovery rather than an explicit YAML

We considered an explicit registry with CI guarding new fixtures. Auto-discovery is strictly stronger: the failure mode of \"someone added a fixture and forgot to register it\" disappears entirely. The cost is one more directory walk per process; results are cached and the walk runs once. The few inputs that genuinely vary across scripts (\`mount=\"head\"\`, \`shooter_id=...\`) are now in the call site as filter args, not in a shared literal.

## Test plan

- [x] 8 new tests in \`tests/test_fixtures_registry.py\` cover discovery, audit/skip rules, mount/shooter/match filters, the wrong-clip exclusion, sort stability, and anchor against the real \`tests/fixtures/\` corpus (>= 13 headcam fixtures for s97dcec94 with required camera_class invariants).
- [x] Full suite passes (1105 passed, 15 skipped, excluding the pre-existing untracked \`tests/test_features_cross_bay_echo.py\` which references a constant that doesn't exist in \`features.py\`).
- [x] Smoke-test of all migrated scripts with \`--help\` confirms they import cleanly and \`DEFAULT_FIXTURES\` resolves to the expected count.

## Follow-ups + interactions

- Once this merges, the \`within-stage-amp-floor\` branch (#305) rebases. After rebase its Phase 0 corpus picks up the 8 newly committed \`s0fe3d797\` fixtures automatically via the registry.
- \`lofo_mining_experiment.py\` had no \`argparse\`, so \`--help\` runs the experiment; it then fails on stale \`-s97dcec94\` cache stems (#301). Pre-existing, not caused by this PR.
- \`scripts/eval_cwt_twopass.py\` keeps its hand-picked 4-stage canary set (intentional research subset, not a \`DEFAULT_FIXTURES\` analogue).

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)