### PR TITLE
stages: manual stage-time entry for projects without scoreboard data

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -326,6 +326,12 @@ class StageEntry(BaseModel):
     scorecard_updated_at: datetime | None = None
     videos: list[StageVideo] = Field(default_factory=list)
     skipped: bool = False
+    # User-entered stage duration when no scoreboard data is available.
+    # Preserved across scoreboard imports so a manual value isn't clobbered
+    # by a later sync. The trim/shot-detect gates only look at
+    # ``time_seconds > 0`` -- this flag exists for auditability and to
+    # tell ``import_scoreboard`` / ``apply_stage_time_results`` to skip.
+    time_seconds_manual: bool = False
     # Placeholder stages are created without a scoreboard ("I shot 6 stages,
     # let me start ingesting"). They carry stage_number + a generic name so the
     # rest of the pipeline works; importing a real scoreboard later overlays
@@ -1213,7 +1219,7 @@ class MatchProject(BaseModel):
             if stage is None:
                 continue
             time_set = False
-            if r.time_seconds is not None:
+            if r.time_seconds is not None and not stage.time_seconds_manual:
                 stage.time_seconds = float(r.time_seconds)
                 time_set = True
             scorecard_set = False

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -22,6 +22,7 @@ Endpoints (locked v1 surface):
   POST /api/stages/{n}/detect-beep  -- submit a beep-detection job (runs in pool)
   POST /api/stages/{n}/beep         -- manual beep_time override (synchronous)
   POST /api/stages/{n}/beep/select  -- promote one ranked candidate (synchronous)
+  POST /api/stages/{n}/time         -- manual stage duration (no-scoreboard path)
   POST /api/stages/{n}/trim         -- submit an audit-mode trim job
   POST /api/stages/{n}/shot-detect  -- submit shot detection on the audit clip
   POST /api/stages/shot-detect      -- bulk shot detection on every eligible stage
@@ -898,6 +899,19 @@ class MoveRequest(BaseModel):
 
 class BeepOverrideRequest(BaseModel):
     beep_time: float | None  # None clears the override
+
+
+class StageTimeRequest(BaseModel):
+    """Body for POST /api/stages/{n}/time.
+
+    Manual stage-duration entry for projects without scoreboard data.
+    ``time_seconds = None`` clears back to placeholder (0.0). Positive
+    values are taken as authoritative and stamped with
+    ``time_seconds_manual=True`` so a later scoreboard sync won't
+    clobber them.
+    """
+
+    time_seconds: float | None
 
 
 class BeepSelectRequest(BaseModel):
