### PR TITLE
deploy: marketing site to Cloudflare Pages (splitsmith.app)

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -1,0 +1,28 @@
+name: Deploy marketing site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "wrangler.toml"
+      - ".github/workflows/deploy-marketing.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: wrangler pages deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=splitsmith --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ tests/fixtures/full/*
 # And audit-mode trim params sidecars from splitsmith.ui.audio.
 *_trimmed.params.json
 .claude/
+
+# Wrangler local state for Cloudflare Pages deploys.
+.wrangler/

--- a/site/README.md
+++ b/site/README.md
@@ -12,22 +12,25 @@ UI — see `docs/ux-redesign/06-design-system.md`.
 
 ## Deploy on Cloudflare Pages
 
-Either via Git integration or direct upload:
+The Pages project `splitsmith` is already created and live at
+[splitsmith.pages.dev](https://splitsmith.pages.dev). It's wired to
+`splitsmith.app` as a custom domain; DNS for the apex + `www` resolves
+through Cloudflare in the same account.
 
-**Git integration (recommended):**
+**CI deploys** — `.github/workflows/deploy-marketing.yml` runs
+`wrangler pages deploy site` on every push to `main` that touches
+`site/**` or `wrangler.toml`. Needs repo secrets `CLOUDFLARE_API_TOKEN`
+(Pages:Edit + Workers:Edit) and `CLOUDFLARE_ACCOUNT_ID`.
 
-1. Cloudflare dashboard → Pages → Create a project → Connect to Git.
-2. Pick this repo.
-3. Build settings:
-   - Framework preset: **None**
-   - Build command: *(leave blank)*
-   - Build output directory: **`site`**
-4. Set the custom domain to `splitsmith.app`.
-
-**Direct upload (Wrangler):**
+**Manual deploy:**
 
 ```bash
-npx wrangler pages deploy site --project-name splitsmith
+export CLOUDFLARE_API_TOKEN=…
+export CLOUDFLARE_ACCOUNT_ID=…
+npx wrangler pages deploy site --project-name splitsmith --branch main
 ```
+
+`wrangler.toml` at the repo root pins `pages_build_output_dir = "./site"`
+so `wrangler pages deploy` (without args) works from anywhere in the tree.
 
 That's it — no build, no JS bundle, no server.

--- a/site/index.html
+++ b/site/index.html
@@ -119,6 +119,7 @@ header.shell {
   display: flex;
   align-items: center;
   gap: 18px;
+  flex-wrap: wrap;
 }
 
 .brand { display: flex; align-items: center; gap: 14px; }
@@ -533,6 +534,66 @@ footer.colophon {
 .colophon-inner .spacer { flex: 1; }
 .colophon-inner .sep { color: var(--whisper); }
 
+/* ============================================================
+   RESPONSIVE — mobile shell + chrome
+   The body sections (hero, pipeline, io-grid) have their own
+   breakpoints higher up. This block fixes the top bar, main
+   padding, and colophon for narrow viewports.
+   ============================================================ */
+@media (max-width: 720px) {
+  .shell-top {
+    padding: 14px 18px;
+    gap: 12px;
+  }
+  .brand { gap: 10px; }
+  .brand .mark { width: 30px; height: 30px; }
+  .brand .name { font-size: 1.25rem; }
+
+  /* Anchors target sections already visible on a short page —
+     drop them on mobile rather than wrap into a hamburger. */
+  .nav-link { display: none; }
+
+  /* Icon-only GitHub button. Keep aria-label on the anchor for SR. */
+  .gh-btn { padding: 9px 11px; gap: 0; }
+  .gh-btn span { display: none; }
+
+  main {
+    padding: 56px 18px 48px;
+  }
+
+  .hero { margin-bottom: 64px; }
+  h1.title { font-size: clamp(2.25rem, 9vw, 3.25rem); margin-bottom: 22px; }
+  .lede { font-size: 1rem; margin-bottom: 28px; }
+
+  .readout { padding: 22px; gap: 22px 24px; border-radius: 12px; }
+  .cell .v { font-size: 2.125rem; }
+
+  .section { margin-bottom: 64px; }
+  .section-head { gap: 14px; margin-bottom: 24px; }
+  .section-head h2 { font-size: 1.375rem; }
+
+  .step { padding: 20px 20px 22px; }
+
+  .io-card { padding: 20px 20px 22px; }
+
+  .quickstart {
+    padding: 18px 16px;
+    font-size: 0.75rem;
+    border-radius: 10px;
+  }
+
+  footer.colophon { padding: 24px 18px; }
+  .colophon-inner { gap: 10px 16px; }
+  .colophon-inner .spacer { display: none; }
+}
+
+@media (max-width: 380px) {
+  .brand .name { font-size: 1.125rem; }
+  h1.title { font-size: 2rem; }
+  .cta { padding: 12px 16px; font-size: 0.8125rem; }
+  .cell .v { font-size: 1.875rem; }
+}
+
 </style>
 </head>
 <body>
@@ -556,7 +617,7 @@ footer.colophon {
 
     <a class="nav-link" href="#pipeline">Pipeline</a>
     <a class="nav-link" href="#quickstart">Quickstart</a>
-    <a class="gh-btn" href="https://github.com/mandakan/splitsmith" target="_blank" rel="noopener">
+    <a class="gh-btn" href="https://github.com/mandakan/splitsmith" target="_blank" rel="noopener" aria-label="Splitsmith on GitHub">
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.04 11.04 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.26 5.69.41.35.78 1.05.78 2.11v3.13c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12.02C23.5 5.65 18.35.5 12 .5Z"/>
       </svg>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "splitsmith"
+pages_build_output_dir = "./site"
+compatibility_date = "2026-05-15"


### PR DESCRIPTION
## Summary

- Created Cloudflare Pages project `splitsmith` in account `e1854db8e2a989281305b1b229319c31` and ran `wrangler pages deploy site --project-name splitsmith --branch main`. Site is live at https://splitsmith.pages.dev/ (HTTP 200).
- Attached `splitsmith.app` and `www.splitsmith.app` to the project as custom domains via the Pages API.
- Added `wrangler.toml` (`pages_build_output_dir = "./site"`) and `.github/workflows/deploy-marketing.yml` so future pushes to `main` that touch `site/**` redeploy automatically via `cloudflare/wrangler-action@v3`.
- Refreshed `site/README.md` with the resolved deploy story and added `.wrangler/` to `.gitignore`.

## DNS — one manual step left

The custom domains are attached but both report `verification_data.error_message: "CNAME record not set"`. The deploy API token only has Pages:Edit, not DNS:Edit on the `splitsmith.app` zone, so I couldn't create the records from CI. Add these in the Cloudflare dashboard (zone `splitsmith.app`, ID `74e7df1b444519b3a77db6174f7aa295`):

| Type  | Name              | Content                | Proxy |
|-------|-------------------|------------------------|-------|
| CNAME | `splitsmith.app`  | `splitsmith.pages.dev` | on    |
| CNAME | `www`             | `splitsmith.pages.dev` | on    |

Cloudflare flattens the apex CNAME automatically. Once those are in, the domain status flips from `initializing` → `active` and the cert provisions on its own.

## GitHub Actions secrets

The workflow expects two repo secrets:

- `CLOUDFLARE_API_TOKEN` — Pages:Edit (Workers:Edit if you ever extend it). Optionally add DNS:Edit on the splitsmith.app zone so future domain wiring is automatable too.
- `CLOUDFLARE_ACCOUNT_ID` — `e1854db8e2a989281305b1b229319c31`.

## Test plan

- [x] `npx wrangler pages project create splitsmith` succeeded
- [x] `npx wrangler pages deploy site --project-name splitsmith --branch main` uploaded 3 files
- [x] `curl https://splitsmith.pages.dev/` → HTTP 200
- [ ] After DNS CNAMEs are added: `curl -I https://splitsmith.app/` → HTTP 200
- [ ] After secrets are set: trigger workflow_dispatch on `deploy-marketing.yml` and confirm a green run

---
_Generated by [Claude Code](https://claude.ai/code/session_018YYqKHKPQq9JTK4RzdCgtr)_