### PR TITLE
docs: drop false "can't carry a timer" claim, reframe copy around splits + clip prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Extract per-shot split times from head-mounted camera footage of IPSC matches an
 
 ![audit view](docs/screenshots/audit.png)
 
-Shot timers like the CED7000 give you splits during practice, but at matches you can't carry one. Head-mounted cameras (Insta360 Go 3S in this case) capture audio that contains all the shot information -- this tool extracts it and turns it into actionable training data.
+Built to do two things from a single stage video: get per-shot splits for analysis and coaching, and prepare frame-marked clips for match-footage review. Your head-mounted cam (Insta360 Go 3S in this case) already captures audio of every shot; the RO's timer only records your total stage time, so the splits live in the video and nowhere else. Splitsmith extracts them and turns them into a CSV plus an FCPXML timeline with per-shot markers you can step through in Final Cut Pro.
 
 **Inputs:** raw MP4s from a head-mounted cam, stage time data from SSI Scoreboard.
 **Outputs (per stage):** lossless trim around the start beep, splits CSV, FCPXML with frame-aligned markers, anomaly report.

--- a/site/index.html
+++ b/site/index.html
@@ -639,11 +639,11 @@ footer.colophon {
       </span>
       <h1 class="title">Splits from your <span class="accent">stage video.</span></h1>
       <p class="lede">
-        Shot timers like the CED7000 give you splits during practice — but at matches you can't carry one.
-        Head-mounted cameras capture audio that contains all the shot information.
-        <span class="term">Splitsmith</span> extracts it and turns it into actionable training data:
+        Per-shot splits for analysis and coaching, and frame-marked clips ready for match-footage review.
+        Your head-mounted cam already captures audio of every shot; <span class="term">Splitsmith</span> turns it into
         per-shot times, a <span class="num">CSV</span> of splits, and an FCPXML timeline with frame-aligned markers
-        you can pop open in Final Cut Pro and review on <span class="num">M</span> / <span class="num">Shift+M</span>.
+        you can pop open in Final Cut Pro and step through on <span class="num">M</span> / <span class="num">Shift+M</span>.
+        The RO's timer only records your total stage time — the splits live in your video, and this is how you get them out.
       </p>
 
       <div class="cta-row">


### PR DESCRIPTION
## Summary

The README intro and the marketing site hero both claimed that competitors can't carry a shot timer at IPSC matches. There is no IPSC rule that says so — the practical situation is that the RO operates the official timer and only your total stage time hits the scorecard, so per-shot data only survives in your head-mounted cam's audio. The old copy was both inaccurate and defensively framed.

Reworked both intros to:

- Drop the false rule claim.
- Lead with the actual value props: per-shot splits for analysis/coaching, and frame-marked clips for match-footage review.
- Keep the motivation for why your video is the only source of splits, but state it accurately (RO's timer captures total stage time, not your splits).

## Files

- `README.md` — rewrote the lede paragraph (`README.md:7`).
- `site/index.html` — rewrote the hero `<p class="lede">` (`site/index.html:641-647`).

## Test plan

- [ ] Visual check of the rendered marketing page (`site/index.html`) — hero paragraph reads cleanly with the existing `.term` / `.num` styling.
- [ ] README renders cleanly on GitHub (no broken links, image still loads).
- [ ] Spot-check that no other doc still asserts "can't carry a timer" — confirmed via `grep` across `*.md` / `*.html`; only these two files contained the claim.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T9XTyKBymviciYeJQdScwi)_