@@ -3380,6 +3394,39 @@ def create_app(
         project.save(state.project_root)
         if req.beep_time is not None:
             _maybe_chain_trim(stage, primary)
+        return JSONResponse(project.model_dump(mode="json"))
+
+    @app.post("/api/stages/{stage_number}/time")
+    def set_stage_time(stage_number: int, req: StageTimeRequest) -> JSONResponse:
+        """Manually set or clear the stage duration.
+
+        For projects without scoreboard data (the only source that
+        normally populates ``time_seconds``). Setting a positive value
+        stamps ``time_seconds_manual=True`` so a later scoreboard sync
+        won't clobber it. ``time_seconds = None`` clears back to 0.0
+        (and clears the manual flag), which re-blocks trim / shot
+        detection.
+
+        Does NOT auto-chain a trim job -- the user clicks Trim
+        themselves once they're satisfied with the duration.
+        """
+        project = state.load()
+        try:
+            stage = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if req.time_seconds is None:
+            stage.time_seconds = 0.0
+            stage.time_seconds_manual = False
+        else:
+            if req.time_seconds <= 0.0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="time_seconds must be > 0 (use null to clear)",
+                )
+            stage.time_seconds = float(req.time_seconds)
+            stage.time_seconds_manual = True
+        project.save(state.project_root)
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/snap")

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -676,13 +676,17 @@ export function BeepSection({
  *  Generic over role: peaks + audio come from per-video endpoints
  *  (`/api/stages/{n}/videos/{vid}/...`) so primary and secondary use the
  *  same component, the same controls, and the same snap-to-beep flow. */
-function BeepWaveformPicker({
+export function BeepWaveformPicker({
   stageNumber,
   videoId,
   videoBeepTime,
   draftSourceTime,
   onPick,
   setError,
+  snapEnabled = true,
+  showFallbackBeepMarker = true,
+  instructions,
+  ariaLabel,
 }: {
   stageNumber: number;
   videoId: string;
@@ -690,6 +694,18 @@ function BeepWaveformPicker({
   draftSourceTime: number | null;
   onPick: (sourceTime: number) => void;
   setError: (msg: string | null) => void;
+  /** When false, hide the "Snap to beep" button. Useful for reuse cases
+   *  (e.g. manual stage-time entry) where snap semantics don't apply. */
+  snapEnabled?: boolean;
+  /** When false, the waveform shows no marker until the user picks one.
+   *  Default ``true`` falls back to the auto-detected beep_time when
+   *  draftSourceTime is null -- helpful for beep editing, misleading for
+   *  stage-end picking. */
+  showFallbackBeepMarker?: boolean;
+  /** Override the hint shown above the waveform. */
+  instructions?: string;
+  /** Override the canvas aria-label for screen readers. */
+  ariaLabel?: string;
 }) {
   const [peaks, setPeaks] = useState<PeaksResult | null>(null);
   const [loading, setLoading] = useState(true);
@@ -742,8 +758,8 @@ function BeepWaveformPicker({
       if (local >= 0 && local <= peaks.duration) return local;
       return null;
     }
-    return peaks.beep_time;
-  }, [peaks, draftSourceTime, offset]);
+    return showFallbackBeepMarker ? peaks.beep_time : null;
+  }, [peaks, draftSourceTime, offset, showFallbackBeepMarker]);
 
   // Drive the playhead from the <audio> element while playing. The
   // browser fires `timeupdate` only ~4 Hz; rAF gives us ~60 Hz so the
@@ -863,8 +879,10 @@ function BeepWaveformPicker({
     <div className="space-y-1">
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs text-muted-foreground">
-          Click / drag the waveform to set the marker (input below
-          updates), then "Snap to beep"
+          {instructions ??
+            (snapEnabled
+              ? 'Click / drag the waveform to set the marker (input below updates), then "Snap to beep"'
+              : "Click / drag the waveform to set the marker (input below updates)")}
         </span>
         <div className="flex items-center gap-1">
           <Button
@@ -899,7 +917,7 @@ function BeepWaveformPicker({
         beepTime={markerLocal}
         pixelsPerSecond={pxPerSec}
         height={80}
-        ariaLabel={`Beep editor waveform for stage ${stageNumber}`}
+        ariaLabel={ariaLabel ?? `Beep editor waveform for stage ${stageNumber}`}
       />
       <audio
         ref={audioRef}
@@ -921,16 +939,18 @@ function BeepWaveformPicker({
           {playing ? <Pause /> : <Play />}
           {playing ? "Pause" : "Play"}
         </Button>
-        <Button
-          size="sm"
-          variant="default"
-          onClick={() => void requestSnap()}
-          disabled={draftSourceTime == null || snapping}
-          title="Snap the marker to the rise-foot of the nearest beep tone (±1.5s)"
-        >
-          {snapping ? <Loader2 className="animate-spin" /> : <Crosshair />}
-          Snap to beep
-        </Button>
+        {snapEnabled ? (
+          <Button
+            size="sm"
+            variant="default"
+            onClick={() => void requestSnap()}
+            disabled={draftSourceTime == null || snapping}
+            title="Snap the marker to the rise-foot of the nearest beep tone (±1.5s)"
+          >
+            {snapping ? <Loader2 className="animate-spin" /> : <Crosshair />}
+            Snap to beep
+          </Button>
+        ) : null}
       </div>
       {proposal != null ? (
         <SnapProposal

--- a/src/splitsmith/ui_static/src/components/StageTimeSection.tsx
+++ b/src/splitsmith/ui_static/src/components/StageTimeSection.tsx
@@ -1,0 +1,200 @@
+/**
+ * Manual stage-duration editor for projects without scoreboard data.
+ *
+ * The trim / shot-detect pipeline gates on ``stage.time_seconds > 0`` --
+ * which is only populated by a scoreboard import. Users who shoot a
+ * match without (or before) syncing the scoreboard are stuck: beep
+ * detection works, but trim refuses without a duration, and shot
+ * detection won't run without a trimmed clip.
+ *
+ * This component lets the user pick the end-of-stage moment on the
+ * primary's waveform (same canvas + audio player as ``BeepSection``,
+ * but without "Snap to beep" -- the snap detector looks for the
+ * beep tone's rise-foot, which is the wrong target here). The
+ * displayed duration is computed as ``end_source_time - beep_time``;
+ * the server stores it on ``stage.time_seconds`` and stamps
+ * ``time_seconds_manual=True`` so a later scoreboard sync won't
+ * overwrite it.
+ *
+ * Visibility:
+ *   - Hidden until the primary has a beep_time (we need the anchor
+ *     to translate the picker's source-time into a duration).
+ *   - Shows as a "Set stage time manually" affordance when
+ *     ``time_seconds <= 0``.
+ *   - Shows as a pencil icon next to the displayed duration when
+ *     ``time_seconds_manual === true`` (so the user can correct a
+ *     mis-pick).
+ */
+
+import { useCallback, useState } from "react";
+import { Check, Loader2, Pencil, Timer } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { BeepWaveformPicker } from "@/components/BeepSection";
+import { cn } from "@/lib/utils";
+import { api, type MatchProject, type StageEntry, type StageVideo } from "@/lib/api";
+
+interface Props {
+  stageNumber: number;
+  stage: StageEntry;
+  primary: StageVideo;
+  onProjectUpdate: (next: MatchProject) => void;
+  setError: (msg: string | null) => void;
+}
+
+export function StageTimeSection({
+  stageNumber,
+  stage,
+  primary,
+  onProjectUpdate,
+  setError,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Picker-side state: the user picks a source time (seconds into the
+  // primary's source video), we translate to duration on save.
+  const beepTime = primary.beep_time;
+  const initialEndSource = stage.time_seconds > 0 && beepTime != null
+    ? beepTime + stage.time_seconds
+    : null;
+  const [endSourceTime, setEndSourceTime] = useState<number | null>(initialEndSource);
+
+  const hasManualValue = stage.time_seconds_manual && stage.time_seconds > 0;
+  const hasNoValue = stage.time_seconds <= 0;
+
+  // Gate on having a beep: without it we can't translate the picker's
+  // source-time into a duration. The user must run beep detection first.
+  if (beepTime == null) return null;
+
+  const draftDuration =
+    endSourceTime != null ? Math.max(0, endSourceTime - beepTime) : null;
+
+  const reset = useCallback(() => {
+    setEditing(false);
+    setEndSourceTime(
+      stage.time_seconds > 0 && beepTime != null
+        ? beepTime + stage.time_seconds
+        : null,
+    );
+  }, [stage.time_seconds, beepTime]);
+
+  const apply = async () => {
+    if (draftDuration == null || draftDuration <= 0) {
+      setError("Pick a point after the beep on the waveform to set the stage duration.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await api.setStageTime(stageNumber, draftDuration);
+      onProjectUpdate(updated);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await api.setStageTime(stageNumber, null);
+      onProjectUpdate(updated);
+      setEditing(false);
+      setEndSourceTime(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!editing) {
+    // Collapsed affordance: prompt to open the picker when no time is
+    // set yet, or a small pencil icon to re-edit a manual value.
+    if (hasNoValue) {
+      return (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 text-xs">
+          <Timer className="size-3.5 text-muted-foreground" />
+          <span className="text-muted-foreground">
+            No scoreboard time. Pick the end of the stage on the waveform to
+            unblock trim + shot detection.
+          </span>
+          <Button
+            size="sm"
+            variant="default"
+            className="ml-auto"
+            onClick={() => setEditing(true)}
+            disabled={busy}
+          >
+            <Pencil />
+            Set stage time
+          </Button>
+        </div>
+      );
+    }
+    if (hasManualValue) {
+      return (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 px-1.5 text-[11px]"
+          onClick={() => setEditing(true)}
+          disabled={busy}
+          title="Edit the manually-entered stage time"
+        >
+          <Pencil className="size-3" />
+          Edit stage time
+        </Button>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Stage duration (seconds)</span>
+          <div
+            className={cn(
+              "flex h-8 w-32 items-center rounded-md border border-input bg-background px-2 py-1 font-mono text-sm shadow-sm",
+              draftDuration == null && "text-muted-foreground",
+            )}
+            aria-label={`Manual stage time for stage ${stageNumber}`}
+            role="status"
+          >
+            {draftDuration != null ? draftDuration.toFixed(2) : "--"}
+          </div>
+        </div>
+        <Button size="sm" onClick={apply} disabled={busy || draftDuration == null}>
+          <Check />
+          Apply
+        </Button>
+        {hasManualValue ? (
+          <Button size="sm" variant="ghost" onClick={clear} disabled={busy}>
+            Clear
+          </Button>
+        ) : null}
+        <Button size="sm" variant="ghost" onClick={reset} disabled={busy}>
+          Cancel
+        </Button>
+        {busy ? <Loader2 className="size-4 animate-spin text-muted-foreground" /> : null}
+      </div>
+      <BeepWaveformPicker
+        stageNumber={stageNumber}
+        videoId={primary.video_id}
+        videoBeepTime={beepTime}
+        draftSourceTime={endSourceTime}
+        onPick={(sourceTime) => setEndSourceTime(sourceTime)}
+        setError={setError}
+        snapEnabled={false}
+        showFallbackBeepMarker={false}
+        instructions="Scrub to the end of the stage (e.g. the RO's 'unload and show clear' command), then Apply."
+        ariaLabel={`Stage time picker for stage ${stageNumber}`}
+      />
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -172,6 +172,10 @@ export interface StageEntry {
   videos: StageVideo[];
   skipped: boolean;
   placeholder: boolean;
+  /** True when the duration was entered manually (POST /api/stages/{n}/time)
+   *  rather than imported from a scoreboard. Preserved across scoreboard
+   *  syncs so a manual value isn't clobbered. */
+  time_seconds_manual: boolean;
 }
 
 export interface MatchProject {
@@ -1429,6 +1433,16 @@ export const api = {
     request<MatchProject>(`/api/stages/${stageNumber}/beep`, {
       method: "POST",
       json: { beep_time: beepTime },
+    }),
+
+  /** Manually set or clear a stage's duration. Used for projects without
+   *  scoreboard data, where ``time_seconds`` would otherwise stay 0 and
+   *  block the trim / shot-detect gates. Pass ``null`` to clear back to
+   *  placeholder. Does NOT chain a trim -- caller clicks Trim explicitly. */
+  setStageTime: (stageNumber: number, timeSeconds: number | null) =>
+    request<MatchProject>(`/api/stages/${stageNumber}/time`, {
+      method: "POST",
+      json: { time_seconds: timeSeconds },
     }),
 
   /** Manually set or clear ``video``'s beep timestamp. ``beepTime=null``

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1812,8 +1812,14 @@ function DetectShotsBadge({
   // Auto-adopt an in-flight shot-detect job after reload. Auto-trim
   // chains shot detection; the user often lands on Audit while it's
   // still mid-flight.
+  //
+  // Reset local state on stage change before the async lookup -- same
+  // reasoning as the trim badge: navigating from a stage with a running
+  // job to one without otherwise leaves the stale ``job`` in place.
   useEffect(() => {
     let cancelled = false;
+    setJob(null);
+    setError(null);
     api
       .listJobs()
       .then(async (jobs) => {
@@ -1950,8 +1956,16 @@ function TrimNowBadge({
   // Auto-adopt an in-flight trim on mount / stage change. After a page
   // reload the server still has the running job; we reattach to it
   // instead of leaving the user a "Trim now" button that double-submits.
+  //
+  // Reset local state synchronously on stage change before the async
+  // lookup -- otherwise navigating from a stage with a running trim to
+  // one without leaves the stale ``job`` in place (the effect's no-match
+  // branch never cleared it), making every other stage look like it's
+  // trimming too.
   useEffect(() => {
     let cancelled = false;
+    setJob(null);
+    setError(null);
     api
       .listJobs()
       .then(async (jobs) => {

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 
 import { BeepSection } from "@/components/BeepSection";
+import { StageTimeSection } from "@/components/StageTimeSection";
 import { CleanupDialog } from "@/components/CleanupDialog";
 import { RelinkDialog } from "@/components/RelinkDialog";
 import { FolderPicker } from "@/components/FolderPicker";
@@ -2616,9 +2617,11 @@ function StageCard({
               {stage.time_seconds.toFixed(2)}s &middot;{" "}
               {stage.scorecard_updated_at
                 ? new Date(stage.scorecard_updated_at).toLocaleString()
-                : stage.placeholder
-                  ? "times pending -- pin yourself in Scoreboard"
-                  : "no scorecard time"}
+                : stage.time_seconds_manual
+                  ? "manual time"
+                  : stage.placeholder
+                    ? "times pending -- pin yourself in Scoreboard"
+                    : "no scorecard time"}
             </CardDescription>
           </div>
           <div className="flex flex-col items-end gap-1">
@@ -2693,6 +2696,13 @@ function StageCard({
               stageNumber={stage.stage_number}
               video={primary}
               bare
+              setError={setError}
+              onProjectUpdate={onProjectUpdate}
+            />
+            <StageTimeSection
+              stageNumber={stage.stage_number}
+              stage={stage}
+              primary={primary}
               setError={setError}
               onProjectUpdate={onProjectUpdate}
             />

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1094,6 +1094,82 @@ def test_override_beep_400_on_negative(tmp_path: Path) -> None:
     assert resp.status_code == 400
 
 
+def test_set_stage_time_manual_unblocks_no_scoreboard_project(tmp_path: Path) -> None:
+    """Placeholder stage with no scoreboard data: manual time entry stamps
+    time_seconds + flags it so a later sync won't clobber, and unblocks the
+    trim / shot-detect gates that look at ``time_seconds > 0``."""
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    client.post(
+        "/api/project/placeholder-stages",
+        json={"stage_count": 1, "match_name": "Manual Times"},
+    )
+    resp = client.post("/api/stages/1/time", json={"time_seconds": 18.42})
+    assert resp.status_code == 200
+    stage = resp.json()["stages"][0]
+    assert stage["time_seconds"] == 18.42
+    assert stage["time_seconds_manual"] is True
+
+
+def test_set_stage_time_null_clears_back_to_placeholder(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    client.post("/api/project/placeholder-stages", json={"stage_count": 1})
+    client.post("/api/stages/1/time", json={"time_seconds": 12.0})
+    resp = client.post("/api/stages/1/time", json={"time_seconds": None})
+    assert resp.status_code == 200
+    stage = resp.json()["stages"][0]
+    assert stage["time_seconds"] == 0.0
+    assert stage["time_seconds_manual"] is False
+
+
+def test_set_stage_time_400_on_non_positive(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    client.post("/api/project/placeholder-stages", json={"stage_count": 1})
+    for bad in (0.0, -1.0):
+        resp = client.post("/api/stages/1/time", json={"time_seconds": bad})
+        assert resp.status_code == 400, f"expected 400 for {bad}, got {resp.status_code}"
+
+
+def test_manual_stage_time_survives_scoreboard_sync(tmp_path: Path) -> None:
+    """``merge_stage_times`` (the per-competitor sync path) must
+    leave manual values alone -- otherwise pinning yourself in the
+    Scoreboard would silently overwrite a duration the user typed in."""
+    from splitsmith.ui.project import MatchProject
+    from splitsmith.ui.scoreboard.models import (
+        CompetitorStageResult,
+        CompetitorStageResults,
+    )
+
+    proj = MatchProject(name="t", schema_version=1)
+    proj.init_placeholder_stages(count=2)
+    proj.stages[0].time_seconds = 9.5
+    proj.stages[0].time_seconds_manual = True
+
+    results = CompetitorStageResults(
+        competitorId=1,
+        stages=[
+            CompetitorStageResult(
+                stage_number=1,
+                time_seconds=42.0,
+                scorecard_updated_at="2026-01-01T00:00:00+00:00",
+            ),
+            CompetitorStageResult(
+                stage_number=2,
+                time_seconds=11.0,
+                scorecard_updated_at="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+    )
+    proj.merge_stage_times(results)
+
+    assert proj.stages[0].time_seconds == 9.5
+    assert proj.stages[0].time_seconds_manual is True
+    assert proj.stages[1].time_seconds == 11.0
+    assert proj.stages[1].time_seconds_manual is False
+
+
 def _three_candidates() -> list:
     from splitsmith.config import BeepCandidate
 


### PR DESCRIPTION
## Summary

Unblocks ingestion for projects shot without scoreboard data. Previously the trim + shot-detect pipeline gated on `time_seconds > 0` (only populated by scoreboard import), leaving the user stuck: beep detection worked, but trim refused, and shot detection couldn't run without a trim.

- **Backend**: `POST /api/stages/{n}/time` accepts `{time_seconds: float|null}`. Positive value sets + flags `time_seconds_manual=True`; null clears. `merge_stage_times` now skips manual stages so a later scoreboard sync can't silently clobber a typed-in duration.
- **Frontend**: Stage card grows a "Set stage time" affordance under the primary's `BeepSection`. The editor reuses `BeepWaveformPicker` (now exported, with `snapEnabled`, `showFallbackBeepMarker`, `instructions` props) but with snap disabled -- snap looks for beep-tone rise-foot, wrong target for the stage end. Instructions hint at the RO's "unload and show clear" command. Once set, a small pencil "Edit stage time" affordance lets the user correct.
- Card description shows "manual time" instead of "times pending -- pin yourself in Scoreboard" once a manual value is set.
- Duration computed client-side as `end_source_time - beep_time` (hence the picker is gated on the primary having a beep).

**Deliberate non-goals:**
- No auto-trim chain after manual entry -- user clicks Trim explicitly (matches the conservative one-decision-at-a-time pattern).
- No ASR fallback for RO commands yet -- would need Whisper or similar, deferred.

## Test plan

- [x] `tests/test_ui_server.py` -- 4 new tests: manual set unblocks placeholder, null clears, non-positive 400s, manual value survives `merge_stage_times` sync.
- [x] Full `test_ui_server.py` (210) + `test_ui_project.py` (51) suites pass.
- [x] Frontend `tsc -b --noEmit` clean.
- [ ] Manual: create placeholder stages, detect beep on primary, click "Set stage time", scrub to RO command, Apply. Verify Trim + Detect shots now work.
- [ ] Manual: with manual time set, run a scoreboard import (via `merge_stage_times` path) and verify the manual value is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)