### PR TITLE
docs(saas): SaaS readiness doc set (00-09 + README)

### DIFF
--- a/docs/saas-readiness/00-context-and-principles.md
+++ b/docs/saas-readiness/00-context-and-principles.md
@@ -1,0 +1,310 @@
+# 00 -- Context and principles
+
+This document captures the **why** behind the SaaS readiness initiative,
+the principles that shape every other doc in this set, and the
+decision record from the ideation conversation that produced this plan.
+
+## Why this initiative exists
+
+Splitsmith today is a local-first Python app: install via PyPI, run
+`splitsmith ui`, work fully offline. That model is the right default for
+the user (an IPSC competitive shooter) -- it's free, private, and
+performant on the user's own hardware.
+
+But the user wants to add a **hosted SaaS option that complements --
+not replaces -- local mode**, primarily so that:
+
+- Users without capable hardware can still run the detection workflow
+- Squadmates can share matches without exporting tarballs over Dropbox
+- Cross-device access (phone preview, desktop editing) becomes possible
+- A curated public match repository can grow over time
+
+The plan keeps both modes alive in the same codebase and pipes the
+hosted path's needs through the same orchestration code that already
+runs locally.
+
+## Working principle (highest)
+
+> **Use off-the-shelf frameworks and libraries. Use off-the-shelf
+> hosted services where they make sense and are cost-efficient.
+> Do not invent things.**
+
+Splitsmith is a single-author project. Every component built in-house
+-- and every piece of infrastructure self-hosted -- is one we have to
+maintain in perpetuity. The SaaS readiness work multiplies the surface
+area (auth, storage, jobs, billing, uploads, an admin/billing UI). If
+we roll any of those ourselves, the project will spend more time on
+plumbing than on its actual job (extracting shot splits from head-cam
+footage).
+
+Every architectural decision in this doc set names a **specific,
+existing, documented library or hosted service**. If we can't find one
+that fits, we revisit the decision before writing custom code or
+running custom infrastructure.
+
+The bias order is:
+
+1. **Hosted service** -- rent, don't run. If a managed offering is
+   cheap enough at our scale, we use it (Stripe for billing, Clerk
+   for auth, Cloudflare R2 for storage, Sentry for errors, Resend for
+   email, Neon for Postgres).
+2. **Library** -- open-source, well-maintained, fits the use case.
+   Use it inside our own deploy (fsspec for storage abstraction,
+   SQLAlchemy for ORM, arq for job queue).
+3. **Custom code** -- only when no library or service exists, and
+   even then prefer a thin shim around an existing primitive.
+
+**Cost efficiency means total cost of ownership.** A service that
+costs $20/month but saves 40 hours of yearly maintenance wins over a
+free self-hosted alternative. We track each pick in this doc and
+revisit yearly. As scale grows, some hosted picks may flip to
+self-hosted (e.g. Clerk -> Auth.js + SQLite if user count makes
+Clerk's per-user pricing dominate) but only after the cost cross-over
+is measured, not preemptively.
+
+### Hosted services (rent, don't run)
+
+| Concern | Service | Notes |
+| --- | --- | --- |
+| Auth (magic link) | [Clerk](https://clerk.com/) or [WorkOS](https://workos.com/) | Free tier covers <100s of users; pick after a v1 prototype with each |
+| Object storage | [Cloudflare R2](https://www.cloudflare.com/products/r2/) | S3-compatible API, **$0 egress**, ~$0.015/GB stored. Massive cost advantage over S3 for media workloads. |
+| Database hosting | [Neon](https://neon.tech/) (Postgres) or [Turso](https://turso.tech/) (SQLite-as-a-service) | Free tiers for v1; both scale up with usage |
+| Background workers (hosted) | [Inngest](https://www.inngest.com/) or [Trigger.dev](https://trigger.dev/) | Use only if `arq` + small Redis instance turns into too much ops |
+| Email (magic links + transactional) | [Resend](https://resend.com/) or [Postmark](https://postmarkapp.com/) | No SMTP self-hosting; generous free tiers |
+| Billing | [Stripe Checkout](https://stripe.com/docs/payments/checkout) + [Stripe webhooks](https://stripe.com/docs/webhooks) | Stripe-hosted checkout page; we never touch card data |
+| Errors / monitoring | [Sentry](https://sentry.io/) | Hosted; free tier covers our scale |
+| Analytics (optional v2) | [PostHog](https://posthog.com/) or [Plausible](https://plausible.io/) | Privacy-respecting; PostHog also handles feature flags + session replay |
+| Deploy target | [Fly.io](https://fly.io/) or [Railway](https://railway.app/) | Both support Python + workers + Postgres + R2 without bespoke infra |
+| CDN | [Cloudflare](https://www.cloudflare.com/) | Free tier; sits in front of R2 anyway |
+
+### Libraries (open-source, in-deploy)
+
+| Concern | Library | Notes |
+| --- | --- | --- |
+| Storage abstraction | [`fsspec`](https://filesystem-spec.readthedocs.io/) | One API across filesystem / S3 / R2 / GCS / Azure |
+| Database / migrations | [SQLAlchemy](https://www.sqlalchemy.org/) + [Alembic](https://alembic.sqlalchemy.org/) | Already idiomatic for FastAPI |
+| Auth (self-host fallback) | [Auth.js](https://authjs.dev/) backed by SQLite | If Clerk/WorkOS pricing flips at scale |
+| Job queue (in-deploy) | [arq](https://arq-docs.helpmanual.io/) (Redis-backed) or [Procrastinate](https://procrastinate.readthedocs.io/) (Postgres-backed, no Redis) | Both well-maintained, ~asyncio-native |
+| ML inference | [ONNX Runtime](https://onnxruntime.ai/) + [Web variant](https://onnxruntime.ai/docs/tutorials/web/) | Same model artifact runs server-side and in-browser |
+| ML export | [`sklearn-onnx`](https://onnx.ai/sklearn-onnx/) for GBDT | CLAP/PANN already PyTorch -> ONNX exportable |
+| Resumable upload | [tus.io](https://tus.io/) protocol; [tus-py-server](https://github.com/tus-project) + [tus-js-client](https://github.com/tus/tus-js-client) | Proven; resumes mid-upload after network drops |
+| Stripe SDK | [`stripe-python`](https://github.com/stripe/stripe-python) | First-party |
+| API patterns | Standard `/api/v1/` prefix; OpenAPI auto-generated by FastAPI | Already in stack |
+
+We re-evaluate each pick when it's time to implement, but the bias is
+strong: if the off-the-shelf option does 80% of what we need, we adopt
+it and live with the 20%.
+
+## Decision record (2026-05-15 ideation)
+
+The plan was shaped by a four-question clarifying round followed by a
+three-question refinement round. Capturing the questions + answers here
+so future maintainers can see *how* the plan was scoped, not just
+*what* the plan says.
+
+### Round 1 -- foundational decisions
+
+#### Q1. Sync model: how do local and hosted relate?
+
+**Answer: All three over time.** Start with two-modes-shared-code as
+v1, build hybrid sync (local <-> cloud bidirectional) as v2, defer
+cloud-first unless usage proves it's needed.
+
+**Implication:** v1 has no sync engine. The local desktop app and the
+hosted web app both run the same backend code but talk to different
+storage + auth backends. The v1 abstractions (Storage, Auth,
+ComputeBackend) must not foreclose v2's sync engine -- specifically the
+data layer must support "this match exists in both places, reconcile
+them" without a schema rewrite.
+
+#### Q2. Raw data residency in hosted mode
+
+**Answer: Raw uploaded, opt-in.** Default: raw stays local. Optional
+per-match: upload raw to cloud to enable cross-device playback +
+share-with-squadmate features. Storage interface must handle "raw is
+here / raw is there / raw is unreachable" as a first-class state per
+video.
+
+#### Q3. Compute model
+
+**Answer:** Three-tier with auto-selection:
+
+- **Tier 1 -- local desktop:** today's Python ensemble, native speed,
+  fully offline. Free.
+- **Tier 2 -- audio upload + cloud ML (premium):** client extracts
+  audio (~5 MB/stage instead of ~5 GB/stage for video), uploads it to
+  the hosted service, server runs CLAP + PANN (the heavy models),
+  returns features. Client runs the cheap pieces locally (envelope
+  onset detector, GBDT). Result: minimal data leaves the user's
+  machine, but heavy compute is amortised across the user base.
+- **Tier 3 -- full cloud (premium):** raw video is uploaded; server
+  runs the full pipeline.
+
+Auto-selection: first-run benchmark in the browser; if the GBDT-in-
+browser pass exceeds a latency threshold the UI prefers Tier 2 even
+when the data is local. The user can override in settings.
+
+**No commitment to in-browser ML beyond the cheap pieces.** CLAP/PANN
+stay server-side -- they're 150 MB combined and not worth shipping to
+every browser.
+
+#### Q4. Collaboration scope
+
+**Answer: All three over time.** v1 = single-user accounts (each user
+sees their own matches only). v2 = squad-level sharing (invite
+squadmates to view/edit a specific match). v3 = public match repository
+(the community-curated catalog from the earlier scoreboard memory).
+
+**Implication:** the data model has `User`, `Project`,
+`ProjectMember` tables from v1 even though only the owner ACL is
+exposed. Adding ACLs after-the-fact would require a painful migration.
+
+### Round 2 -- scope and entry-point decisions
+
+#### Q5. v1 scope
+
+**Answer: Abstractions + minimal hosted MVP.** v1 ships:
+
+- The three abstractions (Storage, Auth, ComputeBackend) in the
+  codebase, with local-mode implementations matching today's behaviour
+- A working hosted deployment with: magic-link signup, single-user
+  accounts, audio upload, Tier 2 compute, S3-compatible storage,
+  Stripe Checkout gating premium access, a flat tier with no usage
+  metering
+- A migration path: desktop app gains "Sign in to hosted" + per-match
+  "Sync to cloud" actions
+
+**Not in v1:** raw video upload, squad sharing, public match
+repository, hybrid bidirectional sync, per-tenant retrain.
+
+**Why not "abstractions only":** the abstractions are easy to get
+wrong without a real consumer. Building the hosted MVP at the same
+time forces the abstractions to be honest. Without the MVP we'd ship
+unconstrained interfaces that turn out to not fit reality.
+
+**Why not "full hosted launch":** every feature deferred to v2 has a
+clear architectural ramp from v1 -- shipping v1 alone is meaningful and
+reduces risk on v2.
+
+#### Q6. Migration path (local -> hosted)
+
+**Answer: Hosted login from local app -> direct sync** as the
+preferred flow; tarball import as the fallback for users who don't
+want to install the desktop app.
+
+**Implication:** the desktop app gains a "Sign in to cloud" action.
+Once signed in, each match in the picker has a "Sync to cloud" button.
+The sync flow uploads audio + match.json + per-shooter state + audits.
+Raw video sync stays opt-in per match (see Q2). This same machinery
+becomes the v2 bidirectional sync engine.
+
+#### Q7. Auth provider
+
+**Answer: Email magic link.** No passwords, no MFA, no password reset
+flows. The magic link IS the second factor. Lowest implementation
+surface area; modern UX; well-supported by both hosted services
+(Clerk, WorkOS, Magic) and open-source libraries (Auth.js).
+
+**Federated providers** (Google, GitHub) are deferred until usage
+proves friction.
+
+## Locked-in decisions table
+
+| Axis              | v1                                                          | v2                                       | v3+                |
+| ----------------- | ----------------------------------------------------------- | ---------------------------------------- | ------------------ |
+| Sync model        | Two modes, shared codebase                                  | Hybrid sync (local <-> cloud)            | (only if needed)   |
+| Raw data          | Stays local                                                 | Opt-in upload + squad-share              | Public repo        |
+| Compute           | Tier 2 default (audio up, cloud ML, GBDT in browser)        | + Tier 3 (raw cloud)                     | --                 |
+| Collaboration     | Single-user                                                 | Squad sharing                            | Public repo        |
+| Storage           | Pluggable (`FilesystemStorage` + `S3Storage`); JSON canonical | + Postgres index for cross-match queries | --                 |
+| Auth              | Email magic link                                            | + Google OAuth                           | --                 |
+| Migration         | Direct sync from desktop app                                | Bidirectional sync                       | --                 |
+| Billing           | Stripe Checkout; flat-rate premium gate                     | + usage metering                         | --                 |
+| Database          | SQLite for auth state only                                  | Promote to Postgres                      | --                 |
+
+## Derived principles
+
+These follow from the working principle + the locked-in decisions.
+They shape the rest of the doc set.
+
+1. **Off-the-shelf-first.** Already stated. Every doc names libraries,
+   not abstract patterns.
+
+2. **The local experience never regresses.** Every abstraction has a
+   no-op / local-friendly default implementation. Today's `splitsmith
+   ui` user must not see new login prompts, sync nudges, or quota
+   warnings.
+
+3. **The data model accommodates v2 today, even if only v1 is exposed.**
+   ACL tables exist; only the owner ACL is used. Storage paths support
+   "elsewhere" addressing; only local addresses are written.
+
+4. **Hosted-mode default is privacy-preserving.** Audio-only upload
+   (Tier 2) is the default for premium users; raw upload is opt-in.
+
+5. **Heavy data is never on the critical path twice.** If a video is
+   already on the user's disk, the hosted UI does not re-upload it to
+   stream it back. The Storage interface knows "this is here".
+
+6. **JSON files stay the canonical per-project record.** Even in
+   hosted mode, `match.json` + `shooters/<slug>/project.json` are the
+   source of truth, just stored on S3 instead of local disk. The
+   database indexes them; it does not own them. This keeps the local
+   and hosted modes structurally identical and makes "export this
+   match" trivial in either direction.
+
+7. **API surface is versioned.** `/api/v1/` from day one. Breaking
+   changes ship as `/api/v2/` with a deprecation window.
+
+8. **No bespoke job queue, identity provider, or upload protocol.**
+   Each of those is a tarpit; off-the-shelf solutions exist for all
+   three.
+
+## What this doc set is NOT
+
+- **An implementation plan.** Implementation lives in GitHub issues
+  once a doc is approved. The doc set says *what* and *why*; issues
+  say *how* and *when*.
+- **A pricing strategy doc.** Pricing decisions belong to the
+  business, not the architecture. 08-billing-and-quotas.md describes
+  *how* billing integrates, not *what* to charge.
+- **A go-to-market plan.** Marketing, positioning, and launch timing
+  are out of scope.
+
+## Open questions to validate during implementation
+
+These are flagged here because they're cross-cutting; per-doc open
+questions live in the relevant doc.
+
+- **Auth provider final pick.** Clerk vs WorkOS vs Auth.js depends on
+  cost at the user counts we expect. Cheapest at <100 users is
+  probably Auth.js + SQLite; cheapest at >1000 is probably Clerk free
+  tier; WorkOS becomes interesting if we want enterprise SSO later.
+  Pick after one v1-shaped prototype with each.
+- **Deploy target.** Fly.io vs Railway vs Render all work. Fly's
+  region pinning is nice for EU users (the user is in Sweden) and its
+  pricing is predictable. Railway's developer experience is the
+  smoothest. Decide when implementing 06-api-surface.md.
+- **Job queue: arq vs Procrastinate.** arq needs Redis. Procrastinate
+  needs Postgres (which we have anyway in v2+ but not v1). v1 might
+  ship with arq + a tiny Redis instance because v1 doesn't have
+  Postgres yet.
+- **WASM ML bundle size budget.** GBDT-only stays under 5 MB. If we
+  want to add envelope onset (currently pure DSP) as a WASM module
+  too, the bundle grows but we lose a server round-trip per detection
+  call. Measure after the first hosted MVP runs.
+
+## Reading order
+
+The doc set is meant to be read in order on the first pass:
+
+1. **This doc (00)** -- you're here.
+2. **01-deployment-modes.md** -- what each mode promises.
+3. **02-tenancy-and-identity.md** through **04-compute-backends.md** --
+   the three foundational abstractions.
+4. **05-uploads-and-streaming.md** through **08-billing-and-quotas.md**
+   -- wire formats + flows + business integration.
+5. **09-saas-progress.md** -- track shipped vs in-flight work.
+
+After the first pass, the docs are reference: jump to whichever covers
+the system you're touching.

--- a/docs/saas-readiness/01-deployment-modes.md
+++ b/docs/saas-readiness/01-deployment-modes.md
@@ -1,0 +1,210 @@
+# 01 -- Deployment modes
+
+This doc defines the **two deployment modes Splitsmith ships in** and
+the contracts each mode must honour. It exists so that every later doc
+can say "in local mode X, in hosted mode Y" without re-litigating what
+those modes mean.
+
+The two modes are **local** and **hosted**. They share the same
+codebase. The differences are which implementations of the three
+abstractions (Storage, Auth, ComputeBackend -- see docs 02-04) are
+wired in at startup, plus a small number of UI affordances.
+
+A third mode -- **self-hosted** (a user runs the FastAPI app on their
+own server) -- is not a v1 deliverable but the abstractions must not
+foreclose it. See "Self-hosted (deferred)" below.
+
+## Mode summary
+
+| Mode       | Who runs the server           | Where data lives         | Auth                | Compute       | v1? |
+| ---------- | ----------------------------- | ------------------------ | ------------------- | ------------- | --- |
+| Local      | The user (`splitsmith ui`)    | User's disk              | None (loopback)     | Tier 1 only   | yes |
+| Hosted     | We do (Fly.io / Railway)      | Cloudflare R2 + Postgres | Magic link (Clerk)  | Tier 2 + 3    | yes |
+| Self-host  | A third party                 | Their disk + their S3    | Whatever they wire  | Their choice  | no  |
+
+## Local mode -- the default
+
+**Promise:** today's `splitsmith ui` user must not see any change.
+Same install, same UX, same offline guarantee.
+
+**What it means concretely:**
+
+- Server bound to `127.0.0.1` by default; no external listeners.
+- `Storage` = `FilesystemStorage` rooted at `~/.splitsmith/projects/`
+  (or `$SPLITSMITH_PROJECTS_DIR` if set).
+- `Auth` = `LoopbackAuth` -- a no-op implementation that returns a
+  fixed `User` for every request. No login screen, no cookies, no
+  CSRF tokens.
+- `ComputeBackend` = `LocalComputeBackend` -- runs the existing
+  Python ensemble in-process or via the existing worker.
+- No outbound network calls except: (a) optional update check, (b)
+  optional crash report to Sentry if the user opted in.
+- No SQLite database is created. State lives in `match.json` +
+  per-shooter JSON files exactly as today. (If we need a DB later
+  for indexing, it lives at `~/.splitsmith/index.sqlite` and is
+  rebuildable from the JSON canonical files at any time.)
+- No quota display. No "upgrade" buttons. No "sign in" affordance
+  unless the user explicitly enables hosted-account integration.
+
+**What local mode is NOT:**
+
+- Not a multi-user mode. The loopback assumption is "one human at the
+  keyboard". If two people share a desktop OS account they share one
+  Splitsmith identity.
+- Not network-reachable. The server refuses to bind to `0.0.0.0` in
+  local mode unless the user passes `--unsafe-bind-all`. This is a
+  guardrail against accidentally exposing private match data.
+
+**Optional hosted-account hook:** the local app can be linked to a
+hosted account (see 07-sync-and-migration.md). Linking is opt-in,
+adds a "Sign in to cloud" action in settings, and unlocks the
+per-match "Sync to cloud" buttons in the picker. Linking does NOT
+change any other local-mode behaviour -- detection still runs
+locally, files still live on disk, the loopback auth still applies
+to local API calls.
+
+## Hosted mode -- the SaaS option
+
+**Promise:** zero install, works in any modern browser, audio-only
+upload by default, premium pricing tier gates access.
+
+**What it means concretely:**
+
+- Server runs behind a public TLS endpoint (`splitsmith.app` or
+  similar). Bound to `0.0.0.0` inside the deploy.
+- `Storage` = `S3Storage` pointing at Cloudflare R2 (S3-compatible,
+  $0 egress -- see 03-storage-layer.md for why).
+- `Auth` = `MagicLinkAuth` backed by Clerk or WorkOS (final pick
+  per 02-tenancy-and-identity.md). Sessions are httpOnly cookies.
+- `ComputeBackend` = `RemoteComputeBackend` running CLAP + PANN
+  server-side, with the GBDT shipped to the browser as ONNX-Web (see
+  04-compute-backends.md, Tier 2). Tier 3 (full cloud, raw video)
+  available per-match.
+- Database: Postgres on Neon or whatever the deploy target offers.
+  Holds users, projects, project members, billing entitlements,
+  upload sessions. **Does NOT hold detection results -- those stay
+  in the JSON files in R2** (principle 6 in doc 00).
+- Background jobs run on `arq` workers (or hosted Inngest / Trigger
+  if ops cost flips against us -- see doc 00).
+- Stripe Checkout is the paywall. Webhooks update entitlements in
+  Postgres. See 08-billing-and-quotas.md.
+- Sentry is on, with PII scrubbing. PostHog optional in v2.
+
+**What hosted mode is NOT (in v1):**
+
+- Not multi-shooter shared. Each user sees only their own matches.
+  (Squad sharing is v2 per 02.)
+- Not raw-video-by-default. Audio upload is the default; raw upload
+  is opt-in per match. (See 05-uploads-and-streaming.md.)
+- Not a public match catalog. (v3.)
+- Not retrain-per-tenant. The shipped ensemble artifacts apply to
+  everyone.
+
+## Self-hosted (deferred)
+
+A third party should be able to `pip install splitsmith[server]`,
+set environment variables (`STORAGE_BACKEND=s3`, `AUTH_BACKEND=authjs`,
+`STRIPE_SECRET_KEY=...` or omit billing entirely), and run a private
+deployment for their squad / club / range.
+
+This is **not a v1 deliverable**, but the abstractions in 02-04 must
+not preclude it. Concretely:
+
+- No hardcoded references to Clerk's hosted endpoints. The auth
+  abstraction must accept any provider implementing the interface.
+- No hardcoded references to Stripe webhook URLs in the data model.
+  Entitlements are local rows; the source of those rows is pluggable.
+- Configuration is environment-driven, not compiled in.
+
+If we discover during v1 implementation that one of the picked
+hosted services makes self-hosting impossible (e.g. an auth provider
+that hard-requires their domain in the OAuth callback), we either pick
+a different provider or accept that self-hosting needs an alternate
+auth implementation. Both are acceptable -- what's NOT acceptable is
+silently building in a coupling that someone discovers only when they
+try to self-host.
+
+## Mode selection at runtime
+
+A single `splitsmith` binary does not exist in v1. There are two
+entry points:
+
+- `splitsmith ui` -- launches local mode. Reads `~/.splitsmith/
+  config.yaml` for overrides; otherwise defaults documented above
+  apply.
+- `splitsmith serve` (or the deploy's equivalent, e.g.
+  `uvicorn splitsmith.api:app`) -- launches hosted mode. Reads
+  required env vars (`SPLITSMITH_MODE=hosted`,
+  `STORAGE_BUCKET=...`, `DATABASE_URL=...`, `AUTH_PROVIDER=...`,
+  etc.). Refuses to start if any required env var is missing.
+
+The mode is **set at process startup** and immutable for the life of
+the process. The same binary can run in either mode, but it cannot
+switch modes dynamically. This keeps every "is this hosted?" check
+in the codebase resolvable to a constant after startup.
+
+## Cross-mode invariants
+
+Both modes must honour these invariants. Violating them breaks the
+"same codebase, two deployments" promise.
+
+1. **JSON canonical.** The on-disk / in-bucket layout per project
+   is identical -- `match.json`, `shooters/<slug>/project.json`,
+   `audits/`, etc. (See 03-storage-layer.md.) A project tarball
+   exported from local mode imports cleanly into hosted mode and vice
+   versa.
+
+2. **Same detection ensemble.** Local mode's Tier 1 and hosted
+   mode's Tier 2/3 produce results from the same 3-voter ensemble
+   with the same calibrated thresholds. Hosted may use ONNX-exported
+   models for portability; the artifacts come from the same training
+   run as the local Python models. We don't ship divergent
+   detection per mode.
+
+3. **Same JSON schemas.** Pydantic models for projects, audits,
+   shots, etc. are mode-agnostic. No `local_only` or `hosted_only`
+   fields. If hosted mode needs richer metadata (e.g. who uploaded
+   what), it goes in a sidecar (the Postgres index) -- not in the
+   canonical JSON.
+
+4. **Same UI components.** The React frontend has no `if (hosted)`
+   branches in component logic. Mode-specific affordances (login
+   button, quota chip, upgrade CTA) are conditionally rendered at
+   the layout level based on a single `mode` value supplied by the
+   server at page load. Component-level code stays mode-blind.
+
+5. **Same orchestration.** The detection-pipeline orchestration
+   (split, calibrate, detect, audit) is the same code path in both
+   modes. The differences are which `ComputeBackend` it dispatches
+   to and where the input bytes come from, both of which are
+   already abstracted.
+
+## What this implies for the codebase
+
+- The current `splitsmith ui` entry point becomes one of two entry
+  points; it's not deprecated.
+- The existing `Storage`-shaped helpers in the project layout module
+  formalise into an actual interface (see 03).
+- The existing implicit "no auth" assumption formalises into a
+  `LoopbackAuth` implementation (see 02).
+- The current worker becomes one of two `ComputeBackend`
+  implementations (see 04).
+- A new `splitsmith serve` entry point + dependency injection wiring
+  for the hosted-mode implementations.
+- Deployment: a `Dockerfile` + Fly.io / Railway config; a `docker-
+  compose.yml` for local server-mode dev (so contributors can run
+  hosted-mode locally with R2 LocalStack + Postgres in containers).
+
+## Open questions
+
+- **Should `splitsmith ui` ever optionally enable network listeners?**
+  E.g. a user wants their phone on the same Wi-Fi to view match
+  results from the desktop. This is a real ergonomic ask but it's a
+  multi-device-single-user case, not multi-user. Defer until someone
+  asks; the hosted mode covers cross-device for users who want it.
+- **Where does the desktop "linked-to-cloud" state live?** Probably
+  `~/.splitsmith/auth.json` with a refresh token. Detail in 02.
+- **Does hosted mode ever need a SQLite fallback for local dev?**
+  Probably yes -- a contributor without R2 + Postgres credentials
+  should still be able to `docker compose up` and exercise the
+  hosted-mode code paths. Detail in 03.

--- a/docs/saas-readiness/02-tenancy-and-identity.md
+++ b/docs/saas-readiness/02-tenancy-and-identity.md
@@ -1,0 +1,289 @@
+# 02 -- Tenancy and identity
+
+This doc defines **how Splitsmith identifies users and authorises
+access to projects**. It covers the auth abstraction, the v1 magic-
+link implementation, the session model, and the data model for users
++ project membership.
+
+The data model is **forward-compatible with v2 squad sharing and v3
+public repository** even though v1 only exposes the owner ACL. Adding
+ACL tables after-the-fact is painful; we pay the small cost up front.
+
+## The `Auth` abstraction
+
+A single Python interface, two implementations in v1.
+
+```python
+class AuthBackend(Protocol):
+    async def authenticate_request(
+        self, request: Request
+    ) -> User | None:
+        """
+        Inspect the request (cookies, headers) and return the
+        authenticated User or None. None means anonymous --
+        downstream middleware decides whether that's allowed.
+        """
+
+    async def begin_login(self, email: str) -> LoginChallenge:
+        """
+        Hosted mode: send a magic link; return a challenge handle.
+        Local mode: not called -- LoopbackAuth raises NotImplementedError.
+        """
+
+    async def complete_login(
+        self, challenge_id: str, token: str
+    ) -> Session:
+        """
+        Verify the magic-link token; return a session.
+        Local mode: not called.
+        """
+
+    async def end_session(self, session_id: str) -> None: ...
+```
+
+The interface intentionally does NOT include password operations,
+MFA setup, or password reset. Magic link is the only flow.
+
+### Implementations
+
+- **`LoopbackAuth`** -- local mode. `authenticate_request` always
+  returns the singleton `User(id="local", email="local@splitsmith")`.
+  All login-flow methods raise `NotImplementedError` (they should
+  never be called -- the local UI doesn't render login affordances).
+
+- **`MagicLinkAuth`** -- hosted mode. Wraps Clerk or WorkOS or Auth.js
+  depending on the final pick. Routes magic-link emails through
+  Resend / Postmark.
+
+The wrapper is thin: we don't reimplement session storage, token
+rotation, etc. Whatever the provider does is fine.
+
+## Magic-link flow (hosted mode)
+
+The flow is standard:
+
+1. User submits email at `/login`.
+2. Server calls `auth.begin_login(email)`. The auth provider sends
+   an email with a unique link to `/auth/callback?token=<...>`.
+3. User clicks the link.
+4. `/auth/callback` handler calls `auth.complete_login(token)`,
+   which returns a `Session`. Server sets an httpOnly Secure
+   cookie with the session ID.
+5. Subsequent requests carry the cookie; `auth.authenticate_request`
+   resolves it back to a `User`.
+
+**Token lifetime:** magic-link tokens expire 15 minutes after
+issuance and are single-use. (Default for all the picked providers;
+we don't need to override.)
+
+**Session lifetime:** 30 days, sliding (extends on activity). The
+user can sign out from any device; signing out invalidates only
+that session.
+
+**Email throttling:** the picked provider handles per-email rate
+limits (typically "max 5 magic links per email per hour"). We don't
+add our own rate limiter on top.
+
+### Why no passwords
+
+Three reasons:
+
+1. **Surface area.** Passwords mean a password reset flow, password
+   strength rules, breach detection, MFA pressure, and a password
+   storage column we're now liable for. Magic link has none of that.
+2. **UX.** "Type your email, click the link" is fewer steps than
+   "remember your password, find it in your manager, get told it's
+   expired".
+3. **Threat model.** The magic link IS the second factor (you need
+   email access to receive it). For a hobbyist tool with personal
+   match data, this is sufficient.
+
+If a user demands passwords (e.g. because their email is unreliable),
+we point them at a password manager that supports magic-link auto-
+fill, or we ship federated SSO (Q4 in doc 00, deferred to v2).
+
+## Session model
+
+```python
+class Session(BaseModel):
+    id: str                   # opaque; never the user ID
+    user_id: str
+    created_at: datetime
+    last_used_at: datetime
+    user_agent: str | None    # for the "your devices" UI later
+    ip_inet: IPvAnyAddress | None
+```
+
+Sessions live in Postgres, not in the auth provider, so we can:
+
+- List a user's active sessions.
+- Revoke a single session without nuking all of them.
+- Hold session metadata (UA, last-used) without depending on the
+  provider exposing it.
+
+Cookie attributes: `HttpOnly`, `Secure`, `SameSite=Lax`, host-only
+(no `Domain=` set). 30-day expiry refreshed on activity.
+
+CSRF: the FastAPI `CsrfProtect` middleware (or whatever Starlette
+helper we settle on) on all state-changing routes. Magic-link
+callback is a GET, so it's CSRF-safe by definition.
+
+## The `User` table
+
+```sql
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,         -- ULID, not auto-increment
+  email         TEXT UNIQUE NOT NULL,
+  email_verified_at TIMESTAMPTZ,
+  display_name  TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- billing
+  stripe_customer_id  TEXT UNIQUE,        -- nullable; set on first checkout
+  entitlement         TEXT NOT NULL DEFAULT 'free',
+                                          -- 'free' | 'premium'
+  entitlement_until   TIMESTAMPTZ,        -- null = perpetual; otherwise expiry
+  -- soft delete
+  deleted_at    TIMESTAMPTZ
+);
+
+CREATE INDEX users_email_idx ON users (lower(email));
+```
+
+Email is the natural key from the user's perspective (magic link
+lookup) but we use a synthetic ULID as the PK so we can change email
+without rewriting foreign keys.
+
+## The project ACL data model
+
+This is the v1-vs-v2 forward-compat hot zone. We ship v2's ACL tables
+in v1; we just only ever insert one row per project (the owner).
+
+```sql
+CREATE TABLE projects (
+  id              TEXT PRIMARY KEY,        -- ULID
+  storage_path    TEXT NOT NULL,           -- e.g. 's3://bucket/projects/<id>/'
+  display_name    TEXT NOT NULL,
+  match_date      DATE,
+  owner_user_id   TEXT NOT NULL REFERENCES users(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- v2 fields, present but always default in v1
+  visibility      TEXT NOT NULL DEFAULT 'private',
+                                            -- 'private' | 'shared' | 'public'
+  deleted_at      TIMESTAMPTZ
+);
+
+CREATE TABLE project_members (
+  project_id      TEXT NOT NULL REFERENCES projects(id),
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  role            TEXT NOT NULL,           -- 'owner' | 'editor' | 'viewer'
+  added_by        TEXT NOT NULL REFERENCES users(id),
+  added_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, user_id)
+);
+```
+
+In v1:
+
+- Every project has exactly one row in `project_members` with role
+  `'owner'`.
+- The hosted ACL check is a single query: "does this user have a
+  `project_members` row for this project?"
+- `visibility` is always `'private'` for new projects.
+
+In v2:
+
+- Squad sharing inserts additional rows with role `'editor'` /
+  `'viewer'`. The check above already covers the new cases.
+- `visibility = 'shared'` means the squad-share invite link is
+  enabled.
+- `visibility = 'public'` is v3 (public repo). The check changes to
+  "ACL row OR (visibility='public' AND read-only operation)".
+
+Every API handler that touches a project takes the project_id and
+asserts membership before doing anything else. There is **no
+"current project" implicit context** in the request -- always
+explicit, always checked.
+
+## Project ID -- what it represents
+
+A `project_id` corresponds to one **single-shooter MatchProject** --
+the same unit as today's local on-disk projects. A multi-shooter
+match where N people use Splitsmith means N project_id rows, each
+owned by the respective user.
+
+The cross-shooter compare flow (`splitsmith compare export`) becomes
+"the system enumerates project_ids the requesting user has access
+to, filters to the same `match_date` + venue, and offers them as
+manifest entries". That's a v2 deliverable -- v1 hosted does not have
+multi-shooter compare in the UI.
+
+## The `linked accounts` model (desktop -> cloud)
+
+When a desktop user signs into hosted from the local app:
+
+- The desktop opens a browser to `/link/desktop?challenge=<...>`.
+- The user signs in (magic link as usual).
+- The hosted app redirects to a deep link `splitsmith://link?
+  token=<...>`.
+- The desktop captures the token, exchanges it server-side for a
+  long-lived refresh token (NOT a session cookie -- desktop is not
+  a browser).
+- Refresh token + access token are stored at `~/.splitsmith/auth.json`
+  with `0600` perms.
+
+```sql
+CREATE TABLE desktop_links (
+  id                TEXT PRIMARY KEY,
+  user_id           TEXT NOT NULL REFERENCES users(id),
+  refresh_token_hash TEXT NOT NULL,        -- argon2 of the actual token
+  device_name       TEXT,                  -- 'Mathias's MacBook Pro'
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at      TIMESTAMPTZ,
+  revoked_at        TIMESTAMPTZ
+);
+```
+
+Desktop link tokens have separate revocation from browser sessions
+so the user can "revoke this Mac from my account" without losing
+their browser session.
+
+API requests from the desktop carry `Authorization: Bearer <access>`;
+the access token is short-lived (1h) and refreshed on demand.
+
+## Anonymous access
+
+Hosted mode has no anonymous endpoints in v1 except:
+
+- `GET /` (marketing page)
+- `POST /api/v1/auth/begin` (start magic link)
+- `GET /auth/callback` (complete magic link)
+- `GET /healthz`
+
+Every other API endpoint requires authentication. The default
+middleware response for unauth'd access is 401 with no body --
+no implicit redirect to login (that's a frontend concern).
+
+## What about the local-mode "user"?
+
+Local mode's `LoopbackAuth.user.id == 'local'`. Any code path that
+embeds the user ID into a JSON file or a path uses this stable
+sentinel. Importing a local-mode tarball into hosted mode rewrites
+this sentinel to the importing user's real ID; see 07-sync-and-
+migration.md.
+
+## Open questions
+
+- **Final pick: Clerk vs WorkOS vs Auth.js.** Pricing, EU residency
+  story, and self-host blast radius all matter. Prototype each.
+- **Display name source.** Magic link gives us only the email.
+  Probably ask the user for a display name on first login (one-
+  field form). Can't be required (we'd block them from doing
+  anything) but should be prompted.
+- **Username for sharing URLs.** v2's squad-share invite probably
+  wants a `splitsmith.app/u/<handle>` URL. Defer the handle
+  reservation question until v2 design.
+- **Revoking sessions on entitlement downgrade.** If a user cancels
+  their premium subscription, do we keep their sessions? Yes -- they
+  can still read their data; they just can't run new Tier 2/3 jobs.
+  Detail in 08.

--- a/docs/saas-readiness/03-storage-layer.md
+++ b/docs/saas-readiness/03-storage-layer.md
@@ -1,0 +1,263 @@
+# 03 -- Storage layer
+
+This doc defines the **`Storage` abstraction** that lets the same
+project code read/write to a local filesystem in local mode and to
+Cloudflare R2 (S3-compatible) in hosted mode. It also pins the
+**JSON-as-canonical** invariant from doc 00, principle 6, and
+explains how the Postgres index relates to those JSON files.
+
+## The `Storage` abstraction
+
+Backed by [`fsspec`](https://filesystem-spec.readthedocs.io/) -- one
+API across local FS, S3, R2, GCS, Azure Blob. We don't reimplement
+this layer; we wrap fsspec with a small typed surface that hides the
+fsspec-specific quirks our callers shouldn't care about.
+
+```python
+class Storage(Protocol):
+    """
+    Project-scoped object storage. All paths are relative to the
+    storage root (e.g. 'projects/<id>/match.json').
+    """
+
+    async def read_bytes(self, path: str) -> bytes: ...
+    async def write_bytes(self, path: str, data: bytes) -> None: ...
+
+    async def read_json(self, path: str, model: type[T]) -> T: ...
+    async def write_json(self, path: str, value: BaseModel) -> None: ...
+
+    async def open_stream(
+        self, path: str, mode: Literal['rb', 'wb']
+    ) -> AsyncIterator[bytes]: ...
+
+    async def stat(self, path: str) -> StorageObject | None:
+        """Return None if the path doesn't exist."""
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObject]: ...
+
+    async def delete(self, path: str) -> None: ...
+
+    async def signed_url(
+        self,
+        path: str,
+        method: Literal['GET', 'PUT'],
+        expires: timedelta,
+    ) -> str:
+        """
+        Hosted mode: presigned S3 URL. Local mode: a 'file://' URL
+        valid for the same duration through the local server's
+        signed-redirect handler.
+        """
+```
+
+`StorageObject` carries `path`, `size`, `etag`, `last_modified` --
+the union of fsspec metadata fields we use.
+
+### Implementations
+
+- **`FilesystemStorage`** -- local mode. Wraps fsspec's `LocalFileSystem`.
+  Storage root = `~/.splitsmith/projects/` by default. `signed_url`
+  for `'GET'` returns a `file:///` URL the local server's
+  `/api/files/signed/<token>` redirects to (token-bound, 1-hour
+  expiry, in-memory map -- no DB needed).
+- **`S3Storage`** -- hosted mode. Wraps fsspec's `S3FileSystem`
+  pointing at R2. Bucket = `SPLITSMITH_BUCKET` env var. Region =
+  `auto` (R2 doesn't care). `signed_url` uses R2's S3-compatible
+  presign API.
+- **`MemoryStorage`** -- test-only. fsspec's `MemoryFileSystem`. For
+  unit tests that exercise project lifecycle without touching disk.
+
+We do NOT add a custom HTTP-streaming abstraction. If a caller wants
+to stream a large file, they call `open_stream` and iterate; the
+underlying fsspec implementation handles range requests on S3 and
+buffered file IO locally.
+
+## Cloudflare R2 vs AWS S3
+
+R2 wins for our workload:
+
+- **$0 egress.** Splitsmith serves audio + (eventually) raw video to
+  the browser. Egress is the dominant cost on S3 for media. R2
+  charges $0 to egress to anyone, anywhere.
+- **S3-compatible API.** fsspec talks to R2 via `S3FileSystem` with
+  custom endpoint URL. No code changes vs S3.
+- **Storage cost.** ~$0.015/GB-month, comparable to S3 IA tier.
+- **Class A operations** (PUT, COPY, LIST) cost $4.50/million; Class
+  B (GET) $0.36/million. Both are cheaper than S3 standard.
+
+R2 loses on:
+
+- **Lifecycle policies.** Less mature than S3. We don't need much
+  lifecycle (we hold project data indefinitely until the user
+  deletes); the simple "expire incomplete multipart uploads after
+  7 days" rule is supported.
+- **Cross-region replication.** Not relevant for v1 -- we're a
+  single-region deploy.
+- **Vendor lock-in.** Mitigated by fsspec -- swapping to S3 is one
+  config change.
+
+We pick R2 for v1, with S3 as the documented escape hatch.
+
+## Storage layout
+
+### Per-project layout (the canonical record)
+
+```
+projects/<project_id>/
+  match.json
+  shooters/
+    <shooter_slug>/
+      project.json              # MatchProject record
+      audio.wav                 # extracted audio (Tier 2 input)
+      shots.csv                 # detected shots
+      shots.fcpxml              # FCPXML export
+      audits/
+        <iso_timestamp>.json    # detection audit history
+      stage_<n>/
+        trim_<shooter>.mp4      # per-stage trims (Tier 1 + 3 only)
+  raw/                          # opt-in; only present if user enabled raw upload
+    headcam.mp4
+  exports/
+    <iso_timestamp>.fcpxml
+```
+
+This layout is **identical between local mode and hosted mode**. A
+local-mode project rsync'd to an R2 bucket produces a working
+hosted-mode project (modulo the database index, which gets rebuilt --
+see "Index rebuild" below).
+
+Path conventions:
+
+- `<project_id>` -- ULID, opaque, never the display name.
+- `<shooter_slug>` -- slugified shooter display name; collision-free
+  within a project. Stable once assigned.
+- `<iso_timestamp>` -- `YYYYMMDDTHHMMSSZ`, no fractional seconds.
+
+### Why JSON files instead of a database for project state
+
+The principle is in doc 00, derived #6. Restating concretely:
+
+1. **Local mode has no database.** If we put detection results in
+   Postgres, local mode either spins up SQLite (more complexity, more
+   bugs, harder to ship single-binary) or local mode diverges from
+   hosted (worst-case rewrite to add hosted later).
+2. **Export is trivial.** "Email this project to a friend" is `tar -
+   czf project.tar.gz projects/<id>/` in either mode.
+3. **The detection audit trail is the source of truth.** We've
+   committed in the project guidance to "optimise for the audit
+   trail". JSON files are the audit trail. The DB indexing those
+   files is rebuildable.
+4. **We don't query detection results across projects.** Postgres
+   would shine for "find every shot under 0.18s across all my
+   matches". v1 doesn't need that. v2 might want it -- when it does,
+   it's an indexer over the JSON, not a primary store.
+
+### What IS in Postgres
+
+Only data that:
+
+- Crosses projects, OR
+- Is needed to authorise access before reading any JSON file, OR
+- Is mutated frequently in ways that don't fit a write-then-read
+  JSON model.
+
+Concretely:
+
+- `users`, `sessions`, `desktop_links` (see 02)
+- `projects` -- one row per project, holds `owner_user_id`,
+  `storage_path`, `display_name`. Indexes the JSON, doesn't own it.
+- `project_members` -- ACL (see 02)
+- `upload_sessions` -- in-flight tus uploads (see 05)
+- `compute_jobs` -- in-flight + recent detection jobs, for the
+  jobs drawer (see 04 + 06)
+- `billing_events` -- Stripe webhook log (see 08)
+
+That's the entire schema for v1. ~7 tables. Detection results, shot
+times, audit history, shooter projects -- all JSON in storage.
+
+## Index rebuild
+
+If the database is lost or a project is imported from a tarball, the
+projects table can be rebuilt by walking the storage prefix:
+
+```python
+async def reindex_project(project_id: str) -> None:
+    storage = get_storage()
+    match = await storage.read_json(
+        f'projects/{project_id}/match.json', MatchRecord
+    )
+    # ...upsert into projects table
+```
+
+This makes the JSON files genuinely the source of truth: lose the
+database and we lose user accounts + ACLs (bad), but we don't lose
+any match data. The reindex is part of the import flow (see
+07-sync-and-migration.md).
+
+## Concurrency and conflicts
+
+In local mode there's one writer (the local server, single user).
+We rely on local filesystem semantics: write-temp-then-rename for
+atomicity. No locking needed.
+
+In hosted mode there can in principle be multiple writers (the user
+on two browser tabs, a worker finishing a detection job, the desktop
+syncing). v1 mitigates this with:
+
+- **One-writer-per-project at a time.** The first request to a
+  project takes a Postgres advisory lock; concurrent writes 409.
+  This is coarse but adequate for a single-user-per-project v1.
+- **Conditional writes for JSON updates.** Every JSON update reads
+  current ETag, modifies, writes with `If-Match`. Conflict =>
+  reload + retry once, then surface to the user. This is a
+  belt-and-braces check on top of the advisory lock.
+- **No partial writes.** All JSON updates are full-file rewrites.
+  Append patterns (e.g. audit log) are full reads + full writes
+  rather than appends, so there's no torn-write window.
+
+v2 (squad sharing) likely needs proper optimistic concurrency control
+on per-stage edits. Defer until then.
+
+## Storage paths in the data model
+
+The `projects.storage_path` column holds the **prefix** under which
+the project's files live. In hosted mode this is `s3://splitsmith-
+prod/projects/<id>/`. In local mode -- if the local app ever writes
+to a Postgres index, which v1 doesn't -- it would be
+`file:///Users/.../projects/<id>/`.
+
+The prefix model means a project can move between buckets (e.g. a
+data residency request, or a user moving to a self-hosted deployment)
+by updating one row + copying objects. The fsspec implementation
+behind `Storage` happily handles a per-project bucket choice -- we
+just don't expose the configurability in v1.
+
+## What stays out of storage
+
+These do NOT live in the storage layer:
+
+- **Auth tokens.** Postgres-only. Never written to JSON or storage
+  paths.
+- **Stripe customer IDs / webhook payloads.** Postgres-only.
+- **Computed in-memory caches** (e.g. the loaded ONNX model). Live
+  in the process, not in storage.
+- **Logs.** Stdout in v1; Sentry for errors. We don't write logs to
+  R2.
+
+## Open questions
+
+- **Lifecycle for orphaned files.** If a user uploads audio but
+  abandons the upload, the bytes sit in R2 forever. We should run a
+  weekly "delete files referenced by no project" job. Probably
+  trivial; track in 09.
+- **Per-project encryption.** R2 encrypts at rest by default. If a
+  user wants client-side encryption (their key, our blind storage)
+  that's a v3+ feature. v1 trusts R2's server-side encryption.
+- **Virus scanning on raw upload.** Probably overkill for video
+  files -- the format is fixed and we don't execute anything from
+  storage. Skip in v1; revisit if we ever accept user-uploaded
+  binaries that could end up on the user's machine.
+- **Per-tenant prefixes vs flat.** We currently flat-prefix
+  `projects/<id>/`. We could go `users/<owner_id>/projects/<id>/`
+  to make per-user deletion (GDPR) easier. Probably worth doing
+  even in v1 -- decide during implementation.

--- a/docs/saas-readiness/04-compute-backends.md
+++ b/docs/saas-readiness/04-compute-backends.md
@@ -1,0 +1,315 @@
+# 04 -- Compute backends
+
+This doc defines the **`ComputeBackend` abstraction** that decides
+where the detection ensemble runs, the **three-tier compute model**
+from doc 00 Q3, the **auto-selection** logic, and the **shape of the
+cloud worker** that hosts Tier 2 + 3.
+
+The detection ensemble itself is documented in CLAUDE.md and SPEC.md
+under "Detection pipeline". This doc is about *where* it runs, not
+*what* it does. The three voters (envelope onset, CLAP differential,
+GBDT-with-PANN-feature) are the same in every tier; only the
+execution location differs.
+
+## The `ComputeBackend` abstraction
+
+```python
+class ComputeBackend(Protocol):
+    """
+    Runs the shot-detection ensemble for a single stage.
+    Implementations decide where the work happens.
+    """
+
+    name: str  # 'local' | 'remote-tier2' | 'remote-tier3'
+
+    async def detect_stage(
+        self,
+        project_id: str,
+        stage_number: int,
+        audio: AudioRef,           # see below
+        config: DetectionConfig,
+        progress: ProgressSink,
+    ) -> DetectionResult: ...
+
+    async def health(self) -> BackendHealth:
+        """Quick check: model artifacts loaded, worker reachable."""
+```
+
+`AudioRef` is a tagged union:
+
+```python
+class AudioRef(BaseModel):
+    kind: Literal['inline', 'storage', 'video']
+    inline_bytes: bytes | None = None     # kind='inline'
+    storage_path: str | None = None       # kind='storage'
+    video_path: str | None = None         # kind='video'
+    sample_rate: int | None = None        # required for 'inline'
+```
+
+The three kinds correspond to "audio is in memory" (typical for the
+desktop where the user just opened a file), "audio is in
+storage" (typical for hosted Tier 2 -- the browser uploaded WAV to
+R2), and "audio still has to be extracted from a video" (Tier 1 +
+Tier 3 from raw).
+
+## The three tiers
+
+### Tier 1 -- local desktop
+
+**Backend:** `LocalComputeBackend`
+**Where:** the user's machine, in-process or via the existing local
+worker.
+**Inputs:** raw video (or pre-extracted audio if the user supplies it).
+**Outputs:** `DetectionResult` written to the local FilesystemStorage.
+
+This is what `splitsmith ui` does today. No change in v1 except that
+the orchestration code now goes through the `ComputeBackend`
+interface instead of calling the ensemble module directly.
+
+Pros: free, fully offline, native PyTorch speed.
+Cons: needs CLAP + PANN downloaded (~150 MB) on first run, slow on
+machines without GPU acceleration.
+
+### Tier 2 -- audio upload + cloud ML (default for hosted premium)
+
+**Backend:** `RemoteComputeBackend(tier='audio')`
+**Where:** the browser handles cheap pieces, the cloud worker handles
+heavy pieces.
+**Inputs:** audio extracted in the browser via WebAudio (or in the
+desktop and shipped over). Typically ~5 MB per stage as 16 kHz mono
+WAV.
+**Outputs:** `DetectionResult` written to S3Storage; the browser
+displays it.
+
+The split:
+
+| Step                           | Where it runs (Tier 2) |
+| ------------------------------ | ---------------------- |
+| Extract audio from video       | Browser (WebAudio)     |
+| Voter A -- envelope onset      | Browser (WASM, ~50 KB) |
+| Run CLAP -> per-prompt sims    | Cloud worker           |
+| Run PANN -> gunshot prob       | Cloud worker           |
+| Voter B -- CLAP differential   | Browser (cheap math)   |
+| Voter C -- GBDT                | Browser (ONNX-Web, ~3 MB) |
+| Consensus + apriori            | Browser                |
+| Audit JSON write               | Server (signed PUT to R2) |
+
+Why this split:
+
+- **CLAP and PANN are 150 MB combined.** Shipping them to every
+  browser is a bandwidth + memory non-starter. They run server-side.
+- **The GBDT is 3 MB and runs in milliseconds.** Shipping it to the
+  browser saves a server round-trip per detection call and keeps
+  the user's audio out of the cloud one more layer (only the audio
+  goes up; the per-prompt similarities come back; the actual
+  classification happens locally).
+- **Envelope onset is pure DSP.** It compiles to small WASM and
+  runs in the browser too.
+
+The cloud worker's job in Tier 2 is narrowly: *take audio, return
+features*. It does not see the final shot list, doesn't know the
+consensus threshold, doesn't make per-shot decisions.
+
+Pros: tiny upload (5 MB vs 5 GB), heavy models amortised, browser
+keeps user-controlled control over the final consensus.
+Cons: needs a network round-trip; CLAP runs serverside (privacy:
+audio is in their datacenter for ~1s).
+
+### Tier 3 -- full cloud (hosted, opt-in)
+
+**Backend:** `RemoteComputeBackend(tier='video')`
+**Where:** raw video on R2; the cloud worker does the entire pipeline
+including audio extraction, beep detect, trim, ensemble.
+**Inputs:** the raw video upload (5-30 GB per stage).
+**Outputs:** stage trims written to R2; `DetectionResult` written to
+R2; the browser fetches them.
+
+This is the "I'm on a Chromebook and my video is on Drive" case.
+The browser is a thin client.
+
+Pros: any device, any bandwidth-after-upload.
+Cons: full upload cost; the user's raw footage sits in our bucket
+(opt-in per match per doc 00 Q2).
+
+### Tier picker
+
+```python
+class TierPicker:
+    async def pick(self, *, project: Project, stage: Stage) -> ComputeBackend:
+        ...
+```
+
+Decision logic, in order:
+
+1. **User override.** If `settings.compute_tier_override` is set
+   for this project, honour it.
+2. **Local data + capable browser?** -- pick Tier 1 (or Tier 2 if
+   the WASM bench failed).
+3. **Local data + incapable browser?** -- pick Tier 2.
+4. **Cloud data?** -- pick Tier 3.
+5. **Free-tier user?** -- always Tier 1; Tier 2/3 attempts return a
+   paywall response (handled by the API layer, not the picker).
+
+"Capable browser" is gated by a one-time bench (see "Browser
+capability bench" below).
+
+## Browser capability bench
+
+On first hosted-mode visit, the browser runs:
+
+1. **WASM cold start.** Load the envelope-onset WASM module, run it
+   on a 5-second synthetic clip, measure latency. Target: <500ms.
+   Above 1500ms => fall back to "cheap pieces server-side too" path
+   (which means Tier 2 stops being available; the user is forced to
+   Tier 3 for hosted detection).
+2. **ONNX-Web cold start.** Load the GBDT, classify 100 fake feature
+   vectors, measure. Target: <200ms total. Above 1000ms => same
+   fallback as above.
+3. **WebAudio decode.** Decode a 5-second AAC fragment to PCM,
+   measure. Target: <300ms.
+
+Bench results are cached in `localStorage` keyed by user-agent +
+hardware concurrency. Re-run on UA change. Bench takes ~3 seconds
+total on first visit; the user sees a "preparing your workspace"
+spinner.
+
+## The cloud worker
+
+A FastAPI app + an `arq` worker, deployed together (Fly machines or
+Railway services). The HTTP app receives detection requests, the
+worker processes them.
+
+### Job shape
+
+A detection job in Postgres:
+
+```sql
+CREATE TABLE compute_jobs (
+  id              TEXT PRIMARY KEY,        -- ULID
+  project_id      TEXT NOT NULL REFERENCES projects(id),
+  stage_number    INT NOT NULL,
+  tier            TEXT NOT NULL,           -- 'tier2' | 'tier3'
+  status          TEXT NOT NULL,           -- 'queued' | 'running' | 'done' | 'failed'
+  audio_storage_path TEXT,                 -- tier2: where the WAV is
+  video_storage_path TEXT,                 -- tier3: where the source is
+  result_storage_path TEXT,                -- where the DetectionResult JSON lives
+  features_json   JSONB,                   -- tier2: per-prompt sims + PANN prob
+  error_message   TEXT,
+  enqueued_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  started_at      TIMESTAMPTZ,
+  finished_at     TIMESTAMPTZ
+);
+
+CREATE INDEX compute_jobs_status_idx ON compute_jobs (status);
+CREATE INDEX compute_jobs_project_idx ON compute_jobs (project_id);
+```
+
+The browser polls `GET /api/v1/projects/{pid}/jobs/{jid}` (or
+subscribes via SSE) for status. The jobs drawer in the UI (already
+shipped in the desktop redesign) reads from this table.
+
+### Worker pool
+
+- **Tier 2 worker:** runs CLAP + PANN. The model artifacts live in a
+  baked-in Docker layer. Memory: ~600 MB resident with both models
+  loaded. CPU only is fine for v1; GPU instances cost more than
+  they save at our load. Concurrency: one job per worker process;
+  spawn N processes per machine.
+- **Tier 3 worker:** runs the full Python ensemble + ffmpeg. Needs
+  more memory (~2 GB peak during ffmpeg), and IO bandwidth to R2.
+  Same concurrency model.
+
+For v1 the Tier 2 and Tier 3 workers are the same code with a flag.
+We split into separate worker pools only if Tier 3 throughput becomes
+a bottleneck.
+
+### Idempotency
+
+Job IDs are client-generated ULIDs. Re-submitting a job with the same
+ID is a no-op (returns the existing job). This means the browser can
+retry a failed POST without spawning duplicate work.
+
+Result writes are idempotent because they're full-file overwrites at
+known storage paths.
+
+### Failure handling
+
+- Worker crashes mid-job => `arq` retries up to 3 times with
+  exponential backoff. After 3 fails, the job moves to `failed`
+  with `error_message` set.
+- The user sees a "Retry" button. Retry creates a new job ID
+  (different ULID) -- the failed job stays in the table for
+  debugging.
+- Sentry captures the exception with `project_id` + `stage_number`
+  context; PII (audio bytes, full storage paths) is scrubbed.
+
+## Cost model (rough, for sizing)
+
+Tier 2 per stage:
+- 5 MB audio upload (R2: free) + 5 MB egress to worker (free, in-
+  region) + ~200 KB features back to browser.
+- Worker: ~3 seconds of CPU on a 1-vCPU machine. At Fly.io's
+  shared-CPU pricing (~$0.005/h) that's ~$0.000004/stage. Round up
+  for cold starts and overhead: $0.001/stage.
+
+Tier 3 per stage:
+- 5-30 GB video upload (R2: free) + 5-30 GB egress to worker (free).
+- Worker: ~30s-2min CPU + ffmpeg IO. ~$0.001-$0.005/stage.
+
+A heavy user with 100 stages/month costs us ~$0.10-$0.50 in compute
++ ~$5-15 in R2 storage if they keep raw video. Either way, the
+margins on a $5-10/month flat tier are healthy. Detail in 08.
+
+## Local-mode degradation
+
+If the local user's machine doesn't have CLAP/PANN downloaded yet,
+the local backend falls back to "envelope-onset only" with a UI
+banner asking the user to either (a) download the models (one-time
+~150 MB), or (b) sign in to hosted to use Tier 2 without the
+download.
+
+This degradation path matters because the desktop's first-run
+experience is "open the app, point at a video, see shots". We can't
+require a 150 MB download before the user sees value. The envelope-
+onset fallback is fast and produces a reasonable approximation; the
+audit shows "ensemble unavailable -- voter A only" so the user
+knows it's preliminary.
+
+## Configuration
+
+Per-project settings written to `match.json`:
+
+```json
+{
+  "compute": {
+    "tier_override": null,         // null | 'local' | 'tier2' | 'tier3'
+    "raw_uploaded": false,         // tier3 only available if true
+    "ensemble_consensus": 2        // 2-of-3 default, user-tuneable
+  }
+}
+```
+
+Per-user settings in Postgres `users` table (hosted mode only):
+
+- `default_tier_override` -- "always force Tier 2", e.g.
+- `bench_results` -- the cached browser-capability bench scores
+
+Both are nullable; null means "use the picker default".
+
+## Open questions
+
+- **Tier 1 in the browser.** Could we ship CLAP + PANN as ONNX-Web
+  and run *everything* in the browser? Probably yes someday; today
+  the model sizes are too large. Track for v2 if WASM ML toolchains
+  improve.
+- **Per-tenant retrain.** Premium users might want to retrain the
+  GBDT on their own audited data. v3+. Not in v1.
+- **GPU workers for Tier 3.** A user with 30+ stages of raw video
+  per match would benefit. Defer until usage shows the bottleneck.
+- **Cold-start latency.** Fly.io machines suspend after inactivity.
+  First detection request after suspend pays a ~5s cold start.
+  Acceptable for v1; worth measuring under real load.
+- **Local <-> remote feature parity.** If hosted's CLAP runs through
+  ONNX and local's runs through PyTorch, do their per-prompt
+  similarities match within a tolerance? Should be yes if we export
+  with `opset=17` and disable dropout, but verify before launch.

--- a/docs/saas-readiness/05-uploads-and-streaming.md
+++ b/docs/saas-readiness/05-uploads-and-streaming.md
@@ -1,0 +1,297 @@
+# 05 -- Uploads and streaming
+
+This doc defines **how bytes get from the user into the hosted
+service** (audio + opt-in raw video) and **how they come back out**
+(stream-on-demand for playback). It pins the upload protocol,
+signed-URL pattern, and the v1 vs v2 scope on raw upload.
+
+The top constraint is **don't move heavy data twice**. If the user's
+audio is in their browser and we're going to run Tier 2 detection on
+it, the audio goes to R2 once and the worker reads it from R2 -- not
+"upload to API server, API server forwards to R2, worker downloads
+again".
+
+## Upload protocol: tus
+
+We use the [tus.io](https://tus.io/) resumable-upload protocol via
+[tus-js-client](https://github.com/tus/tus-js-client) on the browser
+and [tus-py-server](https://github.com/tus-project) on the server.
+
+Why tus over a custom multipart scheme:
+
+- **Resume after network drop.** Critical for raw-video uploads
+  (5-30 GB on home internet). Tus persists upload state on the
+  server and lets the client resume from the last byte received.
+- **Battle-tested.** Used by Vimeo, Cloudflare Stream, etc. We don't
+  reinvent the upload state machine.
+- **Standardised.** Client and server libraries exist for every
+  major language; if we want a CLI uploader later, one already
+  exists.
+- **S3 multipart compatibility.** The tus-py-server has an S3 store
+  that uses S3's multipart upload API under the hood, so the bytes
+  go straight to R2 without buffering on our API server.
+
+Why not direct presigned-PUT to R2:
+
+- Presigned PUT works for small files but doesn't resume. The user
+  loses their ~10 GB raw video when their Wi-Fi blips at 90%.
+- Multipart upload via presigned URLs is doable but means
+  reimplementing chunk tracking, retry, and abort logic. Tus is
+  exactly that, packaged.
+
+### Upload flow
+
+```
+Browser                          API server                   R2
+  |                                  |                          |
+  |-- POST /api/v1/uploads --------->|                          |
+  |   { kind: 'audio',               |                          |
+  |     project_id, stage_n,         |                          |
+  |     size_bytes, sha256 }         |                          |
+  |                                  |-- create multipart ----->|
+  |                                  |<- upload_id -------------|
+  |<-- { upload_id,                 -|                          |
+  |     tus_endpoint } -------------|                          |
+  |                                  |                          |
+  |-- PATCH tus_endpoint ------------|------ stream chunks --->|
+  |   (resumable; tus protocol)      |   (S3 multipart parts)   |
+  |        ...                       |                          |
+  |-- PATCH tus_endpoint (last) -----|------ complete -------->|
+  |                                  |<- etag ------------------|
+  |<-- 204 No Content ---------------|                          |
+  |                                  |                          |
+  |-- POST /api/v1/jobs ------------>|                          |
+  |   { project_id, stage_n,         |                          |
+  |     upload_id }                  |                          |
+  |                                  |-- enqueue arq job        |
+  |<-- { job_id } ------------------|                          |
+```
+
+### Upload session table
+
+```sql
+CREATE TABLE upload_sessions (
+  id              TEXT PRIMARY KEY,        -- ULID, 'upload_id' in API
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  project_id      TEXT REFERENCES projects(id),  -- nullable; new projects
+  kind            TEXT NOT NULL,           -- 'audio' | 'raw_video' | 'project_tarball'
+  stage_number    INT,                     -- nullable; tarballs span stages
+  size_bytes      BIGINT NOT NULL,
+  sha256          TEXT,                    -- declared by client
+  storage_path    TEXT NOT NULL,           -- where the bytes will land
+  s3_upload_id    TEXT,                    -- the underlying multipart id
+  bytes_received  BIGINT NOT NULL DEFAULT 0,
+  status          TEXT NOT NULL,           -- 'in_progress' | 'completed' | 'aborted'
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at    TIMESTAMPTZ,
+  expires_at      TIMESTAMPTZ NOT NULL     -- 24h from creation; tus aborts after
+);
+```
+
+The `expires_at` lets us abort stalled uploads -- a daily cron calls
+`AbortMultipartUpload` on R2 for any session past its expiry. R2's
+own "expire incomplete multiparts after 7 days" lifecycle rule is the
+backstop.
+
+### Hash verification
+
+The client declares a sha256 in the create-upload request. After the
+last chunk lands, the server verifies (we have the bytes anyway --
+streaming sha256 during the multipart-complete callback). Mismatch =>
+mark the upload aborted, return 422 to the client. Client re-uploads.
+
+This catches:
+- Bytes corrupted in transit (rare with TLS but happens).
+- Browser/desktop bug encoding the audio differently than declared.
+
+## Audio upload (Tier 2 default)
+
+The browser extracts audio in WebAudio:
+
+```javascript
+// Pseudo-code
+const ctx = new OfflineAudioContext(1, video.duration * 16000, 16000);
+const audioBuffer = await ctx.decodeAudioData(videoBytes);
+// downmix to mono if needed; resample to 16k
+const wavBytes = encodeWav(audioBuffer.getChannelData(0), 16000);
+```
+
+The result is ~5 MB per stage at 16 kHz mono 16-bit, regardless of
+the source video's resolution. This is the smallest input that
+preserves the signal CLAP/PANN need.
+
+Audio uploads land at:
+
+```
+projects/<project_id>/shooters/<slug>/stage_<n>/audio.wav
+```
+
+After upload completes, the client posts to `/api/v1/jobs` to enqueue
+detection (see 04). The job reads from this exact path.
+
+The audio file is **kept** after detection -- it's the input the user
+re-runs detection with if they tweak the consensus threshold or audit
+the result. We never re-extract from raw if audio.wav exists.
+
+## Raw video upload (v2; opt-in)
+
+**Not in v1.** Documented here so the v1 abstractions don't preclude
+it.
+
+Raw upload uses the same tus flow, with `kind='raw_video'` and a
+larger `expires_at` window (72h instead of 24h, since 30 GB on home
+internet can take hours). Lands at:
+
+```
+projects/<project_id>/raw/<original_filename>.<ext>
+```
+
+The browser shows a clear consent dialog before starting:
+
+> Upload your raw video to Splitsmith?
+>
+> This makes the video available across your devices and to
+> squadmates you share with. We store it in our EU datacenter
+> (Cloudflare R2 - Frankfurt). You can delete the upload at any
+> time from the project settings.
+>
+> The audio extracted from this video will be uploaded regardless --
+> this option additionally uploads the full video.
+
+Once raw is uploaded, Tier 3 becomes available for that project. Tier
+2 (audio-only) remains the default detection tier; Tier 3 is offered
+when the user explicitly wants the worker to re-run audio extraction
+or wants to verify the trim alignments server-side.
+
+### Raw video state per project
+
+The `match.json` carries a `raw_videos` array:
+
+```json
+{
+  "raw_videos": [
+    {
+      "original_filename": "GH010023.mp4",
+      "size_bytes": 12345678901,
+      "sha256": "...",
+      "uploaded_at": "2026-05-15T12:34:56Z",
+      "storage_path": "projects/<id>/raw/GH010023.mp4",
+      "covers_stages": [1, 2, 3, 4]
+    }
+  ]
+}
+```
+
+This handles the realistic case where one head-cam recording covers
+multiple stages -- the user uploads once, the project knows which
+stages map to which raw file (today's video-match logic continues to
+do this lookup; it just runs against R2 paths now).
+
+## Streaming back to the browser (playback)
+
+Audio playback in the audit / coach views needs to fetch chunks of
+audio.wav. Raw-video preview needs to fetch ranges of the source
+file. Both flow through **signed URLs**.
+
+```
+Browser                      API server                      R2
+  |                              |                            |
+  |-- GET /api/v1/files/         |                            |
+  |    signed-url?path=...&      |                            |
+  |    method=GET&ttl=3600 ----->|                            |
+  |                              |-- ACL check                |
+  |                              |-- presign GET URL          |
+  |<-- { url } ------------------|                            |
+  |                                                           |
+  |-- GET <signed_url> -------------------- range bytes 0-1m->|
+  |<--------------------------------------- response ---------|
+```
+
+URL TTLs are short (15 minutes default; 1 hour for known-large
+files). The browser refetches a new URL when the old one expires.
+
+The frontend's existing audio waveform code (and the FCPXML preview
+playback) only need to know "give me a URL I can fetch ranges
+from"; the signed-URL helper hides the local-vs-hosted difference.
+
+### Why not stream through the API
+
+- **Cost.** R2 -> our API server -> browser doubles egress. Fly.io's
+  egress isn't free (R2 -> R2 customer is free but R2 -> third-
+  party server pays).
+- **Latency.** Direct R2 fetch with a CDN in front (Cloudflare is
+  free and sits in front of R2 anyway) is faster than proxying.
+- **Range requests.** R2 handles HTTP range requests natively for
+  multipart-uploaded objects. Implementing range proxying is
+  another tarpit.
+
+Local mode's `signed_url` returns `file:///` URLs that the local
+server's `/api/files/signed/<token>` redirects to (token-bound, in-
+memory map, 1-hour TTL -- no DB needed). The browser code is
+identical in both modes.
+
+## Project tarball upload (migration)
+
+For users who don't want to install the desktop, the migration path
+(see 07) is "export your local project to a tarball, upload it
+through the web UI". The tarball flow uses the same tus protocol
+with `kind='project_tarball'`, lands at:
+
+```
+imports/<upload_id>.tar.gz
+```
+
+After upload, a worker job:
+1. Streams the tarball, validates structure (must contain
+   `match.json` at the top level, schema-conformant).
+2. Mints a new `project_id`, rewrites paths, uploads files to
+   `projects/<new_id>/`.
+3. Inserts the `projects` row + the owner `project_members` row
+   for the importing user.
+4. Deletes the source tarball.
+
+The user sees the import progress in the jobs drawer.
+
+## Bandwidth budgeting (rough)
+
+- **Audio per stage:** ~5 MB. A 12-stage match = ~60 MB upload.
+- **Raw video per stage:** 2-5 GB on a typical head-cam recording.
+  A 12-stage match = 24-60 GB if all raw is uploaded.
+
+The audio path is fine on any connection. Raw upload at 60 GB on a
+50 Mbps uplink is ~3 hours. Tus resume is essential.
+
+## Server-side limits (v1)
+
+Per upload session:
+- Max size: 50 GB. Above that, we need a conversation about whether
+  the user really wants to upload that much.
+- Max concurrent in-progress: 3 per user. Anything more probably
+  means a runaway client; refuse with 429.
+
+Per user (free tier):
+- No raw upload at all (premium-only).
+- Audio uploads: unlimited count, but jobs are gated by Tier 2
+  access, which is premium-only. Free users use Tier 1 locally.
+
+Per user (premium):
+- v1 has no enforced quota. We measure usage (08) and add quotas in
+  v2 if anyone abuses it.
+
+## Open questions
+
+- **Browser audio extraction quality.** WebAudio decodes most
+  formats but exotic codecs in head-cam files might fail. Need to
+  test against GoPro / Insta360 / Sony A7S samples. Fallback: ship
+  ffmpeg.wasm for the unsupported formats (large but feasible).
+- **Direct-to-R2 from desktop.** The desktop sync flow could write
+  directly to R2 with desktop-bound credentials, skipping the API
+  server entirely. Probably worth doing for raw video when v2 ships.
+- **HEIC / HEVC raw video.** Some cameras output HEVC; ffmpeg in
+  the cloud worker handles this fine, but HEVC playback in the
+  browser is browser-dependent. May need a transcode step server-
+  side for in-browser preview.
+- **Encrypted client-side upload.** A user wanting client-side E2EE
+  for raw video would need a key the worker can decrypt with --
+  i.e. server-held key, which defeats the purpose. Skip until the
+  user articulates a real threat model.

--- a/docs/saas-readiness/06-api-surface.md
+++ b/docs/saas-readiness/06-api-surface.md
@@ -1,0 +1,307 @@
+# 06 -- API surface
+
+This doc defines the **HTTP API contract** between the browser /
+desktop client and the Splitsmith backend. It covers versioning,
+auth headers, error shape, observability, and the deprecation
+policy.
+
+It does NOT enumerate every endpoint -- those are documented by
+FastAPI's auto-generated OpenAPI schema. This doc is the conventions
+that every endpoint follows.
+
+## URL structure
+
+```
+https://splitsmith.app/api/v1/<resource>/<id>/<sub-resource>
+```
+
+Locked-in conventions:
+
+- **`/api/v1/` from day one.** Even if v1 is the only version, the
+  prefix is there. Breaking changes ship as `/api/v2/` with a
+  deprecation window (see "Deprecation policy" below).
+- **Resources are plural nouns.** `/projects`, `/uploads`, `/jobs`.
+- **IDs are ULIDs in path segments.** `/projects/01HX.../jobs/01HX...`.
+- **Sub-resources for things that don't exist standalone.**
+  `/projects/<id>/stages/<n>/shots` -- a shot list doesn't make
+  sense without its stage and project.
+- **No verbs in URLs.** Actions go through HTTP methods + dedicated
+  endpoints (`POST /projects/<id>/jobs` to start a detection job;
+  `DELETE /projects/<id>/jobs/<jid>` to cancel).
+
+The local-mode server uses the same routes. A local request to
+`http://127.0.0.1:8765/api/v1/projects/<id>` returns the same
+shape as the hosted equivalent. The desktop client and the web SPA
+share the same API client code.
+
+## Versioning policy
+
+- **`/api/v1/` is stable.** Once shipped, no breaking changes.
+  Additive-only: new optional fields, new endpoints, new query
+  parameters with defaults that preserve existing behaviour.
+- **Breaking changes ship as `/api/v2/`.** Both versions live in
+  parallel for at least 6 months after `/api/v2/` ships (the
+  "deprecation window").
+- **The "shape" of a v1 response can never change.** Renaming a
+  field is breaking. Tightening a type (string -> enum) is breaking.
+  Removing a field is breaking. Adding a field is fine.
+- **Status codes are part of the contract.** 200 vs 201 vs 204
+  matter; we don't change them mid-version.
+
+Every response carries a `X-Splitsmith-API-Version: v1` header for
+explicit confirmation.
+
+## Authentication
+
+Two acceptable mechanisms:
+
+1. **Browser:** httpOnly session cookie (set by the magic-link
+   callback). CSRF-protected via `X-CSRF-Token` header, fetched from
+   `GET /api/v1/auth/csrf`.
+2. **Desktop / CLI:** `Authorization: Bearer <access_token>` header.
+   Access tokens are short-lived (1h); refresh via `POST /api/v1/
+   auth/refresh` with a refresh token from the desktop link flow
+   (see 02).
+
+Local mode requires neither -- `LoopbackAuth` resolves to the local
+user regardless. Local-mode clients still send the headers if they
+have them (e.g. the desktop linked to a hosted account); the local
+server ignores them.
+
+Anonymous endpoints (no auth required):
+
+- `GET /api/v1/healthz`
+- `POST /api/v1/auth/begin` (start magic link)
+- `GET /api/v1/auth/callback` (magic-link verify; sets cookie)
+- `POST /api/v1/billing/webhooks/stripe` (validated by Stripe
+  signature, not by user auth)
+
+Every other endpoint returns 401 if unauth'd. No body, just `WWW-
+Authenticate: Bearer realm="splitsmith"`.
+
+## Request and response shape
+
+### Request bodies
+
+JSON only. Content-Type `application/json; charset=utf-8`. Reject
+anything else with 415. Exception: tus uploads and webhook payloads,
+which have their own content types.
+
+### Response bodies
+
+JSON only, same content type. Empty bodies for 204 No Content (which
+we use for successful PUTs and DELETEs that have nothing to return).
+
+Top-level shape for resource responses:
+
+```json
+{
+  "data": { ... },           // the resource object, or array
+  "meta": { ... }            // optional pagination, timing, etc.
+}
+```
+
+Top-level shape for error responses:
+
+```json
+{
+  "error": {
+    "code": "project_not_found",       // stable string, snake_case
+    "message": "Project 01HX... not found.",
+    "details": { ... }                  // optional, structured
+  },
+  "trace_id": "..."                    // for support correspondence
+}
+```
+
+The `code` is the stable contract; the `message` is human-readable
+and may change. Clients that branch on errors must branch on `code`.
+
+Error codes are documented per-endpoint in the OpenAPI schema.
+
+### Pagination
+
+List endpoints default to 50 items, max 200, paginated via cursor:
+
+```json
+{
+  "data": [...],
+  "meta": {
+    "cursor": {
+      "next": "opaque-string-or-null",
+      "prev": "opaque-string-or-null"
+    }
+  }
+}
+```
+
+Cursors are opaque base64 strings; clients must not parse them. The
+server may invalidate old cursors during data migrations.
+
+## Idempotency
+
+Endpoints that have side effects accept an optional `Idempotency-
+Key` header. The key is a client-generated ULID. The server caches
+the response for the key for 24h; replays with the same key return
+the cached response (200 if it succeeded, original error if it
+failed).
+
+This makes "the user clicked submit twice" a non-issue and lets the
+desktop sync flow safely retry network failures.
+
+Mandatory idempotency:
+
+- `POST /projects/<id>/jobs` -- detection jobs are expensive; double-
+  submission would charge the user twice.
+- `POST /uploads` -- starting two upload sessions for the same data
+  wastes storage.
+- `POST /billing/checkout` -- spinning up two Stripe Checkout
+  sessions confuses the user.
+
+Optional but recommended for everything else.
+
+## Rate limiting
+
+Per-user, applied at the API gateway:
+
+- Anonymous endpoints: 60 req/min per IP.
+- Authenticated GET: 600 req/min.
+- Authenticated POST/PUT/DELETE: 60 req/min.
+- `POST /uploads`: 10 req/min (each upload session is heavy).
+
+Limits return 429 with `Retry-After` header. We don't need fancier
+than this in v1; if the picked deploy target (Fly / Railway) doesn't
+provide gateway-level limits, we wire up `slowapi` or similar.
+
+Rate limits do NOT apply to local mode (the loopback user can do
+anything as fast as they want).
+
+## Error semantics
+
+Status codes follow standard usage:
+
+- **200 OK** -- success with body.
+- **201 Created** -- POST that created a new resource. Body =
+  resource representation.
+- **204 No Content** -- success with no body (PUTs, DELETEs, idempotent
+  no-ops).
+- **400 Bad Request** -- the request is malformed (bad JSON, missing
+  required fields). Specific to the request.
+- **401 Unauthorized** -- not authenticated.
+- **403 Forbidden** -- authenticated but not allowed (ACL fail).
+- **404 Not Found** -- resource doesn't exist OR the user can't see
+  it (we don't leak existence). Distinguish only via `code` if
+  needed for UX.
+- **409 Conflict** -- write conflict (concurrent edit) or duplicate
+  (slug already taken).
+- **413 Payload Too Large** -- upload exceeds 50 GB cap.
+- **415 Unsupported Media Type** -- non-JSON to a JSON endpoint.
+- **422 Unprocessable Entity** -- semantic validation fail (e.g.
+  uploaded file's sha256 doesn't match the declared one).
+- **429 Too Many Requests** -- rate limited.
+- **500 Internal Server Error** -- bug. Logged to Sentry; user
+  sees a generic message + trace ID.
+- **503 Service Unavailable** -- worker pool saturated, deploy in
+  progress, etc. `Retry-After` set.
+
+5xx responses always include a `trace_id`. Support requests carry
+this ID; we look up the Sentry event by it.
+
+## Observability
+
+### Tracing
+
+Each request gets a unique `trace_id` (ULID), set as a response
+header (`X-Trace-Id`) and logged with every log line for the
+request. Sentry events carry the same ID.
+
+If the request comes in with a `traceparent` header (W3C trace
+context), we honour it -- this lets the desktop client trace
+through to the server and back. We don't ship a full distributed
+tracing setup in v1; just the header passthrough.
+
+### Metrics
+
+Provider-built-in for v1:
+
+- Fly.io / Railway dashboards for request rate, latency, error
+  rate.
+- Sentry for error tracking + performance traces (optional).
+
+We don't run our own Prometheus / Grafana in v1. If we outgrow
+provider dashboards, revisit.
+
+### Logging
+
+Structured logs (JSON), one line per event, going to stdout. Fields:
+
+- `ts`, `level`, `msg`
+- `trace_id`, `user_id`, `project_id` (when applicable)
+- `route`, `method`, `status`, `duration_ms`
+
+PII never in logs (no emails, no IP unless explicitly needed for
+abuse detection).
+
+## OpenAPI schema
+
+FastAPI auto-generates `/openapi.json`. The schema includes:
+
+- Every route, request schema, response schema.
+- Auth requirements per route.
+- Error responses per route with their `code` strings.
+- Examples for every request/response.
+
+We commit to keeping the schema accurate. The frontend's TypeScript
+types are generated from this schema (via `openapi-typescript` or
+similar) so divergence breaks the build.
+
+## Deprecation policy
+
+When `/api/v2/` ships:
+
+1. `/api/v2/` goes live alongside `/api/v1/`. Both are fully
+   supported.
+2. `/api/v1/` responses gain a `Sunset` header (RFC 8594) with the
+   sunset date (>= 6 months out).
+3. `/api/v1/` responses gain a `Deprecation: true` header.
+4. The frontend is migrated to `/api/v2/` first.
+5. Email goes to all users with active desktop links pointing them
+   at the new desktop release that uses `/api/v2/`.
+6. After 6 months, `/api/v1/` returns 410 Gone with a body
+   explaining the sunset and pointing at upgrade docs.
+
+We do not ship `/api/v3/` until `/api/v1/` is gone.
+
+## Local-mode specifics
+
+The local server defaults to `http://127.0.0.1:8765`. Same routes,
+same auth-header tolerance, no rate limits, no Sentry sampling.
+CORS allows the dev origin (localhost:3000 / localhost:5173) by
+default.
+
+The local server exposes one extra endpoint not in the hosted
+version:
+
+- `GET /api/v1/local/projects-dir` -- returns the absolute path of
+  the FilesystemStorage root. The desktop UI uses this to render
+  "Open in Finder" links. Hosted mode returns 404 for this route.
+
+Endpoints that don't make sense in local mode (billing, magic-link
+flows, upload sessions to R2) return 404 with `code:
+"not_supported_in_local_mode"`.
+
+## Open questions
+
+- **gRPC for the desktop?** The desktop client could speak gRPC for
+  smaller payloads + bidi streaming on long-running jobs. Rejected
+  for v1 -- doubles the API surface and JSON-over-HTTP works fine
+  for our scale. Revisit if streaming becomes a real need.
+- **Server-Sent Events vs polling.** The jobs drawer could subscribe
+  to job updates via SSE instead of polling. Probably worth doing
+  in v1 -- one endpoint (`GET /api/v1/jobs/stream`), trivial to
+  implement with Starlette. Track in 09.
+- **Webhooks for users.** Letting users subscribe their own webhooks
+  ("notify me when detection is done") is v2+.
+- **API tokens for users.** A premium user might want a personal
+  access token to script Splitsmith. v2. The desktop link
+  mechanism is enough for v1.

--- a/docs/saas-readiness/07-sync-and-migration.md
+++ b/docs/saas-readiness/07-sync-and-migration.md
@@ -1,0 +1,340 @@
+# 07 -- Sync and migration
+
+This doc defines **how a project moves between local mode and hosted
+mode** -- the user's first onboarding path, the "I started locally but
+want to share with my squad" flow, and the v2 ramp into bidirectional
+sync.
+
+The v1 deliverable is **one-way push from desktop to cloud, with
+tarball import as the no-desktop fallback.** v2 is bidirectional.
+v3 is the public match repository.
+
+## Personas and flows
+
+Three users; each takes a different path into hosted mode.
+
+### Persona A -- desktop-first existing user
+
+Uses `splitsmith ui` daily. Wants to back up matches to cloud + share
+one match with a squadmate.
+
+Flow:
+1. Updates the desktop app. Sees a "Sign in to cloud" affordance in
+   settings (introduced in this v1 release).
+2. Clicks it; magic-link flow opens in browser; clicks the link;
+   browser deep-links back to the desktop with a token.
+3. Desktop now shows "Sync to cloud" buttons next to each project in
+   the picker.
+4. Clicks the button on one project; sees a progress indicator;
+   project lands in their cloud account; the cloud URL is offered
+   for sharing (v1: read-only public link; v2: per-user invite).
+
+### Persona B -- new hosted-first user
+
+Has never installed the desktop. Visits `splitsmith.app`, signs up,
+wants to detect shots in a head-cam video they have on their phone.
+
+Flow:
+1. Lands on marketing page; clicks "Try it".
+2. Magic-link signup.
+3. First-run flow: "Upload audio" or "Upload full video?" choice.
+4. Audio path: browser extracts in WebAudio, uploads via tus, Tier 2
+   detection runs, results displayed.
+5. Free tier preview: first match free, second match prompts for
+   premium upgrade.
+
+### Persona C -- existing local user without desktop access
+
+Has a tarball of an old project from a previous machine. Wants to
+view it in the cloud without reinstalling the desktop.
+
+Flow:
+1. Signs up at `splitsmith.app` (magic link).
+2. Picker shows "Import a project" affordance.
+3. Drags the tarball into the browser; tus uploads it; an importer
+   job processes it; the project appears in their picker.
+
+## Direct sync (Persona A)
+
+The preferred flow. Implemented as **discrete API calls**, not as a
+sync engine. Each call is idempotent; the desktop drives.
+
+### Sign-in
+
+The desktop opens the user's browser at:
+
+```
+https://splitsmith.app/link/desktop?challenge=<random_id>&
+  callback=splitsmith://link
+```
+
+The hosted page handles magic-link auth as usual. On success, it
+redirects to:
+
+```
+splitsmith://link?challenge=<random_id>&token=<short_lived_token>
+```
+
+The desktop's URL handler captures this. It exchanges `token` for a
+refresh token via:
+
+```
+POST /api/v1/auth/desktop/exchange
+  { challenge: "<random_id>", token: "<short_lived_token>",
+    device_name: "Mathias's MacBook Pro" }
+->
+  { refresh_token: "...", access_token: "...", access_expires_in: 3600 }
+```
+
+The refresh token is persisted at `~/.splitsmith/auth.json` (0600).
+The desktop now signs API requests with `Authorization: Bearer
+<access_token>`.
+
+### Pushing a project
+
+The desktop walks the project layout and pushes each file. The flow
+is conceptually:
+
+```
+POST /api/v1/projects
+  { display_name, match_date }
+->
+  { project_id }
+
+# For each file in the project:
+POST /api/v1/uploads
+  { kind: 'project_file',
+    project_id, relative_path: 'shooters/foo/project.json',
+    size_bytes, sha256 }
+->
+  { upload_id, tus_endpoint }
+
+[tus PATCH chunks to tus_endpoint, completing the upload]
+
+# After all files uploaded:
+POST /api/v1/projects/<project_id>/sync/finalize
+->
+  204
+```
+
+The project bytes land at `projects/<project_id>/...` in R2 with the
+exact same layout as on the desktop's disk. The `projects` row in
+Postgres gets created on the first POST.
+
+The desktop maintains a local `sync_state.json` per project recording
+which files were last pushed with which sha256. Subsequent pushes
+diff against this; only changed files re-upload.
+
+Raw video is **excluded by default**. The desktop shows a per-file
+toggle "include raw video?" before sync; defaults off. Audio,
+match.json, project.json, shots.csv, audits, FCPXML exports all
+push.
+
+### Idempotency
+
+Every sync POST carries an `Idempotency-Key` derived from
+`<project_id>:<relative_path>:<sha256>`. Re-running sync after a
+network drop is safe -- already-uploaded files no-op.
+
+### Conflict handling (v1)
+
+v1 doesn't have proper bidirectional sync, so conflicts are simple:
+
+- The desktop never overwrites cloud data unless the user explicitly
+  initiates a push.
+- The cloud never modifies pushed projects on its own (no sneaky
+  re-detection or schema migration that mutates the JSON).
+- If the cloud version was modified out-of-band (theoretically only
+  possible if the user used the web UI to edit the synced project),
+  the next desktop push detects the divergence (cloud `updated_at`
+  > local `last_pushed_at`) and prompts: "Cloud version is newer.
+  Overwrite cloud, abort, or re-pull?"
+
+In v1, the practical recommendation in the UI is "edit a project
+either locally OR in the cloud, not both". v2's bidirectional sync
+removes this restriction.
+
+### Pulling a project (v1: rare path)
+
+The user wants to pull a cloud project to the desktop -- typically
+because they switched machines.
+
+```
+GET /api/v1/projects/<project_id>/manifest
+->
+  { project_id, files: [{path, sha256, size_bytes}, ...] }
+
+# For each file:
+GET /api/v1/files/signed-url?path=projects/<id>/<relative_path>&method=GET
+[fetch from R2]
+```
+
+The manifest includes a flag per file for "available?" -- raw video
+that wasn't uploaded shows up as `available: false` so the desktop
+knows it's there in metadata but not in storage.
+
+After pull, the desktop's `sync_state.json` records the pulled
+sha256s so future pushes diff correctly.
+
+## Tarball import (Persona C)
+
+For users who don't have the desktop running.
+
+Tarball format (already used by `splitsmith export tarball` -- this
+predates the SaaS work):
+
+```
+project-<slug>.tar.gz
+  match.json
+  shooters/
+    <slug>/
+      project.json
+      audio.wav
+      shots.csv
+      shots.fcpxml
+      audits/...
+  raw/                     # excluded by default in export
+    headcam.mp4            # only present if user opted in
+```
+
+Browser flow:
+1. User clicks "Import project" in the picker.
+2. Drags the tarball into the dropzone.
+3. tus upload starts (kind=`project_tarball`), lands at
+   `imports/<upload_id>.tar.gz`.
+4. After upload completes, the browser POSTs to `POST /api/v1/
+   imports/<upload_id>/process`.
+5. A worker job processes:
+   - Streams the tarball.
+   - Validates structure (must have `match.json` at top level,
+     schema-conformant).
+   - Mints a new `project_id`.
+   - Rewrites the `local` user sentinel (see 02) to the importing
+     user's ID anywhere it appears.
+   - Uploads each file to `projects/<new_id>/<original_relative_path>`.
+   - Inserts `projects` + `project_members` rows.
+   - Deletes the source tarball from `imports/`.
+6. The job completes; the picker refreshes; the new project appears.
+
+The whole import takes 1-5 minutes for a typical match (audio only).
+The user sees progress in the jobs drawer.
+
+### Validation
+
+The importer rejects:
+
+- **Missing `match.json`.** Required; no point in importing a non-
+  Splitsmith tarball.
+- **Schema mismatch.** If `match.json` has a major version we don't
+  understand, we reject with a "this project was created with a
+  newer Splitsmith; upgrade your hosted account [link]" error.
+- **Path traversal in tarball.** `../etc/passwd`-style entries
+  rejected; only paths relative to the project root accepted.
+- **Tarball >50 GB.** Same upload limit as everything else.
+
+### What about the inverse: cloud -> tarball?
+
+Available as `GET /api/v1/projects/<id>/export?format=tarball`. The
+server streams a tarball of the project's R2 contents. Idempotent;
+the user can re-export anytime.
+
+This is critical for **data portability**: the user can leave hosted
+mode and take their data with them. We mention this on the marketing
+page; it's a trust signal.
+
+## v2 -- bidirectional sync
+
+Out of scope for v1 implementation. Architectural notes for forward
+compatibility:
+
+- The current sync model is "the desktop pushes; cloud is a passive
+  store." v2 changes this to "either side can edit; reconcile."
+- Reconciliation happens at the per-file level using sha256 + a
+  per-file `last_modified` timestamp from R2 / disk.
+- Conflict resolution: per-file three-way merge isn't feasible
+  (binary files, complex JSON). We do **per-file last-writer-wins
+  with conflict copies**: the loser's version is preserved as
+  `<original_path>.conflict-<timestamp>` in both locations.
+- A real-time sync engine isn't on the table -- we operate in pull
+  intervals (desktop polls every 60s when running; web app polls
+  on tab focus).
+- Squad-share invites (also v2) reuse this same engine: a squadmate
+  sees the project in their picker via an ACL row, and their local
+  desktop pulls a copy to disk for offline editing if they want.
+
+The v1 abstractions don't preclude this:
+- Each file's sync state is an opaque blob in `sync_state.json` --
+  v2 can extend the format without breaking v1.
+- The API surface is additive (new endpoints for v2 reconcile
+  flows; v1 endpoints remain).
+- The data model has nothing v1-specific that would prevent v2
+  sharing.
+
+## Relinking and revoking
+
+The desktop's link can be revoked from the web UI ("Devices" page,
+shipped in v1):
+
+- User sees a list of `desktop_links` rows.
+- Click "Revoke" sets `revoked_at`; the desktop's next API call
+  fails with 401; desktop shows "Sign in again" prompt.
+- The local-mode functionality keeps working; only the cloud bridge
+  breaks.
+
+Re-linking the same desktop creates a new row. We don't try to
+"reuse" old links -- it's simpler to mint new tokens.
+
+## Local-mode-only users
+
+A user who never signs in stays entirely local. Nothing in v1
+changes for them. The "Sign in to cloud" affordance lives in
+settings; if they never click it, they never see hosted-mode UI.
+
+## Concurrency between sync and detection
+
+The desktop should not push a project while a local detection job is
+running on it (the JSON files would be in flux). The sync flow
+takes a local advisory lock per project before walking files; if a
+job is active, it waits or aborts with a UX message.
+
+The cloud doesn't run detection on synced projects automatically.
+Detection only runs when the user explicitly requests it via the
+web UI -- which means the user is online, looking at the project,
+and not simultaneously syncing the same project from the desktop.
+
+## What this implies for the desktop release
+
+A v1 desktop release adds:
+
+- Settings page entry: "Cloud account" -> sign in / out, current
+  email, current device name.
+- Project picker: per-project "Sync to cloud" button + status
+  (synced / not synced / syncing / out of date).
+- Background sync state in `sync_state.json` per project.
+- URL handler for `splitsmith://` (macOS / Windows registration).
+- HTTP client that signs requests with Bearer tokens + handles
+  refresh.
+
+These are additive to the existing local-mode UI. If the user never
+signs in, the cloud-related UI shows "Sign in to enable" stub
+content; nothing else changes.
+
+## Open questions
+
+- **Refresh-token rotation.** Should refresh tokens rotate on every
+  refresh? Best practice says yes; complicates the desktop's auth
+  storage. Probably worth doing in v1; track during impl.
+- **Sync over flaky networks.** Tus handles per-file resume but
+  not "I lost my connection mid-walk and don't know which files I
+  pushed." `sync_state.json` should be append-only with fsync
+  per write so a crash mid-sync doesn't lose progress.
+- **Multi-device same-account.** Two desktops syncing the same
+  account is fine in v1 (each pushes independently; the latest
+  push wins per file). v2's bidirectional model handles it
+  cleanly.
+- **Granularity of "out of date".** Per-file or per-project?
+  Per-project is enough for v1's UX (the badge just says "out of
+  sync"); per-file matters for v2's conflict UI.
+- **What happens to entitlements when a user signs out of the
+  desktop?** They keep their local-mode functionality; only the
+  cloud bridge is severed. Clear in the UI copy.

--- a/docs/saas-readiness/08-billing-and-quotas.md
+++ b/docs/saas-readiness/08-billing-and-quotas.md
@@ -1,0 +1,332 @@
+# 08 -- Billing and quotas
+
+This doc defines **how Splitsmith charges money** and **how it
+enforces tier limits**. It covers Stripe integration, the entitlement
+model, the v1 (display-only) and v2 (enforced) quota approaches, and
+the failure modes (subscription cancellation, payment failure, refund).
+
+This doc does **not** set prices. Pricing is a business decision,
+revisited as we learn what users will pay. The architecture supports
+any flat or per-feature scheme.
+
+## Tier model (v1)
+
+Two tiers:
+
+- **Free.** Local-mode access (the desktop app stays free forever).
+  Hosted mode read-only after first match -- a free user can sign
+  up, run detection on one project, and view the result. Subsequent
+  detection requires premium.
+- **Premium.** Flat-rate subscription. Unlimited Tier 2 detection
+  (audio upload + cloud ML), opt-in raw upload + Tier 3, all
+  current and future hosted features.
+
+A "match" for free-tier limit purposes is one `project_id`. Replays
+on the same project don't count.
+
+### What "free tier" means concretely
+
+Free users in hosted mode can:
+
+- Sign up via magic link.
+- Upload audio for one project.
+- Run Tier 2 detection on that project.
+- View, audit, and export the result (CSV, FCPXML).
+- Delete their data.
+
+Free users CANNOT:
+
+- Create a second project. (Pickerwarn: "Premium required.")
+- Upload raw video. (Toggle disabled with paywall hint.)
+- Use Tier 3.
+- Invite squadmates (v2 feature anyway).
+
+The "one project" limit is generous enough to demonstrate value and
+strict enough to push converted use into the paid tier.
+
+### Why flat-rate
+
+Per-detection pricing was considered and rejected for v1:
+
+- **Friction.** Users hesitate before clicking "detect" if they're
+  paying per click. Bad for a tool whose UX depends on iterative
+  re-runs.
+- **Unpredictability.** A user with a 20-stage match doesn't want
+  surprise charges.
+- **Operational simplicity.** Flat rate = one Stripe product, one
+  webhook, one entitlement bit in Postgres. Per-detection = usage
+  metering, billing aggregation, line-item generation.
+
+Flat rate also fits the "weekend warrior IPSC competitor" persona
+the project guidance describes -- predictable monthly cost beats
+optimal cost.
+
+If usage shows we're losing money on whales, v2 can add per-stage
+overage pricing on top of the flat tier. Today's data: a heavy
+user costs us <$1/month in compute (per 04). Even a $5/month tier
+has plenty of margin.
+
+## Stripe integration
+
+We use **Stripe Checkout** (Stripe-hosted page) + **Stripe Customer
+Portal** (Stripe-hosted billing management) + **webhooks** for
+entitlement updates.
+
+We do not build our own checkout page. We do not store card data.
+Card data never touches our infrastructure.
+
+### Checkout flow
+
+```
+Browser                       API server                  Stripe
+   |                              |                          |
+   |-- POST /api/v1/billing/      |                          |
+   |    checkout                  |                          |
+   |                              |-- Customer.create -----> |
+   |                              |   (if no stripe_customer_id) |
+   |                              |<- customer_id -----------|
+   |                              |                          |
+   |                              |-- CheckoutSession.create>|
+   |                              |   { customer: id,        |
+   |                              |     mode: 'subscription',|
+   |                              |     line_items: [{ price: PREMIUM }],|
+   |                              |     success_url, cancel_url } |
+   |                              |<- session_url -----------|
+   |<-- { url } ------------------|                          |
+   |                                                         |
+   |-- redirect to session_url --------------------------->  |
+   |                            [user enters card]          |
+   |<-- redirect to success_url ---------------------------- |
+   |                                                         |
+   |                              [Stripe sends webhook]     |
+   |                              |<-- POST /api/v1/billing/webhooks/stripe |
+   |                              |    event=checkout.session.completed     |
+   |                              |    or invoice.paid                      |
+   |                              |-- update users.entitlement = 'premium'  |
+   |                              |    + entitlement_until                  |
+   |                              |-- 200 -> Stripe                         |
+```
+
+The `success_url` is `splitsmith.app/billing/success?session_id=
+{CHECKOUT_SESSION_ID}`. The success page polls our API for
+entitlement update (the webhook may arrive a few seconds after the
+redirect).
+
+### Customer Portal
+
+For all post-signup billing operations -- update card, view invoices,
+cancel subscription -- we redirect to Stripe Customer Portal:
+
+```
+POST /api/v1/billing/portal
+->
+  { url: "https://billing.stripe.com/p/session/..." }
+```
+
+The user manages everything Stripe-side. We never build "update
+your card" forms.
+
+### Webhooks
+
+The webhook endpoint at `POST /api/v1/billing/webhooks/stripe`
+handles these events:
+
+| Event | Action |
+| --- | --- |
+| `checkout.session.completed` | Set `entitlement = 'premium'`, `entitlement_until = current_period_end + 24h grace` |
+| `invoice.paid` | Extend `entitlement_until` |
+| `invoice.payment_failed` | Email user; no entitlement change yet |
+| `customer.subscription.deleted` | Schedule `entitlement = 'free'` at `entitlement_until` (no immediate downgrade) |
+| `customer.subscription.updated` | Update `entitlement_until` to new `current_period_end` |
+| `charge.refunded` | Set `entitlement = 'free'` immediately |
+
+Every webhook payload is verified against Stripe's signature header
+using the `STRIPE_WEBHOOK_SECRET` env var. Unverifiable webhooks
+return 400.
+
+We log every webhook in the `billing_events` table for replay /
+debugging:
+
+```sql
+CREATE TABLE billing_events (
+  id              TEXT PRIMARY KEY,        -- ULID
+  stripe_event_id TEXT UNIQUE NOT NULL,    -- evt_... from Stripe
+  type            TEXT NOT NULL,
+  user_id         TEXT REFERENCES users(id),
+  payload         JSONB NOT NULL,
+  processed_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Idempotency: `stripe_event_id` is unique. Re-delivered webhooks are
+no-ops.
+
+### Entitlement model
+
+Two columns on the `users` table (already shown in 02):
+
+- `entitlement` -- `'free'` | `'premium'`
+- `entitlement_until` -- `TIMESTAMPTZ`, nullable
+
+Authorisation logic for premium-gated actions:
+
+```python
+def has_premium(user: User, *, now: datetime | None = None) -> bool:
+    now = now or datetime.now(UTC)
+    if user.entitlement == 'free':
+        return False
+    if user.entitlement_until is not None and user.entitlement_until < now:
+        return False
+    return True
+```
+
+The `+ 24h grace` on entitlement_until covers Stripe webhook delays
+and one-time payment slips. Beyond 24h, the user lapses to free.
+
+### Why entitlement, not a foreign key to a Stripe object
+
+We could resolve "is this user premium?" by hitting Stripe's API
+every request. We don't, because:
+
+- **Latency.** Stripe API calls are 100-200ms. Adds to every request.
+- **Outage tolerance.** Stripe outages should not break detection.
+- **Local cache via webhooks.** We have the webhook signal; storing
+  the derived entitlement is just caching it.
+
+If our entitlement is ever wrong (webhook missed, manual fix needed),
+we have an admin "reconcile this user with Stripe" tool that hits
+Stripe's API and updates the row.
+
+## v1 quota strategy: display, don't enforce (mostly)
+
+For v1 the quota model is intentionally light:
+
+- **Free tier:** the "1 project max" rule is enforced (project create
+  endpoint checks count + entitlement; refuses with 402 Payment
+  Required if the limit is hit).
+- **Premium tier:** no usage caps. Storage, detection requests, raw
+  uploads -- all unlimited within the per-upload size limits from
+  05. We display usage in the user's settings page (storage used,
+  detection runs this month) but don't enforce ceilings.
+
+This matches the "we don't have product-market-fit data yet" stage.
+Adding caps before knowing what real usage looks like risks scaring
+off legitimate users.
+
+If a single premium user starts costing us $50/month in compute (the
+data from 04 says this would require an extreme workload), we add
+quotas in v2 informed by what real usage looks like.
+
+### What we measure
+
+- **Storage used** -- per user, R2 bytes. Recomputed nightly from R2
+  inventory, cached in Postgres.
+- **Detection jobs run** -- counted from `compute_jobs` table per
+  user per month.
+- **Bytes uploaded this month** -- counted from `upload_sessions`
+  per user per month.
+
+These metrics are shown in the user's settings page and used for
+internal cost-per-user dashboards. They are not currently used to
+gate access (for premium users).
+
+## v2 quota strategy: soft + hard limits
+
+When v2 introduces enforced quotas (informed by v1 measurements):
+
+- **Soft limit:** at 80% of cap, banner warning + email.
+- **Hard limit:** at 100%, premium endpoints return 429 with
+  `code: "quota_exceeded"`. User can upgrade tier or wait until the
+  next billing cycle.
+- **Pro-rated overage.** If we add a metered "overage" charge on top
+  of the flat tier, it's metered via Stripe's usage records --
+  one webhook per cycle aggregating from `compute_jobs` /
+  `upload_sessions`.
+
+The tables are ready (`compute_jobs.tier`, `upload_sessions.kind`,
+`size_bytes` -- everything we need for usage records). v1 just
+doesn't read them for enforcement.
+
+## Failure modes
+
+### Payment fails mid-cycle
+
+- Stripe retries the charge per their dunning settings (typically 3
+  retries over 2 weeks).
+- Each `invoice.payment_failed` webhook triggers a user email (sent
+  by Stripe).
+- `entitlement_until` does not extend, so the user lapses to free
+  at end-of-cycle if the dunning fails.
+- Lapsed users keep their data; they just can't run new premium
+  jobs.
+
+### User cancels mid-cycle
+
+- `customer.subscription.deleted` webhook arrives.
+- `entitlement_until` is set to the period end.
+- User retains premium until that date, then lapses.
+- All their data is preserved.
+
+### Refund / chargeback
+
+- `charge.refunded` => immediate downgrade to free.
+- Three chargebacks => account suspended pending review (manual,
+  not automated in v1).
+
+### User deletes account
+
+- Hard delete: `DELETE /api/v1/account` -- queues a deletion job,
+  user gets confirmation email, 7-day grace period to undo.
+- After grace: all R2 data deleted (per-user prefix from 03 makes
+  this easy), Postgres rows soft-deleted (`deleted_at` set), Stripe
+  customer cancelled.
+- After 90 days: Postgres rows hard-deleted.
+
+The 7-day grace + 90-day soft delete is GDPR-shaped: hard delete
+on request, but with a recovery window that catches accidents.
+
+## Local mode and billing
+
+Local mode has no billing UI. The desktop app shows nothing about
+tiers, premium, or upgrade prompts.
+
+The exception is the desktop's hosted-account hookup (07): once
+linked to a hosted account, the desktop respects that account's
+entitlement when offering Tier 2 detection ("Use cloud detection?
+Premium required" if the linked account is free). Tier 1 always
+works regardless.
+
+## Self-hosted mode and billing
+
+A self-hosted deployment can:
+
+- Run with no billing wired up at all (`BILLING_BACKEND=none`). All
+  users default to entitlement `premium`; no Stripe; no paywalls.
+- Wire up their own Stripe with their own products. The
+  `BillingBackend` interface is one method (`is_premium(user_id)`)
+  -- they can implement it any way they want.
+
+We document the self-hosted path but don't ship a v1 example beyond
+the `none` mode.
+
+## Pricing-page and marketing
+
+Out of scope for this doc (see doc 00, "What this doc set is NOT").
+Architecture supports any pricing scheme; the marketing page is a
+separate decision.
+
+## Open questions
+
+- **Free trial of premium?** A 14-day trial would lift conversion
+  but adds churn complexity. Defer to launch-time decision.
+- **Annual vs monthly billing.** Easy to add both Stripe products
+  later; not a v1 architecture concern.
+- **Refunds policy.** Stripe handles the mechanics; the policy
+  ("30-day refund window") is a business decision.
+- **EU VAT / sales tax.** Stripe Tax handles this for ~$0.30/txn
+  if we enable it. Probably worth enabling at launch.
+- **Per-region pricing.** Stripe supports it; defer until usage
+  data shows whether it matters.
+- **Account deletion grace period length.** 7 days vs 30 days. 7
+  matches the "oh shit I clicked the wrong button" recovery; 30 is
+  more conservative. Pick during impl.

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -1,0 +1,252 @@
+# 09 -- SaaS progress
+
+This is the **status doc**. It tracks what's shipped, what's in
+flight, and what's deferred across the v1 / v2 / v3 milestones.
+
+Update this file as work lands. The other docs (00-08) describe the
+target architecture; this doc is the current state.
+
+## How to read this doc
+
+Each milestone has a checklist. Items use one of four marks:
+
+- `[x]` -- shipped on the named branch / PR
+- `[~]` -- in flight (work started, not merged)
+- `[ ]` -- not started
+- `[-]` -- explicitly deferred (with a note saying when to reconsider)
+
+Each shipped item links to the PR. Each in-flight item links to the
+issue or branch.
+
+When this file is updated, the date at the top of the relevant
+section is bumped.
+
+## v1 -- abstractions + minimal hosted MVP
+
+Goal (per doc 00, Q5): the three abstractions (Storage, Auth,
+ComputeBackend) live in the codebase with local-mode implementations
+matching today's behaviour, plus a working hosted deployment with
+magic-link signup, audio upload, Tier 2 compute, R2 storage, Stripe
+Checkout gating premium.
+
+**Last updated:** 2026-05-15 (initial draft of doc set).
+
+### Foundation -- abstractions in the local codebase
+
+These can ship before any hosted-mode infrastructure exists. Each is
+a refactor that makes today's local-mode code pass through the
+abstraction without behavioural change.
+
+- [ ] Extract `Storage` interface; replace direct `pathlib.Path` use
+  in project layout with `FilesystemStorage` calls.
+  (See 03-storage-layer.md.)
+- [ ] Extract `Auth` interface; introduce `LoopbackAuth`; route
+  every API handler through `auth.authenticate_request`.
+  (See 02-tenancy-and-identity.md.)
+- [ ] Extract `ComputeBackend` interface; wrap today's ensemble
+  pipeline as `LocalComputeBackend`. The orchestration in
+  `cli.py` and the FastAPI server call the backend, not the
+  ensemble directly.
+  (See 04-compute-backends.md.)
+- [ ] Add a `splitsmith serve` entry point alongside `splitsmith ui`.
+  Same code; different mode wiring at startup.
+- [ ] Add `docker compose` for hosted-mode dev (Postgres + LocalStack
+  S3 + the worker + the API server). Contributors without R2
+  credentials can exercise the hosted path locally.
+
+### Hosted infrastructure
+
+- [ ] Pick deploy target (Fly.io vs Railway -- doc 00 open question).
+- [ ] Pick auth provider (Clerk vs WorkOS vs Auth.js -- doc 00 open
+  question). Build a v1-shaped prototype with each first.
+- [ ] Provision R2 bucket + lifecycle rule for incomplete multipart
+  uploads.
+- [ ] Provision Postgres (Neon free tier likely).
+- [ ] Provision Redis if going with `arq` (or skip if going with
+  Procrastinate).
+- [ ] Wire Sentry on the API + worker.
+- [ ] Wire Resend (or Postmark) for magic-link email delivery.
+- [ ] Set up the `splitsmith.app` domain + Cloudflare in front.
+
+### Auth + identity (doc 02)
+
+- [ ] `MagicLinkAuth` implementation against the picked provider.
+- [ ] `users` table + Alembic migration.
+- [ ] `sessions` table + cookie middleware.
+- [ ] `desktop_links` table + the desktop link flow API.
+- [ ] `/api/v1/auth/begin`, `/auth/callback`, `/auth/refresh`,
+  `/auth/desktop/exchange` endpoints.
+- [ ] Magic-link email templates (text + HTML).
+- [ ] First-login display-name prompt on the web UI.
+- [ ] Devices page in account settings (list + revoke
+  desktop_links).
+- [ ] CSRF middleware.
+
+### Storage (doc 03)
+
+- [ ] `S3Storage` implementation (fsspec-backed, R2 endpoint).
+- [ ] `MemoryStorage` for tests.
+- [ ] Per-project storage layout standardised; existing local
+  project directories remain compatible.
+- [ ] `signed_url` implementation for both backends.
+- [ ] Reindex helper (rebuild `projects` rows from R2 walk).
+- [ ] Per-user prefix decision (`users/<id>/projects/<id>/` vs
+  `projects/<id>/`) -- pin during implementation.
+
+### ACL + projects (doc 02)
+
+- [ ] `projects` + `project_members` tables.
+- [ ] ACL middleware (`require_project_member(role)`).
+- [ ] `POST /api/v1/projects` (create -- inserts ACL row).
+- [ ] `GET /api/v1/projects` (list mine).
+- [ ] `GET /api/v1/projects/<id>` (read -- after ACL check).
+- [ ] `DELETE /api/v1/projects/<id>` (owner-only).
+- [ ] `GET /api/v1/projects/<id>/manifest` (file listing for
+  desktop pull).
+
+### Uploads (doc 05)
+
+- [ ] tus-py-server wired with S3 backend pointing at R2.
+- [ ] `upload_sessions` table + lifecycle (24h expiry + cron abort).
+- [ ] `POST /api/v1/uploads` to start a session.
+- [ ] tus-js-client integration in the browser SPA.
+- [ ] Browser audio extraction (WebAudio -> 16 kHz mono WAV).
+- [ ] Sha256 verification on upload completion.
+
+### Compute (doc 04)
+
+- [ ] CLAP + PANN model artifacts baked into the worker Docker image.
+- [ ] ONNX-Web GBDT artifact built + served from `/static/models/`.
+- [ ] `compute_jobs` table.
+- [ ] `RemoteComputeBackend` (server-side wrapper that creates jobs).
+- [ ] `arq` worker that processes Tier 2 jobs (CLAP + PANN
+  inference + features back).
+- [ ] `POST /api/v1/projects/<id>/jobs` (enqueue).
+- [ ] `GET /api/v1/jobs/<id>` (poll status).
+- [ ] SSE stream `GET /api/v1/jobs/stream` for the jobs drawer (per
+  06 open question; v1 if cheap).
+- [ ] Browser tier picker + capability bench.
+- [ ] Tier 2 end-to-end test: upload a fixture audio, run job, get
+  results matching the local-mode reference within tolerance.
+
+### Sync (doc 07)
+
+- [ ] Desktop URL handler registration (`splitsmith://`).
+- [ ] Desktop "Sign in to cloud" UI.
+- [ ] Desktop sync_state.json persistence.
+- [ ] Per-project "Sync to cloud" button + status.
+- [ ] Tarball import flow (browser + worker).
+
+### Billing (doc 08)
+
+- [ ] Stripe account + product set up.
+- [ ] `billing_events` table.
+- [ ] `POST /api/v1/billing/checkout` (creates Checkout Session).
+- [ ] `POST /api/v1/billing/portal` (creates Customer Portal session).
+- [ ] `POST /api/v1/billing/webhooks/stripe` with signature
+  verification.
+- [ ] Free-tier "1 project max" enforcement.
+- [ ] Premium-only paywall on Tier 2/3 endpoints.
+- [ ] Account settings: storage used, jobs run, billing portal link.
+- [ ] Account deletion flow (with 7-day grace).
+
+### Frontend
+
+- [ ] Auth screens (sign in, sign in success, sign in expired).
+- [ ] First-run flow for hosted users (upload audio / sign up free).
+- [ ] Project picker (lists user's hosted projects).
+- [ ] Per-project view (reuses existing audit + coach UIs from the
+  desktop, but pulls data via API).
+- [ ] Tier override controls in project settings.
+- [ ] Pricing page + Stripe Checkout entry point.
+- [ ] Account settings page.
+- [ ] Devices page.
+- [ ] Marketing landing page.
+
+### Cross-cutting
+
+- [ ] OpenAPI schema reviewed; TypeScript types regenerated end-to-
+  end.
+- [ ] All API responses include `X-Splitsmith-API-Version: v1`.
+- [ ] Trace IDs propagate from request through worker.
+- [ ] Sentry sampling configured (low for healthy traffic, high for
+  errors).
+- [ ] Privacy policy + terms of service (template to draft, lawyer
+  to review).
+- [ ] Status page (Statuspage.io free tier or similar) for hosted
+  uptime.
+
+### Launch readiness
+
+- [ ] Load test the hosted path (10 concurrent Tier 2 jobs;
+  observe latency + error rate).
+- [ ] DR plan: R2 backups (R2 has built-in replication option),
+  Postgres point-in-time restore (Neon free tier supports 24h),
+  documented restore procedure.
+- [ ] Documentation: hosted user guide, desktop-link guide, FAQ.
+- [ ] Beta-tester invite list (the user has IPSC squadmates who'd
+  trial it).
+
+## v2 -- bidirectional sync, raw upload, squad sharing
+
+Goal (per doc 00, locked-in decisions): hybrid sync, opt-in raw
+video, squad-level sharing. Postgres index for cross-match queries.
+
+**Status:** not started. Detailed planning happens after v1 launch.
+
+High-level scope:
+
+- [ ] Bidirectional sync engine (per-file conflict copies, polled
+  reconciliation).
+- [ ] Raw video upload + Tier 3 compute path.
+- [ ] Squad-share invites (`POST /projects/<id>/invitations`).
+- [ ] Public read links (limited-scope share URLs).
+- [ ] Cross-match indexing (Postgres tables for shot-time queries
+  across all of a user's matches).
+- [ ] Federated SSO (Google OAuth at minimum).
+- [ ] Usage metering (informed by v1's measured usage).
+- [ ] Soft + hard quota enforcement.
+- [ ] Annual billing option.
+- [ ] PostHog analytics + feature flags.
+
+## v3+ -- public match repository
+
+Goal (per doc 00): community-curated catalog of public matches.
+
+**Status:** deferred. Architecture must support it (visibility =
+'public' on `projects`); implementation is post-v2.
+
+High-level scope:
+
+- [ ] Public-visibility `visibility = 'public'` enforcement path
+  (read-only without ACL membership).
+- [ ] Discovery UI (browse / search public matches).
+- [ ] Curation moderation (admin tools).
+- [ ] Per-tenant retrain (optional premium feature).
+- [ ] Cross-region replication for a global public catalogue.
+
+## Deferred / explicitly out of scope
+
+These came up during ideation and are not on any milestone:
+
+- [-] Real-time collaborative editing. Not a fit for the workflow.
+- [-] Mobile apps (iOS/Android). The web UI is responsive; native
+  apps are a "if a real demand emerges" item.
+- [-] Self-serve enterprise SSO (SAML, SCIM). Premium individual is
+  the target market; enterprise SSO is a "if a customer asks"
+  item.
+- [-] On-prem appliance. The self-hosted Docker path covers this.
+- [-] Real-time stage detection (live during a match). Stays out
+  of scope per the project guidance ("real-time tool" is in the
+  "what this project is NOT" list).
+
+## Decision log (changes to the architecture)
+
+Append-only. Format: `YYYY-MM-DD -- doc -- summary`. Bigger changes
+get their own short note.
+
+- 2026-05-15 -- 00 -- Initial doc set drafted. Four-question + three-
+  question ideation captured in 00. Locked-in decisions table
+  established.
+
+(future entries appended below as the architecture evolves.)

--- a/docs/saas-readiness/README.md
+++ b/docs/saas-readiness/README.md
@@ -1,0 +1,124 @@
+# SaaS readiness
+
+Architecture doc set for adding a hosted SaaS option to Splitsmith
+without breaking the local-first desktop app.
+
+The local Python app stays the default and stays free, private, and
+fully offline. The hosted mode is additive: web app + cloud workers
+behind an off-the-shelf identity provider, with audio-only upload
+(Tier 2) as the default detection path. Both modes ship from the
+same codebase wired through three abstractions (Storage, Auth,
+ComputeBackend).
+
+## Reading order
+
+The set is meant to be read in order on the first pass. After that,
+the docs are reference: jump to whichever covers the system you're
+touching.
+
+1. **[00 -- Context and principles](./00-context-and-principles.md)**
+   Why the initiative exists, the off-the-shelf-first working
+   principle, the 7-question decision record from the
+   2026-05-15 ideation, the locked-in v1/v2/v3 axes, and the derived
+   principles every other doc respects.
+
+2. **[01 -- Deployment modes](./01-deployment-modes.md)**
+   What local mode promises (no regression today), what hosted mode
+   promises (zero install, audio-only default), and the cross-mode
+   invariants that keep them structurally identical (JSON canonical,
+   same ensemble, same UI components). Self-hosted is not v1 but is
+   not foreclosed.
+
+3. **[02 -- Tenancy and identity](./02-tenancy-and-identity.md)**
+   The `Auth` abstraction (`LoopbackAuth` + `MagicLinkAuth`), the
+   magic-link flow, sessions, the desktop-link mechanism, and the
+   project ACL data model. ACL tables ship in v1 with only the owner
+   role used so v2 squad sharing is a row insert, not a migration.
+
+4. **[03 -- Storage layer](./03-storage-layer.md)**
+   The fsspec-backed `Storage` abstraction
+   (`FilesystemStorage` + `S3Storage`), Cloudflare R2 over AWS S3
+   (the $0-egress argument), the JSON-as-canonical invariant, and
+   what does and does not live in Postgres. Index rebuilds from JSON
+   keep the JSON files genuinely the source of truth.
+
+5. **[04 -- Compute backends](./04-compute-backends.md)**
+   The `ComputeBackend` abstraction, the three-tier model
+   (Tier 1 local / Tier 2 audio + cloud ML / Tier 3 full cloud), the
+   browser-capability bench that drives auto-selection, the cloud
+   worker shape (`arq` + the `compute_jobs` table), and rough cost
+   sizing per tier.
+
+6. **[05 -- Uploads and streaming](./05-uploads-and-streaming.md)**
+   The tus.io upload protocol, the audio-default flow, opt-in raw
+   video (v2), the `upload_sessions` table, and signed-URL streaming
+   straight from R2 to the browser. Bytes never proxy through the
+   API server.
+
+7. **[06 -- API surface](./06-api-surface.md)**
+   `/api/v1/` from day one, ULID resource IDs, the JSON envelope
+   (`{data, meta}` or `{error, trace_id}`), idempotency keys for
+   expensive POSTs, error-code semantics, observability conventions,
+   and the 6-month deprecation window for v1->v2 transitions.
+
+8. **[07 -- Sync and migration](./07-sync-and-migration.md)**
+   The three onboarding personas (desktop-first, hosted-first,
+   tarball-import), the v1 one-way desktop->cloud sync flow, the
+   tarball import fallback, and a sketch of v2 bidirectional sync as
+   a forward-compat target.
+
+9. **[08 -- Billing and quotas](./08-billing-and-quotas.md)**
+   Stripe Checkout + Customer Portal + webhooks, the entitlement
+   column model with a 24h grace, the v1 stance ("display usage,
+   don't enforce caps for premium"), and how v2 layers soft + hard
+   limits on top.
+
+10. **[09 -- SaaS progress](./09-saas-progress.md)**
+    Status doc with v1/v2/v3 checklists and an append-only decision
+    log. Items flip from `[ ]` to `[x]` as work lands.
+
+## Working principle (one-line restate)
+
+Use off-the-shelf frameworks, libraries, and hosted services. Don't
+invent things. Every architectural decision in this set names a
+specific, existing, documented library or hosted service. Doc 00 has
+the bias order (hosted service > library > custom code) and the
+concrete picks.
+
+## Locked-in axes
+
+Quick lookup -- full version with caveats lives in doc 00.
+
+| Axis           | v1                                          | v2                                  | v3+              |
+| -------------- | ------------------------------------------- | ----------------------------------- | ---------------- |
+| Sync model     | Two modes, shared codebase                  | Hybrid sync (local <-> cloud)       | (only if needed) |
+| Raw data       | Stays local                                 | Opt-in upload + squad-share         | Public repo      |
+| Compute        | Tier 2 default                              | + Tier 3 (raw cloud)                | --               |
+| Collaboration  | Single-user                                 | Squad sharing                       | Public repo      |
+| Storage        | `FilesystemStorage` + `S3Storage`; JSON canonical | + Postgres index for cross-match | --               |
+| Auth           | Email magic link                            | + Google OAuth                      | --               |
+| Migration      | Direct sync from desktop app                | Bidirectional sync                  | --               |
+| Billing        | Stripe Checkout; flat-rate premium gate     | + usage metering                    | --               |
+| Database       | SQLite (auth state only)                    | Promote to Postgres                 | --               |
+
+## What this doc set is not
+
+- An implementation plan -- those live in GitHub issues per shipped
+  doc.
+- A pricing strategy -- 08 describes how billing wires up, not what
+  to charge.
+- A go-to-market plan -- marketing, positioning, launch timing are
+  out of scope.
+
+## Conventions
+
+- **Numbering.** Two-digit prefixes (`00-` ... `09-`) so the docs
+  sort correctly in directory listings.
+- **Tone.** Prose first, tables second, code examples only when they
+  pin a contract (a Python `Protocol`, a SQL DDL, a JSON shape).
+- **Naming libraries and services.** Always with a link the first
+  time they appear in a given doc.
+- **Open questions live with their doc.** Cross-cutting open
+  questions live in doc 00.
+- **Status updates land in doc 09**, not in commit messages or PR
+  descriptions. The decision log at the bottom of 09 is append-only.


### PR DESCRIPTION
## Summary

Architecture doc set in `docs/saas-readiness/` for adding a hosted SaaS option to Splitsmith without breaking the local-first desktop app. The set was drafted out of the 2026-05-15 ideation conversation; the original session captured the locked-in decisions then died before the docs were written. Doc 00 is genuine recovery (the session-reminder preserved its body and the Working Principle revision); docs 01-09 are fresh drafting from the locked-in decisions and need a real review pass.

The local Python app stays the default and stays free, private, and fully offline. The hosted mode is additive: web app + cloud workers behind an off-the-shelf identity provider, with audio-only upload (Tier 2) as the default detection path. Both modes ship from the same codebase wired through three abstractions (Storage, Auth, ComputeBackend).

## Doc set

| Doc | Topic |
| --- | --- |
| [README.md](../blob/claude/resume-remote-session-T8tvd/docs/saas-readiness/README.md) | Index + reading order + locked-in axes table |
| 00-context-and-principles | Why, off-the-shelf-first principle, 7-question decision record, derived principles |
| 01-deployment-modes | Local + hosted contracts, cross-mode invariants, self-hosted deferred |
| 02-tenancy-and-identity | Auth interface, magic-link flow, ACL tables that already accommodate v2 squad sharing |
| 03-storage-layer | fsspec-backed Storage, R2 over S3 ($0 egress), JSON-as-canonical, index rebuild |
| 04-compute-backends | ComputeBackend interface, three-tier model, browser-capability bench, arq workers |
| 05-uploads-and-streaming | tus.io for resumable uploads, audio-default flow, raw upload deferred to v2, signed-URL streaming straight from R2 |
| 06-api-surface | `/api/v1/` from day one, ULID IDs, JSON envelope, idempotency keys, 6-month deprecation window |
| 07-sync-and-migration | Three onboarding personas, v1 one-way desktop->cloud sync, tarball import fallback, v2 bidirectional sketch |
| 08-billing-and-quotas | Stripe Checkout + Customer Portal + webhooks, entitlement column with 24h grace, display-don't-enforce in v1 |
| 09-saas-progress | v1/v2/v3 checklists + append-only decision log |

## What this PR is not

- An implementation plan (issues per doc once approved)
- A pricing strategy (08 wires up billing; doesn't set prices)
- A go-to-market plan

## Reviewer notes

Each doc has an "Open questions" section that flags the calls most worth challenging. The headline ones I made unilaterally (please push back if any are wrong direction):

- Per-project ULIDs as the primary key (vs slugs)
- Cloudflare R2 over AWS S3 as the primary object store
- Flat-rate premium tier with no v1 quota enforcement (only display)
- 7-day account-deletion grace period
- Postgres advisory locks for v1 single-writer concurrency
- ACL tables shipped in v1 with only the owner role used (so v2 squad sharing is a row insert, not a migration)

## Test plan

Docs-only PR; no code, no tests to run.

- [ ] Read 00 first (sets the principles every other doc inherits)
- [ ] Read in numbered order on first pass; refer back later
- [ ] Push back on any open question or unilateral choice flagged above
- [ ] Confirm the locked-in axes table in doc 00 + README matches the ideation conversation

https://claude.ai/code/session_014Qf4jNC8V5UVKxw1W9JwUt