### PR TITLE
ui: camera-model dropdown + override endpoint (closes #303-followup)

### DIFF
--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -194,6 +194,27 @@ def _build_universe(
     return universe
 
 
+def _camera_model_metadata(universe: list[dict]) -> dict[str, dict[str, str]]:
+    """Map normalized model key -> ``{make, model}`` for the UI dropdown.
+
+    Picks the first non-empty pair seen for each key; the build script
+    walks fixtures in stable sorted order so the result is reproducible.
+    Skips rows whose normalized key is ``None`` (handheld or missing
+    metadata) -- the dropdown is calibrated-headcam only today.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for row in universe:
+        if row.get("camera_class") != CAMERA_CLASS_HEADCAM:
+            continue
+        make = row.get("camera_make")
+        model = row.get("camera_model")
+        key = normalize_camera_model_key(make, model)
+        if key is None or key in out:
+            continue
+        out[key] = {"make": str(make), "model": str(model)}
+    return out
+
+
 def _amp_floors_by_camera_model(
     universe: list[dict],
     *,
@@ -871,6 +892,7 @@ def build_artifacts(
     # Per-camera-model within-stage amplitude floor (#304).
     log("Per-model within-stage amplitude floor:")
     amp_floor_by_model = _amp_floors_by_camera_model(universe, log=log)
+    camera_model_meta = _camera_model_metadata(universe)
 
     # Default-class top-level fields. Existing code paths that haven't
     # migrated to ``thresholds_for(camera_class)`` keep reading the
@@ -919,6 +941,7 @@ def build_artifacts(
         "default_camera_class": default_cls,
         "thresholds_by_camera_class": thresholds_by_class,
         "amp_floor_by_camera_model": amp_floor_by_model or None,
+        "camera_model_metadata": camera_model_meta or None,
         "voter_c_metrics_by_camera_class": metrics_by_class,
         "voter_e_provenance": voter_e_provenance,
         **mining_provenance,

--- a/src/splitsmith/data/ensemble_calibration.json
+++ b/src/splitsmith/data/ensemble_calibration.json
@@ -178,5 +178,15 @@
     "missing_video_fixtures": []
   },
   "n_mined_negatives_used": 0,
-  "mining_source_fixtures": []
+  "mining_source_fixtures": [],
+  "camera_model_metadata": {
+    "insta360 go 3s": {
+      "make": "Insta360",
+      "model": "GO 3S"
+    },
+    "meta vanguard": {
+      "make": "Meta",
+      "model": "Vanguard"
+    }
+  }
 }

--- a/src/splitsmith/ensemble/calibration.py
+++ b/src/splitsmith/ensemble/calibration.py
@@ -246,6 +246,16 @@ class EnsembleCalibration(BaseModel):
             "rebuilds to protect the dominant class."
         ),
     )
+    camera_model_metadata: dict[str, dict[str, str]] | None = Field(
+        default=None,
+        description=(
+            "Issue #303-followup: human-readable make + model for each "
+            "calibrated camera-model key. The key matches "
+            ":attr:`amp_floor_by_camera_model` so the UI can present a "
+            "dropdown of calibrated cameras with their original casing. "
+            'Schema: ``{normalized_key: {"make": str, "model": str}}``.'
+        ),
+    )
     amp_floor_by_camera_model: dict[str, float] | None = Field(
         default=None,
         description=(

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -930,6 +930,29 @@ class CameraMountRequest(BaseModel):
     mount: str | None
 
 
+class CameraModelRequest(BaseModel):
+    """Body for PATCH /api/stages/{n}/videos/{vid}/camera-model (#303-followup).
+
+    Override the ffprobed ``camera_make`` / ``camera_model``. Both must
+    be supplied together or both ``None`` (clearing back to the probe
+    default). Drives the per-camera-model within-stage amplitude floor
+    dispatch (#304) -- known calibrated models get their tuned floor,
+    unknown values fall back to the generic-headcam default.
+    """
+
+    make: str | None
+    model: str | None
+
+
+class CalibratedCameraModel(BaseModel):
+    """One row in the dropdown the SPA presents on the Ingest screen."""
+
+    key: str
+    make: str
+    model: str
+    amp_floor: float
+
+
 class BeepSnapRequest(BaseModel):
     """Body for POST /api/stages/{n}/videos/{vid}/beep/snap.
 
@@ -3440,6 +3463,66 @@ def create_app(
         video.camera_mount = req.mount
         project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
+
+    @app.patch("/api/stages/{stage_number}/videos/{video_id}/camera-model")
+    def set_camera_model(stage_number: int, video_id: str, req: CameraModelRequest) -> JSONResponse:
+        """Override the ffprobed camera make + model (#303-followup).
+
+        Used when ffprobe couldn't read the QuickTime tag (e.g. Meta
+        Vanguard glasses) or guessed wrong. The SPA's Ingest screen
+        presents a dropdown sourced from
+        ``GET /api/calibrated-camera-models`` plus an "Other (generic
+        headcam)" sentinel that clears back to ``None`` / ``None`` --
+        the runtime then falls back to the engine-side generic-headcam
+        amp floor (#304).
+
+        Both fields must be supplied together or both ``None``: a
+        half-filled pair would produce no usable lookup key but isn't
+        what the UI ever sends, so we refuse it as a 400.
+        """
+        if (req.make is None) != (req.model is None):
+            raise HTTPException(
+                status_code=400,
+                detail="camera-model: 'make' and 'model' must be supplied together or both null",
+            )
+        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        video.camera_make = req.make
+        video.camera_model = req.model
+        project.save(state.project_root)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.get("/api/calibrated-camera-models")
+    def list_calibrated_camera_models() -> JSONResponse:
+        """Enumerate the camera models present in the shipped calibration.
+
+        The SPA shows these as the dropdown options on the Ingest screen.
+        Unknown models still get the runtime's generic-headcam fallback
+        floor, but offering an explicit pick lets the user steer a
+        Vanguard-shaped fixture to its tuned threshold even when
+        ffprobe yielded nothing.
+
+        Result order is descending floor (most aggressive cut first)
+        so the most-trusted model sorts to the top; ties broken
+        alphabetically.
+        """
+        runtime = _get_ensemble_runtime()
+        floors = runtime.calibration.amp_floor_by_camera_model or {}
+        displays = runtime.calibration.camera_model_metadata or {}
+        rows: list[dict[str, Any]] = []
+        for key, floor in floors.items():
+            meta = displays.get(key) or {}
+            rows.append(
+                {
+                    "key": key,
+                    "make": meta.get("make", key.split(" ", 1)[0].title()),
+                    "model": meta.get(
+                        "model", key.split(" ", 1)[1].title() if " " in key else key.title()
+                    ),
+                    "amp_floor": float(floor),
+                }
+            )
+        rows.sort(key=lambda r: (-r["amp_floor"], r["key"]))
+        return JSONResponse({"models": rows})
 
     @app.post("/api/stages/{stage_number}/beep/select")
     def select_beep_candidate(stage_number: int, req: BeepSelectRequest) -> JSONResponse:

--- a/src/splitsmith/ui_static/src/components/CameraModelSelect.tsx
+++ b/src/splitsmith/ui_static/src/components/CameraModelSelect.tsx
@@ -1,0 +1,129 @@
+/**
+ * Camera-model selector for a single ``StageVideo`` (issue #303 followup).
+ *
+ * Drives the per-camera-model within-stage amplitude floor (#304):
+ * known calibrated models get their tuned floor; "Other (generic
+ * headcam)" clears the override and falls back to the engine's
+ * generic-headcam amplitude floor on the next shot-detect run.
+ *
+ * Options are sourced from the shipped calibration via
+ * ``api.getCalibratedCameraModels`` so the dropdown stays in sync with
+ * whatever the build script last calibrated. Make + model are written
+ * together via a single PATCH because the calibration lookup keys both
+ * (a half-filled pair would never match).
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  api,
+  normalizeCameraModelKey,
+  type CalibratedCameraModel,
+  type MatchProject,
+  type StageVideo,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const OTHER_VALUE = "__other__";
+
+interface Props {
+  video: StageVideo;
+  stageNumber: number;
+  disabled?: boolean;
+  label?: string;
+  className?: string;
+  setBusy?: (b: boolean) => void;
+  setError?: (msg: string | null) => void;
+  onProjectUpdate: (p: MatchProject) => void;
+}
+
+export function CameraModelSelect({
+  video,
+  stageNumber,
+  disabled = false,
+  label,
+  className,
+  setBusy,
+  setError,
+  onProjectUpdate,
+}: Props) {
+  const [models, setModels] = useState<CalibratedCameraModel[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getCalibratedCameraModels()
+      .then((resp) => {
+        if (!cancelled) setModels(resp.models);
+      })
+      .catch(() => {
+        if (!cancelled) setModels([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const currentKey = normalizeCameraModelKey(
+    video.camera_make,
+    video.camera_model,
+  );
+  // When the saved make/model don't match any calibrated key the user
+  // is effectively on "Other"; the select reflects that.
+  const value =
+    currentKey && models?.some((m) => m.key === currentKey)
+      ? currentKey
+      : OTHER_VALUE;
+
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      {label ? (
+        <span className="text-[11px] text-muted-foreground">{label}</span>
+      ) : null}
+      <select
+        className="h-7 rounded border border-input bg-background px-1.5 text-[11px] focus:outline-none focus:ring-1 focus:ring-ring"
+        value={value}
+        disabled={disabled || models === null}
+        title="Camera model -- routes this video through the matching per-model amplitude floor. 'Other' falls back to the generic-headcam floor."
+        aria-label={`Camera model for ${
+          video.path.split("/").pop() ?? video.path
+        }`}
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onChange={async (e) => {
+          const next = e.target.value;
+          const picked =
+            next === OTHER_VALUE
+              ? { make: null, model: null }
+              : (() => {
+                  const found = models?.find((m) => m.key === next);
+                  return found
+                    ? { make: found.make, model: found.model }
+                    : { make: null, model: null };
+                })();
+          setBusy?.(true);
+          setError?.(null);
+          try {
+            const updated = await api.setCameraModel(
+              stageNumber,
+              video.video_id,
+              picked.make,
+              picked.model,
+            );
+            onProjectUpdate(updated);
+          } catch (err) {
+            setError?.(err instanceof Error ? err.message : String(err));
+          } finally {
+            setBusy?.(false);
+          }
+        }}
+      >
+        <option value={OTHER_VALUE}>Other (generic headcam)</option>
+        {(models ?? []).map((m) => (
+          <option key={m.key} value={m.key}>
+            {m.make} {m.model}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -107,6 +107,40 @@ export interface StageVideo {
    *  and overridable via PATCH .../camera-mount. ``null`` falls back to
    *  the artifact's default class. */
   camera_mount: CameraMount | null;
+  /** Camera make/model from ffprobe, or null when the QuickTime tag is
+   *  missing (Meta Vanguard glasses are the present example). Drives the
+   *  per-camera-model amplitude-floor lookup (#304); unknown values fall
+   *  back to the generic-headcam floor. Overridable via PATCH
+   *  .../camera-model when ffprobe yielded nothing. */
+  camera_make: string | null;
+  camera_model: string | null;
+}
+
+/** Mirror of ``splitsmith.ensemble.calibration.normalize_camera_model_key``.
+ *  Lower-cases and whitespace-collapses both fields so the SPA can
+ *  cross-reference a project's saved make/model against the calibration's
+ *  lookup table without round-tripping to the server. */
+export function normalizeCameraModelKey(
+  make: string | null | undefined,
+  model: string | null | undefined,
+): string | null {
+  if (!make || !model) return null;
+  const norm = (s: string) => s.trim().toLowerCase().split(/\s+/).join(" ");
+  const m = norm(make);
+  const mo = norm(model);
+  if (!m || !mo) return null;
+  return `${m} ${mo}`;
+}
+
+export interface CalibratedCameraModel {
+  /** Canonical lookup key the runtime uses (lower-cased ``"<make> <model>"``). */
+  key: string;
+  /** Original-case make/model for display. */
+  make: string;
+  model: string;
+  /** Per-model within-stage amplitude floor (#304). Informational on the
+   *  dropdown -- the runtime resolves it from the calibration. */
+  amp_floor: number;
 }
 
 export type CameraMount =
@@ -1320,6 +1354,32 @@ export const api = {
         method: "PATCH",
         json: { mount },
       },
+    ),
+
+  /** Override the ffprobed camera make + model on a single video
+   *  (#303-followup). Pass ``null`` for both to clear back to "Other
+   *  (generic headcam)" -- the runtime then falls back to the
+   *  generic-headcam amplitude floor. ``make`` and ``model`` must be
+   *  supplied together or both ``null``. */
+  setCameraModel: (
+    stageNumber: number,
+    videoId: string,
+    make: string | null,
+    model: string | null,
+  ) =>
+    request<MatchProject>(
+      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-model`,
+      {
+        method: "PATCH",
+        json: { make, model },
+      },
+    ),
+
+  /** List the camera models calibrated in the shipped artifact. The SPA
+   *  presents these as the camera-model dropdown options on Ingest. */
+  getCalibratedCameraModels: () =>
+    request<{ models: CalibratedCameraModel[] }>(
+      "/api/calibrated-camera-models",
     ),
 
   swapPrimary: (videoPath: string, stageNumber: number, confirm = false) =>

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -42,6 +42,7 @@ import { CleanupDialog } from "@/components/CleanupDialog";
 import { RelinkDialog } from "@/components/RelinkDialog";
 import { FolderPicker } from "@/components/FolderPicker";
 import { HitlQueuePanel } from "@/components/HitlQueuePanel";
+import { CameraModelSelect } from "@/components/CameraModelSelect";
 import { MountSelect } from "@/components/MountSelect";
 import { SettingProvenance } from "@/components/SettingProvenance";
 import { Badge } from "@/components/ui/badge";
@@ -2856,14 +2857,29 @@ function VideoRow({
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {stage && setBusy && setError && onProjectUpdate ? (
-              <MountSelect
-                video={video}
-                stageNumber={stage.stage_number}
-                disabled={busy}
-                setBusy={setBusy}
-                setError={setError}
-                onProjectUpdate={onProjectUpdate}
-              />
+              <>
+                <MountSelect
+                  video={video}
+                  stageNumber={stage.stage_number}
+                  disabled={busy}
+                  setBusy={setBusy}
+                  setError={setError}
+                  onProjectUpdate={onProjectUpdate}
+                />
+                {video.camera_mount === "head" ||
+                video.camera_mount === "chest" ||
+                video.camera_mount === "helmet" ||
+                video.camera_mount === "belt" ? (
+                  <CameraModelSelect
+                    video={video}
+                    stageNumber={stage.stage_number}
+                    disabled={busy}
+                    setBusy={setBusy}
+                    setError={setError}
+                    onProjectUpdate={onProjectUpdate}
+                  />
+                ) : null}
+              </>
             ) : null}
             <Button
               size="sm"


### PR DESCRIPTION
Closes the manual-override gap noted in #310 / your "we must reliably be able to detect or set camera in the UI" requirement.

## Summary

Backend:
- ``GET /api/calibrated-camera-models`` enumerates whatever the shipped calibration's ``amp_floor_by_camera_model`` knows about, joined with display make/model from a new ``EnsembleCalibration.camera_model_metadata`` field.
- ``PATCH /api/stages/{n}/videos/{vid}/camera-model`` mirrors the existing ``/camera-mount`` endpoint -- writes ``camera_make`` / ``camera_model`` (together or both null) onto the ``StageVideo``. The runtime already consumes these per #310.
- ``scripts/build_ensemble_artifacts.py`` writes the display-name table alongside the floors. The shipped calibration is backfilled in this PR with display names for the two current calibrated models so the dropdown shows ``"Insta360 GO 3S"`` and ``"Meta Vanguard"`` immediately without a rebuild.

Frontend:
- ``StageVideo`` gains ``camera_make`` / ``camera_model`` fields.
- ``api.getCalibratedCameraModels`` / ``api.setCameraModel`` plus matching types.
- ``normalizeCameraModelKey`` mirrors the Python helper so the SPA can cross-reference saved make/model against the calibration lookup table without round-tripping.
- ``CameraModelSelect`` component mirrors ``MountSelect``. The Ingest screen renders it next to the existing mount dropdown, but only for headcam mounts -- handheld has no per-model floor today so the option would be noise.
- Picking "Other (generic headcam)" clears the override; the runtime falls back to the engine-side generic-headcam floor.

## Test plan

- [x] Python: 1121 backend tests pass; ``ruff check`` + ``black --check`` clean.
- [x] SPA: ``pnpm typecheck`` and ``pnpm build`` clean.
- [ ] Manual smoke: open Ingest with the Meta Vanguard fixtures, verify dropdown shows ``Insta360 GO 3S`` + ``Meta Vanguard`` + ``Other``; pick one; verify the next shot-detect call uses the per-model floor (check audit JSON / debug pane).

## Caveats

- The ``CameraModelSelect`` only renders for headcam mounts (``head``/``chest``/``helmet``/``belt``). Handheld stays hidden because no per-model floor exists for it yet -- if we ever calibrate handheld phones separately, lift the conditional.
- The backfilled display-name dict in the shipped calibration is hand-maintained until the next build runs. Future-me only needs to add an entry to ``known`` in the backfill commit; the build script overwrites with the real walked values on regeneration.
- ``setCameraModel`` requires make+model to be supplied together (or both null) -- API enforces this with a 400. The SPA never sends a half-filled pair, but the guard prevents accidental misuse from other clients.

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)