### PR TITLE
site: auto-deploy marketing site to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,35 @@
+name: Deploy marketing site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-site.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-site
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Cloudflare Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://splitsmith.app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=splitsmith --branch=main

--- a/site/README.md
+++ b/site/README.md
@@ -12,22 +12,29 @@ UI — see `docs/ux-redesign/06-design-system.md`.
 
 ## Deploy on Cloudflare Pages
 
-Either via Git integration or direct upload:
+**Automated (default):** `.github/workflows/deploy-site.yml` publishes
+`site/` to the `splitsmith` Cloudflare Pages project on every push to
+`main` that touches `site/**`. It can also be triggered manually via
+**Actions → Deploy marketing site → Run workflow**.
 
-**Git integration (recommended):**
+The workflow needs two repo secrets:
 
-1. Cloudflare dashboard → Pages → Create a project → Connect to Git.
-2. Pick this repo.
-3. Build settings:
-   - Framework preset: **None**
-   - Build command: *(leave blank)*
-   - Build output directory: **`site`**
-4. Set the custom domain to `splitsmith.app`.
+- `CLOUDFLARE_API_TOKEN` — token scoped to `Account: Cloudflare Pages — Edit`
+- `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID
 
-**Direct upload (Wrangler):**
+One-time Cloudflare setup (only needed before the first deploy):
+
+1. Cloudflare dashboard → Workers & Pages → Create → Pages → Direct
+   upload (or Connect to Git, if you prefer to skip the Action). Name
+   the project **`splitsmith`**.
+2. Assign the custom domain **`splitsmith.app`** to the project.
+
+After that, every push to `main` ships.
+
+**Manual upload (Wrangler):**
 
 ```bash
 npx wrangler pages deploy site --project-name splitsmith
 ```
 
-That's it — no build, no JS bundle, no server.
+No build, no JS bundle, no server.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-site.yml`: publishes `site/` to the `splitsmith` Cloudflare Pages project on every push to `main` that touches `site/**`, plus manual dispatch. Uses `cloudflare/wrangler-action@v3` and the `production` environment (URL: https://splitsmith.app).
- Updates `site/README.md` to document the new flow.

I can't run `wrangler pages deploy` from this sandbox (no Cloudflare creds in the environment), so this PR wires up the automated path instead. The workflow runs on push to `main`, so the first deploy happens when this is merged — assuming the prerequisites below are met.

## Prerequisites (one-time, on Cloudflare + GitHub)

1. **Create the Pages project.** Cloudflare dashboard → Workers & Pages → Create → Pages → Direct upload. Name the project **`splitsmith`** (must match `--project-name` in the workflow).
2. **Attach the custom domain** `splitsmith.app` to that project.
3. **Add two repo secrets** under Settings → Secrets and variables → Actions:
   - `CLOUDFLARE_API_TOKEN` — scoped to `Account: Cloudflare Pages — Edit`
   - `CLOUDFLARE_ACCOUNT_ID`

Once those are in place, merging this PR ships the site.

## Test plan

- [ ] Confirm the Cloudflare Pages project `splitsmith` exists (create if not).
- [ ] Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets.
- [ ] Merge to `main` and watch **Actions → Deploy marketing site**.
- [ ] Alternatively, trigger via **Run workflow** before merging to validate the secrets without a code change.
- [ ] Verify https://splitsmith.app serves the new `site/index.html`.

https://claude.ai/code/session_01PdhHnpvCYhB3tQ732StPaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdhHnpvCYhB3tQ732StPaW)_