### PR TITLE
jobs: priority-gated dispatch so detect_beep cuts the queue

### DIFF
--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -26,6 +26,12 @@ Design notes
 - Jobs run on a small ``ThreadPoolExecutor`` (default 2 workers). FFmpeg
   is the bottleneck; running 2 in parallel is already on the edge of
   saturating a typical CPU and disk on the user's laptop.
+- Submitted jobs are gated through an internal pending list keyed by
+  :data:`JOB_PRIORITY` (lower number wins). The registry only hands a
+  job to the executor when a worker slot frees up, so a high-priority
+  ``detect_beep`` submitted behind a queue of ``shot_detect`` runs as
+  soon as one of the slow jobs finishes -- no preemption, but no
+  head-of-line blocking either. Within a priority tier, FIFO.
 - Jobs report progress + a human-readable message via :class:`JobHandle`,
   which is the write-only view passed to the worker function.
 - Finished jobs are retained for ~50 entries so a recent failure stays
@@ -52,6 +58,20 @@ from typing import Any
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+
+JOB_PRIORITY: dict[str, int] = {
+    # User-facing ingest path -- responsive when a new video lands.
+    "detect_beep": 0,
+    "trim": 1,
+    # Slow ensemble; happily yields its slot to incoming beep/trim work.
+    "shot_detect": 2,
+}
+DEFAULT_JOB_PRIORITY: int = 3
+
+
+def _priority_for_kind(kind: str) -> int:
+    return JOB_PRIORITY.get(kind, DEFAULT_JOB_PRIORITY)
 
 
 class _Unset:
@@ -224,11 +244,18 @@ class JobRegistry:
         self._jobs: dict[str, Job] = {}
         self._order: list[str] = []
         self._lock = threading.RLock()
+        self._max_concurrent = max_concurrent
         self._executor = ThreadPoolExecutor(
             max_workers=max_concurrent,
             thread_name_prefix="splitsmith-job",
         )
         self._retain = retain_recent
+        # Jobs awaiting dispatch. We keep this list ourselves rather than
+        # leaning on the executor's internal queue because the executor
+        # is FIFO-only; the dispatcher picks the highest-priority entry
+        # (lowest ``JOB_PRIORITY`` value) whenever a worker slot frees up.
+        self._pending: list[tuple[str, Callable[[JobHandle], None]]] = []
+        self._running_count = 0
         # Registered subprocesses keyed by job_id. The trim worker spawns
         # ffmpeg via Popen and registers it via JobHandle.attach_subprocess
         # so we can terminate it on cancel even when the worker is blocked
@@ -261,12 +288,13 @@ class JobRegistry:
         with self._lock:
             self._jobs[job.id] = job
             self._order.append(job.id)
+            self._pending.append((job.id, fn))
             self._trim_retained_locked()
             # Snapshot before releasing the lock + dispatching to the
             # executor; otherwise the worker may have already flipped
             # status to RUNNING by the time we copy.
             snapshot = job.model_copy(deep=True)
-        self._executor.submit(self._run, job.id, fn)
+            self._dispatch_locked()
         return snapshot
 
     def get(self, job_id: str) -> Job | None:
@@ -304,6 +332,18 @@ class JobRegistry:
             j.cancel_requested = True
             j.updated_at = datetime.now(UTC)
             proc_to_kill = self._subprocs.pop(job_id, None)
+            # If the job is still queued (never handed to the executor),
+            # transition it to CANCELLED right here. Otherwise it would
+            # sit in ``_pending`` as PENDING forever -- the worker that
+            # would have observed the cancel never gets scheduled.
+            for i, (jid, _fn) in enumerate(self._pending):
+                if jid == job_id:
+                    del self._pending[i]
+                    j.status = JobStatus.CANCELLED
+                    j.finished_at = datetime.now(UTC)
+                    j.updated_at = j.finished_at
+                    self._trim_retained_locked()
+                    break
             snapshot = j.model_copy(deep=True)
         # Kill outside the lock so a slow ``terminate()`` (proc held a
         # held resource etc.) can't stall other registry callers.
@@ -390,62 +430,90 @@ class JobRegistry:
     # ------------------------------------------------------------------
 
     def _run(self, job_id: str, fn: Callable[[JobHandle], None]) -> None:
-        with self._lock:
-            j = self._jobs.get(job_id)
-            if j is None:
-                return
-            # If the job was cancelled while still PENDING in the queue,
-            # don't even start the worker -- skip straight to CANCELLED.
-            if j.cancel_requested:
-                j.status = JobStatus.CANCELLED
-                j.finished_at = datetime.now(UTC)
-                j.updated_at = j.finished_at
-                self._trim_retained_locked()
-                return
-            j.status = JobStatus.RUNNING
-            j.started_at = datetime.now(UTC)
-            j.updated_at = j.started_at
         try:
