### PR TITLE
ensemble: per-camera-model amplitude floor (closes #303 #304)

### DIFF
--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -47,10 +47,13 @@ from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble import features as feat
 from splitsmith.ensemble import visual as vis
 from splitsmith.ensemble.calibration import (
+    CAMERA_CLASS_HEADCAM,
     DEFAULT_CAMERA_CLASS,
     DEFAULT_VOTER_E_PROBE_FILENAME,
     camera_class_from_mount,
+    normalize_camera_model_key,
 )
+from splitsmith.ensemble.voters import within_stage_amp_anchor
 from splitsmith.ensemble.fixtures import (
     WRONG_CLIP_FIXTURES,
     fixture_stems,
@@ -131,6 +134,10 @@ def _build_universe(
         truth = json.loads(truth_path.read_text())
         camera_block = truth.get("camera") or {}
         cam_class = camera_class_from_mount(camera_block.get("mount"))
+        cam_make = camera_block.get("make")
+        cam_model = camera_block.get("model")
+        stage_rounds_block = truth.get("stage_rounds") or {}
+        expected_rounds_int: int | None = stage_rounds_block.get("expected")
         audio, sr = load_audio(wav_path)
         cfg = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
         shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg)
@@ -172,8 +179,12 @@ def _build_universe(
                 {
                     "fixture": fix,
                     "camera_class": cam_class,
+                    "camera_make": cam_make,
+                    "camera_model": cam_model,
+                    "expected_rounds": expected_rounds_int,
                     "label": labels[i],
                     "confidence": float(shot.confidence),
+                    "peak_amp": float(shot.peak_amplitude),
                     "clap_diff": float(clap_diff[i]),
                     "gunshot_prob": float(gunshot_prob[i]),
                     "hand_feats": hand[i].tolist(),
@@ -181,6 +192,81 @@ def _build_universe(
                 }
             )
     return universe
+
+
+def _amp_floors_by_camera_model(
+    universe: list[dict],
+    *,
+    max_tp_loss: float = 0.05,
+    log: Callable[[str], None] = print,
+) -> dict[str, float]:
+    """Issue #304: per-camera-model safe-ceiling within-stage amplitude floor.
+
+    For each headcam-class camera model in the universe, sweep
+    ``r in [0.05, 0.35]`` and pick the *largest* value where dropping
+    candidates with ``peak_amp < r * within_stage_anchor`` would lose at
+    most ``max_tp_loss`` of that model's positives. Anchor uses each
+    fixture's ``stage_rounds.expected`` (the same logic as the runtime
+    veto), falling back to the p75 of in-fixture peaks when no prior.
+
+    Sweep operates on the full voter-A universe (no consensus pre-filter)
+    -- voters A and B preserve recall by construction and voter C is at
+    95% recall, so consensus-passing TPs are >= 95% of the universe TPs.
+    The ~5% denominator difference doesn't change which side of the
+    cliff a threshold lands on.
+
+    Models with no positives or no calibrated key (``make`` or ``model``
+    is None) are omitted; the runtime falls back to the engine default
+    for those.
+    """
+    rows_by_model: dict[str, list[dict]] = {}
+    for row in universe:
+        if row.get("camera_class") != CAMERA_CLASS_HEADCAM:
+            continue
+        key = normalize_camera_model_key(row.get("camera_make"), row.get("camera_model"))
+        if key is None:
+            continue
+        rows_by_model.setdefault(key, []).append(row)
+
+    r_grid = tuple(round(0.05 + 0.01 * i, 2) for i in range(31))  # 0.05 .. 0.35 inclusive
+    out: dict[str, float] = {}
+    for key, rows in rows_by_model.items():
+        # Group rows by fixture to compute per-stage anchors.
+        by_fix: dict[str, list[dict]] = {}
+        for r in rows:
+            by_fix.setdefault(r["fixture"], []).append(r)
+
+        ratios: list[tuple[float, int]] = []  # (peak_amp / anchor, label)
+        for fix_rows in by_fix.values():
+            peaks = np.array([r["peak_amp"] for r in fix_rows], dtype=np.float64)
+            expected = fix_rows[0].get("expected_rounds")
+            anchor = within_stage_amp_anchor(peaks, expected)
+            denom = anchor if anchor > 1e-9 else 1.0
+            for fr in fix_rows:
+                ratios.append((float(fr["peak_amp"]) / denom, int(fr["label"])))
+
+        n_pos = sum(1 for _, lbl in ratios if lbl == 1)
+        n_neg = sum(1 for _, lbl in ratios if lbl == 0)
+        if n_pos == 0:
+            log(f"  {key}: 0 positives, skipping per-model floor")
+            continue
+
+        picked: float | None = None
+        picked_fp_cut: int = 0
+        for r in r_grid:
+            tp_cut = sum(1 for ratio, lbl in ratios if lbl == 1 and ratio < r)
+            if tp_cut / n_pos <= max_tp_loss:
+                picked = r
+                picked_fp_cut = sum(1 for ratio, lbl in ratios if lbl == 0 and ratio < r)
+        if picked is None:
+            log(f"  {key}: no r meets TP-loss budget {max_tp_loss:.0%}; skipping")
+            continue
+        log(
+            f"  {key}: r={picked:.2f}  (TP loss budget={max_tp_loss:.0%}, "
+            f"cuts {picked_fp_cut}/{n_neg} FPs of {n_pos} TPs)"
+        )
+        out[key] = picked
+    return out
 
 
 def _voter_a_floor(universe: list[dict]) -> float:
@@ -212,10 +298,7 @@ def _x_from(universe: list[dict]) -> np.ndarray:
     if not universe:
         return np.zeros((0, feat.VOTER_C_FEATURE_DIM), dtype=np.float64)
     base = np.array(
-        [
-            c["hand_feats"] + c["clap_sims"] + [c["clap_diff"], c["gunshot_prob"]]
-            for c in universe
-        ],
+        [c["hand_feats"] + c["clap_sims"] + [c["clap_diff"], c["gunshot_prob"]] for c in universe],
         dtype=np.float64,
     )
     classes = [c.get("camera_class", DEFAULT_CAMERA_CLASS) for c in universe]
@@ -428,6 +511,8 @@ def _train_voter_c_for_class(rows: list[dict], target_recall: float):
     )
     clf.fit(X, y)
     return clf, threshold, cv_probs, y
+
+
 DEFAULT_VOTER_E_TARGET_RECALL: float = 0.95
 VISUAL_CACHE_SUFFIX = "_visual.npz"
 
@@ -535,9 +620,7 @@ def _build_visual_universe(
         if embeddings is None:
             audio, sr = load_audio(wav_path)
             cfg = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
-            shots = detect_shots(
-                audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg
-            )
+            shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg)
             if not shots:
                 continue
             cand_t = np.array([s.time_absolute for s in shots], dtype=np.float64)
@@ -549,9 +632,7 @@ def _build_visual_universe(
                 source_beep_time=float(window[0]) + float(truth["beep_time"]),
             )
             try:
-                embeds = vis.compute_visual_features(
-                    source_video, source_times, _ensure_runtime()
-                )
+                embeds = vis.compute_visual_features(source_video, source_times, _ensure_runtime())
             except Exception as exc:
                 log(f"  skip {fix}: visual feature extraction failed -- {exc}")
                 continue
@@ -604,9 +685,7 @@ def _train_voter_e(
         return None, None
 
     binary = [
-        row
-        for row in visual_universe
-        if row["label"] == 1 or row.get("subclass") == "cross_bay"
+        row for row in visual_universe if row["label"] == 1 or row.get("subclass") == "cross_bay"
     ]
     if len(binary) < 20 or sum(1 for r in binary if r["label"] == 1) < 5:
         log(
@@ -626,13 +705,9 @@ def _train_voter_e(
     for held in range(len(fixtures)):
         train_mask = groups != held
         test_mask = groups == held
-        if train_mask.sum() < 10 or y[train_mask].sum() == 0 or (
-            y[train_mask] == 0
-        ).sum() == 0:
+        if train_mask.sum() < 10 or y[train_mask].sum() == 0 or (y[train_mask] == 0).sum() == 0:
             continue
-        clf = LogisticRegression(
-            C=1.0, max_iter=1000, class_weight="balanced", solver="lbfgs"
-        )
+        clf = LogisticRegression(C=1.0, max_iter=1000, class_weight="balanced", solver="lbfgs")
         clf.fit(X[train_mask], y[train_mask])
         cv_probs[test_mask] = clf.predict_proba(X[test_mask])[:, 1]
     if np.isnan(cv_probs).any():
@@ -642,9 +717,7 @@ def _train_voter_e(
         y = y[valid]
     threshold = _threshold_for_recall(cv_probs.astype(np.float64), y, target_recall)
 
-    final = LogisticRegression(
-        C=1.0, max_iter=1000, class_weight="balanced", solver="lbfgs"
-    )
+    final = LogisticRegression(C=1.0, max_iter=1000, class_weight="balanced", solver="lbfgs")
     final.fit(X, y)
     log(
         f"  Voter E: trained on {len(binary)} samples "
@@ -783,10 +856,7 @@ def build_artifacts(
             fixtures, tolerance_ms, rebuild=rebuild_visual, log=log
         )
         if missing_video:
-            log(
-                "  skipped (source_video unreachable): "
-                + ", ".join(sorted(missing_video))
-            )
+            log("  skipped (source_video unreachable): " + ", ".join(sorted(missing_video)))
         voter_e_probe, voter_e_threshold = _train_voter_e(
             visual_universe, target_recall=voter_e_target_recall, log=log
         )
@@ -797,6 +867,10 @@ def build_artifacts(
         }
         if voter_e_probe is not None and DEFAULT_CAMERA_CLASS in thresholds_by_class:
             thresholds_by_class[DEFAULT_CAMERA_CLASS]["voter_e_threshold"] = voter_e_threshold
+
+    # Per-camera-model within-stage amplitude floor (#304).
+    log("Per-model within-stage amplitude floor:")
+    amp_floor_by_model = _amp_floors_by_camera_model(universe, log=log)
 
     # Default-class top-level fields. Existing code paths that haven't
     # migrated to ``thresholds_for(camera_class)`` keep reading the
@@ -834,12 +908,17 @@ def build_artifacts(
         "n_calibration_positives": int(n_pos),
         "voter_c_feature_dim": feat.VOTER_C_FEATURE_DIM,
         "voter_e_clip_model_id": vis.CLIP_VISUAL_MODEL_ID if voter_e_probe is not None else None,
-        "voter_e_frame_offsets": list(vis.DEFAULT_FRAME_OFFSETS) if voter_e_probe is not None else None,
-        "voter_e_probe_artifact": DEFAULT_VOTER_E_PROBE_FILENAME if voter_e_probe is not None else None,
+        "voter_e_frame_offsets": (
+            list(vis.DEFAULT_FRAME_OFFSETS) if voter_e_probe is not None else None
+        ),
+        "voter_e_probe_artifact": (
+            DEFAULT_VOTER_E_PROBE_FILENAME if voter_e_probe is not None else None
+        ),
         "voter_e_audio_strong_min_votes_recommended": 3 if voter_e_probe is not None else None,
         "built_at": dt.datetime.now(dt.UTC).isoformat(),
         "default_camera_class": default_cls,
         "thresholds_by_camera_class": thresholds_by_class,
+        "amp_floor_by_camera_model": amp_floor_by_model or None,
         "voter_c_metrics_by_camera_class": metrics_by_class,
         "voter_e_provenance": voter_e_provenance,
         **mining_provenance,

--- a/src/splitsmith/data/ensemble_calibration.json
+++ b/src/splitsmith/data/ensemble_calibration.json
@@ -81,7 +81,7 @@
   ],
   "voter_e_probe_artifact": "voter_e_visual_probe.joblib",
   "voter_e_audio_strong_min_votes_recommended": 3,
-  "built_at": "2026-05-11T20:01:15.230670+00:00",
+  "built_at": "2026-05-12T07:18:44.562506+00:00",
   "default_camera_class": "headcam",
   "thresholds_by_camera_class": {
     "handheld": {
@@ -149,6 +149,10 @@
       ],
       "voter_e_threshold": 0.3946628928992297
     }
+  },
+  "amp_floor_by_camera_model": {
+    "insta360 go 3s": 0.23,
+    "meta vanguard": 0.15
   },
   "voter_c_metrics_by_camera_class": {
     "handheld": {

--- a/src/splitsmith/ensemble/api.py
+++ b/src/splitsmith/ensemble/api.py
@@ -251,6 +251,8 @@ def detect_shots_ensemble(
     expected_rounds: int | None = None,
     ensemble_config: EnsembleConfig | None = None,
     camera_class: str | None = None,
+    camera_make: str | None = None,
+    camera_model: str | None = None,
     video_path: Path | None = None,
     source_beep_time: float | None = None,
 ) -> EnsembleResult:
@@ -271,6 +273,13 @@ def detect_shots_ensemble(
     calibration (issue #137). ``None`` falls back to the artifact's
     default class -- for existing projects that's ``headcam``, byte-
     identical to pre-#137 behaviour.
+
+    ``camera_make`` + ``camera_model`` are routed to the within-stage
+    amplitude floor lookup (issue #304). When both are set and the
+    calibrated ``amp_floor_by_camera_model`` table knows them, the veto
+    uses the per-model value; otherwise it falls back to
+    ``ensemble_config.within_stage_amp_floor`` (the generic-headcam
+    default). The veto itself remains headcam-only.
 
     ``video_path`` + ``source_beep_time`` enable Voter E (issue #183)
     when ``ensemble_config.enable_voter_e`` is True and ``runtime.visual``
@@ -366,15 +375,24 @@ def detect_shots_ensemble(
 
     effective_cam_class = camera_class or cal.default_camera_class
     amp_floor_vetoed = np.zeros(n, dtype=bool)
-    if cfg.within_stage_amp_floor is not None and effective_cam_class == "headcam":
-        new_keep = voters.within_stage_amp_veto(
-            peak_amps,
-            keep_mask,
-            expected_rounds=expected_rounds,
-            floor_ratio=cfg.within_stage_amp_floor,
+    if effective_cam_class == "headcam":
+        # Per-model override (#304) wins when the camera is calibrated;
+        # otherwise fall back to the engine-side generic-headcam default
+        # so any new model that shows up still gets the safe floor.
+        resolved_floor = cal.amp_floor_for(
+            camera_make,
+            camera_model,
+            default=cfg.within_stage_amp_floor,
         )
-        amp_floor_vetoed = keep_mask & ~new_keep
-        keep_mask = new_keep
+        if resolved_floor is not None:
+            new_keep = voters.within_stage_amp_veto(
+                peak_amps,
+                keep_mask,
+                expected_rounds=expected_rounds,
+                floor_ratio=resolved_floor,
+            )
+            amp_floor_vetoed = keep_mask & ~new_keep
+            keep_mask = new_keep
 
     candidates: list[EnsembleCandidate] = []
     for i in range(n):

--- a/src/splitsmith/ensemble/calibration.py
+++ b/src/splitsmith/ensemble/calibration.py
@@ -60,6 +60,25 @@ def camera_class_from_mount(mount: str | None) -> str:
     return _MOUNT_TO_CLASS.get(str(mount), DEFAULT_CAMERA_CLASS)
 
 
+def normalize_camera_model_key(make: str | None, model: str | None) -> str | None:
+    """Canonical lookup key for the per-model amplitude-floor table.
+
+    ``"Insta360", "GO 3S"`` becomes ``"insta360 go 3s"`` -- lower-cased
+    and whitespace-collapsed so ffprobe quirks ("INSTA360" vs "Insta360",
+    multiple spaces, trailing newlines) don't fragment the lookup.
+
+    Returns ``None`` when either input is missing or empty, signalling
+    the caller to fall back to the class default.
+    """
+    if not make or not model:
+        return None
+    norm_make = " ".join(str(make).strip().lower().split())
+    norm_model = " ".join(str(model).strip().lower().split())
+    if not norm_make or not norm_model:
+        return None
+    return f"{norm_make} {norm_model}"
+
+
 class ClassThresholds(BaseModel):
     """Per-camera-class voter thresholds + the slice of provenance they were derived from.
 
@@ -227,6 +246,45 @@ class EnsembleCalibration(BaseModel):
             "rebuilds to protect the dominant class."
         ),
     )
+    amp_floor_by_camera_model: dict[str, float] | None = Field(
+        default=None,
+        description=(
+            "Issue #304: per-camera-model within-stage amplitude floor. "
+            "Keys come from :func:`normalize_camera_model_key` (lower-cased "
+            '``"<make> <model>"``). Models present here override the '
+            "engine-side ``EnsembleConfig.within_stage_amp_floor`` default; "
+            "unknown models fall back to the config default (the "
+            "generic-headcam value). ``None`` on artifacts built before "
+            "per-model calibration -- everything falls back to the config "
+            "default, byte-identical to pre-#304 behaviour."
+        ),
+    )
+
+    def amp_floor_for(
+        self,
+        camera_make: str | None,
+        camera_model: str | None,
+        *,
+        default: float | None,
+    ) -> float | None:
+        """Resolve the within-stage amplitude floor for a given camera.
+
+        Lookup order:
+
+        1. ``amp_floor_by_camera_model[normalize_camera_model_key(...)]``
+           when both make and model are known and the key is calibrated.
+        2. ``default`` -- the caller's class-level / engine-side fallback
+           (Phase 1's ``EnsembleConfig.within_stage_amp_floor`` value, or
+           ``None`` to disable the veto entirely).
+
+        Returning ``None`` (only possible when ``default`` is ``None``)
+        means "no floor"; the veto is skipped.
+        """
+        if self.amp_floor_by_camera_model:
+            key = normalize_camera_model_key(camera_make, camera_model)
+            if key is not None and key in self.amp_floor_by_camera_model:
+                return self.amp_floor_by_camera_model[key]
+        return default
 
     def thresholds_for(self, camera_class: str | None) -> ClassThresholds:
         """Return calibrated thresholds for ``camera_class``, falling back to the default class.

--- a/src/splitsmith/ensemble/voters.py
+++ b/src/splitsmith/ensemble/voters.py
@@ -117,6 +117,31 @@ def apriori_boost(
     return out
 
 
+def within_stage_amp_anchor(
+    peak_amps: np.ndarray,
+    expected_rounds: int | None,
+    *,
+    fallback_percentile: float = 75.0,
+) -> float:
+    """Per-stage amplitude anchor used by the within-stage veto + per-model floor sweep.
+
+    Returns ``median(top-K peak_amps)`` where ``K = min(expected_rounds, n)``.
+    When ``expected_rounds`` is ``None`` or ``<= 0``, falls back to the
+    ``fallback_percentile`` of the input -- a robust proxy when no
+    round-count prior is available.
+
+    Returns ``0.0`` on empty input; callers either guard or treat the
+    zero as "no anchor, skip the veto".
+    """
+    if peak_amps.size == 0:
+        return 0.0
+    if expected_rounds and expected_rounds > 0:
+        k = min(int(expected_rounds), peak_amps.size)
+        top = np.sort(peak_amps)[-k:]
+        return float(np.median(top))
+    return float(np.percentile(peak_amps, fallback_percentile))
+
+
 def within_stage_amp_veto(
     peak_amps: np.ndarray,
     keep_mask: np.ndarray,
@@ -129,9 +154,7 @@ def within_stage_amp_veto(
     """Drop kept candidates whose peak_amp is too small for the stage.
 
     Headcam-only filter (the caller decides whether to invoke it).
-    Anchor: median of the top-K kept by peak_amp where
-    ``K = min(expected_rounds, n_kept)``. When ``expected_rounds`` is
-    ``None`` or 0, falls back to ``fallback_percentile`` of kept peak_amps.
+    Anchor: :func:`within_stage_amp_anchor` over the kept slice.
 
     Skipped when ``n_kept < min_kept_for_filter`` -- the anchor is too
     fragile on near-empty stages. Returns an updated keep_mask; never
@@ -144,12 +167,9 @@ def within_stage_amp_veto(
     if n_kept < min_kept_for_filter:
         return keep_mask
     kept_amps = peak_amps[kept_idx]
-    if expected_rounds and expected_rounds > 0:
-        k = min(int(expected_rounds), n_kept)
-        top = np.sort(kept_amps)[-k:]
-        anchor = float(np.median(top))
-    else:
-        anchor = float(np.percentile(kept_amps, fallback_percentile))
+    anchor = within_stage_amp_anchor(
+        kept_amps, expected_rounds, fallback_percentile=fallback_percentile
+    )
     if anchor <= 0.0:
         return keep_mask
     cutoff = floor_ratio * anchor

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -291,6 +291,14 @@ class StageVideo(BaseModel):
     # shot-detect and caches the result here. The user can override via
     # the project SPA / API at any time.
     camera_mount: str | None = None
+    # Issue #304: ffprobed camera make/model surfaced at register time and
+    # persisted on the project so the detector can dispatch a per-model
+    # within-stage amplitude floor. ``None`` when ffprobe couldn't read the
+    # tag (Vanguard glasses are the present example -- no QuickTime make/
+    # model). The user can override via the videos PATCH endpoint, same as
+    # ``camera_mount``.
+    camera_make: str | None = None
+    camera_model: str | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -1301,9 +1309,13 @@ class MatchProject(BaseModel):
         # user can correct via the videos PATCH endpoint.
         from ..fixture_schema import probe_camera_metadata
 
+        probed_make: str | None = None
+        probed_model: str | None = None
         try:
             probe = probe_camera_metadata(source)
             mount_default = _heuristic_mount_from_make(probe.make)
+            probed_make = probe.make
+            probed_model = probe.model
         except Exception:
             mount_default = None
 
@@ -1311,6 +1323,8 @@ class MatchProject(BaseModel):
             path=stored,
             match_timestamp=match_ts,
             camera_mount=mount_default,
+            camera_make=probed_make,
+            camera_model=probed_model,
         )
         self.unassigned_videos.append(video)
         return video

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2863,6 +2863,8 @@ def create_app(
             expected_rounds=expected_rounds,
             ensemble_config=ensemble_cfg,
             camera_class=cam_class,
+            camera_make=prim.camera_make,
+            camera_model=prim.camera_model,
             video_path=source if enable_e else None,
             source_beep_time=prim.beep_time if enable_e else None,
         )
@@ -5495,10 +5497,18 @@ def create_app(
                 + float(stage_time_seconds)
                 + float(project.trim_post_buffer_seconds)
             )
+            # Camera make/model (#303): use the values cached on the
+            # StageVideo at register time -- those came from ffprobe and
+            # the user may have overridden them via the videos PATCH
+            # endpoint. Both are ``None`` when ffprobe couldn't read the
+            # QuickTime tag (Meta Vanguard glasses are the present
+            # example -- no tag is exposed). The per-model amplitude
+            # floor lookup (#304) handles the ``None`` case by falling
+            # back to the generic-headcam floor.
             camera_payload: dict[str, Any] = {
                 "id": "unknown",
-                "make": None,
-                "model": None,
+                "make": primary.camera_make,
+                "model": primary.camera_model,
                 "mount": str(primary.camera_mount),
                 "position": "shooter",
                 "audio_source": "internal",

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -195,6 +195,71 @@ def test_consensus_keep_c_required_without_vote_c_raises() -> None:
         consensus_keep(vote_total, boost, threshold=3, c_required=True)
 
 
+def test_normalize_camera_model_key_canonicalizes_whitespace_and_case() -> None:
+    from splitsmith.ensemble.calibration import normalize_camera_model_key
+
+    assert normalize_camera_model_key("Insta360", "GO 3S") == "insta360 go 3s"
+    assert normalize_camera_model_key("INSTA360", "  GO  3S\n") == "insta360 go 3s"
+    assert normalize_camera_model_key("Meta", "Vanguard") == "meta vanguard"
+
+
+def test_normalize_camera_model_key_returns_none_when_either_input_missing() -> None:
+    from splitsmith.ensemble.calibration import normalize_camera_model_key
+
+    assert normalize_camera_model_key(None, "GO 3S") is None
+    assert normalize_camera_model_key("Insta360", None) is None
+    assert normalize_camera_model_key("", "GO 3S") is None
+    assert normalize_camera_model_key("Insta360", "  ") is None
+
+
+def test_amp_floor_for_prefers_per_model_over_default() -> None:
+    cal = EnsembleCalibration(
+        voter_a_floor=0.0,
+        voter_b_threshold=0.0,
+        voter_c_threshold=0.5,
+        voter_c_target_recall=0.95,
+        tolerance_ms=75.0,
+        clap_prompts_shot=list(CLAP_PROMPTS_SHOT),
+        clap_prompts=list(CLAP_PROMPTS),
+        calibration_fixtures=["stub"],
+        n_calibration_candidates=10,
+        n_calibration_positives=5,
+        voter_c_feature_dim=VOTER_C_FEATURE_DIM,
+        built_at="1970-01-01T00:00:00Z",
+        amp_floor_by_camera_model={"insta360 go 3s": 0.20, "meta vanguard": 0.15},
+    )
+    # Known model -> per-model value.
+    assert cal.amp_floor_for("Insta360", "GO 3S", default=0.30) == 0.20
+    # Known model with different casing still matches the canonical key.
+    assert cal.amp_floor_for("insta360", "go 3s", default=0.30) == 0.20
+    # Unknown model -> default.
+    assert cal.amp_floor_for("Random", "Camera", default=0.15) == 0.15
+    # Missing metadata -> default.
+    assert cal.amp_floor_for(None, None, default=0.15) == 0.15
+
+
+def test_amp_floor_for_returns_default_when_per_model_table_absent() -> None:
+    """Pre-#304 calibration artifacts have no per-model table; the lookup
+    must still hand back the caller's default rather than crashing."""
+    cal = EnsembleCalibration(
+        voter_a_floor=0.0,
+        voter_b_threshold=0.0,
+        voter_c_threshold=0.5,
+        voter_c_target_recall=0.95,
+        tolerance_ms=75.0,
+        clap_prompts_shot=list(CLAP_PROMPTS_SHOT),
+        clap_prompts=list(CLAP_PROMPTS),
+        calibration_fixtures=["stub"],
+        n_calibration_candidates=10,
+        n_calibration_positives=5,
+        voter_c_feature_dim=VOTER_C_FEATURE_DIM,
+        built_at="1970-01-01T00:00:00Z",
+    )
+    assert cal.amp_floor_by_camera_model is None
+    assert cal.amp_floor_for("Insta360", "GO 3S", default=0.15) == 0.15
+    assert cal.amp_floor_for("Insta360", "GO 3S", default=None) is None
+
+
 def test_within_stage_amp_veto_drops_quiet_kept_candidates() -> None:
     """5 kept candidates, expected_rounds=4. Top-4 by peak_amp are
     [1.0, 0.9, 0.8, 0.7] -> median anchor = 0.85. At floor_ratio=0.20
@@ -596,6 +661,73 @@ def test_detect_shots_ensemble_within_stage_amp_floor_skipped_on_handheld(
     )
     assert all(c.kept for c in result.candidates)
     assert not any(c.amp_floor_vetoed for c in result.candidates)
+
+
+def test_detect_shots_ensemble_within_stage_amp_floor_uses_per_model_override(
+    monkeypatch,
+) -> None:
+    """Per-model floor from the calibration (#304) wins over the
+    EnsembleConfig default. Same fixture as the headcam-drops-quiet test
+    but with a much more aggressive per-model floor (0.50) so candidates
+    that would have survived the 0.15 config default get cut here.
+    """
+    runtime = _build_stub_runtime()
+    # Inject a per-model override on the stub calibration.
+    runtime.calibration = runtime.calibration.model_copy(
+        update={"amp_floor_by_camera_model": {"meta vanguard": 0.50}}
+    )
+    peak_amps = [1.0, 0.9, 0.8, 0.7, 0.05]
+    # Anchor = median(top-4 of [1, .9, .8, .7]) = 0.85.
+    # At per-model floor 0.50: cutoff = 0.50 * 0.85 = 0.425. So 0.7
+    # survives, 0.05 doesn't, and 0.8/0.9/1.0 survive.
+    # If the config default (0.15) had been used instead, only 0.05 would
+    # have dropped (cutoff 0.1275), so anything > 0.1275 survives.
+    fake_shots = [
+        Shot(
+            shot_number=i + 1,
+            time_absolute=5.0 + i * 0.3,
+            time_from_beep=i * 0.3,
+            split=0.3 if i > 0 else 5.0,
+            peak_amplitude=amp,
+            confidence=0.6,
+            notes="",
+        )
+        for i, amp in enumerate(peak_amps)
+    ]
+    from splitsmith.ensemble import api as ensemble_api
+    from splitsmith.ensemble import features as ensemble_features
+
+    monkeypatch.setattr(ensemble_api, "detect_shots", lambda *a, **kw: fake_shots)
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_clap_similarities",
+        lambda audio, sr, times, runtime: np.full(
+            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
+        ),
+    )
+    monkeypatch.setattr(
+        ensemble_features,
+        "compute_pann_gunshot_probs",
+        lambda audio, sr, times, runtime: np.full(len(times), 0.9, dtype=np.float32),
+    )
+
+    audio = np.zeros(48_000 * 20, dtype=np.float32)
+    result = detect_shots_ensemble(
+        audio,
+        48_000,
+        beep_time=5.0,
+        stage_time=10.0,
+        runtime=runtime,
+        expected_rounds=4,
+        camera_class="headcam",
+        camera_make="Meta",
+        camera_model="Vanguard",
+    )
+    kept = [c.kept for c in result.candidates]
+    vetoed = [c.amp_floor_vetoed for c in result.candidates]
+    # 0.7 survives the 0.50 floor (ratio 0.82 > 0.50); 0.05 does not (0.06 < 0.50).
+    assert kept == [True, True, True, True, False]
+    assert vetoed == [False, False, False, False, True]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #303 and #304. The UI dropdown for explicit camera selection when ffprobe yields nothing is the planned follow-up PR.

## Summary

Per-camera-model within-stage amplitude floor calibration with auto-probe at promotion time, threaded through to the runtime.

Phase 1 (#305) shipped a single global default ``r=0.15`` because that was the conservative ceiling across two known headcams: Meta Vanguard cliffs at r=0.20 (14.5% TP loss) while Insta360 GO 3S handles r=0.20 fine (3.4% TP loss). This PR replaces the global default with per-model values picked at build time, with an explicit fallback chain so unknown cameras stay safe.

## Lookup chain at runtime

1. ``EnsembleCalibration.amp_floor_by_camera_model[normalize_camera_model_key(make, model)]`` -- per-model override when both make and model match a calibrated key.
2. ``EnsembleConfig.within_stage_amp_floor`` -- the engine-side generic-headcam default (still 0.15). Catches new headcam models that haven't been calibrated yet.
3. Veto stays headcam-only -- handheld cameras remain a no-op (mic-decoupled-from-gun, the assumption Phase 1 relies on breaks there).

Pre-#304 calibration artifacts have ``amp_floor_by_camera_model = None``; the lookup falls back to the engine default, byte-identical to today.

## Numbers from the freshly-built calibration

| Model            | Picked r | FPs cut          | TP loss budget |
|------------------|----------|------------------|----------------|
| insta360 go 3s   | 0.23     | 285 / 769 (37%)  | <= 5%          |
| meta vanguard    | 0.15     | 241 / 393 (61%)  | <= 5%          |

Sweep operates on the full voter-A universe (no consensus pre-filter). Voters A/B preserve recall by construction and voter C is at 95% recall, so the ~5% denominator difference between voter-A and consensus-passing TPs doesn't change which side of the cliff a threshold lands on.

## How the make/model gets to the runtime

1. ``probe_camera_metadata`` (already existed) runs on every video registered through the UI. Its result is now persisted on ``StageVideo.camera_make`` / ``camera_model`` instead of discarded after the heuristic mount lookup.
2. ``/api/stages/{n}/shot-detect`` reads those off ``primary`` and passes them to ``detect_shots_ensemble``.
3. UI promotion endpoint reads them off ``primary`` and writes them into ``camera_payload`` instead of hardcoding ``None`` / ``None`` (this is the #303 fix; new s0fe3d797-style fixtures will arrive with make/model populated automatically).
4. Meta Vanguard glasses are a known case where ffprobe can't read the QuickTime tag. They keep arriving with ``None``/``None`` until the UI dropdown lands; until then the engine's generic-headcam fallback covers them.

## Test plan

- [x] 1121 tests pass (15 skipped, excluding the pre-existing untracked ``tests/test_features_cross_bay_echo.py``).
- [x] 5 new unit tests: ``normalize_camera_model_key`` (canonicalization + None handling), ``amp_floor_for`` (per-model preferred, default fallback, legacy artifacts).
- [x] 1 new integration test: per-model override drives a more aggressive cut than the engine default in ``detect_shots_ensemble``.
- [x] Retrained artifact has both ``headcam`` and ``handheld`` GBDTs at dim 31, ``amp_floor_by_camera_model`` populated for the two known models.

## Caveats

- Per-model sweep operates on the full voter-A universe rather than the consensus-passing subset (see commit message rationale -- the difference is at most ~5% in either direction).
- The sweep grid is fixed at ``[0.05, 0.35]`` in 0.01 steps. Models needing values outside this range would need the grid widened; the present two land well inside.
- The Vanguard data still has the same cliff at r=0.20 my Phase 1 work measured. The 5% TP-loss budget picks r=0.15 for it; widening the budget to 6% would not safely raise it past the cliff.
- UI camera-selector dropdown is the explicit follow-up. Today, if ffprobe yields nothing, the generic-headcam fallback applies; the user can override via the existing ``/api/stages/{n}/videos/{vid}/camera-mount`` endpoint -- but there's no analogous PATCH for ``camera_make`` / ``camera_model`` yet.

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)