### PR TITLE
audit: pin /videos/stream so background trim can't desync the player

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4366,15 +4366,29 @@ def create_app(
         return FileResponse(target, media_type=media_type, filename=target.name)
 
     @app.get("/api/videos/stream")
-    def stream_video(path: str = Query(...)) -> FileResponse:
+    def stream_video(
+        path: str = Query(...),
+        kind: Literal["auto", "trim", "source"] = Query("auto"),
+    ) -> FileResponse:
         """Serve a registered video file with HTTP Range support.
 
-        For the primary of a stage, prefers the short-GOP trimmed MP4
-        produced by Sub 5 / #16 (``<trimmed>/stage<N>_cam_<video_id>_trimmed.mp4``).
-        The re-encoded clip seeks frame-accurately, which is what makes the
-        audit screen's drag-scrubbing feel responsive. Secondaries fall
-        through to their source file -- per-video trim runs aren't wired
-        through the production UI yet.
+        ``kind`` selects which file backs the response:
+
+        - ``trim``: per-video short-GOP MP4 produced by Sub 5 / #16
+          (``<trimmed>/stage<N>_cam_<video_id>_trimmed.mp4``); 404 if not
+          built yet. The re-encoded clip seeks frame-accurately, which
+          is what makes the audit screen's drag-scrubbing feel
+          responsive.
+        - ``source``: the original camera file. Used while the trim is
+          still building.
+        - ``auto`` (default, for back-compat with non-audit callers):
+          trim if present, source otherwise.
+
+        The audit screen always passes an explicit ``kind`` so the file
+        bound to a ``<video>`` element can't change mid-session when a
+        background trim job completes -- a switch from source bytes to
+        trim bytes mid-Range-request wedges the player ("source not
+        found") and forced a full reload to recover.
 
         Validates that ``path`` matches a video registered to the project
         (any stage, any role, or unassigned) so the endpoint cannot be
@@ -4390,17 +4404,21 @@ def create_app(
         stage, video = located
 
         served_path: Path | None = None
-        if stage is not None:
-            # Prefer the per-video short-GOP trim when one exists. This is
-            # the multi-cam path: each angle gets its own scrub-friendly
-            # cache cut around its own beep, so dragging the audit
-            # playhead doesn't stall on a 4K MOV from a phone.
+        if kind in ("auto", "trim") and stage is not None:
+            # Per-video short-GOP trim is keyed per role: each angle has
+            # its own scrub clip cut around its own beep, so dragging
+            # the audit playhead doesn't stall on a 4K MOV from a phone.
             trimmed = audio_helpers.trimmed_video_path(
                 state.project_root, stage.stage_number, video, project=project
             )
             if trimmed.exists():
                 served_path = trimmed.resolve()
         if served_path is None:
+            if kind == "trim":
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"trimmed clip not built yet for {path}",
+                )
             served_path = project.resolve_video_path(state.project_root, video.path).resolve()
             # Same structured shape as detect-beep / trim / preview so
             # the SPA's "reconnect external storage" surface is uniform.

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1661,8 +1661,17 @@ export const api = {
   videoBeepPreviewUrl: (stageNumber: number, videoId: string, beepTime: number) =>
     `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep-preview?t=${beepTime.toFixed(3)}`,
 
-  videoStreamUrl: (videoPath: string) =>
-    `/api/videos/stream?path=${encodeURIComponent(videoPath)}`,
+  /** Stream URL for a registered video.
+   *
+   *  ``kind`` selects what the server serves and is encoded into the URL
+   *  so the browser sees a different resource per kind. The audit screen
+   *  passes ``trim`` or ``source`` explicitly so a background trim job
+   *  completing mid-playback can't switch the file under an open
+   *  ``<video>`` element (which fails its next Range request with
+   *  "source not found"). Other callers default to ``auto``: trim if
+   *  present, source otherwise. */
+  videoStreamUrl: (videoPath: string, kind: "auto" | "trim" | "source" = "auto") =>
+    `/api/videos/stream?path=${encodeURIComponent(videoPath)}&kind=${kind}`,
 
   getStagePeaks: (stageNumber: number, bins = 1200) =>
     request<PeaksResult>(`/api/stages/${stageNumber}/peaks?bins=${bins}`),

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1162,7 +1162,22 @@ export function Audit() {
     return () => flushAltNudge();
   }, [stageNumber, flushAltNudge]);
 
-  const videoSrc = activeVideo ? api.videoStreamUrl(activeVideo.path) : "";
+  // Pin the served file to either trim or source for the lifetime of
+  // this <video> element. Without this, a background trim job that
+  // completes mid-playback would flip the server's auto-pick from
+  // source to trim and the browser's next Range request would fall
+  // past the (shorter) trim's EOF -- the player errors out with
+  // "source not found" and only a full reload recovers. Wait for
+  // peaks to load so we know which kind to pin to; when peaks fails
+  // (no beep yet, etc.) the server's ``auto`` still does the right
+  // thing because the trim can't exist without a beep.
+  const videoSrc = activeVideo
+    ? peaks
+      ? api.videoStreamUrl(activeVideo.path, peaks.trimmed ? "trim" : "source")
+      : peaksError != null
+        ? api.videoStreamUrl(activeVideo.path)
+        : ""
+    : "";
 
   // ---- Render ------------------------------------------------------------
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1658,6 +1658,48 @@ def test_stream_video_serves_trimmed_for_primary(tmp_path: Path) -> None:
     assert resp.content == b"TRIMMED_MP4"
 
 
+def test_stream_video_kind_pins_source_even_when_trim_exists(tmp_path: Path) -> None:
+    """``kind=source`` ignores an existing trim so the SPA can pin a live
+    <video> element to the source bytes. Without this, a background trim
+    completing mid-Range-request would switch the file under the element
+    and the next request would fall past the trim's (shorter) EOF."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    resolved = project.resolve_video_path(project_root, primary.path).resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_bytes(b"SOURCE_MP4")
+
+    trimmed_dir = project_root / "trimmed"
+    trimmed_dir.mkdir(parents=True, exist_ok=True)
+    _full, _audit, trimmed_mp4 = _primary_cache_paths(project_root)
+    trimmed_mp4.write_bytes(b"TRIMMED_MP4")
+
+    resp = client.get(f"/api/videos/stream?path={primary.path}&kind=source")
+    assert resp.status_code == 200
+    assert resp.content == b"SOURCE_MP4"
+
+
+def test_stream_video_kind_trim_404_when_not_built(tmp_path: Path) -> None:
+    """``kind=trim`` returns 404 when no trimmed clip exists yet, so the
+    SPA never falls back to source bytes when it's explicitly asking
+    for the (frame-accurate) trim."""
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    project = MatchProject.load(project_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    resolved = project.resolve_video_path(project_root, primary.path).resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_bytes(b"SOURCE_MP4")
+
+    resp = client.get(f"/api/videos/stream?path={primary.path}&kind=trim")
+    assert resp.status_code == 404
+    assert "trimmed clip not built" in resp.json()["detail"]
+
+
 def test_peaks_endpoint_returns_normalized_bins(tmp_path: Path, monkeypatch) -> None:
     """/peaks asks the audio helper for the cached WAV, then computes peaks.
 


### PR DESCRIPTION
## Summary

- ``/api/videos/stream`` was bait-and-switching: it picked source-or-trim per request based on which file existed at the time. In a new project the auto-chained trim finishes a few seconds after the user lands on Audit, so Range request #1 returned source bytes and Range request #2 returned the (shorter) trim -- the offset fell past EOF and the player errored as ``source not found``. Only a full reload recovered.
- Server: ``/api/videos/stream`` now takes ``kind=auto|trim|source``. ``auto`` keeps the existing "trim if present, source otherwise" behaviour for non-audit callers (Ingest, Coach, MCP). ``trim`` 404s when no trim is built yet; ``source`` ignores any existing trim.
- SPA: ``videoStreamUrl`` takes an explicit ``kind``; ``Audit`` defers ``videoSrc`` until ``peaks`` loads, then pins to ``kind=trim`` or ``kind=source``. When the background trim completes, the project-update callback re-fetches peaks, ``peaks.trimmed`` flips, the URL flips to ``&kind=trim``, and the ``key={videoSrc}`` remount in ``VideoPanel`` swaps in a fresh ``<video>`` against the trim from byte 0.

## Test plan

- [x] ``pytest tests/test_ui_server.py -k "stream_video or peaks"`` (15 passed); covers the two new explicit modes (``kind=source`` ignores existing trim; ``kind=trim`` 404s when no trim built) and keeps the existing ``kind=auto`` coverage green.
- [x] ``tsc --noEmit`` and ``vite build`` succeed.
- [ ] Manual: in a fresh project, select a stage with no trim built yet, press space immediately, let the background trim finish mid-playback. Player should keep going (or transition to the trim cleanly once peaks re-fetches) instead of erroring out. Reload should still work too.

### Known minor wart (not addressed here)

When ``peaks.trimmed`` flips true mid-playback, the ``<video>`` remounts and starts at the trim's byte 0 -- you lose your spot. That's a pre-existing remount-on-source-change behaviour from #297; happy to follow up with a re-seek to ``currentTime + beepOffset`` if it gets annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)