-            fn(JobHandle(self, job_id))
-        except JobCancelled:
             with self._lock:
                 j = self._jobs.get(job_id)
-                if j is not None:
+                if j is None:
+                    return
+                # If the job was cancelled between dispatch and the worker
+                # picking it up, skip straight to CANCELLED. Cancels for
+                # still-queued jobs are now resolved in ``cancel()``, but
+                # this branch still covers the race where cancel() fires
+                # after dispatch and before _run acquires the lock.
+                if j.cancel_requested:
                     j.status = JobStatus.CANCELLED
                     j.finished_at = datetime.now(UTC)
                     j.updated_at = j.finished_at
-                self._subprocs.pop(job_id, None)
-                self._trim_retained_locked()
-            return
-        except Exception as exc:  # noqa: BLE001 -- worker exceptions become job state
-            logger.exception("job %s failed", job_id)
+                    self._trim_retained_locked()
+                    return
+                j.status = JobStatus.RUNNING
+                j.started_at = datetime.now(UTC)
+                j.updated_at = j.started_at
+            try:
+                fn(JobHandle(self, job_id))
+            except JobCancelled:
+                with self._lock:
+                    j = self._jobs.get(job_id)
+                    if j is not None:
+                        j.status = JobStatus.CANCELLED
+                        j.finished_at = datetime.now(UTC)
+                        j.updated_at = j.finished_at
+                    self._subprocs.pop(job_id, None)
+                    self._trim_retained_locked()
+                return
+            except Exception as exc:  # noqa: BLE001 -- worker exceptions become job state
+                logger.exception("job %s failed", job_id)
+                with self._lock:
+                    j = self._jobs.get(job_id)
+                    if j is not None:
+                        # If a cancel arrived mid-flight and the worker
+                        # surfaced the resulting ffmpeg failure as a generic
+                        # exception, prefer the CANCELLED label -- the user
+                        # asked for the abort, the noisy stderr is expected.
+                        if j.cancel_requested:
+                            j.status = JobStatus.CANCELLED
+                        else:
+                            j.status = JobStatus.FAILED
+                            j.error = str(exc)
+                        j.finished_at = datetime.now(UTC)
+                        j.updated_at = j.finished_at
+                    self._subprocs.pop(job_id, None)
+                    self._trim_retained_locked()
+                return
             with self._lock:
                 j = self._jobs.get(job_id)
-                if j is not None:
-                    # If a cancel arrived mid-flight and the worker
-                    # surfaced the resulting ffmpeg failure as a generic
-                    # exception, prefer the CANCELLED label -- the user
-                    # asked for the abort, the noisy stderr is expected.
-                    if j.cancel_requested:
-                        j.status = JobStatus.CANCELLED
-                    else:
-                        j.status = JobStatus.FAILED
-                        j.error = str(exc)
+                if j is not None and j.status == JobStatus.RUNNING:
+                    j.status = JobStatus.SUCCEEDED
+                    if j.progress is None or j.progress < 1.0:
+                        j.progress = 1.0
                     j.finished_at = datetime.now(UTC)
                     j.updated_at = j.finished_at
                 self._subprocs.pop(job_id, None)
                 self._trim_retained_locked()
-            return
-        with self._lock:
-            j = self._jobs.get(job_id)
-            if j is not None and j.status == JobStatus.RUNNING:
-                j.status = JobStatus.SUCCEEDED
-                if j.progress is None or j.progress < 1.0:
-                    j.progress = 1.0
-                j.finished_at = datetime.now(UTC)
-                j.updated_at = j.finished_at
-            self._subprocs.pop(job_id, None)
-            self._trim_retained_locked()
+        finally:
+            with self._lock:
+                self._running_count = max(0, self._running_count - 1)
+                self._dispatch_locked()
+
+    def _dispatch_locked(self) -> None:
+        """Hand the highest-priority pending job to the executor.
+
+        Called under ``self._lock``. Drains pending entries up to the
+        worker-slot ceiling; ties within a priority tier go FIFO by
+        original submission order.
+        """
+        while self._running_count < self._max_concurrent and self._pending:
+            best_idx = 0
+            best_priority = _priority_for_kind(self._jobs[self._pending[0][0]].kind)
+            for i in range(1, len(self._pending)):
+                kind = self._jobs[self._pending[i][0]].kind
+                p = _priority_for_kind(kind)
+                if p < best_priority:
+                    best_idx = i
+                    best_priority = p
+            job_id, fn = self._pending.pop(best_idx)
+            self._running_count += 1
+            self._executor.submit(self._run, job_id, fn)
 
     def _patch(self, job_id: str, **fields: Any) -> None:
         with self._lock:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7,7 +7,7 @@ import time
 
 import pytest
 
-from splitsmith.ui.jobs import JobCancelled, JobRegistry, JobStatus
+from splitsmith.ui.jobs import JobCancelled, JobRegistry, JobStatus, _priority_for_kind
 
 
 def _wait_until(predicate, *, timeout=2.0, poll=0.01):
@@ -404,3 +404,197 @@ def test_retention_evicts_acked_failure_before_unacked() -> None:
     surviving = {j.id for j in reg.list()}
     assert newer.id in surviving
     assert older.id not in surviving
+
+
+# ---------------------------------------------------------------------------
+# Priority-gated dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_priority_for_kind_ranks_known_kinds() -> None:
+    """The static priority map gives detect_beep / trim / shot_detect a
+    strict ordering; everything else falls into the lowest tier."""
+    assert _priority_for_kind("detect_beep") < _priority_for_kind("trim")
+    assert _priority_for_kind("trim") < _priority_for_kind("shot_detect")
+    assert _priority_for_kind("shot_detect") < _priority_for_kind("export")
+    assert _priority_for_kind("nonsense") == _priority_for_kind("export")
+
+
+def test_pending_jobs_dispatch_in_priority_order() -> None:
+    """With one worker slot occupied, the queued jobs must dispatch in
+    JOB_PRIORITY order rather than FIFO. We pin the executor with a slow
+    blocker, queue a mix of kinds, then release the blocker and assert on
+    the order they completed."""
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+    blocker_started = threading.Event()
+
+    def hold(_h):
+        blocker_started.set()
+        proceed.wait(timeout=2.0)
+
+    blocker = reg.submit(kind="hold", fn=hold)
+    assert blocker_started.wait(timeout=2.0)
+
+    # Submit low-prio first, high-prio last -- a FIFO queue would run
+    # them in submission order; the priority queue must invert it.
+    completion_order: list[str] = []
+    completion_lock = threading.Lock()
+
+    def make_worker(kind: str):
+        def _w(_h):
+            with completion_lock:
+                completion_order.append(kind)
+
+        return _w
+
+    export_job = reg.submit(kind="export", fn=make_worker("export"))
+    shot_job = reg.submit(kind="shot_detect", fn=make_worker("shot_detect"))
+    trim_job = reg.submit(kind="trim", fn=make_worker("trim"))
+    beep_job = reg.submit(kind="detect_beep", fn=make_worker("detect_beep"))
+
+    for j in (export_job, shot_job, trim_job, beep_job):
+        assert reg.get(j.id).status == JobStatus.PENDING
+
+    proceed.set()
+    assert _wait_until(lambda: reg.get(blocker.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: len(completion_order) == 4)
+    assert completion_order == ["detect_beep", "trim", "shot_detect", "export"]
+
+
+def test_ties_within_priority_tier_run_fifo() -> None:
+    """Two ``detect_beep`` jobs queued behind a blocker dispatch in the
+    order they were submitted -- priority is the primary sort key, but
+    within a tier we preserve insertion order."""
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+    started = threading.Event()
+
+    def hold(_h):
+        started.set()
+        proceed.wait(timeout=2.0)
+
+    blocker = reg.submit(kind="hold", fn=hold)
+    assert started.wait(timeout=2.0)
+
+    order: list[str] = []
+    order_lock = threading.Lock()
+
+    def make(tag: str):
+        def _w(_h):
+            with order_lock:
+                order.append(tag)
+
+        return _w
+
+    first = reg.submit(kind="detect_beep", fn=make("first"))
+    second = reg.submit(kind="detect_beep", fn=make("second"))
+
+    proceed.set()
+    assert _wait_until(lambda: reg.get(blocker.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: reg.get(first.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: reg.get(second.id).status == JobStatus.SUCCEEDED)
+    assert order == ["first", "second"]
+
+
+def test_high_priority_submitted_after_low_priority_runs_first() -> None:
+    """The user's reported scenario: bulk shot-detect saturates the
+    worker pool, the user uploads a new video and a detect_beep is
+    submitted. As soon as a slot frees the beep runs ahead of the other
+    queued shot_detect jobs."""
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+    started = threading.Event()
+
+    def hold(_h):
+        started.set()
+        proceed.wait(timeout=2.0)
+
+    blocker = reg.submit(kind="shot_detect", fn=hold)
+    assert started.wait(timeout=2.0)
+
+    order: list[str] = []
+    order_lock = threading.Lock()
+
+    def make(tag: str):
+        def _w(_h):
+            with order_lock:
+                order.append(tag)
+
+        return _w
+
+    # Two shot_detect entries queued first, then a beep arrives.
+    shot_a = reg.submit(kind="shot_detect", fn=make("shot_a"))
+    shot_b = reg.submit(kind="shot_detect", fn=make("shot_b"))
+    beep = reg.submit(kind="detect_beep", fn=make("beep"))
+
+    proceed.set()
+    assert _wait_until(lambda: reg.get(blocker.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: reg.get(beep.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: reg.get(shot_a.id).status == JobStatus.SUCCEEDED)
+    assert _wait_until(lambda: reg.get(shot_b.id).status == JobStatus.SUCCEEDED)
+    assert order == ["beep", "shot_a", "shot_b"]
+
+
+def test_cancel_of_pending_job_removes_it_from_dispatch_queue() -> None:
+    """A cancel that fires while the job is still queued must transition
+    it to CANCELLED immediately (no waiting for a slot to free)."""
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+    started = threading.Event()
+
+    def hold(_h):
+        started.set()
+        proceed.wait(timeout=2.0)
+
+    blocker = reg.submit(kind="hold", fn=hold)
+    assert started.wait(timeout=2.0)
+
+    ran = threading.Event()
+
+    def victim(_h):
+        ran.set()
+
+    queued = reg.submit(kind="detect_beep", fn=victim)
+    snap = reg.cancel(queued.id)
+    assert snap is not None
+    # No need to wait for the blocker -- cancel of a pending job is
+    # synchronous; the registry resolves it without scheduling the worker.
+    assert reg.get(queued.id).status == JobStatus.CANCELLED
+    assert reg.get(queued.id).finished_at is not None
+
+    proceed.set()
+    assert _wait_until(lambda: reg.get(blocker.id).status == JobStatus.SUCCEEDED)
+    assert not ran.is_set(), "cancelled pending job must not run"
+
+
+def test_dispatcher_respects_max_concurrent() -> None:
+    """With max_concurrent=2 and three slow jobs queued, only two run
+    at any moment. This guards against the priority dispatcher
+    accidentally overshooting the worker ceiling."""
+    reg = JobRegistry(max_concurrent=2)
+    proceed = threading.Event()
+    running_now = 0
+    peak = 0
+    counter_lock = threading.Lock()
+
+    def slow(_h):
+        nonlocal running_now, peak
+        with counter_lock:
+            running_now += 1
+            peak = max(peak, running_now)
+        proceed.wait(timeout=2.0)
+        with counter_lock:
+            running_now -= 1
+
+    jobs = [reg.submit(kind="shot_detect", fn=slow) for _ in range(3)]
+    # Wait for two to be running, then release them.
+    assert _wait_until(
+        lambda: sum(reg.get(j.id).status == JobStatus.RUNNING for j in jobs) == 2
+    )
+    assert reg.get(jobs[2].id).status == JobStatus.PENDING
+
+    proceed.set()
+    for j in jobs:
+        assert _wait_until(lambda jid=j.id: reg.get(jid).status == JobStatus.SUCCEEDED)
+    assert peak == 2

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -589,9 +589,7 @@ def test_dispatcher_respects_max_concurrent() -> None:
 
     jobs = [reg.submit(kind="shot_detect", fn=slow) for _ in range(3)]
     # Wait for two to be running, then release them.
-    assert _wait_until(
-        lambda: sum(reg.get(j.id).status == JobStatus.RUNNING for j in jobs) == 2
-    )
+    assert _wait_until(lambda: sum(reg.get(j.id).status == JobStatus.RUNNING for j in jobs) == 2)
     assert reg.get(jobs[2].id).status == JobStatus.PENDING
 
     proceed.set()


### PR DESCRIPTION
## Summary
- The job registry now keeps its own pending list keyed by ``JOB_PRIORITY`` (``detect_beep=0``, ``trim=1``, ``shot_detect=2``, everything else ``3``) and only hands a job to the executor when a worker slot frees.
- Lowest priority number wins; ties go FIFO. No preemption -- a running ``shot_detect`` keeps its slot -- but a ``detect_beep`` submitted while bulk shot-detect is saturating the pool jumps the queue as soon as the next slot opens.
- ``cancel()`` short-circuits jobs still queued to ``CANCELLED`` immediately so a pending cancel doesn't strand the job waiting for a worker that will never come.

Closes the head-of-line blocking the user hit while working in the ingest screen with full-auto on.

## Test plan
- [x] ``uv run pytest tests/test_jobs.py`` -- 26 passed (20 existing + 6 new)
- [x] ``uv run pytest --ignore=tests/test_features_cross_bay_echo.py`` -- 1145 passed, 15 skipped (the ignored file is unrelated and was already broken on ``main``)

New tests cover: priority ordering across kinds, FIFO tie-break within a tier, the user's "beep arrives behind queued shot_detects" scenario, pending-cancel short-circuit, and ``max_concurrent`` ceiling enforcement under the new dispatcher.