### PR TITLE
Path-scoped shooter binding + UX polish (#353 phases 2--3)

### DIFF
--- a/docs/ux-redesign/01-jobs-to-be-done.md
+++ b/docs/ux-redesign/01-jobs-to-be-done.md
@@ -294,6 +294,133 @@ Frequency: per Coach session. Pain today: high before the fix (shipped
   pending multi-version artifact storage; this is documented in the
   surface so it isn't faking state.
 
+## Jobs surfaced during path-scoped refactor (2026-05-16 addendum)
+
+These jobs were not in the original JTBD set; they surfaced when the
+shooter slug moved into the URL (#353) and the multi-shooter shell was
+exercised on real data. They are listed here so the catalog stays
+exhaustive.
+
+### F. Hold two shooters' contexts open in parallel
+
+**When** I am comparing how two shooters approached the same stage,
+**I want to** keep each shooter's Audit (or Coach) page open in its own
+tab with no cross-contamination, **so I can** flip between them
+without re-binding or losing one's local state every time the other
+loads.
+
+The single in-memory "active shooter" model from before #353 made this
+impossible: the second tab's request would mutate the active slug and
+break the first tab. Addressed by path-scoped URLs
+(`/audit/<slug>/...`, `/ingest/<slug>`, etc.) and a per-page
+``ShooterScopedRoute`` that keys the page on slug.
+
+Frequency: per-multi-shooter match. Pain today: solved.
+
+### G. Manage videos after initial ingest
+
+**When** I have already confirmed footage and started auditing, **I
+want to** keep adding cameras, removing wrong assignments, swapping
+primary, and finding moved source files for the rest of the match,
+**so I can** treat video management as an ongoing workspace, not a
+one-time wizard.
+
+The redesigned shell treated `/ingest` as a setup wizard with no
+persistent nav, so any of those operations after the initial confirm
+required deep-linking or browser-back. Addressed by a persistent
+**Videos** nav row on `MatchShell`'s sidebar (renamed from "Ingest").
+
+Frequency: every multi-camera or messy match. Pain today: solved.
+
+### H. Fix a wrong beep without leaving the audit page
+
+**When** I notice during audit that shots are mis-aligned with the
+beep (clustered too far after t=0, last shot overshoots the official
+stage time, fewer shots than expected), **I want to** re-pick the beep
+on the same screen and have trim + shot-detect re-run, **so I can**
+recover without three context switches into Ingest and back.
+
+Surfaced when the audit page actually got real footage with a wrong
+auto-detected beep. Addressed by an always-visible "Re-pick beep"
+button next to the beep readout, plus a proactive anomaly banner that
+surfaces when the heuristic detects a probably-wrong beep (draw > 2.5s
+or stage-time overshoot > 1s). Both paths open the same inline
+`BeepWaveformPicker`; Apply queues trim + shot-detect via the existing
+override endpoint.
+
+Frequency: per-match (any time auto-detect lands on a non-buzzer
+transient). Pain today: solved.
+
+### I. Find moved source videos from the UI
+
+**When** I move my source footage between drives (NAS, USB, archive),
+**I want to** find the new locations and rewrite the project's broken
+symlinks from the UI, **so I can** keep auditing and exporting without
+re-ingesting from scratch.
+
+The relink dialog (`RelinkDialog` + `/api/shooters/<slug>/videos/relink/*`)
+existed in code but was never mounted after the redesign; JobsPanel
+even carried a stub comment "Inline relink lands with the
+match-settings redesign". Addressed by a "Find moved videos" button on
+Ingest/Videos that opens the existing dialog.
+
+Frequency: ad-hoc, but inevitable across multiple matches. Pain
+today: solved.
+
+### J. Manually retry beep detection when auto-queue never fired
+
+**When** a primary's beep is missing because the auto-queue never
+fired (re-ingest path bug, worker crash, etc.) and the HITL queue
+doesn't surface it (it only emits ``beep_missing`` when
+``beep_auto_detect_failed`` is True), **I want to** click "Detect
+beep" on the video row, **so I can** kick the chain without dropping
+to the CLI.
+
+Surfaced from the May-15 re-ingest bug on the blacksmith project where
+the Pixel headcam was promoted to primary without auto-queueing
+detect_beep. Addressed by a per-video "Detect beep" button on the
+Videos page, visible whenever a non-ignored video lacks a
+``beep_time``. Companion fix: the audit's "beep" filter chip was
+hardcoded to count=1; now reflects whether the primary actually has
+one.
+
+Frequency: rare (depends on auto-queue reliability), but the workflow
+is dead in the water without it. Pain today: solved.
+
+### K. Survive a server bind-state loss without a confusing dead UI
+
+**When** the dev server restarts (uvicorn `--reload` after a code
+change) the in-memory bind is wiped; every request 409s with code
+``no_project``. **I want** the shell to redirect me to `/pick`
+automatically, **so I can** rebind in one click instead of staring at
+a JobsPanel that silently emptied.
+
+Surfaced during the redesign push when reload-driven restarts kept
+catching the user off-guard. Addressed by a `splitsmith:no-project`
+window event fired from the shared `request()` helper on 409
+``no_project``; `MatchShell` listens, bumps its refresh key, the
+existing bound-check `<Navigate to=/pick>` fires.
+
+Frequency: dev-only today; rare in production. Pain today: solved
+short-term, but the underlying architectural question (the backend is
+stateful) is a noted SaaS-readiness follow-up.
+
+### L. URL / on-disk paths must not leak competitor names
+
+**When** I share a screen recording, a log snippet, or an exported
+project archive, **I want** competitor names absent from URL slugs and
+shooter folder names, **so I can** share without PII leaks. (Match
+names and stage names stay readable since they're public match
+metadata.)
+
+Surfaced after #353 propagated the slug into URLs. Addressed by
+opaque shooter slugs of the shape ``s_<8 hex>`` minted with
+``secrets.token_hex``. Display names remain in ``shooter.json``.
+Migration command: ``splitsmith match rename-shooter-slugs <path>``.
+
+Frequency: structural (every multi-shooter match). Pain today:
+solved.
+
 ## Process notes
 
 - Job discovery was iterative: a seeded candidate list, refined into JTBD

--- a/docs/ux-redesign/02-information-architecture.md
+++ b/docs/ux-redesign/02-information-architecture.md
@@ -68,17 +68,32 @@ later.
 |
 +-- <Match X>
     +-- Overview             (meta + shooters + stages grid; entry view)
-    +-- Coach                (match-wide: cross-stage analysis, annotations)
-    +-- Stages
-    |   +-- Stage 1
-    |   |   +-- Audit            (per-shooter timing review)
-    |   |   +-- Compare          (multi-shooter sync preview)
-    |   |   +-- Coach            (per-stage deep dive: shot-by-shot)
-    |   +-- Stage 2 ...
-    +-- Shooters                 (list of contributors and their footage)
-    +-- Export                   (overlays, transitions, scope: stage / match)
-    +-- Settings                 (rename, archive, delete, backup, source links)
+    +-- <shooter S>
+    |   +-- Audit            (per-stage timing review for S)
+    |   +-- Coach            (per-shooter analysis for S)
+    |   +-- Videos           (ingest + manage S's footage)
+    |   +-- Export           (final-cut bundle for S)
+    +-- Compare              (multi-shooter sync preview, per stage)
+    +-- Beep review          (cross-shooter beep queue)
+    +-- Shooters             (list of contributors and their footage)
+    +-- Settings             (rename, archive, delete, backup, source links)
 ```
+
+**Shipped URL shape** (#353): every shooter-scoped page is path-scoped
+on the shooter slug. `/audit/<slug>`, `/audit/<slug>/<stage>`,
+`/coach/<slug>`, `/coach/<slug>/<stage>`, `/ingest/<slug>` (the
+"Videos" sidebar row), `/export/<slug>`, `/export/<slug>/<stage>`.
+Slugless visits redirect to `/shooters`. `Compare`, `Shooters`, and
+`Beep review` stay slug-less (multi-shooter / shooter-management).
+Two browser tabs can hold two shooters' Audit views simultaneously
+with no cross-contamination. Slug values are opaque (`s_<8 hex>`) so
+URLs / disk paths / server logs don't leak competitor names.
+
+**Persistent sidebar nav rows** on `MatchShell`: Overview, Audit,
+Coach, Shooters, **Videos**, Export. The shooter-scoped rows
+(Audit / Coach / Videos / Export) target the URL's current `slug` or
+fall back to `/api/health.default_shooter_slug` so the rows always
+land somewhere sensible; with no shooters they route to `/shooters`.
 
 Coach exists at **two levels**:
 

--- a/docs/ux-redesign/03-capability-inventory.md
+++ b/docs/ux-redesign/03-capability-inventory.md
@@ -39,14 +39,39 @@ Markers:
 - Each match is a folder containing `match.json` + `shooters/<slug>/`
   subdirs; the per-shooter dir holds a `project.json` (legacy shape
   preserved for audit/ingest endpoints)
-- Add, remove, and switch the active shooter on a match
+- Add and remove shooters on a match; *switching* between shooters is
+  per-request via URL slug (no in-memory "active shooter" since #353)
 - List shooters on the active match with per-shooter audit progress,
   camera coverage, and HITL queue counts
 - Per-shooter video streaming for cross-shooter views (Compare)
-- Shooter slug stable across renames; per-shooter racing-color identity
-  used in Compare + Shooters management
+- Per-shooter racing-color identity used in Compare + Shooters
+  management
+- **Path-scoped shooter URLs** (#353): every shooter-scoped page
+  carries the slug in its URL (`/audit/<slug>`, `/audit/<slug>/<stage>`,
+  `/ingest/<slug>`, `/coach/<slug>`, `/coach/<slug>/<stage>`,
+  `/export/<slug>`, `/export/<slug>/<stage>`). Slugless visits redirect
+  to `/shooters`. Two tabs can hold two shooters' views simultaneously
+  with no cross-contamination.
+- **Opaque shooter slugs** (`s_<8 hex>`, minted by
+  `secrets.token_hex`) so URLs / disk paths / server logs don't leak
+  competitor names. Display names live in `shooter.json`. Migration
+  command: `splitsmith match rename-shooter-slugs <path>`.
+- **`default_shooter_slug`** on `/api/health` -- the
+  alphabetically-first shooter in match mode, or the deterministic
+  `legacy_slug(project)` in legacy mode. Lets slug-less surfaces (Home,
+  sidebar Audit/Coach/Export rows) plug into a sensible
+  `/audit/<slug>` URL without the user picking first.
+- **`ShooterChipStrip`** -- shared chip-strip switcher mounted on
+  every shooter-scoped page (Audit, Videos, Coach, Export).
+  Parameterised by `urlBase` + optional `stage`; hides itself for
+  single-shooter matches.
 
-## Footage ingest
+## Footage ingest / video management
+
+The page is reachable from the persistent **Videos** sidebar row on
+every match-mode shell, not just immediately after project creation.
+It functions as the ongoing video-management workspace, not a one-shot
+wizard.
 
 - Scan a folder of video files and symlink into `raw/`
 - Auto-match videos to stages by mtime
@@ -54,17 +79,38 @@ Markers:
 - Unassign videos from a stage
 - Remove videos from the project (and disk)
 - View per-video link status across stages
-- Relink videos to different stages or roles (relink dialog with folder picker)
+- Per-video beep status pill (`beep 12.34s` when set) + manual
+  "Detect beep" button on rows that lack a beep -- explicit retry path
+  for primaries the scan-time auto-queue missed
+- **Find moved videos** -- relink dialog reachable from the page
+  header; scans a folder recursively, matches by basename, lets the
+  user confirm each per-video target before rewriting the symlinks
 - Select camera model and mount type with provenance tracking
 
 ## Beep handling
 
 - Auto-detect beep time on one video or across a stage
+- Auto-queue beep detection at scan / move-assignment /
+  swap-primary time (best-effort; conservative -- never replaces
+  manual entry or fires when the source is unreachable)
+- **Manually trigger detect-beep per video** from the Videos page when
+  the auto-queue missed (no UI dependency on `beep_auto_detect_failed`
+  having ever flipped to True; works on pristine never-attempted
+  primaries too)
 - View beep candidates ranked by confidence with preview clips
 - Manually place / override beep time
 - Snap beep to nearest detected peak
 - Pick a beep from the candidate list
 - Multi-camera beep review (primary + secondary synchronized at detected beep)
+- **Inline beep re-pick on Audit** -- always-visible "Re-pick beep"
+  button next to the audit toolbar beep readout opens an inline
+  `BeepWaveformPicker`. Apply queues a fresh trim + shot-detect
+  chain via `overrideBeepForVideo` (which clears shots[] server-side)
+  so the user fixes a wrong beep without leaving Audit.
+- **Proactive "beep looks wrong" nudge on Audit** -- yellow banner
+  appears when the post-detection state has heuristic signals the
+  beep is mis-placed (draw > 2.5s, last shot overshoots official
+  stage time > 1s). Banner CTA opens the same inline picker.
 - Re-run beep detection with fresh config
 - Suppress auto-detection (env var)
 - View beep waveform preview with confidence score
@@ -250,6 +296,15 @@ Markers:
 - Thumbnail generation and caching for video previews
 - Match-level export overview (stages complete, export ready)
 - Anomaly detection (splits outside expected distribution)
+- **Bind-state drift recovery** (#353): a 409 ``no_project`` from any
+  endpoint dispatches a `splitsmith:no-project` window event;
+  `MatchShell` listens, re-fetches health, and the existing bound
+  check redirects to `/pick`. Survives dev-server restarts cleanly.
+- **`200 null` for "doesn't exist yet" GETs**: `/api/me/scoreboard-identity`,
+  `/api/shooters/<slug>/stages/<n>/audit`, and `.../coach` return
+  `200 null` for the "not pinned yet" / "no audit JSON yet" cases so
+  these don't show up as failed requests in DevTools on every page
+  load. 404 is reserved for genuinely-unknown resources.
 
 ---
 

--- a/docs/ux-redesign/05-accessibility.md
+++ b/docs/ux-redesign/05-accessibility.md
@@ -46,14 +46,29 @@ All values measured against the surrounding surface color.
   dot/border is exempt as decoration as long as a text label is
   present.
 
-Specifically watch the "subtle" tier (`#5C5851` and below on cream
-paper). Anything used for actionable or informational text must hit
-AA, even at small sizes.
+Specifically watch the `subtle` / `whisper` tiers on dark surfaces.
+Anything used for actionable or informational text must hit AA even
+at small sizes.
 
-Branded vermillion (`#C73A2F`) on cream (`#EFEBE2`) is borderline for
-small body text. Use the deeper variant (`#9F2C24`) for body or label
-text; the bright variant is reserved for decorative accents (dots,
-underlines, brand mark).
+**Red text and red CTAs.** Saturated LED red (`#FF2D2D`) against cream
+text is below AA for normal body (4.5:1) and especially fails for
+red-green colorblindness. Two design-system patterns capture the
+fixed approach:
+
+- Filled primary CTAs and any "fill with text inside" surface use
+  `--color-led-fill` (`#DC2626`, slightly deeper red) with
+  `--color-ink` cream text, Antonio 14px bold, and an LED-red glow
+  halo. Captured as `.btn-led-fill` / `.tab-pill-led-fill` /
+  `.badge-led-fill` in `theme.css`. See `06-design-system.md` section
+  2.6.
+- Saturated `--color-led` (`#FF2D2D`) is reserved for accent dots,
+  hairlines, focus rings, and the brand mark -- decorative roles
+  where saturation gives the instrument-panel feel and where the
+  shape is the meaning, not the color.
+
+Do **not** combine saturated `--color-led` with `text-bg` (dark text
+on saturated red). That pattern caused recurring contrast pain and
+was swept out of the codebase in `6ed90bc`.
 
 ## 3. Motion and animation
 

--- a/docs/ux-redesign/06-design-system.md
+++ b/docs/ux-redesign/06-design-system.md
@@ -346,6 +346,24 @@ dependency).
 - **`AppShell`** -- top bar with brand + mode switch + utility +
   profile + heartbeat indicator. Layout primitive that wraps every
   page.
+- **`MatchShell`** -- shooter-mode chrome (header + per-match sidebar
+  + JobsPanel). The sidebar's nav rows: Overview, Audit, Coach,
+  Shooters, Videos, Export. Audit / Coach / Videos / Export rows are
+  *shooter-scoped* -- they take the current URL slug (or
+  `default_shooter_slug` from `/api/health` when there's no URL slug)
+  and land on `/<route>/<slug>`. Slug-less Shooters / Beep-review
+  routes stay slug-less.
+- **`DeveloperShell`** -- developer-mode chrome (cyan accent,
+  workflow stepper sidebar).
+- **`ShooterScopedRoute`** -- route wrapper for every shooter-bearing
+  URL. Keys on `slug` so the page remounts cleanly when the user
+  switches shooters; redirects to `/shooters` when slug is missing.
+- **`ShooterChipStrip`** -- shared shooter switcher. Mounted on every
+  shooter-scoped page (Audit, Videos, Coach, Export). Props: `shooters`,
+  `activeSlug`, `urlBase` ("audit" | "ingest" | "coach" | "export"),
+  optional `stage`, `label` (the verb in front of the chips:
+  "Auditing", "Adding footage for", "Coaching", "Exporting"), optional
+  per-chip `count` formatter. Hides itself in single-shooter matches.
 - **`ContextBar`** -- thin bar under the shell with pulse and
   breadcrumb. Hosts ambient state for the active page.
 - **`MatchCard`** -- a single match row. Slots: index, primary
@@ -433,6 +451,18 @@ toggle, P1-priority numeral tiles, and any inline red link on dark bg
 **Do NOT apply to:** small accent dots, 1-2px hairlines, focus rings,
 the brand mark -- those keep `#FF2D2D` because the saturation is what
 gives the instrument-panel feel at small sizes.
+
+**Sweep history.** Commit `888933c` introduced the three utility
+classes and applied them to five surfaces. Every other red CTA / badge
+in the SPA continued using the legacy `bg-led + text-bg` pair
+(cream-on-saturated-#FF2D2D), and new pages added since then
+reproduced the legacy pattern. Commit `6ed90bc` propagated the fix
+across the rest of the SPA via a scoped find/replace: every
+`bg-led text-bg` became `bg-led-fill text-ink`, and every
+`hover:bg-led-soft hover:text-bg` became `hover:bg-led hover:text-ink`
+(matching `.btn-led-fill:hover`). Other status colors (`bg-done`,
+`bg-beep`, `bg-live`) paired with `text-bg` were left alone -- they
+have enough luminance against dark text to pass AA easily.
 
 A side-by-side ideation with deuteranopia + tritanopia + low-vision
 simulation toggles lives at

--- a/docs/ux-redesign/07-redesign-progress.md
+++ b/docs/ux-redesign/07-redesign-progress.md
@@ -2,7 +2,8 @@
 
 Source-of-truth status doc for the redesign initiative.
 
-Last touched: 2026-05-15 (post-implementation polish + doc resync).
+Last touched: 2026-05-16 (path-scoped shooter refactor + Videos nav +
+inline beep re-pick + a11y sweep).
 
 ## Status: implementation complete, polish ongoing
 
@@ -111,6 +112,26 @@ shooter slug (not initials), drawing from this 4-color rotation.
 | Coach per-stage playhead auto-sync                                  | Shot list + ruler + hero panel froze on click instead of following the video |
 | Cascade-layer fix for `.btn-led-fill` family                        | Component-layer custom utility lost to Tailwind base utilities; moved to utilities layer |
 
+## Path-scoped shooter refactor (2026-05-16, #353)
+
+The shooter slug moved into the URL. Singleton "active shooter" server
+state is gone; per-request slug from the URL is the source of truth.
+
+| Change                                                              | Why                                                                 |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `/audit/<slug>`, `/coach/<slug>`, `/ingest/<slug>`, `/export/<slug>` | Two browser tabs can hold two shooters' views with no cross-contamination |
+| Opaque shooter slugs (`s_<8 hex>`)                                  | URLs / disk paths / server logs no longer leak competitor names; migration via `splitsmith match rename-shooter-slugs` |
+| Shared `ShooterChipStrip` mounted on every shooter-scoped page     | Audit-only switcher pattern propagated to Videos / Coach / Export so the user has one mental model for shooter switching |
+| Persistent **Videos** nav row in MatchShell sidebar                 | Video management is an ongoing workspace, not a one-shot wizard; reachable from anywhere in match mode |
+| "Find moved videos" relink dialog reachable on Videos               | JTBD-I (relocated source files) had API + component support but was never mounted in the redesigned shell |
+| Inline "Re-pick beep" on Audit + proactive anomaly banner           | Fix wrong beep without leaving Audit; opens `BeepWaveformPicker` inline, Apply queues trim + shot-detect via `overrideBeepForVideo` |
+| Per-video "Detect beep" button on Videos                            | Manual retry when scan-time auto-queue never fired (HITL queue can't help -- it requires `beep_auto_detect_failed=true`) |
+| Audit's "beep" filter chip count derived from primary state         | Was hardcoded to 1; now reflects whether the primary actually has a beep (0 or 1) |
+| A11y sweep: every `bg-led text-bg` -> `bg-led-fill text-ink`        | Finishes the work `888933c` started -- the legacy pattern had stayed in 10+ files and every new page reproduced it |
+| `200 null` for "doesn't exist yet" GETs                             | `/api/me/scoreboard-identity`, stage audit, stage coach return `200 null` instead of 404 to stop DevTools showing failed requests on every page load |
+| `default_shooter_slug` on `/api/health`                             | Slug-less surfaces (Home, sidebar Audit/Coach/Export rows) plug into a sensible `/audit/<slug>` without forcing the user to pick first |
+| Auto-redirect on 409 `no_project`                                   | Dev-server restart wipes bind state; `request()` fires a `splitsmith:no-project` event; `MatchShell` re-fetches health and the existing bound-check sends the user to `/pick` |
+
 ## Open items
 
 - **Promote / rollback / multi-version artifact storage** for
@@ -131,6 +152,14 @@ shooter slug (not initials), drawing from this 4-color rotation.
 - **Lab removal milestone.** `/dev/legacy/lab` is reachable for parity
   verification; remove after a few weeks of confirming the new dev
   pages cover the corpus + review flows.
+- **Stateless backend** -- the path-scoped refactor moved the slug
+  into the URL, but `AppState` still holds the bound match-root in
+  memory; a server restart wipes it. The auto-redirect to `/pick` is
+  the safety net; truly stateless would put the match-root in the URL
+  or a request header (option A / B in the design discussion). Noted
+  as a SaaS-readiness follow-up; not blocking the local-first product.
+- **End-to-end JTBD #1 on a fresh project** -- planned. The walk-
+  through is the canonical regression check before the next release.
 
 ## Critical rules (do not break)
 

--- a/docs/ux-redesign/08-known-pain-and-rough-edges.md
+++ b/docs/ux-redesign/08-known-pain-and-rough-edges.md
@@ -1,0 +1,308 @@
+# UX redesign -- known pain and rough edges
+
+A working list of UX gaps, awkward flows, and "feels wrong but I can't
+quite say why" moments the user has hit personally. Use this as the
+entry point for a design review -- these are the *real* grievances,
+not inferred ones.
+
+Format: each item is a short title + the situation that triggers it +
+what was tried + current state (`open` / `mitigated` / `shipped`).
+"Mitigated" means a fix shipped but the underlying tension may not be
+fully resolved.
+
+Last touched: 2026-05-16.
+
+## 1. Workflows that recover from upstream errors
+
+### 1.1 "The beep is on the wrong sound" -- recovery during audit
+
+**Triggered when:** Auditing a stage, the user notices shots are
+clustered well after t=0 or the last shot overshoots the official
+stage time -- both signs the auto-detected beep landed on a non-buzzer
+transient (steel hit, RO chatter, ambient bang).
+
+**Was:** No affordance to fix the beep from Audit. The user had to
+leave Audit -> open Ingest -> find the stage -> re-pick beep -> wait
+for trim + shot-detect to re-run -> navigate back to Audit. Three
+context switches.
+
+**Now (mitigated, commits `788668a` + `10bccf5`):** Always-visible
+"Re-pick beep" button next to the beep readout in the Audit toolbar,
+plus a proactive anomaly banner when heuristics fire (draw > 2.5s,
+last-shot overshoots stage time > 1s). Both paths open an inline
+`BeepWaveformPicker`; Apply queues trim + shot-detect via the existing
+override endpoint.
+
+**Still rough:**
+- Fire-and-forget: the user has to watch JobsPanel for chain completion
+  and manually reload Audit. Inline progress under the picker was
+  considered + rejected as too heavy for a per-stage tweak.
+- The two heuristic thresholds (2.5s / 1s) are guesses. Need real
+  match data to validate they fire only when they should.
+
+### 1.2 "My source videos moved" -- relink
+
+**Triggered when:** Source footage was on a USB drive / NAS and the
+project's symlinks broke because the source was unplugged / moved /
+renamed.
+
+**Was:** `RelinkDialog` + `relinkScan` / `relinkApply` endpoints
+existed but were never mounted in the redesigned shell. The JobsPanel
+even carried a TODO comment "Inline relink lands with the match-
+settings redesign".
+
+**Now (mitigated, commit `6c520b2`):** "Find moved videos" button on
+the Videos page opens the existing dialog. Scans a folder recursively,
+matches by basename, lets the user confirm per-video target paths
+before rewriting symlinks.
+
+**Still rough:**
+- The dialog uses a stock folder picker; it could pre-suggest sensible
+  scan roots (recent dirs, drives, the original scan dir).
+- Bulk-confirm with high-confidence auto-matches would help long lists
+  -- today every video needs a click.
+
+### 1.3 "Auto-queue never fired" -- manual beep retry
+
+**Triggered when:** A primary lacks a beep (`processed.beep: false`,
+`beep_time: null`) because the scan-time auto-queue was never invoked
+or its job failed silently. Real example: re-ingest path on the
+blacksmith project where the Pixel headcam was promoted to primary
+without auto-queueing `detect_beep`.
+
+**Was:** No UI affordance to retry. The HITL queue doesn't help -- it
+only emits `beep_missing` when `beep_auto_detect_failed` is true (a
+job ran and produced nothing). Pristine never-attempted primaries
+were invisible to the queue.
+
+**Now (mitigated, commit `ed4d926`):** Per-video "Detect beep" button
+on the Videos page, visible whenever a non-ignored video lacks a beep.
+Plus a `beep 12.34s` status pill on rows that have one so the user
+can scan the list and see status at a glance.
+
+**Still rough:**
+- N primaries without a beep = N clicks. Should there be a "Detect
+  all missing beeps" action on the page header?
+- The button label is "Detect beep" -- maybe "Retry detection" when
+  `beep_auto_detect_failed` is true and "Detect beep" otherwise so the
+  user knows the prior history.
+
+## 2. Discoverability + nav
+
+### 2.1 "Where do I manage videos after ingestion?"
+
+**Triggered when:** After initial ingest, the user wants to add more
+cameras / remove a wrong assignment / find moved videos / re-detect a
+beep. No persistent path to Ingest from anywhere in the shell.
+
+**Was:** Only post-confirm hint text mentioned the audit page.
+Sidebar had Overview / Audit / Coach / Shooters / Export but no
+Ingest. Implicit assumption: Ingest is a one-time setup wizard.
+
+**Now (mitigated, commits `6c520b2` + `8c9c0e7`):** Persistent
+**Videos** sidebar row in MatchShell, slug-aware so it lands on the
+current shooter's `/ingest/<slug>` or `default_shooter_slug` fallback.
+
+**Still rough:**
+- "Videos" as the label is fine but loses the "add footage" framing
+  the empty state still uses. Could the page header switch between
+  "Add footage" (empty) and "Manage videos" (review state) more
+  clearly?
+
+### 2.2 "How do I switch to another shooter?" before #354
+
+**Triggered when:** Multi-shooter match, user is auditing shooter A
+and wants to flip to shooter B.
+
+**Was:** Audit had a chip strip from #354. Ingest / Coach / Export
+did not -- the user had to navigate to `/shooters`, click another
+shooter, then re-enter the surface.
+
+**Now (mitigated, commit `8c9c0e7`):** Shared `ShooterChipStrip`
+mounted on every shooter-scoped page. Same chip behaviour, same URL
+shape, hidden for single-shooter matches.
+
+**Still rough:**
+- Per-chip "stages audited / total" works on Audit / Coach / Export
+  but the Videos page uses video-count instead; the parameterization
+  works but inconsistency may confuse first-time users.
+
+### 2.3 "Why did the JobsPanel disappear?" -- server-state drift
+
+**Triggered when:** Dev server restarts (uvicorn `--reload` after a
+code change) and wipes the in-memory bind state. Every API call
+returns 409 `no_project`. The user sees a quietly-broken page with no
+explanation.
+
+**Was:** Pages caught individual 409s and either ignored or rendered
+errors; no global handler refreshed `getHealth` or redirected.
+JobsPanel emptied silently.
+
+**Now (mitigated, commit `90c2c8f`):** Shared `request()` in api.ts
+dispatches a `splitsmith:no-project` window event on 409 `no_project`;
+MatchShell listens, refreshes health, and the existing bound-check
+redirects to `/pick`.
+
+**Still rough:**
+- The backend is *not* stateless (AppState holds the bound match-root
+  in memory). The auto-redirect is the safety net. True statelessness
+  (match-root in URL or header) is a noted SaaS-readiness follow-up.
+
+## 3. Visual + a11y
+
+### 3.1 Dark text on saturated red
+
+**Triggered when:** Reading any filled red CTA or badge -- saturated
+`#FF2D2D` background with near-black text. Subjectively shimmery,
+fails for protanopia / deuteranopia, borderline AA.
+
+**Was:** Pattern persisted in 10+ files even after commit `888933c`
+introduced the `.btn-led-fill` recipe (`#DC2626` darker red + cream
+text). The original commit only touched five surfaces.
+
+**Now (mitigated, commit `6ed90bc`):** Every `bg-led + text-bg`
+pairing swept to `bg-led-fill + text-ink`. Hover states updated to
+match `.btn-led-fill:hover` (brighter red, cream text stays). Other
+status colors (`bg-done`, `bg-beep`, `bg-live`) left alone -- they
+have enough luminance to pass AA with dark text.
+
+**Still rough:**
+- ESLint rule against `bg-led text-bg` would catch regressions; not
+  written yet.
+- Future similar mistakes are easy: any tailwind class pairing two
+  tokens that fail AA together. A more general approach (token
+  contrast registry?) would scale.
+
+### 3.2 "1 beep" pill always said 1
+
+**Triggered when:** Auditing a stage whose primary had no beep yet.
+The filter chip on the audit waveform legend showed "1 beep" anyway,
+suggesting there was a beep marker rendered when there wasn't.
+
+**Was:** Hardcoded `count={1}` in `FilterBar`. Symptom of UI built
+against the happy path without considering "this stage has no primary
+beep yet" edge case.
+
+**Now (mitigated, commit `ed4d926`):** Count derived from
+`peaks.beep_time != null ? 1 : 0`. Reflects whether the primary
+actually has a beep on the audit timeline.
+
+**Still rough:**
+- The same "happy-path-only" pattern probably hides in other counts /
+  badges / pills across the SPA. Worth a targeted audit.
+
+## 4. Multi-shooter UX
+
+### 4.1 Compare grid drops unfinished shooters
+
+**Triggered when:** A stage where only some shooters have cached
+trim. Compare's video grid only renders playable shooters; the others
+either disappear or appear in an empty-state fallback only when
+*everyone* is unfinished.
+
+**Was:** Other shooters fell through to chip-strip-only visibility
+when at least one was playable. Easy to miss that they exist.
+
+**Now (mitigated, commit `e577a9a`):** Inline "Unfinished shooters"
+banner above the grid surfaces shooters without a cached trim. Per-
+shooter affordance: "Build trim cache" (if they have audit data) or
+"Open in audit" (if they don't). Calls existing
+`buildShooterTrimCaches` endpoint; fire-and-forget into JobsPanel.
+
+**Still rough:**
+- After "Build trim cache" succeeds, the grid doesn't auto-refresh.
+  User has to reload the page.
+- The banner shows the shooters but doesn't visually preserve the grid
+  slot (i.e. no placeholder tile in the grid itself). A placeholder
+  tile would make the multi-shooter set's *shape* visible even when
+  half the data is missing.
+
+### 4.2 Coach intentionally has no cross-shooter view
+
+**Documented (not pain) but worth flagging to a reviewer:** Per
+`07-redesign-progress.md` open items: "Coach cross-shooter comparison
+-- intentionally absent; shooters take stages in different orders so
+shot N is not the same physical shot for everyone. Self-referential
+baselines only."
+
+A reviewer may want to challenge this. Possible counter-design:
+align by shot-from-beep time, not by shot index. Open question.
+
+## 5. Onboarding / first-run
+
+### 5.1 JTBD #1 has not been walked end-to-end on a fresh project
+
+**Triggered when:** the user wants to validate the redesigned shell on
+a never-before-ingested match. Today every test has been on
+migrated / hand-tweaked projects that carry accumulated state.
+
+**Status: open.** Planned but deferred while the path-scoped
+refactor stabilised.
+
+**Why this matters for a design review:** the redesigned surfaces
+work on data that *was* in a good state; we don't know how they look
+when:
+- A match has 0 shooters
+- A match has 1 shooter and 0 videos
+- A shooter has 0 audited stages
+- A shooter has 8 stages all in different processing states
+  simultaneously
+- The first ingest queues 7+ beep-detect jobs and the JobsPanel
+  becomes the user's mental dashboard
+
+The empty / partial states *exist* in code but have not been
+exercised in a focused session.
+
+### 5.2 Scoreboard search latency
+
+**Triggered when:** User searches scoreboard.urdr.dev for the match
+they just shot. The fetch can take 1-5 seconds depending on cache
+state.
+
+**From original JTBD doc (#4, "dropdown latency needs progress
+feedback").** Status: not addressed in the redesign. The user has
+been working with cached matches throughout development; the latency
+gap surfaces only on fresh searches.
+
+## 6. Progress + feedback
+
+### 6.1 Confirm & Start Processing button is misleading
+
+**Triggered when:** User assembles videos on Ingest, clicks "Confirm
+& start processing", expects something to start. The button only
+navigates to the Match Overview. Processing is auto-queued at scan /
+move-assignment time -- it already started; the user just doesn't know.
+
+**Status: open.** Mentioned in this session but deferred behind the
+JTBD-1 end-to-end work. The right fix is either:
+- Rename to "Done -- back to overview" so it reflects what it does
+- Make it actually trigger detect-beep for primaries that lack one
+  (mirrors the new per-video button, but applied at the page level)
+
+### 6.2 JobsPanel as the universal progress dashboard
+
+**Triggered when:** Many jobs queue at once (initial ingest, "detect
+all missing beeps", batch trim rebuild). The JobsPanel surfaces them
+but the user has to *open* the panel to see anything is happening.
+
+**Status: open.** The FAB does glow when work is running, but the
+glow is the only ambient signal. A reviewer might propose a slimmer
+always-visible progress strip (e.g. under the breadcrumb).
+
+## 7. Things a reviewer should NOT flag
+
+These look like rough edges but are intentional:
+
+- **Saturated `--color-led` (#FF2D2D) on dots / hairlines / focus
+  rings / brand mark.** That saturation is what gives the instrument-
+  panel feel at small sizes. The contrast rule applies to filled
+  surfaces with text, not decorative pixels.
+- **No cross-shooter Coach view.** See section 4.2.
+- **`/dev/retrain` promote/rollback buttons disabled.** Documented in
+  the surface; depends on multi-version artifact storage.
+- **`/dev/legacy/lab` still reachable.** Parity-verification window;
+  removed after a few weeks of confirming the new dev surfaces cover
+  the corpus + review flows.
+- **Slugs are opaque (`s_<8 hex>`).** Deliberately not derived from
+  names so URLs / disk paths / logs don't leak competitor PII. The
+  display name is in `shooter.json`.

--- a/docs/ux-redesign/09-screenshot-tour.md
+++ b/docs/ux-redesign/09-screenshot-tour.md
@@ -1,0 +1,184 @@
+# UX redesign -- screenshot tour
+
+A checklist for capturing the current shipped state of every redesigned
+surface, in the order a reviewer should walk through them. Each row
+gives the route to open, what data to seed, the dominant state to
+capture, plus secondary states worth covering.
+
+**Why this exists:** the polished HTML files (`docs/ux-redesign/
+polished/01-18.html`) are the design spec, but the React port may
+have drifted. A design reviewer needs anchored visuals of the *current
+shipped* product, not just the spec.
+
+## Setup
+
+```sh
+# 1. Ensure venv + ffmpeg ready
+cd /Users/mathias/work/splitsmith
+uv sync
+
+# 2. Build the SPA so the production build is what you screenshot
+cd src/splitsmith/ui_static
+npm install
+npm run build
+cd ../../..
+
+# 3. Pick a project to bind against. Two recommended:
+#    a) Blacksmith Handgun Open 2026 -- multi-shooter, all states present
+#    b) A freshly-created match -- empty / pristine variants
+uv run splitsmith ui  # opens at http://127.0.0.1:5174
+```
+
+Set the browser to **1440 x 900** at 100% zoom. Dark mode (the only
+mode shipped). Screenshots at 2x DPR for retina sharpness.
+
+## A. Picker + create flows (unbound state)
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| A1 | Match picker | `/pick` | Has recent projects from real use | List, active vs archived sections, hover, project-card actions |
+| A2 | Match picker empty | `/pick` (after forgetting all entries) | None | The "no recent projects" empty state + CTAs |
+| A3 | Create match (scoreboard) | `/pick/new` | Pick "scoreboard" variant, search a real match | Search field, results dropdown, selected-shooter row, stage-table preview |
+| A4 | Create match (manual) | `/pick/new` | Pick "manual" variant | Field stack, stage editor table, primary-shooter row |
+| A5 | Merge wizard | `/pick/merge` | Two legacy single-shooter projects on disk | Selection list, plan preview, conflict dialog (if applicable) |
+
+## B. Match-mode shell (bound state)
+
+Open the blacksmith match. The shell is the same across every match-
+mode page so it's worth a dedicated set.
+
+| # | Surface | Route | What to capture |
+|---|---------|-------|-----------------|
+| B1 | Brand header + breadcrumb | any match page | The top bar with brand, mode switch, breadcrumb, identity slot |
+| B2 | Match sidebar -- mid-match | `/` (Overview) | Match card + nav rows + stages list with mixed status dots + next-up callout |
+| B3 | Match sidebar -- single-shooter match | (open a single-shooter match) | Same shell but `Shooters` row count is 1 |
+| B4 | Match sidebar -- multi-shooter match | (multi-shooter) | Same shell with `Shooters` row showing N |
+| B5 | JobsPanel closed (FAB) | any page | The FAB in its glow state when work is running |
+| B6 | JobsPanel open | click the FAB while jobs run | Running / Needs attention / Queued / Completed groups + worker pool chip |
+
+## C. Match overview
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| C1 | Active match overview | `/` | Audited stages + in-progress + todo | Mission-briefing layout with stat cards, next-up CTA, stages grid, shooters strip |
+| C2 | Empty match overview | `/` | Fresh match, no footage | Empty state with ingest CTA + empty shooter slots + help cards |
+
+## D. Shooter management
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| D1 | Shooters list | `/shooters` | Multi-shooter match | Per-shooter cards, racing-color rails, camera counts, missing-trim CTAs |
+| D2 | Add shooter | `/shooters` then click +Add | -- | The inline add-shooter form |
+
+## E. Videos / Ingest
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| E1 | Videos -- review state | `/ingest/<slug>` | Existing shooter with assigned + unassigned videos | ShooterChipStrip at top, "Find moved videos" button, storage-choice cards, per-stage blocks, role toggles, beep status pills + Detect-beep buttons |
+| E2 | Videos -- empty state | `/ingest/<slug>` | Fresh shooter with no footage | Drop-state hero, FolderPicker inline, tip cards |
+| E3 | Folder picker | open from Videos -> "Add more" | Real filesystem | Sidebar with recent / drives / network, file list, video probe results |
+| E4 | Find moved videos | open from Videos -> "Find moved videos" | Project with broken symlinks | Relink dialog with scan results + per-video confirmation rows |
+| E5 | HITL queue panel | Videos page, when missing beeps exist | Stage with `beep_auto_detect_failed` items | The right-rail queue with rows for beep_missing / beep_low_confidence |
+
+## F. Audit
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| F1 | Audit -- normal state | `/audit/<slug>/3` | Stage with a confirmed beep + detected shots | Toolbar (beep readout, MountSelect, chips), ShooterChipStrip, waveform, video panel, transport, marker layer, shot stepper |
+| F2 | Audit -- multi-cam | same | Stage with primary + 1 secondary | Grid-mode video panel toggle on |
+| F3 | Audit -- no beep | `/audit/<slug>/<stage with no beep>` | Stage whose primary lacks a beep | "no beep yet" chip + TrimNow + DetectShots blocked |
+| F4 | Audit -- Re-pick beep open | open from any audited stage | Click "Re-pick beep" | Inline BeepWaveformPicker under the toolbar with current/draft labels + Apply CTA |
+| F5 | Audit -- anomaly nudge | stage with > 2.5s first shot or > 1s overshoot | -- | The yellow "Looks like the beep is wrong" banner above the toolbar |
+| F6 | Audit -- list drawer | press `L` | -- | Marker list overlay (kept / rejected / manual filters) |
+| F7 | Audit -- help overlay | press `?` | -- | Keyboard shortcuts panel |
+
+## G. Compare
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| G1 | Compare -- 2 shooters playable | `/compare/3` | Stage with 2 shooters who have trim caches | Multi-cam grid, sync timeline, ranking table, audio-source chip with LED ring |
+| G2 | Compare -- some shooters unfinished | `/compare/N` | Stage where 1 of 3 shooters lacks trim | The "Unfinished shooters" banner above the grid with Build / Open-in-audit affordances |
+| G3 | Compare -- nobody playable | `/compare/N` | Stage where no shooter has trim yet | The CompareEmptyState fallback with full-screen unfinished list |
+| G4 | Compare -- layout toggle states | each of grid / row / stack | -- | One screenshot per layout |
+
+## H. Coach
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| H1 | Coach -- match-wide | `/coach/<slug>` | Audited shooter | Headline metrics, per-stage table, distribution histogram, annotations feed |
+| H2 | Coach -- per-stage | `/coach/<slug>/3` | Audited stage | Stat cards, shot ruler, video tile, per-shot list with auto-advance |
+| H3 | Coach -- no audit yet | `/coach/<slug>/<unaudited>` | -- | The 200-null fallback ("no audit yet") |
+
+## I. Export
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| I1 | Export -- ready | `/export/<slug>` | All stages audited | Numbered sections + sticky summary rail + LED export CTA |
+| I2 | Export -- in flight | `/export/<slug>` after clicking Export | -- | Progress states for trim / overlay / stitch |
+| I3 | Export -- result panel | `/export/<slug>` after completion | -- | Resulting FCPXML + CSV + report rows with Reveal CTAs |
+
+## J. Cross-shooter beep review
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| J1 | Beep review queue | `/beep-review` | Multi-shooter match with mixed beep statuses | Two-pane queue grouped by stage, status dots, alt-candidate panel, mini-waveform |
+
+## K. Developer mode
+
+Toggle mode in the header. Cyan accent should flip immediately.
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| K1 | Dev shell | any `/dev/*` route | -- | The cyan-accented workflow stepper sidebar, model chip, mode switch active state |
+| K2 | Corpus | `/dev/corpus` | Real fixture catalog | Fixtures table, tag taxonomy, inbox card, workflow status banner |
+| K3 | Review queue | `/dev/review` | Pending promotions + dev tasks | 3-column shell |
+| K4 | Validate | `/dev/validate` | Last validate run cached | Run-config bar, headline metrics, per-shooter holdout, per-venue breakdown |
+| K5 | Retrain | `/dev/retrain` | Last calibration cached | 6-stage pipeline, log tail, before/after rows |
+| K6 | Legacy Lab | `/dev/legacy/lab` | Real fixture | Catalog table + waveform + ensemble eval (legacy parity) |
+
+## L. Fixture review (no project context)
+
+| # | Surface | Route | Seed | What to capture |
+|---|---------|-------|------|-----------------|
+| L1 | Review fixture | `/review?fixture=<slug>` | Real fixture audit | Standalone audit (similar shell to Audit but without project chrome) |
+| L2 | Promote review | `/promote-review` | Promotion in progress | Anchor-based promotion view |
+
+## M. Design system reference
+
+| # | Surface | Route | What to capture |
+|---|---------|-------|-----------------|
+| M1 | Token + primitives sandbox | `/_design` | The full design system page -- swatches, type spec, primitives |
+
+## Capture process recommendation
+
+1. **Take F1-F7 first** -- Audit is the most-used surface and the
+   highest-leverage screen to review. If anything feels off here, fix
+   before continuing.
+2. **Then E and G** -- multi-shooter video management + compare. The
+   biggest IA change relative to legacy.
+3. **Then C and H** -- match-level views (overview + coach).
+4. **Then I, J** -- export + beep review.
+5. **Save dev mode (K) and design system (M) for last** -- developer
+   workflows are stable; design system page is a reference, not a
+   destination.
+
+For each surface, also capture:
+- The same screen at **prefers-reduced-motion** if you can flip it
+  (Chrome devtools -> Rendering -> Emulate CSS media feature).
+- The same screen at **200% browser zoom** (Cmd-+ a few times) so the
+  reviewer can confirm reflow.
+- One **greyscale** version per category (Audit, Compare, Coach,
+  Export) to confirm color isn't carrying state alone.
+
+## Annotated review brief
+
+If you want the reviewer to focus on specific things per surface,
+pair each screenshot with a one-line note from
+`08-known-pain-and-rough-edges.md`. Example:
+
+> **F1 Audit -- normal state.** Q for reviewer: is the beep readout
+> in the toolbar legible at a glance? See pain #3.2 -- the "1 beep"
+> filter pill was hardcoded for the last six months; same blind spot
+> may exist in adjacent chips.
+
+That coupling makes the review a focused critique, not a tour.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,14 @@ dev = [
 ]
 
 [tool.ruff]
-line-length = 100
+# 110, not 100, to give black's conservative wrapping room. Black's
+# line-length policy is "soft" -- it won't split a call that has a long
+# string literal arg even if the line ends up at 100-110 chars. Aligning
+# ruff's E501 to 110 stops it from firing on lines black already accepts.
+# When a line crosses 110, the magic-trailing-comma convention is the
+# canonical fix: add a trailing comma to the argument list and black
+# auto-wraps one-arg-per-line.
+line-length = 110
 target-version = "py311"
 
 [tool.ruff.lint]
@@ -108,7 +115,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "PTH"]
 "src/splitsmith/ui/scoreboard/http.py" = ["N818"]
 
 [tool.black]
-line-length = 100
+line-length = 110
 target-version = ["py311"]
 
 [tool.pytest.ini_options]

--- a/src/splitsmith/audit.py
+++ b/src/splitsmith/audit.py
@@ -60,8 +60,7 @@ def apply_audit_to_fixture(candidates_csv: Path, fixture_json: Path) -> int:
     candidates = data.get("_candidates_pending_audit", {}).get("candidates")
     if not candidates:
         raise ValueError(
-            f"{fixture_json}: no candidates block found. Expected "
-            f"'_candidates_pending_audit.candidates'."
+            f"{fixture_json}: no candidates block found. Expected " f"'_candidates_pending_audit.candidates'."
         )
     by_num = {c["candidate_number"]: c for c in candidates}
 

--- a/src/splitsmith/automation.py
+++ b/src/splitsmith/automation.py
@@ -169,9 +169,7 @@ def load_global(config_path: Path | None = None) -> AutomationSettings:
         # Pass the YAML block as init kwargs; pydantic-settings will
         # still let env vars override missing keys.
         return AutomationSettings(**block)
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 -- log then fall back so a malformed config doesn't break the app
+    except Exception as exc:  # noqa: BLE001 -- log then fall back so a malformed config doesn't break the app
         logger.warning("Discarding malformed automation block at %s: %s", path, exc)
         return AutomationSettings()
 

--- a/src/splitsmith/backup.py
+++ b/src/splitsmith/backup.py
@@ -138,9 +138,7 @@ def export_project(
                 skipped.append(SkippedDir(name=name, reason="missing"))
                 continue
             if not src_resolved.exists():
-                skipped.append(
-                    SkippedDir(name=name, reason="missing", resolved_path=str(src_resolved))
-                )
+                skipped.append(SkippedDir(name=name, reason="missing", resolved_path=str(src_resolved)))
                 continue
             if not _is_inside(src_resolved, project_root):
                 skipped.append(

--- a/src/splitsmith/beep_detect.py
+++ b/src/splitsmith/beep_detect.py
@@ -347,9 +347,7 @@ def detect_beep(
     )
 
 
-def _rise_foot_leading_edge(
-    env: np.ndarray, run_start: int, run_end: int, noise_floor: float
-) -> int:
+def _rise_foot_leading_edge(env: np.ndarray, run_start: int, run_end: int, noise_floor: float) -> int:
     """Rise-foot of the tone: walk backward from the envelope peak (within the
     strong run) while the envelope stays at or above ``max(peak *
     RISE_FOOT_FRAC, noise_floor * RISE_FOOT_NOISE_FACTOR)``. The earliest

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -293,9 +293,7 @@ def process(
 
     competitor_stages = _load_stage_json(stages)
     video_paths = sorted(_iter_video_files(videos))
-    match = video_match.match_videos_to_stages(
-        video_paths, competitor_stages.stages, config.video_match
-    )
+    match = video_match.match_videos_to_stages(video_paths, competitor_stages.stages, config.video_match)
 
     if match.unmatched_stages or match.ambiguous_stages or match.orphan_videos:
         _print_match_diagnostics(match)
@@ -596,9 +594,7 @@ def audit_prep(
         )
 
     fixture_json_data = {
-        "source": (
-            f"{video.name} stage {stage_number} '{stage_name}' " "(audio extracted at 48 kHz mono)"
-        ),
+        "source": (f"{video.name} stage {stage_number} '{stage_name}' " "(audio extracted at 48 kHz mono)"),
         # Structured absolute path to the source video. Lets the
         # Lab UI's Re-label button hop straight to /review with the
         # video bound, instead of needing the CLI ``--video`` flag.
@@ -693,15 +689,12 @@ def audit_apply(
     candidates: Path = typer.Option(
         ..., "--candidates", help="The audited candidates CSV (must contain audit_keep column)."
     ),
-    fixture: Path = typer.Option(
-        ..., "--fixture", help="The corresponding fixture JSON to update in place."
-    ),
+    fixture: Path = typer.Option(..., "--fixture", help="The corresponding fixture JSON to update in place."),
 ) -> None:
     """Merge audit_keep-marked rows from a candidates CSV into a fixture JSON's shots[]."""
     n = audit.apply_audit_to_fixture(candidates, fixture)
     console.print(
-        f"[green]Wrote {n} audited shots[/] to {fixture} "
-        f"(from {candidates.name}, audit_keep column)."
+        f"[green]Wrote {n} audited shots[/] to {fixture} " f"(from {candidates.name}, audit_keep column)."
     )
 
 
@@ -784,9 +777,7 @@ def clean(
 
     result = cleanup_mod.apply_cleanup(plan, root=project)
     freed_mb = result.bytes_freed / (1024 * 1024)
-    console.print(
-        f"\n[green]Deleted {len(result.deleted)} file(s)[/], freed [bold]{freed_mb:.1f} MB[/]."
-    )
+    console.print(f"\n[green]Deleted {len(result.deleted)} file(s)[/], freed [bold]{freed_mb:.1f} MB[/].")
     if result.failed:
         console.print(f"[yellow]{len(result.failed)} failed:[/]")
         for path, err in result.failed[:10]:
@@ -839,9 +830,7 @@ def overlay(
     audit_path: Path = typer.Option(
         ..., "--audit", help="Audited stage JSON (e.g. <project>/audit/stage<N>.json)."
     ),
-    video: Path = typer.Option(
-        ..., "--video", help="Trimmed video the overlay must mirror frame-for-frame."
-    ),
+    video: Path = typer.Option(..., "--video", help="Trimmed video the overlay must mirror frame-for-frame."),
     output: Path = typer.Option(..., "--output", help="Output overlay MOV (alpha)."),
     beep_offset: float = typer.Option(
         5.0, "--beep-offset", help="Seconds from start of trimmed video to the beep."
@@ -885,13 +874,9 @@ def overlay(
     mirrors the trimmed clip's resolution / fps / duration unless capped.
     """
     if codec not in overlay_render.OVERLAY_CODECS:
-        raise typer.BadParameter(
-            f"--codec must be one of {overlay_render.OVERLAY_CODECS}, got {codec!r}"
-        )
+        raise typer.BadParameter(f"--codec must be one of {overlay_render.OVERLAY_CODECS}, got {codec!r}")
     if theme not in overlay_theme.THEME_NAMES:
-        raise typer.BadParameter(
-            f"--theme must be one of {overlay_theme.THEME_NAMES}, got {theme!r}"
-        )
+        raise typer.BadParameter(f"--theme must be one of {overlay_theme.THEME_NAMES}, got {theme!r}")
     overlay_render.render_overlay(
         audit_path=audit_path,
         trimmed_video_path=video,
@@ -998,9 +983,7 @@ def _process_one(
     )
 
     if auto_detect_shots:
-        shots = shot_detect.detect_shots(
-            audio, sr, beep.time, stage.time_seconds, config.shot_detect
-        )
+        shots = shot_detect.detect_shots(audio, sr, beep.time, stage.time_seconds, config.shot_detect)
         shots, refine_diffs = _refine_shot_times(audio, sr, shots, beep.time, config)
         if refine_diffs:
             console.print(

--- a/src/splitsmith/coach_distributions.py
+++ b/src/splitsmith/coach_distributions.py
@@ -226,9 +226,7 @@ def stage_distributions(
     classes: tuple[IntervalClass, ...] = DEFAULT_HISTOGRAM_CLASSES,
 ) -> StageDistributionsResponse:
     grouped, first_shot_s = _gaps_by_class_for_stage(shots, config)
-    distributions = [
-        _build_distribution(cls, [g for _, g in grouped.get(cls, [])]) for cls in classes
-    ]
+    distributions = [_build_distribution(cls, [g for _, g in grouped.get(cls, [])]) for cls in classes]
     return StageDistributionsResponse(
         stage_number=stage_number,
         stage_name=stage_name,

--- a/src/splitsmith/compare/cli.py
+++ b/src/splitsmith/compare/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from ..match_model import Match, is_match_folder, slugify
+from ..match_model import Match, is_match_folder
 from . import emitter as emitter_mod
 from . import manifest as manifest_mod
 from . import project_loader
@@ -135,22 +135,19 @@ def _export_from_match(match_root: Path, *, audio_from: str, output: Path) -> No
 def _resolve_audio_slug(match: Match, match_root: Path, audio_from: str) -> str | None:
     """Match ``audio_from`` to a shooter slug.
 
-    Accepts an exact slug match (``"anton-johansson"``) or a display name
-    that slugifies to a registered slug (``"Anton Johansson"``,
-    ``"anton johansson"``). Returns the canonical slug or ``None`` when no
-    match is found.
+    Accepts an exact slug (``"s_a4f12d8e"``) or a display name
+    (``"Anton Johansson"``, case-insensitive). Slugs are opaque random
+    ids now, so the old "slugify the display name to guess a slug"
+    fallback no longer applies; we look up by display name instead.
     """
     if audio_from in match.shooters:
         return audio_from
-    target = slugify(audio_from)
-    if target in match.shooters:
-        return target
-    # Fall back to matching against display names.
+    needle = audio_from.casefold().strip()
     for slug in match.shooters:
         try:
             shooter = match.load_shooter(match_root, slug)
         except FileNotFoundError:
             continue
-        if shooter.name == audio_from or slugify(shooter.name) == target:
+        if shooter.name.casefold().strip() == needle:
             return slug
     return None

--- a/src/splitsmith/compare/emitter.py
+++ b/src/splitsmith/compare/emitter.py
@@ -47,9 +47,7 @@ class _AssetEntry:
     metadata: VideoMetadata
 
 
-def _grid_transform_attrs(
-    slot: GridSlot, *, sequence_width: int, sequence_height: int
-) -> dict[str, str]:
+def _grid_transform_attrs(slot: GridSlot, *, sequence_width: int, sequence_height: int) -> dict[str, str]:
     """``<adjust-transform>`` attrs for a grid slot.
 
     Mirrors :func:`splitsmith.fcpxml_gen._pip_transform_attrs`'s normalised
@@ -283,9 +281,7 @@ def emit_compare_fcpxml(
         if stage_number in audio_bundle.stages_by_number:
             stage_name = audio_bundle.stages_by_number[stage_number].stage_name
         else:
-            stage_name = (
-                bundles_by_label[ordered_present[0]].stages_by_number[stage_number].stage_name
-            )
+            stage_name = bundles_by_label[ordered_present[0]].stages_by_number[stage_number].stage_name
 
         # Layout uses native pixel dims of the first present shooter for
         # the letterbox scale. All tiles get the same scale per slot --
@@ -329,8 +325,7 @@ def emit_compare_fcpxml(
 
         # Compound duration: longest tile-end across present labels.
         compound_frames = max(
-            tile_offsets_frames[lab] + tile_durations_in_parent_frames[lab]
-            for lab in present_labels
+            tile_offsets_frames[lab] + tile_durations_in_parent_frames[lab] for lab in present_labels
         )
 
         media_id = _next_id()
@@ -367,9 +362,7 @@ def emit_compare_fcpxml(
                     tile_starts_frames[lab] * fd_seconds,
                     asset.metadata,
                 ),
-                "duration": _frame_aligned_str(
-                    tile_durations_in_parent_frames[lab], fd_num, fd_den
-                ),
+                "duration": _frame_aligned_str(tile_durations_in_parent_frames[lab], fd_num, fd_den),
                 "format": asset.format_id,
             }
             if lab != spine_label:
@@ -457,7 +450,5 @@ def emit_compare_fcpxml(
     ET.indent(fcpxml, space="    ")
     tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
     decl_end = tree_bytes.index(b"?>") + 2
-    output_path.write_bytes(
-        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
-    )
+    output_path.write_bytes(tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :])
     _tag_source_application(output_path)

--- a/src/splitsmith/compare/filler.py
+++ b/src/splitsmith/compare/filler.py
@@ -24,10 +24,7 @@ def filler_filename(
     sub-millisecond rounding.
     """
     duration_ms = int(round(duration_seconds * 1000))
-    return (
-        f"_compare_filler_{width}x{height}_{frame_rate_num}-{frame_rate_den}"
-        f"_{duration_ms}ms.mp4"
-    )
+    return f"_compare_filler_{width}x{height}_{frame_rate_num}-{frame_rate_den}" f"_{duration_ms}ms.mp4"
 
 
 def ensure_filler(

--- a/src/splitsmith/compare/manifest.py
+++ b/src/splitsmith/compare/manifest.py
@@ -62,8 +62,7 @@ class CompareManifest(BaseModel):
         labels = {s.label for s in self.shooters}
         if self.audio_from not in labels:
             raise ValueError(
-                f"audio_from={self.audio_from!r} does not match any shooter label "
-                f"({sorted(labels)})"
+                f"audio_from={self.audio_from!r} does not match any shooter label " f"({sorted(labels)})"
             )
         return self
 
@@ -88,7 +87,5 @@ def load_manifest(path: Path) -> CompareManifest:
     def _resolve(p: Path) -> Path:
         return p if p.is_absolute() else (base / p).resolve()
 
-    resolved_shooters = [
-        s.model_copy(update={"project": _resolve(s.project)}) for s in manifest.shooters
-    ]
+    resolved_shooters = [s.model_copy(update={"project": _resolve(s.project)}) for s in manifest.shooters]
     return manifest.model_copy(update={"shooters": resolved_shooters})

--- a/src/splitsmith/compare/project_loader.py
+++ b/src/splitsmith/compare/project_loader.py
@@ -133,9 +133,7 @@ def _trim_path_for_shooter_stage(
 ) -> Path:
     """Same naming as :func:`trim_path_for_stage` but rooted at a shooter dir."""
     base = f"stage{stage_number}_{_slugify(stage_name)}"
-    exports = (
-        Path(shooter.exports_dir).expanduser() if shooter.exports_dir else shooter_root / "exports"
-    )
+    exports = Path(shooter.exports_dir).expanduser() if shooter.exports_dir else shooter_root / "exports"
     if not exports.is_absolute():
         exports = shooter_root / exports
     return exports / f"{base}_trimmed.mp4"

--- a/src/splitsmith/composition.py
+++ b/src/splitsmith/composition.py
@@ -325,9 +325,7 @@ def from_stage_compositions(
         overlay: ConnectedClip | None = None
         if stage_comp.overlay_path is not None:
             overlay_meta = (
-                stage_comp.overlay_video
-                if stage_comp.overlay_video is not None
-                else stage_comp.video
+                stage_comp.overlay_video if stage_comp.overlay_video is not None else stage_comp.video
             )
             overlay = ConnectedClip(
                 asset=Asset(path=stage_comp.overlay_path, metadata=overlay_meta),
@@ -389,9 +387,7 @@ def to_stage_compositions(
         secondaries: list[fcpxml_gen.SecondaryClip] = []
         for sec in stage.secondaries:
             pip = (
-                _transform_to_pip(sec.transform, composition.sequence)
-                if sec.transform is not None
-                else None
+                _transform_to_pip(sec.transform, composition.sequence) if sec.transform is not None else None
             )
             assert sec.beep_offset_seconds is not None  # cam role guarantees this
             secondaries.append(

--- a/src/splitsmith/cross_align.py
+++ b/src/splitsmith/cross_align.py
@@ -133,8 +133,7 @@ def align_secondary_to_primary(
     primary_dur = primary_audio.size / primary_sr
     if primary_beep_time > primary_dur:
         raise CrossAlignError(
-            f"primary_beep_time {primary_beep_time:.3f}s exceeds primary duration "
-            f"{primary_dur:.3f}s"
+            f"primary_beep_time {primary_beep_time:.3f}s exceeds primary duration " f"{primary_dur:.3f}s"
         )
 
     landmark_start = primary_beep_time - landmark_pre_s

--- a/src/splitsmith/csv_gen.py
+++ b/src/splitsmith/csv_gen.py
@@ -51,8 +51,7 @@ def read_splits_csv(path: Path) -> list[CsvShot]:
         reader = csv.DictReader(f)
         if reader.fieldnames != CSV_HEADER:
             raise ValueError(
-                f"unexpected CSV header in {path}: got {reader.fieldnames}, "
-                f"expected {CSV_HEADER}"
+                f"unexpected CSV header in {path}: got {reader.fieldnames}, " f"expected {CSV_HEADER}"
             )
         return [
             CsvShot(

--- a/src/splitsmith/ensemble/api.py
+++ b/src/splitsmith/ensemble/api.py
@@ -300,9 +300,7 @@ def detect_shots_ensemble(
     shots = detect_shots(audio, sample_rate, beep_time, stage_time, detector_cfg)
     n = len(shots)
     if n == 0:
-        return EnsembleResult(
-            candidates=[], consensus=cfg.consensus, expected_rounds=expected_rounds
-        )
+        return EnsembleResult(candidates=[], consensus=cfg.consensus, expected_rounds=expected_rounds)
 
     times = np.array([s.time_absolute for s in shots], dtype=np.float64)
     confidences = np.array([s.confidence for s in shots], dtype=np.float64)
@@ -345,11 +343,7 @@ def detect_shots_ensemble(
             audit_beep_in_clip=beep_time,
             source_beep_time=float(source_beep_time),
         )
-        offsets = (
-            tuple(cal.voter_e_frame_offsets)
-            if cal.voter_e_frame_offsets
-            else vis.DEFAULT_FRAME_OFFSETS
-        )
+        offsets = tuple(cal.voter_e_frame_offsets) if cal.voter_e_frame_offsets else vis.DEFAULT_FRAME_OFFSETS
         features = vis.compute_visual_features(
             Path(video_path), source_times, runtime.visual, frame_offsets=offsets
         )

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -107,9 +107,7 @@ HAND_FEATURE_DIM: int = len(_HAND_FEATURE_NAMES)
 # (api.py / voter_c_feature_matrix).
 CAMERA_CLASS_FEATURE_NAMES: tuple[str, ...] = ("headcam", "handheld")
 CAMERA_CLASS_FEATURE_DIM: int = len(CAMERA_CLASS_FEATURE_NAMES)
-_CAMERA_CLASS_TO_INDEX: dict[str, int] = {
-    name: idx for idx, name in enumerate(CAMERA_CLASS_FEATURE_NAMES)
-}
+_CAMERA_CLASS_TO_INDEX: dict[str, int] = {name: idx for idx, name in enumerate(CAMERA_CLASS_FEATURE_NAMES)}
 
 # +1 for clap_diff, +1 for gunshot_prob (folded in from voter D).
 VOTER_C_FEATURE_DIM: int = HAND_FEATURE_DIM + len(CLAP_PROMPTS) + 1 + 1 + CAMERA_CLASS_FEATURE_DIM
@@ -241,9 +239,7 @@ def compute_hand_features(
         pre_lo, pre_hi = max(0, idx - win), idx
         post_lo, post_hi = idx, min(n, idx + win)
         rms_pre = (
-            float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2)))
-            if pre_hi > pre_lo
-            else 0.0
+            float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2))) if pre_hi > pre_lo else 0.0
         )
         rms_post = (
             float(np.sqrt(np.mean(audio[post_lo:post_hi].astype(np.float64) ** 2)))
@@ -265,9 +261,7 @@ def compute_hand_features(
         psearch_hi = min(n, idx + peak_search_n)
         if abs_audio is None:
             abs_audio = np.abs(audio.astype(np.float64))
-        peak_local_idx = (
-            idx + int(np.argmax(abs_audio[idx:psearch_hi])) if psearch_hi > idx else idx
-        )
+        peak_local_idx = idx + int(np.argmax(abs_audio[idx:psearch_hi])) if psearch_hi > idx else idx
         tail_lo = min(n, peak_local_idx + int(0.050 * sample_rate))
         tail_hi = min(n, peak_local_idx + int(0.200 * sample_rate))
         tail_amp = float(abs_audio[tail_lo:tail_hi].mean()) if tail_hi > tail_lo else 0.0
@@ -348,9 +342,7 @@ def compute_clap_similarities(
     if not len(candidate_times):
         return np.zeros((0, len(CLAP_PROMPTS)), dtype=np.float32)
     if sample_rate != CLAP_SR:
-        clap_audio = librosa.resample(
-            audio.astype(np.float32), orig_sr=sample_rate, target_sr=CLAP_SR
-        )
+        clap_audio = librosa.resample(audio.astype(np.float32), orig_sr=sample_rate, target_sr=CLAP_SR)
     else:
         clap_audio = audio.astype(np.float32)
 
@@ -401,9 +393,7 @@ def compute_pann_gunshot_probs(
     if not len(candidate_times):
         return np.zeros(0, dtype=np.float32)
     if sample_rate != PANN_SR:
-        pann_audio = librosa.resample(
-            audio.astype(np.float32), orig_sr=sample_rate, target_sr=PANN_SR
-        )
+        pann_audio = librosa.resample(audio.astype(np.float32), orig_sr=sample_rate, target_sr=PANN_SR)
     else:
         pann_audio = audio.astype(np.float32)
     batch = np.stack(

--- a/src/splitsmith/ensemble/fixtures.py
+++ b/src/splitsmith/ensemble/fixtures.py
@@ -53,9 +53,7 @@ _NON_AUDIT_SUFFIXES = (
     ".peaks-1500.json",
 )
 
-_MATCH_STAGE_RE = re.compile(
-    r"^stage-shots-(?P<match>.+?-\d{4})-stage(?P<stage>\d+)(?:-(?P<rest>.+))?$"
-)
+_MATCH_STAGE_RE = re.compile(r"^stage-shots-(?P<match>.+?-\d{4})-stage(?P<stage>\d+)(?:-(?P<rest>.+))?$")
 
 
 @dataclass(frozen=True)

--- a/src/splitsmith/ensemble/tta.py
+++ b/src/splitsmith/ensemble/tta.py
@@ -69,9 +69,7 @@ def compute_tta_agreement(
     # Amplitude perturbations: scale, redetect, no time-axis remapping.
     for db in (-db_perturb, +db_perturb):
         scaled = audio_f32 * np.float32(10.0 ** (db / 20.0))
-        perturbations.append(
-            _detect_times(scaled, sample_rate, beep_time, stage_time, detector_cfg)
-        )
+        perturbations.append(_detect_times(scaled, sample_rate, beep_time, stage_time, detector_cfg))
 
     # Time perturbations via np.roll. Positive roll = content moved later
     # in the array by ``shift_n`` samples. A candidate at time ``t`` in the

--- a/src/splitsmith/ensemble/visual.py
+++ b/src/splitsmith/ensemble/visual.py
@@ -106,9 +106,7 @@ def _frame_path(cache_dir: Path, fingerprint: str, time_s: float, offset_s: floa
     return cache_dir / fingerprint / f"t{time_ms:09d}_o{offset_ms:+05d}.jpg"
 
 
-def _extract_frame(
-    video_path: Path, source_time: float, dest: Path, *, ffmpeg: str = "ffmpeg"
-) -> bool:
+def _extract_frame(video_path: Path, source_time: float, dest: Path, *, ffmpeg: str = "ffmpeg") -> bool:
     """Extract a single frame at ``source_time`` (seconds in source video).
 
     Two-step seek: fast pre-seek to ``source_time - 2.0``, then accurate

--- a/src/splitsmith/ensemble/voters.py
+++ b/src/splitsmith/ensemble/voters.py
@@ -167,9 +167,7 @@ def within_stage_amp_veto(
     if n_kept < min_kept_for_filter:
         return keep_mask
     kept_amps = peak_amps[kept_idx]
-    anchor = within_stage_amp_anchor(
-        kept_amps, expected_rounds, fallback_percentile=fallback_percentile
-    )
+    anchor = within_stage_amp_anchor(kept_amps, expected_rounds, fallback_percentile=fallback_percentile)
     if anchor <= 0.0:
         return keep_mask
     cutoff = floor_ratio * anchor

--- a/src/splitsmith/fcp7xml_render.py
+++ b/src/splitsmith/fcp7xml_render.py
@@ -62,9 +62,7 @@ def render_fcp7xml(
     seq = composition.sequence
     timebase, ntsc = _fcp7_rate(seq.frame_rate_num, seq.frame_rate_den)
 
-    plans = [
-        _plan_stage(stage, seq.frame_rate_num, seq.frame_rate_den) for stage in composition.stages
-    ]
+    plans = [_plan_stage(stage, seq.frame_rate_num, seq.frame_rate_den) for stage in composition.stages]
     total_frames = sum(p.effective_duration_frames for p in plans)
     max_secondaries = max((len(stage.secondaries) for stage in composition.stages), default=0)
     has_overlay = any(stage.overlay is not None for stage in composition.stages)
@@ -150,9 +148,7 @@ def render_fcp7xml(
     ET.indent(xmeml, space="    ")
     tree_bytes = ET.tostring(xmeml, encoding="utf-8", xml_declaration=True)
     decl_end = tree_bytes.index(b"?>") + 2
-    output_path.write_bytes(
-        tree_bytes[:decl_end] + b"\n<!DOCTYPE xmeml>\n" + tree_bytes[decl_end + 1 :]
-    )
+    output_path.write_bytes(tree_bytes[:decl_end] + b"\n<!DOCTYPE xmeml>\n" + tree_bytes[decl_end + 1 :])
 
 
 # --- planning -------------------------------------------------------------
@@ -363,10 +359,7 @@ def _emit_primary_clipitem(
         # FCP7 markers ride inside the clipitem and use source-frame
         # coordinates (same as our ``in`` value), so no spine math here.
         frame = round(marker.time_seconds / fd_seconds)
-        if (
-            frame < plan.head_trim_frames
-            or frame >= plan.head_trim_frames + plan.effective_duration_frames
-        ):
+        if frame < plan.head_trim_frames or frame >= plan.head_trim_frames + plan.effective_duration_frames:
             continue
         _emit_marker(clip, frame=frame, label=_marker_label(marker))
 
@@ -392,8 +385,7 @@ def _emit_secondary_clipitem(
     sec_duration_frames = round(sec_meta.duration_seconds / fd_seconds)
     assert secondary.beep_offset_seconds is not None  # cam role guarantees this
     delta_frames = round(
-        ((stage.beep_offset_seconds - plan.head_trim_seconds) - secondary.beep_offset_seconds)
-        / fd_seconds
+        ((stage.beep_offset_seconds - plan.head_trim_seconds) - secondary.beep_offset_seconds) / fd_seconds
     )
     if delta_frames >= 0:
         cam_spine_offset = spine_offset_frames + delta_frames

--- a/src/splitsmith/fcpxml_gen.py
+++ b/src/splitsmith/fcpxml_gen.py
@@ -164,9 +164,7 @@ def _pip_transform_attrs(
     ``scale`` stays a unit-less ratio (1.0 == native size); only
     position needs the conversion.
     """
-    scale, (x_px, y_px) = pip.resolve(
-        sequence_width=sequence_width, sequence_height=sequence_height
-    )
+    scale, (x_px, y_px) = pip.resolve(sequence_width=sequence_width, sequence_height=sequence_height)
     unit_per_px = 100.0 / sequence_height
     x = x_px * unit_per_px
     y = y_px * unit_per_px
@@ -238,9 +236,7 @@ def _attach_pip_transform(
     """
     if pip is None:
         return
-    attrs = _pip_transform_attrs(
-        pip, sequence_width=sequence_width, sequence_height=sequence_height
-    )
+    attrs = _pip_transform_attrs(pip, sequence_width=sequence_width, sequence_height=sequence_height)
     transform = ET.Element("adjust-transform", attrs)
     asset_clip.insert(0, transform)
 
@@ -280,9 +276,7 @@ def probe_video(
     except FileNotFoundError as exc:
         raise FFprobeError(f"ffprobe binary not found: {ffprobe_binary}") from exc
     except subprocess.CalledProcessError as exc:
-        raise FFprobeError(
-            f"ffprobe failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise FFprobeError(f"ffprobe failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
 
     try:
         data = json.loads(proc.stdout)
@@ -373,9 +367,7 @@ def generate_fcpxml(
     usable_secondaries = [s for s in (secondaries or []) if s.video_path.exists()]
     use_overlay = overlay_path is not None and overlay_path.exists()
     overlay_meta_for_format = overlay_video if overlay_video is not None else video
-    overlay_uses_own_format = use_overlay and _overlay_format_differs(
-        video, overlay_meta_for_format
-    )
+    overlay_uses_own_format = use_overlay and _overlay_format_differs(video, overlay_meta_for_format)
     next_id = 3 + len(usable_secondaries)
     overlay_format_id: str | None = None
     if overlay_uses_own_format:
@@ -443,9 +435,7 @@ def generate_fcpxml(
         # so the source rate is preserved -- if they differ, FCP will round
         # on import (acceptable for a connected cam) but the spec for
         # multi-rate timelines is out of scope here.
-        sec_duration_in_parent_frames = int(
-            round(sec.video.duration_seconds / float(frame_duration))
-        )
+        sec_duration_in_parent_frames = int(round(sec.video.duration_seconds / float(frame_duration)))
         sec_duration_parent_str = _frame_aligned_str(sec_duration_in_parent_frames, fd_num, fd_den)
         sec_asset = ET.SubElement(
             resources,
@@ -564,9 +554,7 @@ def generate_fcpxml(
     #   - sb >  pb: head sits at parent t=0; skip ``sb - pb`` frames of the
     #     cam so the beep still lines up.
     fd_seconds_for_align = float(frame_duration)
-    for lane_idx, (sec, sec_id, sec_duration_parent_str) in enumerate(
-        secondary_asset_entries, start=1
-    ):
+    for lane_idx, (sec, sec_id, sec_duration_parent_str) in enumerate(secondary_asset_entries, start=1):
         delta_frames = round((beep_offset_seconds - sec.beep_offset_seconds) / fd_seconds_for_align)
         if delta_frames >= 0:
             sec_offset_str = _frame_aligned_str(delta_frames, fd_num, fd_den)
@@ -636,9 +624,7 @@ def generate_fcpxml(
     tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
     # Inject the FCPXML DOCTYPE (ElementTree does not emit it).
     decl_end = tree_bytes.index(b"?>") + 2
-    output_path.write_bytes(
-        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
-    )
+    output_path.write_bytes(tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :])
     _tag_source_application(output_path)
 
 
@@ -882,8 +868,7 @@ def generate_match_fcpxml(
             )
         if ti.duration_seconds <= 0:
             raise ValueError(
-                f"title for stage {ti.stage_index} has non-positive "
-                f"duration ({ti.duration_seconds:g}s)"
+                f"title for stage {ti.stage_index} has non-positive " f"duration ({ti.duration_seconds:g}s)"
             )
         seen_title_indices.add(ti.stage_index)
     has_slate = any(ti.style == "slate" for ti in titles)
@@ -1098,9 +1083,7 @@ def generate_match_fcpxml(
                         int(
                             round(
                                 sec.video.duration_seconds
-                                / float(
-                                    Fraction(sec.video.frame_rate_den, sec.video.frame_rate_num)
-                                )
+                                / float(Fraction(sec.video.frame_rate_den, sec.video.frame_rate_num))
                             )
                         ),
                         sec.video.frame_rate_den,
@@ -1393,8 +1376,7 @@ def generate_match_fcpxml(
             plan.usable_secondaries, start=1
         ):
             delta_frames = round(
-                ((stage.beep_offset_seconds - head_trim_seconds) - sec.beep_offset_seconds)
-                / fd_seconds
+                ((stage.beep_offset_seconds - head_trim_seconds) - sec.beep_offset_seconds) / fd_seconds
             )
             if delta_frames >= 0:
                 sec_offset_frames = plan.head_trim_frames + delta_frames
@@ -1489,9 +1471,7 @@ def generate_match_fcpxml(
             parent_offset_str = _asset_grid_str(head_trim_seconds, stage.video)
             assert plan.overlay_format_id is not None  # set whenever overlay_asset_id is
             overlay_meta = (
-                plan.stage.overlay_video
-                if plan.stage.overlay_video is not None
-                else plan.stage.video
+                plan.stage.overlay_video if plan.stage.overlay_video is not None else plan.stage.video
             )
             ET.SubElement(
                 primary_clip,
@@ -1630,9 +1610,7 @@ def generate_match_fcpxml(
     ET.indent(fcpxml, space="    ")
     tree_bytes = ET.tostring(fcpxml, encoding="utf-8", xml_declaration=True)
     decl_end = tree_bytes.index(b"?>") + 2
-    output_path.write_bytes(
-        tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :]
-    )
+    output_path.write_bytes(tree_bytes[:decl_end] + b"\n<!DOCTYPE fcpxml>\n" + tree_bytes[decl_end + 1 :])
     _tag_source_application(output_path)
 
 

--- a/src/splitsmith/lab/core.py
+++ b/src/splitsmith/lab/core.py
@@ -729,9 +729,7 @@ def run_eval(
             ensemble_config=ec,
         )
         cand_times = np.array([c.time for c in result.candidates], dtype=np.float64)
-        labels, matched, truth_times = _label_truth(
-            cand_times, audit.get("shots", []), cfg.tolerance_ms
-        )
+        labels, matched, truth_times = _label_truth(cand_times, audit.get("shots", []), cfg.tolerance_ms)
         reason_by_time, subclass_entries = _load_labels_from_audit(audit)
         candidates = [
             EvalCandidate(
@@ -821,9 +819,7 @@ def relabel_run(run: EvalRun) -> EvalRun:
             for c in fix.candidates
         ]
         metrics = _metrics(fix.truth_times, new_candidates)
-        new_fixtures.append(
-            fix.model_copy(update={"candidates": new_candidates, "metrics": metrics})
-        )
+        new_fixtures.append(fix.model_copy(update={"candidates": new_candidates, "metrics": metrics}))
 
     new_universe = run.universe.model_copy(update={"fixtures": new_fixtures})
     summary = _summary(new_fixtures)
@@ -844,9 +840,7 @@ def rescore_universe(universe: EvalUniverse, config: EvalConfig) -> EvalRun:
     (or the override). No model calls; sub-100 ms for the full set.
     """
     a_floor = (
-        config.voter_a_floor_override
-        if config.voter_a_floor_override is not None
-        else universe.voter_a_floor
+        config.voter_a_floor_override if config.voter_a_floor_override is not None else universe.voter_a_floor
     )
     b_thr = (
         config.voter_b_threshold_override

--- a/src/splitsmith/lab/promote.py
+++ b/src/splitsmith/lab/promote.py
@@ -173,9 +173,7 @@ def promote_from_anchor(
         runtime=runtime,
         expected_rounds=expected_rounds,
     )
-    voter_a_candidates = [
-        (c.time, c.confidence) for c in ensemble_result.candidates if c.vote_a >= 1
-    ]
+    voter_a_candidates = [(c.time, c.confidence) for c in ensemble_result.candidates if c.vote_a >= 1]
 
     # 3. Snap. Two paths:
     #    - Trusted-prior (project flow with known beep): guided snap in
@@ -204,9 +202,7 @@ def promote_from_anchor(
         )
         first_pass_drift_per_minute = _estimate_drift(first_pass)
         drift_ms_per_s = (
-            (first_pass_drift_per_minute or 0.0) / 60.0
-            if first_pass_drift_per_minute is not None
-            else 0.0
+            (first_pass_drift_per_minute or 0.0) / 60.0 if first_pass_drift_per_minute is not None else 0.0
         )
         snaps = guided_snap_anchor_shots(
             anchor_beep_time=anchor_beep,
@@ -512,8 +508,7 @@ def _build_report(
         )
     if snap_rate < 0.6:
         quality_warnings.append(
-            f"only {len(snapped)}/{len(snaps)} shots snapped; "
-            "verify that this clip covers the right stage"
+            f"only {len(snapped)}/{len(snaps)} shots snapped; " "verify that this clip covers the right stage"
         )
 
     return {
@@ -524,9 +519,7 @@ def _build_report(
             "method": align.method,
             "secondary_beep_time": round(align.secondary_beep_time, 4),
             "offset_seconds": round(align.lag_seconds, 4),
-            "confidence": (
-                None if align.confidence == float("inf") else round(align.confidence, 3)
-            ),
+            "confidence": (None if align.confidence == float("inf") else round(align.confidence, 3)),
             "peak_correlation": round(align.peak_correlation, 4),
         },
         "snap_window_ms": snap_window_ms,

--- a/src/splitsmith/lab/sweeps.py
+++ b/src/splitsmith/lab/sweeps.py
@@ -31,9 +31,7 @@ class SweepRunSummary(BaseModel):
 
     run_id: str
     signals_build_id: str
-    swept_keys: list[str] = Field(
-        description="Names of parameters that actually varied across this run."
-    )
+    swept_keys: list[str] = Field(description="Names of parameters that actually varied across this run.")
     n_combos: int
     n_fixtures: int
     best_f1: float

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -171,13 +171,9 @@ def rescore(
 
 @app.command("promote")
 def promote(
-    audit_json: Path = typer.Option(
-        ..., "--audit-json", help="Path to <project>/audit/stage<N>.json."
-    ),
+    audit_json: Path = typer.Option(..., "--audit-json", help="Path to <project>/audit/stage<N>.json."),
     audit_wav: Path = typer.Option(..., "--audit-wav", help="Path to the stage's audit-clip WAV."),
-    slug: str = typer.Option(
-        ..., "--slug", help="Target fixture stem (e.g. stage-shots-foo-2026-stage4)."
-    ),
+    slug: str = typer.Option(..., "--slug", help="Target fixture stem (e.g. stage-shots-foo-2026-stage4)."),
     fixtures_root: Path | None = typer.Option(None, "--fixtures-root"),
     overwrite: bool = typer.Option(False, "--overwrite"),
     pretty: bool = typer.Option(True, "--pretty/--no-pretty"),
@@ -208,18 +204,14 @@ def promote(
 
 @app.command("save-config")
 def save_config(
-    name: str = typer.Option(
-        ..., "--name", help="Slug for the YAML file (configs/ensemble.<slug>.yaml)."
-    ),
+    name: str = typer.Option(..., "--name", help="Slug for the YAML file (configs/ensemble.<slug>.yaml)."),
     universe_path: Path = typer.Option(
         Path("build/lab/runs/latest.json"),
         "--universe",
         help="Run JSON whose config + summary will be captured (defaults to latest run).",
     ),
     output_dir: Path = typer.Option(Path("configs"), "--output-dir"),
-    note: str | None = typer.Option(
-        None, "--note", help="Free-text note saved alongside provenance."
-    ),
+    note: str | None = typer.Option(None, "--note", help="Free-text note saved alongside provenance."),
     overwrite: bool = typer.Option(False, "--overwrite"),
 ) -> None:
     """Capture a run's config + headline metrics as committable YAML."""
@@ -494,9 +486,7 @@ def measure_snap(
 
 @app.command("promote-from-anchor")
 def promote_from_anchor_cmd(
-    anchor: Path = typer.Option(
-        ..., "--anchor", help="Audited headcam fixture JSON (ground truth source)."
-    ),
+    anchor: Path = typer.Option(..., "--anchor", help="Audited headcam fixture JSON (ground truth source)."),
     secondary: Path | None = typer.Option(
         None,
         "--secondary",
@@ -507,9 +497,7 @@ def promote_from_anchor_cmd(
         "--secondary-wav",
         help="Pre-extracted secondary audio WAV. Mutually exclusive with --secondary.",
     ),
-    slug: str = typer.Option(
-        ..., "--slug", help="Target fixture slug (e.g. tallmilan-2026-stage5-phone)."
-    ),
+    slug: str = typer.Option(..., "--slug", help="Target fixture slug (e.g. tallmilan-2026-stage5-phone)."),
     camera_id: str = typer.Option(
         ...,
         "--camera-id",
@@ -540,9 +528,7 @@ def promote_from_anchor_cmd(
         80.0, "--min-spacing-ms", min=0.0, help="Min gap between adjacent snapped shots."
     ),
     sample_rate: int = typer.Option(48000, "--sample-rate", min=8000),
-    anchor_wav: Path | None = typer.Option(
-        None, "--anchor-wav", help="Override anchor sibling WAV."
-    ),
+    anchor_wav: Path | None = typer.Option(None, "--anchor-wav", help="Override anchor sibling WAV."),
     report_only: bool = typer.Option(
         False,
         "--report-only",
@@ -576,9 +562,7 @@ def promote_from_anchor_cmd(
     target_json = root / f"{slug}.json"
     target_wav = root / f"{slug}.wav"
     if not report_only and target_json.exists() and not overwrite:
-        raise typer.BadParameter(
-            f"fixture already exists: {target_json}  (use --overwrite to replace)"
-        )
+        raise typer.BadParameter(f"fixture already exists: {target_json}  (use --overwrite to replace)")
 
     anchor_data = json.loads(anchor_path.read_text(encoding="utf-8"))
     primary_audio, primary_sr = beep_detect.load_audio(wav_path)

--- a/src/splitsmith/match_cli.py
+++ b/src/splitsmith/match_cli.py
@@ -196,6 +196,87 @@ def info(
     console.print(table)
 
 
+@match_app.command("rename-shooter-slugs")
+def rename_shooter_slugs(
+    path: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        help="Match folder (with match.json) whose shooter slugs should be replaced with opaque ids.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the rename plan without touching disk.",
+    ),
+) -> None:
+    """Rename every shooter under PATH from a human-readable slug to an
+    opaque random id (``s_<hex>``).
+
+    Use this once after upgrading to drop PII from on-disk paths and
+    URLs. Renames the ``shooters/<old>/`` directory, rewrites
+    ``match.json`` with the new slug, and refreshes the shooter list in
+    place. Safe to re-run; shooters that already have an opaque slug
+    (``s_*``) are skipped.
+    """
+    if not is_match_folder(path):
+        console.print(
+            f"[red]Not a match folder:[/] {path}\n"
+            f"Expected {MATCH_FILE} alongside a shooters/ subdir."
+        )
+        raise typer.Exit(code=2)
+
+    match = Match.load(path)
+    shooters_dir = path / match_model.SHOOTERS_DIR
+    plan: list[tuple[str, str]] = []  # (old_slug, new_slug)
+    taken: set[str] = set()
+    for old in match.shooters:
+        if old.startswith("s_") and len(old) == 10:
+            taken.add(old)
+            continue
+        new = match_model.mint_shooter_slug(taken)
+        taken.add(new)
+        plan.append((old, new))
+
+    if not plan:
+        console.print("[green]Nothing to rename.[/] Every shooter slug is already opaque.")
+        return
+
+    console.print(f"[bold cyan]Slug rename plan ({len(plan)} shooter(s))[/]")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("From")
+    table.add_column("To")
+    for old, new in plan:
+        table.add_row(old, new)
+    console.print(table)
+
+    if dry_run:
+        console.print("[dim]Dry run -- no changes written.[/]")
+        return
+
+    # Apply: rename dirs first, then rewrite match.json. If any rename
+    # fails halfway we leave the disk in a known-bad state; the user
+    # can re-run after fixing permissions / collisions.
+    new_shooters: list[str] = []
+    rename_map = dict(plan)
+    for old in match.shooters:
+        new = rename_map.get(old, old)
+        if new != old:
+            src = shooters_dir / old
+            dst = shooters_dir / new
+            if dst.exists():
+                console.print(f"[red]Refusing to rename {old} -> {new}: target dir exists[/]")
+                raise typer.Exit(code=1)
+            src.rename(dst)
+        new_shooters.append(new)
+
+    match.shooters = new_shooters
+    match.save(path)
+    console.print(f"[green]Renamed {len(plan)} shooter(s).[/]")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/src/splitsmith/match_cli.py
+++ b/src/splitsmith/match_cli.py
@@ -204,7 +204,7 @@ def rename_shooter_slugs(
         file_okay=False,
         dir_okay=True,
         readable=True,
-        help="Match folder (with match.json) whose shooter slugs should be replaced with opaque ids.",
+        help=("Match folder (with match.json) whose shooter slugs should be " "replaced with opaque ids."),
     ),
     dry_run: bool = typer.Option(
         False,
@@ -223,8 +223,7 @@ def rename_shooter_slugs(
     """
     if not is_match_folder(path):
         console.print(
-            f"[red]Not a match folder:[/] {path}\n"
-            f"Expected {MATCH_FILE} alongside a shooters/ subdir."
+            f"[red]Not a match folder:[/] {path}\n" f"Expected {MATCH_FILE} alongside a shooters/ subdir."
         )
         raise typer.Exit(code=2)
 

--- a/src/splitsmith/match_model.py
+++ b/src/splitsmith/match_model.py
@@ -325,7 +325,11 @@ def legacy_to_match_view(project: MatchProject) -> tuple[Match, Shooter]:
       - the FastAPI endpoint refactor (#321) when it lands, so the SPA can
         speak the new URL space even against legacy projects on disk
     """
-    slug = slugify(project.competitor_name or "unknown")
+    # legacy_to_match_view: synthesise a Match view for a legacy single-
+    # shooter project. The slug is opaque (no PII leak) but deterministic
+    # for a given project root so callers that build URLs against the
+    # same project across reloads see a stable id.
+    slug = _legacy_view_slug(project)
     match = Match(
         name=project.name,
         created_at=project.created_at,
@@ -383,11 +387,53 @@ def legacy_to_match_view(project: MatchProject) -> tuple[Match, Shooter]:
 # ---------------------------------------------------------------------------
 
 
-def slugify(name: str) -> str:
-    """Kebab-case a name for use as a shooter slug.
+def _legacy_view_slug(project: "MatchProject") -> str:
+    """Deterministic opaque slug for the synthetic view over a legacy
+    single-shooter project. The legacy disk layout has no
+    ``shooters/<slug>/`` dir so the slug is purely a routing token; we
+    hash the project name + scoreboard ids so the same project gets the
+    same slug across reloads without leaking the competitor name.
+    """
+    import hashlib
 
-    Strips accents, keeps ``[a-z0-9]``, collapses runs of separators to a
-    single dash. Falls back to ``"shooter"`` for empty/garbage input.
+    seed = "|".join(
+        str(x or "")
+        for x in (
+            project.name,
+            project.scoreboard_content_type,
+            project.scoreboard_match_id,
+            project.selected_shooter_id,
+        )
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:8]
+    return f"s_{digest}"
+
+
+def mint_shooter_slug(taken: set[str] | None = None) -> str:
+    """Mint a fresh opaque shooter slug.
+
+    Shape: ``s_<8 lowercase hex>``. Random, never derived from the
+    shooter's name, so URLs / on-disk paths / server logs don't leak
+    competitor PII. ``taken`` is consulted to avoid the 1-in-4-billion
+    chance of collision within a match (and to keep tests deterministic
+    when they mock the RNG).
+    """
+    import secrets
+
+    while True:
+        candidate = f"s_{secrets.token_hex(4)}"
+        if not taken or candidate not in taken:
+            return candidate
+
+
+def slugify_filename(name: str) -> str:
+    """Kebab-case a string for filesystem-safe filenames.
+
+    Used for stage / match filenames where readability matters and the
+    name is not PII. ``slugify`` (the old shooter-slug helper) used to
+    do this with the same impl; it now mints opaque shooter slugs, so
+    callers that want the old kebab-case behavior must use this helper
+    explicitly.
     """
     import re
     import unicodedata
@@ -396,17 +442,7 @@ def slugify(name: str) -> str:
     ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
     lower = ascii_only.lower()
     slugged = re.sub(r"[^a-z0-9]+", "-", lower).strip("-")
-    return slugged or "shooter"
-
-
-def disambiguate_slug(slug: str, taken: set[str]) -> str:
-    """Append a numeric suffix to ``slug`` until it doesn't collide with ``taken``."""
-    if slug not in taken:
-        return slug
-    n = 2
-    while f"{slug}-{n}" in taken:
-        n += 1
-    return f"{slug}-{n}"
+    return slugged or "name"
 
 
 # ---------------------------------------------------------------------------
@@ -546,12 +582,11 @@ def plan_merge(
 
     stage_defs = [stages_by_number[k] for k in sorted(stages_by_number)]
 
-    # Assign slugs (kebab-cased competitor names, disambiguated on collision).
+    # Assign opaque slugs so on-disk paths / URLs / logs don't leak names.
     taken: set[str] = set()
     moves: list[ShooterMove] = []
     for src, proj in projects:
-        base = slugify(proj.competitor_name or src.name)
-        slug = disambiguate_slug(base, taken)
+        slug = mint_shooter_slug(taken)
         taken.add(slug)
         moves.append(
             ShooterMove(
@@ -709,15 +744,15 @@ __all__ = [
     "Shooter",
     "ShooterMove",
     "ShooterStageData",
-    "disambiguate_slug",
     "execute_merge",
     "from_path",
     "is_legacy_project_folder",
     "is_match_folder",
     "legacy_to_match_view",
     "load_match_or_legacy",
+    "mint_shooter_slug",
     "plan_merge",
-    "slugify",
+    "slugify_filename",
 ]
 
 

--- a/src/splitsmith/match_model.py
+++ b/src/splitsmith/match_model.py
@@ -257,9 +257,7 @@ class Match(BaseModel):
         collides with an existing slug.
         """
         if shooter.slug in self.shooters:
-            raise ValueError(
-                f"shooter slug {shooter.slug!r} already registered on match {self.name!r}"
-            )
+            raise ValueError(f"shooter slug {shooter.slug!r} already registered on match {self.name!r}")
         shooter_root = self.shooter_root(match_root, shooter.slug)
         shooter_root.mkdir(parents=True, exist_ok=True)
         for sub in SHOOTER_SUBDIRS:
@@ -306,9 +304,7 @@ def from_path(path: Path) -> tuple[str, Path]:
         return "match", path
     if is_legacy_project_folder(path):
         return "legacy", path
-    raise FileNotFoundError(
-        f"{path} has neither {MATCH_FILE} nor {PROJECT_FILE}; not a splitsmith project"
-    )
+    raise FileNotFoundError(f"{path} has neither {MATCH_FILE} nor {PROJECT_FILE}; not a splitsmith project")
 
 
 def legacy_to_match_view(project: MatchProject) -> tuple[Match, Shooter]:
@@ -387,7 +383,7 @@ def legacy_to_match_view(project: MatchProject) -> tuple[Match, Shooter]:
 # ---------------------------------------------------------------------------
 
 
-def _legacy_view_slug(project: "MatchProject") -> str:
+def _legacy_view_slug(project: MatchProject) -> str:
     """Deterministic opaque slug for the synthetic view over a legacy
     single-shooter project. The legacy disk layout has no
     ``shooters/<slug>/`` dir so the slug is purely a routing token; we
@@ -507,34 +503,24 @@ def plan_merge(
     projects: list[tuple[Path, MatchProject]] = []
     for src in inputs:
         if not is_legacy_project_folder(src):
-            raise MergeConflictError(
-                f"{src} is not a legacy single-shooter project (no {PROJECT_FILE})"
-            )
+            raise MergeConflictError(f"{src} is not a legacy single-shooter project (no {PROJECT_FILE})")
         projects.append((src, MatchProject.load(src)))
 
     # Validate identity.
     scoreboard_ids = {p.scoreboard_match_id for _, p in projects if p.scoreboard_match_id}
     if len(scoreboard_ids) > 1:
-        raise MergeConflictError(
-            f"inputs disagree on scoreboard_match_id: {sorted(scoreboard_ids)}"
-        )
+        raise MergeConflictError(f"inputs disagree on scoreboard_match_id: {sorted(scoreboard_ids)}")
     sb_id = next(iter(scoreboard_ids), None)
 
-    content_types = {
-        p.scoreboard_content_type for _, p in projects if p.scoreboard_content_type is not None
-    }
+    content_types = {p.scoreboard_content_type for _, p in projects if p.scoreboard_content_type is not None}
     if len(content_types) > 1:
-        raise MergeConflictError(
-            f"inputs disagree on scoreboard_content_type: {sorted(content_types)}"
-        )
+        raise MergeConflictError(f"inputs disagree on scoreboard_content_type: {sorted(content_types)}")
     sb_ct = next(iter(content_types), None)
 
     names = {p.name for _, p in projects}
     if name is None:
         if len(names) > 1:
-            raise MergeConflictError(
-                f"inputs have different names {sorted(names)}; pass --name explicitly"
-            )
+            raise MergeConflictError(f"inputs have different names {sorted(names)}; pass --name explicitly")
         name = next(iter(names))
 
     dates = {p.match_date for _, p in projects if p.match_date}
@@ -573,9 +559,7 @@ def plan_merge(
                 and candidate.stage_rounds is not None
                 and existing.stage_rounds != candidate.stage_rounds
             ):
-                raise MergeConflictError(
-                    f"stage {s.stage_number}: stage_rounds disagreement (in {src})"
-                )
+                raise MergeConflictError(f"stage {s.stage_number}: stage_rounds disagreement (in {src})")
             # Prefer the one that has stage_rounds populated.
             if existing.stage_rounds is None and candidate.stage_rounds is not None:
                 stages_by_number[s.stage_number] = candidate
@@ -629,9 +613,7 @@ def execute_merge(
     import shutil
 
     if (plan.output_root / MATCH_FILE).exists():
-        raise FileExistsError(
-            f"{plan.output_root} already contains {MATCH_FILE}; refusing to overwrite"
-        )
+        raise FileExistsError(f"{plan.output_root} already contains {MATCH_FILE}; refusing to overwrite")
 
     plan.output_root.mkdir(parents=True, exist_ok=True)
     for sub in MATCH_SUBDIRS:

--- a/src/splitsmith/mcp/detect_tools.py
+++ b/src/splitsmith/mcp/detect_tools.py
@@ -98,8 +98,7 @@ def detect_beep_for_video(
     _stage, video = _resolve_stage_video(project, stage_number=stage_number, video_id=video_id)
     if video.role == "ignored":
         raise ValueError(
-            f"video {video_id} on stage {stage_number} is ignored; "
-            "assign it as primary or secondary first"
+            f"video {video_id} on stage {stage_number} is ignored; " "assign it as primary or secondary first"
         )
     if not force and video.beep_time is not None and video.beep_source == "manual":
         # Manual entries are explicit user intent; never overwrite
@@ -111,9 +110,7 @@ def detect_beep_for_video(
 
     source = project.resolve_video_path(root, video.path)
     if not source.exists():
-        raise FileNotFoundError(
-            f"source video missing for stage {stage_number} video {video_id}: {source}"
-        )
+        raise FileNotFoundError(f"source video missing for stage {stage_number} video {video_id}: {source}")
 
     try:
         beep = audio_helpers.detect_video_beep(
@@ -184,9 +181,7 @@ def _apply_beep_not_found(video: Any) -> None:
         video.processed["shot_detect"] = False
 
 
-def _summary(
-    video: Any, *, gate_threshold: float | None, error: str | None = None
-) -> dict[str, Any]:
+def _summary(video: Any, *, gate_threshold: float | None, error: str | None = None) -> dict[str, Any]:
     """Compact response shape -- enough for the agent to decide what
     to do next without a separate get_project round-trip."""
     return {
@@ -243,8 +238,7 @@ def detect_shots_for_stage(
         raise ValueError(f"stage {stage_number} has no primary video")
     if primary.beep_time is None:
         raise ValueError(
-            f"stage {stage_number} primary has no beep_time yet; "
-            "run detect_beep or set_beep_manual first"
+            f"stage {stage_number} primary has no beep_time yet; " "run detect_beep or set_beep_manual first"
         )
     if stage.time_seconds <= 0:
         raise ValueError(
@@ -255,9 +249,7 @@ def detect_shots_for_stage(
     if not source.exists():
         raise FileNotFoundError(f"primary source missing for stage {stage_number}: {source}")
 
-    audit = audio_helpers.ensure_audit_audio(
-        root, stage_number, source, primary.beep_time, project=project
-    )
+    audit = audio_helpers.ensure_audit_audio(root, stage_number, source, primary.beep_time, project=project)
     beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else primary.beep_time
 
     audit_dir = project.audit_path(root)
@@ -265,9 +257,7 @@ def detect_shots_for_stage(
     audit_file = audit_dir / f"stage{stage_number}.json"
     existing_json = _load_or_seed_audit_json(audit_file, stage, beep_in_clip)
     if stage.stage_rounds is not None:
-        existing_json["stage_rounds"] = stage.stage_rounds.model_dump(
-            mode="json", exclude_none=True
-        )
+        existing_json["stage_rounds"] = stage.stage_rounds.model_dump(mode="json", exclude_none=True)
     expected_rounds = _expected_rounds_from(existing_json)
 
     runtime = _get_ensemble_runtime()
@@ -442,9 +432,7 @@ def trim_audit_clip(
     except KeyError as exc:
         raise ValueError(f"stage {stage_number} not found") from exc
     if stage.time_seconds <= 0:
-        raise ValueError(
-            f"stage {stage_number} has time_seconds=0; set the stage time " "before trimming"
-        )
+        raise ValueError(f"stage {stage_number} has time_seconds=0; set the stage time " "before trimming")
     if video_id is None:
         target = next((v for v in stage.videos if v.role == "primary"), None)
         if target is None:

--- a/src/splitsmith/mcp/export_tools.py
+++ b/src/splitsmith/mcp/export_tools.py
@@ -125,8 +125,7 @@ def export_stage_tool(
         raise ValueError(f"stage {stage_number} has no primary video")
     if primary.beep_time is None:
         raise ValueError(
-            f"stage {stage_number} primary has no beep_time yet; "
-            "run detect_beep or set_beep_manual first"
+            f"stage {stage_number} primary has no beep_time yet; " "run detect_beep or set_beep_manual first"
         )
     source = project.resolve_video_path(root, primary.path)
     if not source.exists():
@@ -192,9 +191,7 @@ def export_stage_tool(
         "overlay_path": _path_or_none(result.overlay_path),
         "shots_written": result.shots_written,
         "anomalies": list(result.anomalies),
-        "secondary_trimmed_paths": {
-            vid: str(p) for vid, p in result.secondary_trimmed_paths.items()
-        },
+        "secondary_trimmed_paths": {vid: str(p) for vid, p in result.secondary_trimmed_paths.items()},
     }
 
 

--- a/src/splitsmith/mcp/tools.py
+++ b/src/splitsmith/mcp/tools.py
@@ -190,11 +190,7 @@ def get_hitl_queue(project_root: str) -> dict[str, Any]:
                 }
             )
             continue
-        if (
-            primary.beep_source == "auto"
-            and primary.beep_time is not None
-            and not primary.beep_reviewed
-        ):
+        if primary.beep_source == "auto" and primary.beep_time is not None and not primary.beep_reviewed:
             items.append(
                 {
                     "kind": "beep_low_confidence",

--- a/src/splitsmith/mp4_render.py
+++ b/src/splitsmith/mp4_render.py
@@ -447,8 +447,7 @@ def _build_stage_filter_graph(
         end_time = align.cam_spine_start + align.cam_visible_seconds
         enable = f"between(t,{align.cam_spine_start:g},{end_time:g})"
         parts.append(
-            f"[{base_label}][{scaled_label}]"
-            f"overlay=x={x:g}:y={y:g}:enable='{enable}'[{out_label}]"
+            f"[{base_label}][{scaled_label}]" f"overlay=x={x:g}:y={y:g}:enable='{enable}'[{out_label}]"
         )
         base_label = out_label
 

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -203,9 +203,7 @@ class DefaultTemplate(Template):
         # turning the glyphs into blobs; shadow blur slightly larger than
         # offset gives a soft halo rather than a hard duplicate.
         self.stroke_width_px = stroke_width_px if stroke_width_px is not None else max(2, big // 18)
-        self.shadow_offset_px = (
-            shadow_offset_px if shadow_offset_px is not None else max(2, big // 24)
-        )
+        self.shadow_offset_px = shadow_offset_px if shadow_offset_px is not None else max(2, big // 24)
         self.shadow_blur_px = shadow_blur_px if shadow_blur_px is not None else max(3, big // 12)
 
     def draw_frame(self, canvas: Image.Image, state: FrameState) -> None:
@@ -403,8 +401,7 @@ def _load_font(
             pass
         elif key not in _FONT_PRESETS:
             raise OverlayRenderError(
-                f"unknown font_name {font_name!r}; "
-                f"available: {', '.join(available_font_names())}"
+                f"unknown font_name {font_name!r}; " f"available: {', '.join(available_font_names())}"
             )
         for candidate in _FONT_PRESETS.get(key, ()):
             p = Path(candidate)
@@ -531,12 +528,8 @@ def _resolve_codec(codec: OverlayCodec, ffmpeg_binary: str) -> Literal["hevc-alp
     if codec == "hevc-alpha" or codec == "prores-4444":
         return codec
     if codec != "auto":
-        raise OverlayRenderError(
-            f"unknown overlay codec {codec!r}; expected one of {OVERLAY_CODECS}"
-        )
-    if platform.system() == "Darwin" and _ffmpeg_supports_encoder(
-        ffmpeg_binary, "hevc_videotoolbox"
-    ):
+        raise OverlayRenderError(f"unknown overlay codec {codec!r}; expected one of {OVERLAY_CODECS}")
+    if platform.system() == "Darwin" and _ffmpeg_supports_encoder(ffmpeg_binary, "hevc_videotoolbox"):
         return "hevc-alpha"
     return "prores-4444"
 

--- a/src/splitsmith/overlay_theme.py
+++ b/src/splitsmith/overlay_theme.py
@@ -97,9 +97,7 @@ def _load_splitsmith() -> OverlayTheme:
         ):
             data = json.load(fh)
     except (FileNotFoundError, OSError) as exc:
-        raise OverlayThemeError(
-            "overlay_theme.json missing; run scripts/build_overlay_theme.py"
-        ) from exc
+        raise OverlayThemeError("overlay_theme.json missing; run scripts/build_overlay_theme.py") from exc
     except json.JSONDecodeError as exc:
         raise OverlayThemeError(f"overlay_theme.json is not valid JSON: {exc}") from exc
 

--- a/src/splitsmith/relink.py
+++ b/src/splitsmith/relink.py
@@ -230,9 +230,7 @@ def apply_relink(
             previous = Path(link_path.readlink())
             link_path.unlink()
         elif link_path.exists():
-            raise ValueError(
-                f"refusing to overwrite non-symlink at {link_path} (status not_a_symlink)"
-            )
+            raise ValueError(f"refusing to overwrite non-symlink at {link_path} (status not_a_symlink)")
         link_path.parent.mkdir(parents=True, exist_ok=True)
         link_path.symlink_to(new_target_abs)
         applied.append(

--- a/src/splitsmith/shot_detect.py
+++ b/src/splitsmith/shot_detect.py
@@ -153,18 +153,13 @@ def detect_shots(
     if onset_frames.size == 0:
         return []
 
-    onset_times_segment = librosa.frames_to_time(
-        onset_frames, sr=sample_rate, hop_length=_HOP_LENGTH
-    )
+    onset_times_segment = librosa.frames_to_time(onset_frames, sr=sample_rate, hop_length=_HOP_LENGTH)
     onset_times_absolute = onset_times_segment + search_lo / sample_rate
 
     onset_strengths = onset_env[onset_frames]
     peak_win_samples = int(round(sample_rate * _PEAK_WIN_MS / 1000.0))
     onset_peaks = np.array(
-        [
-            _peak_amplitude(audio, float(t), sample_rate, peak_win_samples)
-            for t in onset_times_absolute
-        ],
+        [_peak_amplitude(audio, float(t), sample_rate, peak_win_samples) for t in onset_times_absolute],
         dtype=np.float32,
     )
 
@@ -232,9 +227,7 @@ def detect_shots(
 
     shots: list[Shot] = []
     prev_t = beep_time
-    for t_abs, strength, peak, hf_lf in zip(
-        kept_times, kept_strengths, kept_peaks, kept_hf_lf, strict=True
-    ):
+    for t_abs, strength, peak, hf_lf in zip(kept_times, kept_strengths, kept_peaks, kept_hf_lf, strict=True):
         s_norm = strength / max_kept_strength if max_kept_strength > 0 else 0.0
         p_norm = peak / max_kept_peak if max_kept_peak > 0 else 0.0
         hf_norm = hf_lf / max_kept_hf_lf if max_kept_hf_lf > 0 else 0.0

--- a/src/splitsmith/shot_refine.py
+++ b/src/splitsmith/shot_refine.py
@@ -167,9 +167,7 @@ def _tight_rise_foot(
     if win_hi - win_lo < 8:
         return RefinedShot(approx_time, approx_time, confidence, True, "envelope-tight")
     smooth_n = max(1, int(round(sr * _ENV_SMOOTH_S)))
-    env = maximum_filter1d(
-        np.abs(audio[win_lo:win_hi]).astype(np.float32), size=smooth_n, mode="nearest"
-    )
+    env = maximum_filter1d(np.abs(audio[win_lo:win_hi]).astype(np.float32), size=smooth_n, mode="nearest")
     peak_local = int(np.argmax(env))
     peak = float(env[peak_local])
     if peak <= 0.0:

--- a/src/splitsmith/templates.py
+++ b/src/splitsmith/templates.py
@@ -59,9 +59,7 @@ class MatchExportTemplate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(
-        ..., description="Template schema version; must equal SCHEMA_VERSION."
-    )
+    schema_version: int = Field(..., description="Template schema version; must equal SCHEMA_VERSION.")
     name: str | None = Field(
         None,
         description=("Display name in the dropdown; falls back to the file stem."),
@@ -132,9 +130,7 @@ def load_template(path: Path) -> MatchExportTemplate:
     if not isinstance(raw, dict):
         raise TemplateError(f"{path}: top-level YAML must be a mapping, got {type(raw).__name__}")
     if "schema_version" not in raw:
-        raise TemplateError(
-            f"{path}: missing required ``schema_version`` (expected {SCHEMA_VERSION})"
-        )
+        raise TemplateError(f"{path}: missing required ``schema_version`` (expected {SCHEMA_VERSION})")
     try:
         version = int(raw["schema_version"])
     except (TypeError, ValueError) as exc:

--- a/src/splitsmith/thumbnail.py
+++ b/src/splitsmith/thumbnail.py
@@ -111,9 +111,7 @@ def ensure(
     except subprocess.TimeoutExpired as exc:
         raise ThumbnailError(f"ffmpeg timed out extracting thumbnail for {source}") from exc
     except subprocess.CalledProcessError as exc:
-        raise ThumbnailError(
-            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise ThumbnailError(f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
     if not dest.exists():
         raise ThumbnailError(f"ffmpeg produced no output for {source}")
     return dest
@@ -226,9 +224,7 @@ def ensure_clip(
     except subprocess.TimeoutExpired as exc:
         raise ThumbnailError(f"ffmpeg timed out extracting clip for {source}") from exc
     except subprocess.CalledProcessError as exc:
-        raise ThumbnailError(
-            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise ThumbnailError(f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
     if not dest.exists():
         raise ThumbnailError(f"ffmpeg produced no clip for {source}")
     return dest

--- a/src/splitsmith/trim.py
+++ b/src/splitsmith/trim.py
@@ -206,8 +206,6 @@ def trim_video(
     except FileNotFoundError as exc:
         raise FFmpegError(f"ffmpeg binary not found: {ffmpeg_binary}") from exc
     except subprocess.CalledProcessError as exc:
-        raise FFmpegError(
-            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise FFmpegError(f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
 
     return TrimResult(output_path=output_path, start_time=start, end_time=end)

--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -188,9 +188,7 @@ def trimmed_video_path(
     Keyed by ``video_id`` for every role so each angle has its own scrub
     clip cut around its own beep.
     """
-    return (
-        project.trimmed_path(project_root) / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
-    )
+    return project.trimmed_path(project_root) / f"stage{stage_number}_cam_{video.video_id}_trimmed.mp4"
 
 
 def trimmed_primary_path(project_root: Path, stage_number: int, *, project: MatchProject) -> Path:
@@ -258,9 +256,7 @@ def ensure_audit_audio(
         # trim_start. trim_start = max(0, beep - pre_buffer); so:
         #   beep_in_clip = min(beep_in_source, pre_buffer)
         beep_in_clip = (
-            min(primary_beep_time, project.trim_pre_buffer_seconds)
-            if primary_beep_time is not None
-            else None
+            min(primary_beep_time, project.trim_pre_buffer_seconds) if primary_beep_time is not None else None
         )
         return AuditAudioResult(audio_path=audio_path, beep_in_clip=beep_in_clip, trimmed=True)
 
@@ -394,9 +390,7 @@ def ensure_video_audit_trim(
         raise FileNotFoundError(f"video missing on disk: {src_resolved}")
 
     cache_hit = (
-        output.exists()
-        and output.stat().st_mtime >= src_resolved.stat().st_mtime
-        and params_file.exists()
+        output.exists() and output.stat().st_mtime >= src_resolved.stat().st_mtime and params_file.exists()
     )
     if cache_hit:
         try:
@@ -415,9 +409,7 @@ def ensure_video_audit_trim(
         if p.exists():
             p.unlink()
 
-    encoder = trim_module.select_audit_encoder(
-        project.trim_audit_encoder, ffmpeg_binary=ffmpeg_binary
-    )
+    encoder = trim_module.select_audit_encoder(project.trim_audit_encoder, ffmpeg_binary=ffmpeg_binary)
     trim_kwargs: dict[str, object] = {
         "input_path": src_resolved,
         "output_path": partial,

--- a/src/splitsmith/ui/exports.py
+++ b/src/splitsmith/ui/exports.py
@@ -437,9 +437,7 @@ def export_stage(
                     try:
                         sec_meta = fcpxml_gen.probe_video(sec_path)
                     except fcpxml_gen.FFprobeError as exc:
-                        skip_reasons.append(
-                            f"secondary cam {sec.video_id} dropped from FCPXML: {exc}"
-                        )
+                        skip_reasons.append(f"secondary cam {sec.video_id} dropped from FCPXML: {exc}")
                         continue
                     # Each cam was trimmed with the same pre-buffer as the
                     # primary, so its clip-local beep is at
@@ -514,9 +512,7 @@ def export_stage(
     secondary_paths_present = {vid: p for vid, p in secondary_trimmed.items() if p.exists()}
     return StageExportResult(
         stage_number=stage_data.stage_number,
-        trimmed_video_path=(
-            trimmed_path if trimmed_path is not None and trimmed_path.exists() else None
-        ),
+        trimmed_video_path=(trimmed_path if trimmed_path is not None and trimmed_path.exists() else None),
         csv_path=csv_path,
         fcpxml_path=fcpxml_path,
         report_path=report_path,

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -305,9 +305,7 @@ class JobRegistry:
     def list(self) -> list[Job]:
         """Snapshot of all retained jobs in submission order."""
         with self._lock:
-            return [
-                self._jobs[jid].model_copy(deep=True) for jid in self._order if jid in self._jobs
-            ]
+            return [self._jobs[jid].model_copy(deep=True) for jid in self._order if jid in self._jobs]
 
     def cancel(self, job_id: str) -> Job | None:
         """Mark a job for cooperative cancellation.
@@ -570,8 +568,7 @@ class JobRegistry:
         finished = [
             jid
             for jid in self._order
-            if jid in self._jobs
-            and self._jobs[jid].status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
+            if jid in self._jobs and self._jobs[jid].status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
         ]
         excess = len(finished) - self._retain
         if excess <= 0:

--- a/src/splitsmith/ui/match_exports.py
+++ b/src/splitsmith/ui/match_exports.py
@@ -177,8 +177,7 @@ def export_match(
             )
         if not stage_input.audit_path.exists():
             raise MatchExportError(
-                f"stage {stage_input.stage_number}: audit JSON missing at "
-                f"{stage_input.audit_path}"
+                f"stage {stage_input.stage_number}: audit JSON missing at " f"{stage_input.audit_path}"
             )
         try:
             audit_data = json.loads(stage_input.audit_path.read_text(encoding="utf-8"))
@@ -205,8 +204,7 @@ def export_match(
             primary_meta = probe(stage_input.trimmed_path)  # type: ignore[operator]
         except fcpxml_gen.FFprobeError as exc:
             raise MatchExportError(
-                f"stage {stage_input.stage_number}: ffprobe failed on "
-                f"{stage_input.trimmed_path}: {exc}"
+                f"stage {stage_input.stage_number}: ffprobe failed on " f"{stage_input.trimmed_path}: {exc}"
             ) from exc
 
         secondaries: list[fcpxml_gen.SecondaryClip] = []
@@ -221,9 +219,7 @@ def export_match(
                 try:
                     sec_meta = probe(sec.trimmed_path)  # type: ignore[operator]
                 except fcpxml_gen.FFprobeError as exc:
-                    anomalies.append(
-                        f"stage {stage_input.stage_number}: cam {sec.video_id} dropped: {exc}"
-                    )
+                    anomalies.append(f"stage {stage_input.stage_number}: cam {sec.video_id} dropped: {exc}")
                     continue
                 secondaries.append(
                     fcpxml_gen.SecondaryClip(
@@ -262,9 +258,7 @@ def export_match(
                 )
 
         if request.pip_layout == "pip-corners" and secondaries:
-            laid_out = fcpxml_gen.apply_pip_corner_cycle(
-                secondaries, default=fcpxml_gen.PipPlacement()
-            )
+            laid_out = fcpxml_gen.apply_pip_corner_cycle(secondaries, default=fcpxml_gen.PipPlacement())
         else:
             laid_out = tuple(secondaries)
 
@@ -468,8 +462,7 @@ def _resolve_segment(
         return None
     if renderer != "fcpxml":
         anomalies.append(
-            f"{label} ignored: not yet supported by the "
-            f"{renderer} renderer (issue #173 follow-ups)"
+            f"{label} ignored: not yet supported by the " f"{renderer} renderer (issue #173 follow-ups)"
         )
         return None
     if not path.exists():

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -976,8 +976,7 @@ class MatchProject(BaseModel):
         real = [s for s in self.stages if not s.placeholder]
         if real:
             raise ScoreboardImportConflictError(
-                "project already has scoreboard-backed stages; "
-                "clear them or import via overwrite first"
+                "project already has scoreboard-backed stages; " "clear them or import via overwrite first"
             )
         # Move any videos out of existing placeholders -- the new placeholder
         # layout might have a different stage count.
@@ -1370,13 +1369,9 @@ class MatchProject(BaseModel):
 
         # Detach from current location.
         if current_stage is None:
-            self.unassigned_videos = [
-                v for v in self.unassigned_videos if str(v.path) != str(video.path)
-            ]
+            self.unassigned_videos = [v for v in self.unassigned_videos if str(v.path) != str(video.path)]
         else:
-            current_stage.videos = [
-                v for v in current_stage.videos if str(v.path) != str(video.path)
-            ]
+            current_stage.videos = [v for v in current_stage.videos if str(v.path) != str(video.path)]
 
         # Reattach.
         if to_stage_number is None:
@@ -1517,13 +1512,9 @@ class MatchProject(BaseModel):
         stage_number = current_stage.stage_number if current_stage else None
 
         if current_stage is None:
-            self.unassigned_videos = [
-                v for v in self.unassigned_videos if str(v.path) != str(video.path)
-            ]
+            self.unassigned_videos = [v for v in self.unassigned_videos if str(v.path) != str(video.path)]
         else:
-            current_stage.videos = [
-                v for v in current_stage.videos if str(v.path) != str(video.path)
-            ]
+            current_stage.videos = [v for v in current_stage.videos if str(v.path) != str(video.path)]
 
         raw_link = self.resolve_video_path(root, video.path)
 

--- a/src/splitsmith/ui/scoreboard/cache.py
+++ b/src/splitsmith/ui/scoreboard/cache.py
@@ -108,9 +108,7 @@ class CachingScoreboardClient:
     def is_cached(self, content_type: int, match_id: int) -> bool:
         return self._match_cache_path(content_type, match_id).exists()
 
-    def get_stage_times(
-        self, content_type: int, match_id: int, competitor_id: int
-    ) -> CompetitorStageResults:
+    def get_stage_times(self, content_type: int, match_id: int, competitor_id: int) -> CompetitorStageResults:
         cache_path = self._stage_times_cache_path(content_type, match_id, competitor_id)
         cached = _read_envelope(cache_path)
         if cached is not None and not cached.get("in_progress", False):
@@ -175,14 +173,9 @@ class CachingScoreboardClient:
             "match_id": match_id,
             "competitor_id": competitor_id,
         }
-        return (
-            self._cache_dir
-            / f"stage_times_{match_prefix}_{_param_hash('stage_times', params)}.json"
-        )
+        return self._cache_dir / f"stage_times_{match_prefix}_{_param_hash('stage_times', params)}.json"
 
-    def _sibling_match_in_progress(
-        self, content_type: int, match_id: int, *, default: bool
-    ) -> bool:
+    def _sibling_match_in_progress(self, content_type: int, match_id: int, *, default: bool) -> bool:
         envelope = _read_envelope(self._match_cache_path(content_type, match_id))
         if envelope is None:
             return default

--- a/src/splitsmith/ui/scoreboard/http.py
+++ b/src/splitsmith/ui/scoreboard/http.py
@@ -105,8 +105,7 @@ class SsiHttpClient:
         resolved_token = token if token is not None else os.environ.get(TOKEN_ENV_VAR)
         if not resolved_token:
             raise ScoreboardAuthError(
-                f"{TOKEN_ENV_VAR} is not set; obtain a bearer token and export it. "
-                f"See {API_DOCS_URL}"
+                f"{TOKEN_ENV_VAR} is not set; obtain a bearer token and export it. " f"See {API_DOCS_URL}"
             )
         self._owns_client = client is None
         self._client = client or httpx.Client(
@@ -128,9 +127,7 @@ class SsiHttpClient:
     def search_matches(self, query: str) -> list[MatchRef]:
         data = self._get_json("/events", params={"q": query} if query else None)
         if not isinstance(data, list):
-            raise ScoreboardUpstreamError(
-                f"unexpected /events response shape: {type(data).__name__}"
-            )
+            raise ScoreboardUpstreamError(f"unexpected /events response shape: {type(data).__name__}")
         return [MatchRef.model_validate(item) for item in data]
 
     def get_match(self, content_type: int, match_id: int) -> MatchData:
@@ -143,9 +140,7 @@ class SsiHttpClient:
     def find_shooter(self, name: str) -> list[ShooterRef]:
         data = self._get_json("/shooter/search", params={"q": name})
         if not isinstance(data, list):
-            raise ScoreboardUpstreamError(
-                f"unexpected /shooter/search response shape: {type(data).__name__}"
-            )
+            raise ScoreboardUpstreamError(f"unexpected /shooter/search response shape: {type(data).__name__}")
         return [ShooterRef.model_validate(item) for item in data]
 
     def get_shooter(self, shooter_id: int) -> ShooterDashboard:
@@ -155,9 +150,7 @@ class SsiHttpClient:
             raise ShooterNotFound(f"shooter {shooter_id} not found on scoreboard") from exc
         return ShooterDashboard.model_validate(data)
 
-    def get_stage_times(
-        self, content_type: int, match_id: int, competitor_id: int
-    ) -> CompetitorStageResults:
+    def get_stage_times(self, content_type: int, match_id: int, competitor_id: int) -> CompetitorStageResults:
         # Mirrors the live ``GET /match/{ct}/{id}/competitor/{cid}/stages``
         # shipped in ssi-scoreboard#400. A 404 here -- now that the
         # endpoint is part of the v1 contract -- means the competitor
@@ -165,9 +158,7 @@ class SsiHttpClient:
         # as ``CompetitorNotInMatch`` so the UI can prompt for a re-pick
         # rather than blaming the upstream.
         try:
-            data = self._get_json(
-                f"/match/{content_type}/{match_id}/competitor/{competitor_id}/stages"
-            )
+            data = self._get_json(f"/match/{content_type}/{match_id}/competitor/{competitor_id}/stages")
         except _NotFound as exc:
             raise CompetitorNotInMatch(
                 f"competitor {competitor_id} isn't part of match "
@@ -190,8 +181,7 @@ class SsiHttpClient:
             return response.json()
         if status == 401:
             raise ScoreboardAuthError(
-                f"scoreboard rejected the bearer token (401). "
-                f"Set {TOKEN_ENV_VAR}; see {API_DOCS_URL}"
+                f"scoreboard rejected the bearer token (401). " f"Set {TOKEN_ENV_VAR}; see {API_DOCS_URL}"
             )
         if status == 404:
             raise _NotFound(path)
@@ -208,9 +198,7 @@ class SsiHttpClient:
                 retry_after=retry_after,
             )
         if 500 <= status < 600:
-            raise ScoreboardUpstreamError(
-                f"scoreboard upstream returned {status}; try the offline JSON path"
-            )
+            raise ScoreboardUpstreamError(f"scoreboard upstream returned {status}; try the offline JSON path")
         raise ScoreboardError(f"unexpected scoreboard response: {status} {response.text[:200]}")
 
 

--- a/src/splitsmith/ui/scoreboard/local.py
+++ b/src/splitsmith/ui/scoreboard/local.py
@@ -158,9 +158,7 @@ class LocalJsonScoreboard:
             "carries a single match's competitor list, not cross-match aggregates"
         )
 
-    def get_stage_times(
-        self, content_type: int, match_id: int, competitor_id: int
-    ) -> CompetitorStageResults:
+    def get_stage_times(self, content_type: int, match_id: int, competitor_id: int) -> CompetitorStageResults:
         if (
             self._content_type is not None
             and self._match_id is not None
@@ -355,9 +353,7 @@ def _from_combined_v1(
         if not isinstance(cid, int):
             continue
         results = [
-            CompetitorStageResult.model_validate(r)
-            for r in entry.get("stages", [])
-            if isinstance(r, dict)
+            CompetitorStageResult.model_validate(r) for r in entry.get("stages", []) if isinstance(r, dict)
         ]
         out[cid] = results
     return out

--- a/src/splitsmith/ui/scoreboard/protocol.py
+++ b/src/splitsmith/ui/scoreboard/protocol.py
@@ -39,9 +39,7 @@ class ScoreboardClient(Protocol):
         """Cross-match dashboard; mirrors ``GET /api/v1/shooter/{shooterId}``."""
         ...
 
-    def get_stage_times(
-        self, content_type: int, match_id: int, competitor_id: int
-    ) -> CompetitorStageResults:
+    def get_stage_times(self, content_type: int, match_id: int, competitor_id: int) -> CompetitorStageResults:
         """Per-competitor, per-stage results for one (match, competitor) pair.
 
         Mirrors the proposed ``GET /api/v1/match/{ct}/{id}/competitor/

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -502,52 +502,160 @@ def _no_project_error() -> HTTPException:
 
 @dataclass
 class AppState:
-    """Per-process state. Holds at most one bound project at a time.
+    """Process state. One bound project at a time (#353).
 
-    The server can boot without a project (``splitsmith ui`` with no
-    ``--project`` arg). In that mode every project-bound endpoint raises
-    409 ``no_project`` via the :attr:`project_root` property; the SPA
-    renders the picker route until the user binds via
-    ``POST /api/user/recent-projects/bind``.
+    A bound project is either a **Match folder** (multi-shooter) or a
+    **legacy single-shooter project**. The two layouts share a single
+    state record but expose different resolution paths:
+
+    - Match-level operations (list shooters, merge, export the whole
+      match) read :attr:`match_root` directly.
+    - Shooter-scoped operations require a slug from the URL path and
+      resolve via :meth:`shooter_root` / :meth:`shooter_project`.
+
+    There is no notion of an "active" or "current" shooter on the
+    server. Every shooter-scoped request must carry the slug in its
+    path; the SPA's URL is the single source of truth.
+
+    The server can boot without a bound project (``splitsmith ui`` with
+    no ``--project``); in that mode every scoped property raises 409
+    ``no_project`` and the SPA stays on the picker.
     """
 
-    _project_root: Path | None = None
-    _project_name: str | None = None
+    _bound_root: Path | None = None
+    _bound_kind: Literal["match", "legacy"] | None = None
+    _bound_name: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
 
     @property
-    def project_root(self) -> Path:
-        """Bound project root. Raises 409 ``no_project`` when unbound.
-
-        Property indirection means every existing call-site
-        (``state.project_root``) gets the right behaviour automatically
-        without auditing 80+ usages -- FastAPI translates the
-        HTTPException into a structured response the SPA recognises.
-        """
-        if self._project_root is None:
-            raise _no_project_error()
-        return self._project_root
+    def is_bound(self) -> bool:
+        return self._bound_root is not None
 
     @property
-    def is_bound(self) -> bool:
-        return self._project_root is not None
+    def bound_kind(self) -> Literal["match", "legacy"] | None:
+        return self._bound_kind
+
+    @property
+    def bound_name(self) -> str | None:
+        return self._bound_name
+
+    @property
+    def bound_root(self) -> Path:
+        """The bound project's on-disk root (match folder OR legacy project)."""
+        if self._bound_root is None:
+            raise _no_project_error()
+        return self._bound_root
+
+    @property
+    def match_root(self) -> Path:
+        """The bound match folder. 409 ``not_a_match`` for legacy projects."""
+        if self._bound_root is None:
+            raise _no_project_error()
+        if self._bound_kind != "match":
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "not_a_match",
+                    "message": (
+                        "Bound project is a legacy single-shooter layout. "
+                        "Match-level operations require a Match folder."
+                    ),
+                },
+            )
+        return self._bound_root
+
+    def shooter_root(self, slug: str) -> Path:
+        """Resolve ``slug`` to the shooter's project directory on disk.
+
+        For a Match folder: validates the slug is registered and the
+        directory exists, then returns ``<match>/shooters/<slug>``.
+
+        For a legacy single-shooter project: there is exactly one shooter
+        and its data lives at the bound root. The slug is accepted as-is
+        (the SPA derives it from ``competitor_name`` via :func:`legacy_slug`)
+        so callers don't need to special-case the legacy layout.
+        """
+        if self._bound_root is None:
+            raise _no_project_error()
+        if self._bound_kind == "legacy":
+            return self._bound_root
+        match = match_model.Match.load(self._bound_root)
+        if slug not in match.shooters:
+            raise HTTPException(
+                status_code=404,
+                detail=f"shooter {slug!r} is not registered on this match",
+            )
+        return match_model.Match.shooter_root(self._bound_root, slug)
+
+    def shooter_project(self, slug: str) -> MatchProject:
+        """Load the legacy ``MatchProject`` for ``slug``."""
+        return MatchProject.load(self.shooter_root(slug))
+
+    def bind_match(self, root: Path, name: str) -> None:
+        self._bound_root = root
+        self._bound_kind = "match"
+        self._bound_name = name
+
+    def bind_legacy(self, root: Path, name: str) -> None:
+        self._bound_root = root
+        self._bound_kind = "legacy"
+        self._bound_name = name
+
+    def unbind(self) -> None:
+        self._bound_root = None
+        self._bound_kind = None
+        self._bound_name = None
+
+    # ------------------------------------------------------------------
+    # Migration scaffolding (#353 follow-up). REMOVE before merging the
+    # path-scoped refactor. Lets endpoints that haven't been migrated to
+    # the slug-in-path model keep functioning while the refactor is in
+    # flight. Match-mode: returns the first-registered shooter's root
+    # (matches the legacy "active shooter" behaviour the singleton used
+    # to encode). Legacy: returns the bound root directly.
+    @property
+    def project_root(self) -> Path:
+        if self._bound_root is None:
+            raise _no_project_error()
+        if self._bound_kind == "legacy":
+            return self._bound_root
+        match = match_model.Match.load(self._bound_root)
+        if not match.shooters:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "match_empty",
+                    "message": f"Match {self._bound_root} has no shooters.",
+                },
+            )
+        return match_model.Match.shooter_root(self._bound_root, match.shooters[0])
 
     @property
     def project_name(self) -> str | None:
-        return self._project_name
-
-    def bind(self, root: Path, name: str) -> None:
-        self._project_root = root
-        self._project_name = name
-
-    def unbind(self) -> None:
-        self._project_root = None
-        self._project_name = None
+        return self._bound_name
 
     def load(self) -> MatchProject:
-        if self._project_root is None:
-            raise _no_project_error()
-        return MatchProject.load(self._project_root)
+        return MatchProject.load(self.project_root)
+
+    def bind(self, root: Path, name: str) -> None:
+        """Legacy bind alias. Detects layout and dispatches to bind_match
+        or bind_legacy. REMOVE once every caller uses the typed variants."""
+        if (root / match_model.MATCH_FILE).exists():
+            self.bind_match(root, name)
+        else:
+            self.bind_legacy(root, name)
+
+
+def legacy_slug(project: MatchProject) -> str:
+    """Synthesise a shooter slug for a legacy single-shooter project.
+
+    Legacy projects predate the Match -> Shooter split; their on-disk
+    layout has no ``shooters/<slug>/`` subdir. To keep every shooter-
+    scoped URL slug-bearing (no second URL family for legacy projects),
+    we mint a deterministic slug from the project's ``competitor_name``.
+    The SPA reads it via /api/health.bound_shooter_slug after binding.
+    """
+    return match_model.slugify(project.competitor_name or "shooter")
 
 
 def _any_active_job(state: AppState) -> Job | None:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -613,10 +613,12 @@ def legacy_slug(project: MatchProject) -> str:
     Legacy projects predate the Match -> Shooter split; their on-disk
     layout has no ``shooters/<slug>/`` subdir. To keep every shooter-
     scoped URL slug-bearing (no second URL family for legacy projects),
-    we mint a deterministic slug from the project's ``competitor_name``.
-    The SPA reads it via /api/health.bound_shooter_slug after binding.
+    we mint a deterministic *opaque* slug from the project's metadata
+    (name + scoreboard ids) so the URL is stable across reloads but
+    doesn't carry the competitor name. The SPA reads it via
+    ``/api/health.default_shooter_slug`` after binding.
     """
-    return match_model.slugify(project.competitor_name or "shooter")
+    return match_model._legacy_view_slug(project)
 
 
 def _any_active_job(state: AppState) -> Job | None:
@@ -6195,7 +6197,7 @@ def create_app(
         ]
         match.save(target)
 
-        shooter_slug = match_model.slugify(req.primary_shooter.name)
+        shooter_slug = match_model.mint_shooter_slug()
         shooter = match_model.Shooter(
             slug=shooter_slug,
             name=req.primary_shooter.name,
@@ -6277,7 +6279,7 @@ def create_app(
         match.scoreboard_content_type = req.content_type
         match.save(target)
 
-        shooter_slug = match_model.slugify(req.primary_shooter_name)
+        shooter_slug = match_model.mint_shooter_slug()
         shooter = match_model.Shooter(
             slug=shooter_slug,
             name=req.primary_shooter_name,
@@ -6520,13 +6522,14 @@ def create_app(
 
         Creates the ``<match>/shooters/<slug>/`` tree, mirrors the match's
         stage definitions into the shooter's ``project.json``, and saves a
-        ``shooter.json`` next to it. Returns the refreshed list. Slug is
-        derived from ``name`` and disambiguated if it collides.
+        ``shooter.json`` next to it. Returns the refreshed list. Slugs are
+        opaque random ids (``s_<hex>``) so URLs / disk paths don't leak
+        competitor names.
         """
         match_root, match = _resolve_match_context()
         if not req.name.strip():
             raise HTTPException(status_code=400, detail="name is required")
-        slug = match_model.disambiguate_slug(match_model.slugify(req.name), set(match.shooters))
+        slug = match_model.mint_shooter_slug(set(match.shooters))
         shooter = match_model.Shooter(
             slug=slug,
             name=req.name,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -709,6 +709,14 @@ class HealthResponse(BaseModel):
     bound: bool
     project_name: str | None = None
     project_root: str | None = None
+    # Layout discriminator + a default slug for shooter-scoped URLs (#353).
+    # Match-bound: the alphabetically-first registered shooter, or ``None``
+    # when the match is empty. Legacy-bound: the deterministic legacy slug.
+    # Lets the SPA build /audit/<slug>/... links from any slugless surface
+    # (Home, sidebar Audit/Coach/Export rows) without forcing the user to
+    # pick a shooter when there's only one sensible default.
+    kind: str | None = None  # "match" | "legacy" | None when unbound
+    default_shooter_slug: str | None = None
 
 
 class PromoteSecondaryBody(BaseModel):
@@ -1854,10 +1862,24 @@ def create_app(
 
     def _health_after_bind(recorded_name: str) -> HealthResponse:
         """Build a HealthResponse from the currently-bound project."""
+        default_slug: str | None = None
+        kind = state.bound_kind
+        if kind == "match":
+            match = match_model.Match.load(state.bound_root)
+            shooters = sorted(match.shooters)
+            default_slug = shooters[0] if shooters else None
+        elif kind == "legacy":
+            try:
+                project = MatchProject.load(state.bound_root)
+                default_slug = legacy_slug(project)
+            except Exception:  # noqa: BLE001 -- defensive
+                default_slug = None
         return HealthResponse(
             bound=True,
             project_name=recorded_name,
             project_root=str(state.bound_root),
+            kind=kind,
+            default_shooter_slug=default_slug,
         )
 
     @app.get("/api/health", response_model=HealthResponse)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -4532,9 +4532,11 @@ def create_app(
         """Return the stage's audit JSON (issue #15) if one has been written.
 
         Lives at ``<project>/audit/stage<N>.json`` -- the same path the
-        existing audit-prep / audit-apply flow uses. 404 when no audit file
-        exists yet (the audit screen treats this as "fresh -- start from
-        candidates if any, otherwise empty markers").
+        existing audit-prep / audit-apply flow uses. Returns ``200 null``
+        when no audit file exists yet (the audit screen treats this as
+        "fresh -- start from candidates if any, otherwise empty
+        markers"); 404 is reserved for genuinely-unknown stages so the
+        SPA can distinguish.
         """
         project = state.shooter_project(slug)
         try:
@@ -4543,10 +4545,7 @@ def create_app(
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
         if not audit_file.exists():
-            raise HTTPException(
-                status_code=404,
-                detail=f"no audit JSON yet for stage {stage_number}",
-            )
+            return JSONResponse(None)
         try:
             payload = json.loads(audit_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -4802,8 +4801,18 @@ def create_app(
         Read-only: the stored ``interval_class`` is surfaced as-is, plus a
         ``stale`` flag indicating whether the current rule disagrees. The
         client can call ``POST /coach/reclassify`` to persist the rule's
-        verdict onto unset/auto entries.
+        verdict onto unset/auto entries. Returns ``200 null`` when the
+        stage has no audit JSON yet (a normal pre-audit state); 404 is
+        reserved for genuinely-unknown stage numbers.
         """
+        project = state.shooter_project(slug)
+        try:
+            stg = project.stage(stage_number)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
+        if not audit_file.exists():
+            return JSONResponse(None)
         payload, _audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
@@ -7009,9 +7018,12 @@ def create_app(
 
     @app.get("/api/me/scoreboard-identity")
     def get_scoreboard_identity() -> JSONResponse:
+        # "Not pinned yet" is a normal state, not an error -- return a
+        # 200 with a null body so the SPA doesn't have to catch a 404
+        # on every page load and DevTools doesn't log a failed request.
         identity = user_config.load_scoreboard_identity()
         if identity is None:
-            raise HTTPException(status_code=404, detail="no scoreboard identity saved")
+            return JSONResponse(None)
         return JSONResponse(identity.model_dump(mode="json"))
 
     @app.put("/api/me/scoreboard-identity")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -637,14 +637,6 @@ class AppState:
     def load(self) -> MatchProject:
         return MatchProject.load(self.project_root)
 
-    def bind(self, root: Path, name: str) -> None:
-        """Legacy bind alias. Detects layout and dispatches to bind_match
-        or bind_legacy. REMOVE once every caller uses the typed variants."""
-        if (root / match_model.MATCH_FILE).exists():
-            self.bind_match(root, name)
-        else:
-            self.bind_legacy(root, name)
-
 
 def legacy_slug(project: MatchProject) -> str:
     """Synthesise a shooter slug for a legacy single-shooter project.
@@ -748,7 +740,6 @@ class HealthResponse(BaseModel):
     bound: bool
     project_name: str | None = None
     project_root: str | None = None
-    schema_version: int | None = None
 
 
 class PromoteSecondaryBody(BaseModel):
@@ -900,7 +891,6 @@ class ShooterListEntry(BaseModel):
 
     slug: str
     name: str
-    is_active: bool
     selected_shooter_id: int | None
     selected_competitor_id: int | None
     stages_audited: int
@@ -943,7 +933,6 @@ class CompareShooterRecord(BaseModel):
 
     slug: str
     name: str
-    is_active: bool
     # Path to the lossless trim clip on disk; the SPA streams via
     # GET /api/match/shooters/{slug}/videos/stream?path=...
     video_path: str | None
@@ -1680,15 +1669,11 @@ def _bind_project_to_state(
     on-disk display name so the caller can echo it back.
 
     When ``root`` is a redesign-era Match folder (has ``match.json``),
-    the first shooter's directory is bound instead so the rest of the
-    server (which still speaks legacy ``MatchProject``) keeps working.
-    The match folder is recorded in the recent-projects index with
-    ``kind="match"`` so the picker can reopen it as a match next time.
-    Multi-shooter selection lives in #324; for now we pick the first
-    registered shooter.
+    the match itself is bound (``state.bind_match``) and the SPA addresses
+    individual shooters via slug-bearing URLs. Otherwise we bind the
+    legacy single-shooter project directly.
     """
     resolved = root.resolve()
-    # If this is a Match folder, transparently bind its first shooter.
     if match_model.is_match_folder(resolved):
         try:
             match = match_model.Match.load(resolved)
@@ -1708,15 +1693,13 @@ def _bind_project_to_state(
                     ),
                 },
             )
-        shooter_slug = match.shooters[0]
-        shooter_root = match_model.Match.shooter_root(resolved, shooter_slug)
-        user_config.record_project_open(resolved, match.name or fallback_name, kind="match")
-        return _bind_legacy_root_to_state(
-            state,
-            shooter_root,
-            fallback_name=match.name or fallback_name,
-            register=False,
-        )
+        name = match.name or fallback_name
+        user_config.record_project_open(resolved, name, kind="match")
+        loaded_env = _load_env_files(resolved)
+        if loaded_env:
+            logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
+        state.bind_match(resolved, name)
+        return name
     return _bind_legacy_root_to_state(state, resolved, fallback_name=fallback_name)
 
 
@@ -1724,15 +1707,8 @@ def _bind_legacy_root_to_state(
     state: AppState,
     root: Path,
     fallback_name: str,
-    *,
-    register: bool = True,
 ) -> str:
-    """Bind a legacy MatchProject directory (project.json layout).
-
-    ``register=False`` is for shooter subdirs inside a match: the parent
-    match is already recorded in recent-projects, and the shooter dir
-    must not show up as a standalone "legacy" project in the picker.
-    """
+    """Bind a legacy MatchProject directory (project.json layout)."""
     MatchProject.init(root, name=fallback_name)
     resolved = root.resolve()
     loaded_env = _load_env_files(resolved)
@@ -1743,9 +1719,8 @@ def _bind_legacy_root_to_state(
         recorded_name = loaded_project.name or fallback_name
     except Exception:  # pragma: no cover -- defensive: never block boot
         recorded_name = fallback_name
-    if register:
-        user_config.record_project_open(resolved, recorded_name, kind="legacy")
-    state.bind(resolved, recorded_name)
+    user_config.record_project_open(resolved, recorded_name, kind="legacy")
+    state.bind_legacy(resolved, recorded_name)
     return recorded_name
 
 
@@ -1908,17 +1883,19 @@ def create_app(
         cached = CachingScoreboardClient(http, cache_dir)
         return _ScoreboardClientCtx(cached, owns_close=True, inner_http=http)
 
+    def _health_after_bind(recorded_name: str) -> HealthResponse:
+        """Build a HealthResponse from the currently-bound project."""
+        return HealthResponse(
+            bound=True,
+            project_name=recorded_name,
+            project_root=str(state.bound_root),
+        )
+
     @app.get("/api/health", response_model=HealthResponse)
     def health() -> HealthResponse:
         if not state.is_bound:
             return HealthResponse(bound=False)
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=project.name,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
-        )
+        return _health_after_bind(state.bound_name or "")
 
     @app.get("/api/project")
     def get_project() -> JSONResponse:
@@ -1996,8 +1973,9 @@ def create_app(
             shutil.rmtree(tmp, ignore_errors=True)
 
         if bind:
-            state.bind(result.project_root, result.project_name)
-            user_config.record_project_open(result.project_root, result.project_name)
+            _bind_project_to_state(
+                state, result.project_root, fallback_name=result.project_name
+            )
 
         return JSONResponse(
             {
@@ -6135,13 +6113,7 @@ def create_app(
             )
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=recorded,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
-        )
+        return _health_after_bind(recorded)
 
     @app.post("/api/match/create-manual")
     def create_match_manual(req: CreateMatchManualRequest) -> HealthResponse:
@@ -6231,13 +6203,7 @@ def create_app(
             recorded = _bind_project_to_state(state, target, fallback_name=req.name)
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=recorded,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
-        )
+        return _health_after_bind(recorded)
 
     @app.post("/api/match/create-from-scoreboard")
     def create_match_from_scoreboard(
@@ -6296,43 +6262,20 @@ def create_app(
             recorded = _bind_project_to_state(state, target, fallback_name=req.name)
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=recorded,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
-        )
+        return _health_after_bind(recorded)
 
     # ----------------------------------------------------------------------
     # Shooters management (#324)
     # ----------------------------------------------------------------------
 
-    def _resolve_match_context() -> tuple[Path, match_model.Match, str]:
-        """Return ``(match_root, match, active_slug)`` for the bound project.
+    def _resolve_match_context() -> tuple[Path, match_model.Match]:
+        """Return ``(match_root, match)`` for the bound project.
 
-        Detects whether ``state.project_root`` lives at
-        ``<match_root>/shooters/<slug>/``; if so the SPA is browsing a
-        match-as-object project. Otherwise raises a structured 409 so the
-        shooters page can hide itself (the legacy single-shooter layout
-        has no concept of swapping shooters).
+        Raises 409 ``not_a_match`` for legacy single-shooter layouts (the
+        shooter-listing / merge / compare endpoints are match-only).
         """
-        root = state.project_root
-        parent = root.parent
-        match_root = parent.parent if parent.name == match_model.SHOOTERS_DIR else None
-        if match_root is None or not match_model.is_match_folder(match_root):
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "code": "not_a_match",
-                    "message": (
-                        "Bound project is a legacy single-shooter layout; "
-                        "shooter management is match-folder only."
-                    ),
-                },
-            )
-        match = match_model.Match.load(match_root)
-        return match_root, match, root.name
+        match_root = state.match_root
+        return match_root, match_model.Match.load(match_root)
 
     def _classify_shooter(shooter_root: Path, match: match_model.Match) -> ShooterListEntry:
         """Build a list entry for a single shooter directory."""
@@ -6393,7 +6336,6 @@ def create_app(
         return ShooterListEntry(
             slug=shooter_root.name,
             name=legacy.competitor_name or shooter_root.name,
-            is_active=False,
             selected_shooter_id=legacy.selected_shooter_id,
             selected_competitor_id=legacy.selected_competitor_id,
             stages_audited=stages_audited,
@@ -6507,83 +6449,31 @@ def create_app(
         except OSError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        # Bind the new match. _bind_project_to_state's match branch
-        # records the match path in recent-projects (kind="match") and
-        # transparently binds the first shooter so existing audit/ingest
-        # endpoints have a working project context immediately. Passing
-        # the shooter path directly here would mis-register the shooter
-        # subdir as a standalone legacy project.
+        # Bind the new match. ``_bind_project_to_state`` records the match
+        # in recent-projects (kind="match") and switches state.bound_root
+        # to the match folder; shooters are addressed by slug from there.
         try:
             recorded = _bind_project_to_state(state, output, fallback_name=match.name)
         except OSError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=recorded,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
-        )
+        return _health_after_bind(recorded)
 
     @app.get("/api/match/shooters", response_model=ShooterListResponse)
     def list_match_shooters() -> ShooterListResponse:
         """List every shooter in the currently-bound match with coverage."""
-        match_root, match, active_slug = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         entries: list[ShooterListEntry] = []
         for slug in match.shooters:
             shooter_root = match_model.Match.shooter_root(match_root, slug)
             try:
-                entry = _classify_shooter(shooter_root, match)
+                entries.append(_classify_shooter(shooter_root, match))
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Skipping shooter %s: %s", slug, exc)
                 continue
-            entry.is_active = slug == active_slug
-            entries.append(entry)
         return ShooterListResponse(
             match_root=str(match_root),
             match_name=match.name,
             shooters=entries,
-        )
-
-    @app.post("/api/match/shooters/{slug}/select")
-    def select_active_shooter(slug: str) -> HealthResponse:
-        """Re-bind the server to a different shooter inside the same match.
-
-        After this call ``state.project_root`` points at the new shooter
-        dir; every subsequent project-bound endpoint reads that shooter's
-        data. The match folder itself stays bound in the recent-projects
-        index.
-        """
-        match_root, match, _ = _resolve_match_context()
-        if slug not in match.shooters:
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "code": "shooter_not_found",
-                    "message": f"shooter {slug!r} is not registered on this match",
-                },
-            )
-        shooter_root = match_model.Match.shooter_root(match_root, slug)
-        if not shooter_root.exists():
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "code": "shooter_dir_missing",
-                    "message": (
-                        f"shooter {slug!r} is registered but {shooter_root} "
-                        "doesn't exist on disk"
-                    ),
-                },
-            )
-        recorded = _bind_legacy_root_to_state(
-            state, shooter_root, fallback_name=match.name, register=False
-        )
-        project = state.load()
-        return HealthResponse(
-            bound=True,
-            project_name=recorded,
-            project_root=str(state.project_root),
-            schema_version=project.schema_version,
         )
 
     @app.post("/api/match/shooters", response_model=ShooterListResponse)
@@ -6595,7 +6485,7 @@ def create_app(
         ``shooter.json`` next to it. Returns the refreshed list. Slug is
         derived from ``name`` and disambiguated if it collides.
         """
-        match_root, match, _ = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         if not req.name.strip():
             raise HTTPException(status_code=400, detail="name is required")
         slug = match_model.disambiguate_slug(match_model.slugify(req.name), set(match.shooters))
@@ -6636,21 +6526,9 @@ def create_app(
         """Remove a shooter from the bound match.
 
         Drops the slug from ``match.json`` and deletes
-        ``<match>/shooters/<slug>/`` from disk. Refuses if ``slug`` is
-        currently the active shooter (the SPA should switch first).
+        ``<match>/shooters/<slug>/`` from disk.
         """
-        match_root, match, active_slug = _resolve_match_context()
-        if slug == active_slug:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "code": "active_shooter",
-                    "message": (
-                        "Cannot remove the currently-active shooter. "
-                        "Switch to another shooter first."
-                    ),
-                },
-            )
+        match_root, match = _resolve_match_context()
         if slug not in match.shooters:
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, slug)
@@ -6674,7 +6552,7 @@ def create_app(
         ``ensure_video_audit_trim`` is idempotent, but skipping early
         avoids the queue churn).
         """
-        match_root, match, _ = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         if slug not in match.shooters:
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, slug)
@@ -6757,7 +6635,7 @@ def create_app(
         scalars. Shooters with no trim still appear so the SPA can render
         empty tiles instead of silently dropping the slot.
         """
-        match_root, match, active_slug = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         try:
             stage_def = match.stage(stage_number)
         except KeyError as exc:
@@ -6853,7 +6731,6 @@ def create_app(
                 CompareShooterRecord(
                     slug=slug,
                     name=legacy.competitor_name or slug,
-                    is_active=slug == active_slug,
                     video_path=video_path,
                     beep_offset_in_clip=beep_offset,
                     duration_seconds=duration_seconds,
@@ -6881,7 +6758,7 @@ def create_app(
         the named shooter's project then returns a FileResponse on the
         resolved trim/source.
         """
-        match_root, match, _ = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         if slug not in match.shooters:
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, slug)
@@ -6953,7 +6830,7 @@ def create_app(
         Items are grouped by stage; per-stage shot detection is gated on
         every shooter's primary in that stage being ``beep_reviewed``.
         """
-        match_root, match, _ = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         # Resolve the low-confidence threshold from the active shooter's
         # automation settings; per-shooter thresholds aren't supported.
         try:
@@ -7045,7 +6922,7 @@ def create_app(
         When ``time`` is supplied, it overrides ``beep_time``; the call
         always sets ``beep_reviewed = True``.
         """
-        match_root, match, _ = _resolve_match_context()
+        match_root, match = _resolve_match_context()
         if req.slug not in match.shooters:
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, req.slug)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1858,12 +1858,12 @@ def create_app(
     # API
     # ----------------------------------------------------------------------
 
-    def _local_match_path() -> Path:
-        """Resolve ``<project>/scoreboard/match.json`` (offline source path)."""
-        return state.project_root / DEFAULT_SCOREBOARD_DIRNAME / DEFAULT_MATCH_FILENAME
+    def _local_match_path(root: Path) -> Path:
+        """Resolve ``<root>/scoreboard/match.json`` (offline source path)."""
+        return root / DEFAULT_SCOREBOARD_DIRNAME / DEFAULT_MATCH_FILENAME
 
-    def _resolve_scoreboard_client() -> ScoreboardClient:
-        """Pick the concrete ``ScoreboardClient`` for this request.
+    def _resolve_scoreboard_client(root: Path) -> ScoreboardClient:
+        """Pick the concrete ``ScoreboardClient`` for this shooter root.
 
         Local JSON wins when present so the user can stay fully offline by
         dropping a file. Otherwise we wrap the HTTP client in the project-
@@ -1871,7 +1871,7 @@ def create_app(
         caller is responsible for ``close()`` -- both implementations are
         context managers (Local is a no-op; HTTP closes the httpx Client).
         """
-        local_path = _local_match_path()
+        local_path = _local_match_path(root)
         if local_path.exists():
             local = LocalJsonScoreboard(local_path)
             return _ScoreboardClientCtx(local, owns_close=False)
@@ -1879,7 +1879,7 @@ def create_app(
             http = SsiHttpClient()
         except ScoreboardAuthError as exc:
             _raise_scoreboard_http(exc)
-        cache_dir = state.project_root / "scoreboard" / "cache"
+        cache_dir = root / "scoreboard" / "cache"
         cached = CachingScoreboardClient(http, cache_dir)
         return _ScoreboardClientCtx(cached, owns_close=True, inner_http=http)
 
@@ -1897,12 +1897,13 @@ def create_app(
             return HealthResponse(bound=False)
         return _health_after_bind(state.bound_name or "")
 
-    @app.get("/api/project")
-    def get_project() -> JSONResponse:
-        return JSONResponse(state.load().model_dump(mode="json"))
+    @app.get("/api/shooters/{slug}/project")
+    def get_project(slug: str) -> JSONResponse:
+        return JSONResponse(state.shooter_project(slug).model_dump(mode="json"))
 
-    @app.get("/api/project/export")
+    @app.get("/api/shooters/{slug}/project/export")
     def export_project_endpoint(
+        slug: str,
         include_trimmed: bool = Query(False),
         include_exports: bool = Query(False),
         include_raw: bool = Query(False),
@@ -1917,7 +1918,7 @@ def create_app(
         written to a temp file and deleted once the response finishes
         streaming.
         """
-        root = state.project_root
+        root = state.shooter_root(slug)
         tmp = Path(tempfile.mkdtemp(prefix="splitsmith-export-"))
         archive = tmp / f"{root.name}.tar.gz"
         try:
@@ -1985,8 +1986,8 @@ def create_app(
             }
         )
 
-    @app.get("/api/automation")
-    def get_automation() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/automation")
+    def get_automation(slug: str) -> JSONResponse:
         """Resolved automation settings + per-field provenance (#215 / #216).
 
         Combines the global YAML / env-var defaults with the bound
@@ -1995,7 +1996,7 @@ def create_app(
         ``cli_value`` is always None on the daemon path -- the server
         doesn't take per-call CLI flags.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         resolved = automation_settings.resolve_automation(
             project_override=project.automation,
         )
@@ -2014,8 +2015,8 @@ def create_app(
             }
         )
 
-    @app.post("/api/project/nudges/dismiss")
-    def dismiss_nudge(req: NudgeDismissRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/project/nudges/dismiss")
+    def dismiss_nudge(slug: str, req: NudgeDismissRequest) -> JSONResponse:
         """Persist a per-project nudge dismissal (#218 phase 4).
 
         Adds ``stage_number`` to ``MatchProject.nudges_dismissed_stages``
@@ -2023,7 +2024,8 @@ def create_app(
         Returns the full project dump so the SPA can replace its
         cached state without a separate refetch.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             project.stage(req.stage_number)
         except KeyError as exc:
@@ -2034,11 +2036,11 @@ def create_app(
         else:
             current.discard(req.stage_number)
         project.nudges_dismissed_stages = sorted(current)
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.get("/api/hitl-queue")
-    def get_hitl_queue() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/hitl-queue")
+    def get_hitl_queue(slug: str) -> JSONResponse:
         """Items in the project that need human (or agent) attention (#219).
 
         Walks every primary video and emits one item per beep that's
@@ -2069,7 +2071,7 @@ def create_app(
         order. The SPA shows this as a project-level work queue; the
         MCP exposes it as a resource so an agent can drive the picks.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         resolved = automation_settings.resolve_automation(
             project_override=project.automation,
         )
@@ -2118,8 +2120,8 @@ def create_app(
                 )
         return JSONResponse({"items": items, "threshold": threshold})
 
-    @app.get("/api/project/match-analysis")
-    def get_match_analysis() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/project/match-analysis")
+    def get_match_analysis(slug: str) -> JSONResponse:
         """Run the canonical video-match heuristic over the project and return
         per-stage windows + per-video classification.
 
@@ -2129,19 +2131,20 @@ def create_app(
         improvements (per-stage tolerance, ML-based scoring, confidence
         bands) extend this endpoint rather than adding policy to the SPA.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         return JSONResponse(project.match_analysis().model_dump(mode="json"))
 
-    @app.post("/api/scoreboard/import")
-    def import_scoreboard(req: ScoreboardImportRequest) -> JSONResponse:
-        project = state.load()
+    @app.post("/api/shooters/{slug}/scoreboard/import")
+    def import_scoreboard(slug: str, req: ScoreboardImportRequest) -> JSONResponse:
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             project.import_scoreboard(req.data, overwrite=req.overwrite)
         except ScoreboardImportConflictError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except (KeyError, ValueError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(project.model_dump(mode="json"))
 
     # ----------------------------------------------------------------------
@@ -2155,15 +2158,15 @@ def create_app(
     # next request hits the live API. Errors are mapped to HTTP statuses
     # the SPA can render as actionable banners (acceptance criterion).
 
-    @app.get("/api/scoreboard/source")
-    def scoreboard_source() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/scoreboard/source")
+    def scoreboard_source(slug: str) -> JSONResponse:
         """Report whether the offline JSON or the live API will serve requests.
 
         The SPA renders a "loaded from local JSON, no network used" indicator
         when ``mode == "local"`` so the user can verify the offline path
         without watching dev tools.
         """
-        local_path = _local_match_path()
+        local_path = _local_match_path(state.shooter_root(slug))
         local = local_path.exists()
         http_ready = bool(os.environ.get("SPLITSMITH_SSI_TOKEN"))
         return JSONResponse(
@@ -2174,8 +2177,8 @@ def create_app(
             }
         )
 
-    @app.post("/api/scoreboard/upload")
-    def scoreboard_upload(req: ScoreboardUploadRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/scoreboard/upload")
+    def scoreboard_upload(slug: str, req: ScoreboardUploadRequest) -> JSONResponse:
         """Accept a dropped SSI ``match.json`` and populate the project.
 
         Three input shapes are accepted (see ``LocalJsonScoreboard``):
@@ -2188,7 +2191,8 @@ def create_app(
         competitor -- auto-pins that competitor and merges the times so
         the user lands on a fully-populated stage list in one drop.
         """
-        local_path = _local_match_path()
+        root = state.shooter_root(slug)
+        local_path = _local_match_path(root)
         local_path.parent.mkdir(parents=True, exist_ok=True)
         local_path.write_text(
             json.dumps(req.data, indent=2, sort_keys=True),
@@ -2202,7 +2206,7 @@ def create_app(
                 detail=f"dropped JSON is not a recognized scoreboard payload: {exc}",
             ) from exc
 
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             project.populate_from_match_data(scoreboard.match, overwrite=req.overwrite)
         except ScoreboardImportConflictError as exc:
@@ -2238,21 +2242,21 @@ def create_app(
                 if picked is not None:
                     project.selected_shooter_id = picked.shooterId
                     project.competitor_name = picked.name
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse({**project.model_dump(mode="json"), "stage_times_merged": merged})
 
-    @app.get("/api/scoreboard/search")
-    def scoreboard_search(q: str = Query("", min_length=0)) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/scoreboard/search")
+    def scoreboard_search(slug: str, q: str = Query("", min_length=0)) -> JSONResponse:
         """Search the active scoreboard source for matches by free-text query."""
-        with _resolve_scoreboard_client() as client:
+        with _resolve_scoreboard_client(state.shooter_root(slug)) as client:
             try:
                 refs = client.search_matches(q)
             except ScoreboardError as exc:
                 _raise_scoreboard_http(exc)
         return JSONResponse([ref.model_dump(mode="json") for ref in refs])
 
-    @app.post("/api/scoreboard/fetch")
-    def scoreboard_fetch(req: ScoreboardFetchRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/scoreboard/fetch")
+    def scoreboard_fetch(slug: str, req: ScoreboardFetchRequest) -> JSONResponse:
         """Fetch a full match (cache-first) and populate the project.
 
         When the project already has a pinned competitor (carried over from
@@ -2260,14 +2264,15 @@ def create_app(
         round-trip. New picks (no pin yet) still need ``/select-shooter``
         afterwards -- the SPA flow stays the same.
         """
-        with _resolve_scoreboard_client() as client:
+        root = state.shooter_root(slug)
+        with _resolve_scoreboard_client(root) as client:
             try:
                 match_data = client.get_match(req.content_type, req.match_id)
             except MatchNotFound as exc:
                 raise HTTPException(status_code=404, detail=str(exc)) from exc
             except ScoreboardError as exc:
                 _raise_scoreboard_http(exc)
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             project.populate_from_match_data(match_data, overwrite=req.overwrite)
         except ScoreboardImportConflictError as exc:
@@ -2277,6 +2282,7 @@ def create_app(
         if project.selected_competitor_id is not None:
             try:
                 merged = _fetch_and_merge_stage_times(
+                    root,
                     project,
                     req.content_type,
                     req.match_id,
@@ -2287,14 +2293,14 @@ def create_app(
                 # Persist the populated stage shell anyway so the user
                 # has something to work with; they can hit refresh-times
                 # once the upstream resolves.
-                project.save(state.project_root)
+                project.save(root)
                 raise
         else:
-            project.save(state.project_root)
+            project.save(root)
         return JSONResponse({**project.model_dump(mode="json"), "stage_times_merged": merged})
 
-    @app.get("/api/scoreboard/match-data")
-    def scoreboard_match_data() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/scoreboard/match-data")
+    def scoreboard_match_data(slug: str) -> JSONResponse:
         """Return the resolved ``MatchData`` for the project's loaded match.
 
         The SPA needs this to map a picked ``shooterId`` to the per-match
@@ -2303,7 +2309,8 @@ def create_app(
         drifts when upstream re-fetches; serving on demand keeps the
         cache as the single source of truth.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         if project.scoreboard_match_id is None or project.scoreboard_content_type is None:
             raise HTTPException(
                 status_code=404,
@@ -2320,7 +2327,7 @@ def create_app(
                     "predates the v1 wiring (#50). Re-import via /upload or /fetch."
                 ),
             ) from exc
-        with _resolve_scoreboard_client() as client:
+        with _resolve_scoreboard_client(root) as client:
             try:
                 match_data = client.get_match(ct, mid)
             except MatchNotFound as exc:
@@ -2329,21 +2336,21 @@ def create_app(
                 _raise_scoreboard_http(exc)
         return JSONResponse(match_data.model_dump(mode="json"))
 
-    @app.get("/api/scoreboard/shooter/search")
-    def scoreboard_shooter_search(q: str = Query("", min_length=0)) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/scoreboard/shooter/search")
+    def scoreboard_shooter_search(slug: str, q: str = Query("", min_length=0)) -> JSONResponse:
         """Find shooters by name. Offline mode searches this match's
         competitor list only; online mode hits the live shooter index."""
         if not q.strip():
             return JSONResponse([])
-        with _resolve_scoreboard_client() as client:
+        with _resolve_scoreboard_client(state.shooter_root(slug)) as client:
             try:
                 refs = client.find_shooter(q)
             except ScoreboardError as exc:
                 _raise_scoreboard_http(exc)
         return JSONResponse([ref.model_dump(mode="json") for ref in refs])
 
-    @app.post("/api/scoreboard/select-shooter")
-    def scoreboard_select_shooter(req: SelectShooterRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/scoreboard/select-shooter")
+    def scoreboard_select_shooter(slug: str, req: SelectShooterRequest) -> JSONResponse:
         """Pin (shooter_id, competitor_id) and merge stage times into the project.
 
         Validates the competitor against the loaded match before
@@ -2361,7 +2368,8 @@ def create_app(
         - 502 ``scoreboard_offline``: transient upstream issue;
           pin persisted so refresh-times retries on the same selection
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         if project.scoreboard_match_id is None or project.scoreboard_content_type is None:
             raise HTTPException(
                 status_code=409,
@@ -2384,7 +2392,7 @@ def create_app(
         # avoids the "I picked a shooter and now my project is in a bad
         # state" pattern. 404 with a discrete code so the SPA can prompt
         # the user to pick again rather than rendering an upstream banner.
-        with _resolve_scoreboard_client() as client:
+        with _resolve_scoreboard_client(root) as client:
             try:
                 match_data = client.get_match(ct, mid)
             except ScoreboardError as exc:
@@ -2411,13 +2419,13 @@ def create_app(
         # scoreboard summary doesn't have to re-fetch MatchData just to
         # render "pinned: Mathias Rinaldo" instead of an integer id.
         project.competitor_name = picked.name
-        project.save(state.project_root)
+        project.save(root)
 
-        merged = _fetch_and_merge_stage_times(project, ct, mid, req.competitor_id)
+        merged = _fetch_and_merge_stage_times(root, project, ct, mid, req.competitor_id)
         return JSONResponse({**project.model_dump(mode="json"), "stage_times_merged": merged})
 
-    @app.post("/api/scoreboard/refresh-times")
-    def scoreboard_refresh_times() -> JSONResponse:
+    @app.post("/api/shooters/{slug}/scoreboard/refresh-times")
+    def scoreboard_refresh_times(slug: str) -> JSONResponse:
         """Re-pull and re-merge stage times for the pinned competitor.
 
         Invalidates every cached stage-times entry for the match (not
@@ -2425,7 +2433,8 @@ def create_app(
         update multiple shooters at once and a fresh pull is cheap. Use
         this after the user knows the upstream has new scorecards.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         if (
             project.selected_competitor_id is None
             or project.scoreboard_match_id is None
@@ -2446,16 +2455,16 @@ def create_app(
 
         # Drop every cached stage_times entry for this match so the
         # next get_stage_times call goes upstream.
-        cache_dir = state.project_root / "scoreboard" / "cache"
+        cache_dir = root / "scoreboard" / "cache"
         if cache_dir.exists():
             cache = CachingScoreboardClient(_NoOpClient(), cache_dir)
             cache.invalidate_match_stage_times(ct, mid)
 
-        merged = _fetch_and_merge_stage_times(project, ct, mid, project.selected_competitor_id)
+        merged = _fetch_and_merge_stage_times(root, project, ct, mid, project.selected_competitor_id)
         return JSONResponse({**project.model_dump(mode="json"), "stage_times_merged": merged})
 
     def _fetch_and_merge_stage_times(
-        project: MatchProject, ct: int, mid: int, competitor_id: int
+        root: Path, project: MatchProject, ct: int, mid: int, competitor_id: int
     ) -> int:
         """Shared helper -- get_stage_times + merge_stage_times, with the
         right error mapping. Persists the project on success.
@@ -2466,7 +2475,7 @@ def create_app(
         requiring a full overwrite-import that would orphan video
         assignments.
         """
-        with _resolve_scoreboard_client() as client:
+        with _resolve_scoreboard_client(root) as client:
             try:
                 results = client.get_stage_times(ct, mid, competitor_id)
             except ScoreboardError as exc:
@@ -2486,15 +2495,16 @@ def create_app(
             except ScoreboardError:
                 pass
         merged = project.merge_stage_times(results)
-        project.save(state.project_root)
+        project.save(root)
         return merged
 
-    @app.post("/api/project/placeholder-stages")
-    def create_placeholder_stages(req: PlaceholderStagesRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/project/placeholder-stages")
+    def create_placeholder_stages(slug: str, req: PlaceholderStagesRequest) -> JSONResponse:
         """Create N placeholder stages so source-first ingest works without a
         scoreboard. A real scoreboard import later overlays the placeholders
         and preserves video assignments by ``stage_number``."""
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             project.init_placeholder_stages(
                 req.stage_count,
@@ -2505,11 +2515,11 @@ def create_app(
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/videos/scan", response_model=ScanResponse)
-    def scan_videos(req: ScanRequest) -> ScanResponse:
+    @app.post("/api/shooters/{slug}/videos/scan", response_model=ScanResponse)
+    def scan_videos(slug: str, req: ScanRequest) -> ScanResponse:
         if req.link_mode not in ("symlink", "copy"):
             raise HTTPException(status_code=400, detail="link_mode must be 'symlink' or 'copy'")
         if (req.source_dir is None) == (req.source_paths is None):
@@ -2553,14 +2563,15 @@ def create_app(
                 candidates.append(p)
             last_dir = candidates[0].parent.resolve() if candidates else None
 
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         registered: list[str] = []
         skipped: list[str] = []
         for entry in candidates:
             try:
                 video = project.register_video(
                     entry,
-                    state.project_root,
+                    root,
                     link_mode=req.link_mode,  # type: ignore[arg-type]
                 )
             except (FileNotFoundError, ValueError) as exc:
@@ -2570,7 +2581,7 @@ def create_app(
 
         auto_assigned: dict[int, str] = {}
         if req.auto_assign_primary:
-            suggestions = project.auto_match(state.project_root)
+            suggestions = project.auto_match(root)
             for stage_num, video_path in suggestions.items():
                 stage = project.stage(stage_num)
                 # Only auto-assign primary when the stage has no primary yet.
@@ -2582,7 +2593,7 @@ def create_app(
         if last_dir is not None:
             project.last_scanned_dir = str(last_dir)
 
-        project.save(state.project_root)
+        project.save(root)
 
         # Queue auto-beep for every freshly-primaried video (#67). Done
         # after save so the persisted state reflects the assignment when
@@ -2599,8 +2610,8 @@ def create_app(
             skipped=skipped,
         )
 
-    @app.get("/api/videos/link-status", response_model=LinkStatusResponse)
-    def get_link_status() -> LinkStatusResponse:
+    @app.get("/api/shooters/{slug}/videos/link-status", response_model=LinkStatusResponse)
+    def get_link_status(slug: str) -> LinkStatusResponse:
         """Per-video status of ``raw/<name>`` symlinks.
 
         Lets the SPA badge broken / missing entries on the project page
@@ -2608,8 +2619,9 @@ def create_app(
         """
         from .. import relink as relink_mod
 
-        project = state.load()
-        infos = relink_mod.inspect_links(project, state.project_root)
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
+        infos = relink_mod.inspect_links(project, root)
         return LinkStatusResponse(
             entries=[
                 LinkStatusEntry(
@@ -2623,8 +2635,8 @@ def create_app(
             ]
         )
 
-    @app.post("/api/videos/relink/scan", response_model=RelinkScanResponse)
-    def relink_scan(req: RelinkScanRequest) -> RelinkScanResponse:
+    @app.post("/api/shooters/{slug}/videos/relink/scan", response_model=RelinkScanResponse)
+    def relink_scan(slug: str, req: RelinkScanRequest) -> RelinkScanResponse:
         """Recursive dry-run: walk ``search_root`` and report per-video
         candidates without touching the filesystem.
         """
@@ -2635,8 +2647,8 @@ def create_app(
             index = relink_mod.index_search_root(search_root)
         except (FileNotFoundError, NotADirectoryError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        project = state.load()
-        infos = relink_mod.inspect_links(project, state.project_root)
+        project = state.shooter_project(slug)
+        infos = relink_mod.inspect_links(project, state.shooter_root(slug))
         plan = relink_mod.plan_relink(infos, index)
         return RelinkScanResponse(
             search_root=str(search_root.resolve()),
@@ -2658,8 +2670,8 @@ def create_app(
             ],
         )
 
-    @app.post("/api/videos/relink/apply", response_model=RelinkApplyResponse)
-    def relink_apply(req: RelinkApplyRequest) -> RelinkApplyResponse:
+    @app.post("/api/shooters/{slug}/videos/relink/apply", response_model=RelinkApplyResponse)
+    def relink_apply(slug: str, req: RelinkApplyRequest) -> RelinkApplyResponse:
         """Apply a user-confirmed set of symlink rewrites.
 
         ``project.json`` is not modified -- only the symlinks under
@@ -2670,9 +2682,9 @@ def create_app(
 
         if not req.decisions:
             raise HTTPException(status_code=400, detail="decisions must be non-empty")
-        project = state.load()
+        project = state.shooter_project(slug)
         infos = {
-            info.video_id: info for info in relink_mod.inspect_links(project, state.project_root)
+            info.video_id: info for info in relink_mod.inspect_links(project, state.shooter_root(slug))
         }
         decisions: list[tuple[Path, Path]] = []
         id_for_link: dict[Path, str] = {}
@@ -2708,8 +2720,8 @@ def create_app(
             ]
         )
 
-    @app.post("/api/project/settings")
-    def update_settings(req: SettingsRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/project/settings")
+    def update_settings(slug: str, req: SettingsRequest) -> JSONResponse:
         """Update storage path overrides. Any None field is left unchanged;
         pass an empty string to clear back to the project-root default.
 
@@ -2718,7 +2730,8 @@ def create_app(
         ``confirm=True`` is sent. Existing files are not auto-migrated --
         the warning lets the caller surface "you'll be leaving these behind".
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         update: dict[str, str | None] = {}
         for fname in (
             "raw_dir",
@@ -2747,7 +2760,7 @@ def create_app(
         for fname, new_value in update.items():
             if new_value == getattr(project, fname):
                 continue  # no change
-            old_path = resolver_for[fname](state.project_root)
+            old_path = resolver_for[fname](root)
             if not old_path.exists() or not old_path.is_dir():
                 continue
             try:
@@ -2809,7 +2822,7 @@ def create_app(
             project.probes_path,
             project.thumbs_path,
         ):
-            target = resolver(state.project_root)
+            target = resolver(root)
             try:
                 target.mkdir(parents=True, exist_ok=True)
             except OSError as exc:
@@ -2818,11 +2831,11 @@ def create_app(
                     detail=f"cannot create directory {target}: {exc}",
                 ) from exc
 
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(project.model_dump(mode="json"))
 
     def _resolve_stage_video(
-        stage_number: int, video_id: str
+        slug: str, stage_number: int, video_id: str
     ) -> tuple[MatchProject, StageEntry, StageVideo]:
         """Load the project + stage + video for a per-video endpoint.
 
@@ -2831,7 +2844,7 @@ def create_app(
         source-on-disk lives at the call site so endpoints that don't need
         a reachable file (clear, manual override) can skip it.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -2859,6 +2872,7 @@ def create_app(
     _align_confidence_floor = 1.10
 
     def _try_align_secondary_to_primary(
+        root: Path,
         proj: MatchProject,
         stage: StageEntry,
         video: StageVideo,
@@ -2881,10 +2895,10 @@ def create_app(
         if primary is None or primary.beep_time is None:
             return None
         primary_audio_path = audio_helpers.primary_audio_path(
-            state.project_root, stage.stage_number, project=proj
+            root, stage.stage_number, project=proj
         )
         secondary_audio_path = audio_helpers.video_audio_path(
-            state.project_root, stage.stage_number, video, project=proj
+            root, stage.stage_number, video, project=proj
         )
         if not primary_audio_path.exists() or not secondary_audio_path.exists():
             # Either side missing means the user hasn't run beep-detect on
@@ -3785,12 +3799,12 @@ def create_app(
         )
         return JSONResponse(job.model_dump(mode="json"))
 
-    @app.get("/api/jobs", response_model=list[Job])
+    @app.get("/api/me/jobs", response_model=list[Job])
     def list_jobs() -> list[Job]:
         """Snapshot of all retained jobs (active + recently finished)."""
         return state.jobs.list()
 
-    @app.get("/api/jobs/{job_id}", response_model=Job)
+    @app.get("/api/me/jobs/{job_id}", response_model=Job)
     def get_job(job_id: str) -> Job:
         """Poll a single job. SPA polls ~1 Hz while a job is active."""
         job = state.jobs.get(job_id)
@@ -3798,7 +3812,7 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"unknown job: {job_id}")
         return job
 
-    @app.post("/api/jobs/acknowledge-failures", response_model=list[Job])
+    @app.post("/api/me/jobs/acknowledge-failures", response_model=list[Job])
     def acknowledge_all_failures() -> list[Job]:
         """Mark every currently-unacknowledged FAILED job as seen (issue #73).
 
@@ -3808,7 +3822,7 @@ def create_app(
         """
         return state.jobs.acknowledge_all_failures()
 
-    @app.post("/api/jobs/{job_id}/acknowledge", response_model=Job)
+    @app.post("/api/me/jobs/{job_id}/acknowledge", response_model=Job)
     def acknowledge_job(job_id: str) -> Job:
         """Mark a single failed job as seen (issue #73).
 
@@ -3821,7 +3835,7 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"unknown job: {job_id}")
         return job
 
-    @app.post("/api/jobs/{job_id}/cancel", response_model=Job)
+    @app.post("/api/me/jobs/{job_id}/cancel", response_model=Job)
     def cancel_job(job_id: str) -> Job:
         """Request cooperative cancellation of a running or pending job.
 
@@ -6051,7 +6065,7 @@ def create_app(
     # project picker and read/write the saved SSI Scoreboard identity so the
     # scoreboard import flow can prefill 'me' instead of asking each project.
 
-    @app.get("/api/user/recent-projects")
+    @app.get("/api/me/recent-projects")
     def list_recent_projects(detail: bool = Query(False)) -> JSONResponse:
         """Return the recent-projects list.
 
@@ -6068,7 +6082,7 @@ def create_app(
             return JSONResponse({"projects": [p.model_dump(mode="json") for p in enriched]})
         return JSONResponse({"projects": [p.model_dump(mode="json") for p in projects]})
 
-    @app.post("/api/user/recent-projects/forget")
+    @app.post("/api/me/recent-projects/forget")
     def forget_recent_project(req: ForgetRecentProjectRequest) -> JSONResponse:
         removed = user_config.remove_recent_project(Path(req.path))
         projects = user_config.get_recent_projects()
@@ -6079,7 +6093,7 @@ def create_app(
             }
         )
 
-    @app.post("/api/user/recent-projects/bind")
+    @app.post("/api/me/recent-projects/bind")
     def bind_recent_project(req: BindRecentProjectRequest) -> HealthResponse:
         """Switch the in-memory project. Used by the SPA picker route.
 
@@ -6951,7 +6965,7 @@ def create_app(
         proj.save(shooter_root)
         return get_beep_queue()
 
-    @app.post("/api/user/recent-projects/unbind")
+    @app.post("/api/me/recent-projects/unbind")
     def unbind_recent_project() -> HealthResponse:
         """Drop the bound project so the SPA returns to the picker.
 
@@ -6962,14 +6976,14 @@ def create_app(
         state.unbind()
         return HealthResponse(bound=False)
 
-    @app.get("/api/user/scoreboard-identity")
+    @app.get("/api/me/scoreboard-identity")
     def get_scoreboard_identity() -> JSONResponse:
         identity = user_config.load_scoreboard_identity()
         if identity is None:
             raise HTTPException(status_code=404, detail="no scoreboard identity saved")
         return JSONResponse(identity.model_dump(mode="json"))
 
-    @app.put("/api/user/scoreboard-identity")
+    @app.put("/api/me/scoreboard-identity")
     def put_scoreboard_identity(req: ScoreboardIdentityRequest) -> JSONResponse:
         identity = user_config.ScoreboardIdentity(
             shooter_id=req.shooter_id,
@@ -6981,7 +6995,7 @@ def create_app(
         user_config.save_scoreboard_identity(identity)
         return JSONResponse(identity.model_dump(mode="json"))
 
-    @app.delete("/api/user/scoreboard-identity")
+    @app.delete("/api/me/scoreboard-identity")
     def delete_scoreboard_identity() -> JSONResponse:
         user_config.clear_scoreboard_identity()
         return JSONResponse({"ok": True})

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -606,37 +606,6 @@ class AppState:
         self._bound_kind = None
         self._bound_name = None
 
-    # ------------------------------------------------------------------
-    # Migration scaffolding (#353 follow-up). REMOVE before merging the
-    # path-scoped refactor. Lets endpoints that haven't been migrated to
-    # the slug-in-path model keep functioning while the refactor is in
-    # flight. Match-mode: returns the first-registered shooter's root
-    # (matches the legacy "active shooter" behaviour the singleton used
-    # to encode). Legacy: returns the bound root directly.
-    @property
-    def project_root(self) -> Path:
-        if self._bound_root is None:
-            raise _no_project_error()
-        if self._bound_kind == "legacy":
-            return self._bound_root
-        match = match_model.Match.load(self._bound_root)
-        if not match.shooters:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "code": "match_empty",
-                    "message": f"Match {self._bound_root} has no shooters.",
-                },
-            )
-        return match_model.Match.shooter_root(self._bound_root, match.shooters[0])
-
-    @property
-    def project_name(self) -> str | None:
-        return self._bound_name
-
-    def load(self) -> MatchProject:
-        return MatchProject.load(self.project_root)
-
 
 def legacy_slug(project: MatchProject) -> str:
     """Synthesise a shooter slug for a legacy single-shooter project.
@@ -1943,7 +1912,7 @@ def create_app(
             background=BackgroundTask(shutil.rmtree, tmp, ignore_errors=True),
         )
 
-    @app.post("/api/project/import")
+    @app.post("/api/me/projects/import")
     async def import_project_endpoint(
         archive: UploadFile = File(...),
         dest_root: str = Form(...),
@@ -2602,7 +2571,7 @@ def create_app(
             stage = project.stage(stage_num)
             video = next((v for v in stage.videos if str(v.path) == video_path), None)
             if video is not None:
-                _auto_queue_beep_if_needed(project, stage_num, video)
+                _auto_queue_beep_if_needed(slug, project, stage_num, video)
 
         return ScanResponse(
             registered=registered,
@@ -2927,7 +2896,9 @@ def create_app(
             return None
         return result
 
-    def _run_detect_beep_for_video(handle: JobHandle, stage_number: int, video_id: str) -> None:
+    def _run_detect_beep_for_video(
+        handle: JobHandle, slug: str, stage_number: int, video_id: str
+    ) -> None:
         """Worker: detect ``video``'s beep, then auto-chain trim.
 
         Generic over role:
@@ -2939,12 +2910,12 @@ def create_app(
         own and the SPA can re-trim later.
         """
         handle.update(progress=0.05, message="Loading project...")
-        proj = state.load()
+        proj = state.shooter_project(slug)
         stg = proj.stage(stage_number)
         video = stg.find_video_by_id(video_id)
         if video is None:
             raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
-        source = proj.resolve_video_path(state.project_root, video.path)
+        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
         role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
         handle.update(
             progress=0.15,
@@ -2952,7 +2923,7 @@ def create_app(
         )
         try:
             beep = audio_helpers.detect_video_beep(
-                state.project_root,
+                state.shooter_root(slug),
                 stage_number,
                 video,
                 source,
@@ -2981,7 +2952,7 @@ def create_app(
             # same room means the loudness envelopes line up modulo a
             # constant time offset, even when the secondary's mic missed
             # the sustained 2-5 kHz tone the in-stream detector wants.
-            aligned = _try_align_secondary_to_primary(proj, stg, video, handle)
+            aligned = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
             video.beep_peak_amplitude = None
             video.beep_duration_ms = None
             video.beep_candidates = []
@@ -3062,7 +3033,7 @@ def create_app(
             # trust the in-stream answer; when they disagree we let the
             # user decide.
             if video.role != "primary":
-                check = _try_align_secondary_to_primary(proj, stg, video, handle)
+                check = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
                 if check is not None and check.confidence >= _align_confidence_floor:
                     video.beep_alignment_confidence = check.confidence
                     video.beep_alignment_delta_ms = (beep.time - check.secondary_beep_time) * 1000.0
@@ -3073,7 +3044,7 @@ def create_app(
             handle.update(progress=0.55, message=f"Trimming audit clip ({role_label})...")
             try:
                 audio_helpers.ensure_video_audit_trim(
-                    state.project_root,
+                    state.shooter_root(slug),
                     stage_number,
                     video,
                     source,
@@ -3101,7 +3072,7 @@ def create_app(
         # copying our targeted fields onto the fresh project preserves
         # those concurrent edits instead of stomping them with the
         # snapshot we loaded at job start.
-        fresh = state.load()
+        fresh = state.shooter_project(slug)
         try:
             stg_fresh = fresh.stage(stage_number)
         except KeyError:
@@ -3121,7 +3092,7 @@ def create_app(
             v_fresh.processed["beep"] = True
             if trimmed_ok:
                 v_fresh.processed["trim"] = True
-            fresh.save(state.project_root)
+            fresh.save(state.shooter_root(slug))
         if trimmed_ok and video.role == "primary" and video.beep_reviewed:
             # Shot detection is primary-only AND gated on
             # ``beep_reviewed`` (#71). That flag is True either because
@@ -3147,11 +3118,13 @@ def create_app(
                 state.jobs.submit(
                     kind="shot_detect",
                     stage_number=stage_number,
-                    fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+                    fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
                 )
         handle.update(progress=1.0, message="Done")
 
-    def _submit_detect_beep(stage_number: int, video: StageVideo) -> JSONResponse:
+    def _submit_detect_beep(
+        slug: str, stage_number: int, video: StageVideo
+    ) -> JSONResponse:
         """Validate + dedupe + queue a detect-beep job for ``video``.
 
         Shared by the per-video endpoint and the primary-only legacy
@@ -3167,12 +3140,14 @@ def create_app(
             kind="detect_beep",
             stage_number=stage_number,
             video_id=video.video_id,
-            fn=lambda h, n=stage_number, vid=video.video_id: _run_detect_beep_for_video(h, n, vid),
+            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: (
+                _run_detect_beep_for_video(h, sl, n, vid)
+            ),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
     def _auto_queue_beep_if_needed(
-        project: MatchProject, stage_number: int, video: StageVideo
+        slug: str, project: MatchProject, stage_number: int, video: StageVideo
     ) -> bool:
         """Best-effort auto-queue of detect_beep on a freshly-assigned video.
 
@@ -3206,7 +3181,7 @@ def create_app(
             return False
         if video.beep_source == "manual":
             return False
-        source = project.resolve_video_path(state.project_root, video.path)
+        source = project.resolve_video_path(state.shooter_root(slug), video.path)
         if not source.exists():
             logger.info(
                 "auto-beep skipped for stage %d video %s: source not reachable (%s)",
@@ -3215,11 +3190,12 @@ def create_app(
                 source,
             )
             return False
-        _submit_detect_beep(stage_number, video)
+        _submit_detect_beep(slug, stage_number, video)
         return True
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/detect-beep")
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/detect-beep")
     def detect_beep_for_video(
+        slug: str,
         stage_number: int, video_id: str, force: bool = False
     ) -> JSONResponse:
         """Submit a beep-detection job for ``video_id`` on ``stage_number``.
@@ -3231,9 +3207,9 @@ def create_app(
         primary results; secondaries align to the primary timeline by
         their own beep so they don't need their own shot timeline.
         """
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
         _ensure_source_reachable(
-            stage_number, project.resolve_video_path(state.project_root, video.path)
+            stage_number, project.resolve_video_path(state.shooter_root(slug), video.path)
         )
         if video.beep_source == "manual" and not force:
             raise HTTPException(
@@ -3243,10 +3219,10 @@ def create_app(
                     "replace it with auto-detected output"
                 ),
             )
-        return _submit_detect_beep(stage_number, video)
+        return _submit_detect_beep(slug, stage_number, video)
 
-    @app.post("/api/stages/{stage_number}/detect-beep")
-    def detect_beep(stage_number: int, force: bool = False) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/detect-beep")
+    def detect_beep(slug: str, stage_number: int, force: bool = False) -> JSONResponse:
         """Submit a beep-detection job for the stage's primary.
 
         Backward-compat shim that resolves the primary's id and forwards to
@@ -3254,7 +3230,7 @@ def create_app(
         polls ``/api/jobs/{id}`` for progress and refetches ``/api/project``
         on completion.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -3266,7 +3242,7 @@ def create_app(
                 detail=f"stage {stage_number} has no primary video",
             )
         _ensure_source_reachable(
-            stage_number, project.resolve_video_path(state.project_root, primary.path)
+            stage_number, project.resolve_video_path(state.shooter_root(slug), primary.path)
         )
         if primary.beep_source == "manual" and not force:
             raise HTTPException(
@@ -3276,10 +3252,10 @@ def create_app(
                     "replace it with auto-detected output"
                 ),
             )
-        return _submit_detect_beep(stage_number, primary)
+        return _submit_detect_beep(slug, stage_number, primary)
 
-    @app.post("/api/stages/{stage_number}/trim")
-    def trim_stage(stage_number: int) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/trim")
+    def trim_stage(slug: str, stage_number: int) -> JSONResponse:
         """Submit an audit-mode short-GOP trim job for the stage's primary.
 
         Backward-compat shim: forwards to the per-video pipeline. Returns
@@ -3287,7 +3263,7 @@ def create_app(
         MP4 is newer than the source, the job completes near-instantly
         without re-encoding.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -3298,9 +3274,10 @@ def create_app(
                 status_code=400,
                 detail=f"stage {stage_number} has no primary video",
             )
-        return _submit_trim(stage_number, stage, primary, project)
+        return _submit_trim(slug, stage_number, stage, primary, project)
 
     def _submit_trim(
+        slug: str,
         stage_number: int,
         stage: StageEntry,
         video: StageVideo,
@@ -3313,7 +3290,7 @@ def create_app(
         and a non-zero stage_time to define the trim window.
         """
         _ensure_source_reachable(
-            stage_number, project.resolve_video_path(state.project_root, video.path)
+            stage_number, project.resolve_video_path(state.shooter_root(slug), video.path)
         )
         if video.beep_time is None:
             raise HTTPException(
@@ -3337,17 +3314,19 @@ def create_app(
             kind="trim",
             stage_number=stage_number,
             video_id=video.video_id,
-            fn=lambda h, n=stage_number, vid=video.video_id: _run_trim_for_video(h, n, vid),
+            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: _run_trim_for_video(h, sl, n, vid),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/trim")
-    def trim_for_video(stage_number: int, video_id: str) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/trim")
+    def trim_for_video(slug: str, stage_number: int, video_id: str) -> JSONResponse:
         """Submit an audit-mode trim job for ``video_id`` on ``stage_number``."""
-        project, stage, video = _resolve_stage_video(stage_number, video_id)
-        return _submit_trim(stage_number, stage, video, project)
+        project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
+        return _submit_trim(slug, stage_number, stage, video, project)
 
-    def _run_trim_for_video(handle: JobHandle, stage_number: int, video_id: str) -> None:
+    def _run_trim_for_video(
+        handle: JobHandle, slug: str, stage_number: int, video_id: str
+    ) -> None:
         """Worker for the audit-mode trim of a specific video.
 
         Auto-chains shot detection only when the trimmed video is the
@@ -3355,17 +3334,17 @@ def create_app(
         their own beep, so they do not need their own shot-detection run.
         """
         handle.update(progress=0.1, message="Preparing trim...")
-        proj = state.load()
+        proj = state.shooter_project(slug)
         stg = proj.stage(stage_number)
         video = stg.find_video_by_id(video_id)
         if video is None or video.beep_time is None:
             raise RuntimeError("video or beep disappeared mid-flight")
-        source = proj.resolve_video_path(state.project_root, video.path)
+        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
         handle.check_cancel()
         role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
         handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
         audio_helpers.ensure_video_audit_trim(
-            state.project_root,
+            state.shooter_root(slug),
             stage_number,
             video,
             source,
@@ -3377,12 +3356,12 @@ def create_app(
         handle.update(progress=0.85, message="Saving project...")
         # Read-modify-write to avoid stomping concurrent edits made
         # while ffmpeg was running (e.g. another stage's beep review).
-        fresh = state.load()
+        fresh = state.shooter_project(slug)
         stg_fresh = fresh.stage(stage_number)
         v_fresh = stg_fresh.find_video_by_id(video_id)
         if v_fresh is not None:
             v_fresh.processed["trim"] = True
-            fresh.save(state.project_root)
+            fresh.save(state.shooter_root(slug))
         if (
             video.role == "primary"
             and video.beep_reviewed
@@ -3404,7 +3383,7 @@ def create_app(
                 state.jobs.submit(
                     kind="shot_detect",
                     stage_number=stage_number,
-                    fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+                    fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
                 )
         handle.update(progress=1.0, message="Done")
 
@@ -3453,7 +3432,7 @@ def create_app(
             fresh.save(shooter_root)
         handle.update(progress=1.0, message="Done")
 
-    def _run_trim_for_stage(handle: JobHandle, stage_number: int) -> None:
+    def _run_trim_for_stage(handle: JobHandle, slug: str, stage_number: int) -> None:
         """Backward-compat shim for legacy callers (e.g. beep-override
         endpoints) that submit a trim by stage_number alone.
 
@@ -3461,7 +3440,7 @@ def create_app(
         worker. New callers should pass a ``video_id`` and submit via
         :func:`_run_trim_for_video` directly.
         """
-        proj = state.load()
+        proj = state.shooter_project(slug)
         try:
             stg = proj.stage(stage_number)
         except KeyError as exc:
@@ -3469,9 +3448,11 @@ def create_app(
         primary = stg.primary()
         if primary is None:
             raise RuntimeError(f"stage {stage_number} has no primary mid-flight")
-        _run_trim_for_video(handle, stage_number, primary.video_id)
+        _run_trim_for_video(handle, slug, stage_number, primary.video_id)
 
-    def _run_shot_detect(handle: JobHandle, stage_number: int, reset: bool = False) -> None:
+    def _run_shot_detect(
+        handle: JobHandle, slug: str, stage_number: int, reset: bool = False
+    ) -> None:
         """Worker that runs the 4-voter ensemble on the stage's audit clip.
 
         Reads the trimmed clip's WAV (extracting it on demand if needed),
@@ -3492,7 +3473,7 @@ def create_app(
         top-(K+slack) mode and the apriori boost lifts the top-K
         confidence-ranked candidates over the consensus line.
         """
-        proj = state.load()
+        proj = state.shooter_project(slug)
         stg = proj.stage(stage_number)
         prim = stg.primary()
         if prim is None or prim.beep_time is None:
@@ -3502,7 +3483,7 @@ def create_app(
                 f"stage {stage_number} has time_seconds=0; import a "
                 "scoreboard before running shot detection"
             )
-        source = proj.resolve_video_path(state.project_root, prim.path)
+        source = proj.resolve_video_path(state.shooter_root(slug), prim.path)
 
         # Re-detect-all on an old project (and the v1->v2 cache migration in
         # #298) leaves stages with no trimmed MP4 cached. Without that file,
@@ -3514,7 +3495,7 @@ def create_app(
         handle.update(progress=0.05, message="Ensuring audit trim...")
         try:
             audio_helpers.ensure_video_audit_trim(
-                state.project_root,
+                state.shooter_root(slug),
                 stage_number,
                 prim,
                 source,
@@ -3523,14 +3504,14 @@ def create_app(
                 project=proj,
                 runner=_cancellable_runner(handle),
             )
-            trim_fresh = state.load()
+            trim_fresh = state.shooter_project(slug)
             try:
                 v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
             except KeyError:
                 v_fresh = None
             if v_fresh is not None and not v_fresh.processed.get("trim"):
                 v_fresh.processed["trim"] = True
-                trim_fresh.save(state.project_root)
+                trim_fresh.save(state.shooter_root(slug))
         except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
             # Soft failure: detection can still proceed against the source
             # WAV. ensure_audit_audio's fallback handles the missing trim,
@@ -3543,7 +3524,7 @@ def create_app(
 
         handle.update(progress=0.1, message="Preparing audio...")
         audit = audio_helpers.ensure_audit_audio(
-            state.project_root,
+            state.shooter_root(slug),
             stage_number,
             source,
             prim.beep_time,
@@ -3554,7 +3535,7 @@ def create_app(
         # Read existing audit JSON up-front: we need ``stage_rounds.expected``
         # before running detection (it changes voter C's mode and the
         # apriori boost) and we'll merge results back into the same dict.
-        audit_dir = proj.audit_path(state.project_root)
+        audit_dir = proj.audit_path(state.shooter_root(slug))
         audit_dir.mkdir(parents=True, exist_ok=True)
         audit_file = audit_dir / f"stage{stage_number}.json"
         if audit_file.exists():
@@ -3703,16 +3684,16 @@ def create_app(
         # interim (the review action kicks shot_detect, so concurrent
         # bursts are the common case). Reloading from disk and mutating
         # only the targeted field preserves those concurrent edits.
-        fresh = state.load()
+        fresh = state.shooter_project(slug)
         stg_fresh = fresh.stage(stage_number)
         prim_fresh = stg_fresh.primary()
         if prim_fresh is not None:
             prim_fresh.processed["shot_detect"] = True
-            fresh.save(state.project_root)
+            fresh.save(state.shooter_root(slug))
         handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
 
-    @app.post("/api/stages/shot-detect")
-    def shot_detect_all_endpoint(reset: bool = False) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/shot-detect")
+    def shot_detect_all_endpoint(slug: str, reset: bool = False) -> JSONResponse:
         """Submit shot-detection on every eligible stage in the project.
 
         A stage is eligible when it has a primary video with a confirmed
@@ -3726,7 +3707,7 @@ def create_app(
         ``reset=true`` clears each affected stage's ``shots[]`` before
         running, matching the per-stage endpoint's semantics.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         jobs: list[dict[str, Any]] = []
         skipped: list[dict[str, Any]] = []
         for stage in project.stages:
@@ -3748,13 +3729,13 @@ def create_app(
             job = state.jobs.submit(
                 kind="shot_detect",
                 stage_number=stage_number,
-                fn=lambda h, n=stage_number, r=reset: _run_shot_detect(h, n, reset=r),
+                fn=lambda h, sl=slug, n=stage_number, r=reset: _run_shot_detect(h, sl, n, reset=r),
             )
             jobs.append(job.model_dump(mode="json"))
         return JSONResponse({"jobs": jobs, "skipped": skipped})
 
-    @app.post("/api/stages/{stage_number}/shot-detect")
-    def shot_detect_endpoint(stage_number: int, reset: bool = False) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/shot-detect")
+    def shot_detect_endpoint(slug: str, stage_number: int, reset: bool = False) -> JSONResponse:
         """Submit a shot-detection job for the stage's audit clip.
 
         Returns a Job snapshot. Idempotent dedupe via the registry: a second
@@ -3764,7 +3745,7 @@ def create_app(
 
         ``reset=true`` wipes ``shots[]`` first so the user can start over.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -3795,7 +3776,7 @@ def create_app(
         job = state.jobs.submit(
             kind="shot_detect",
             stage_number=stage_number,
-            fn=lambda h, r=reset: _run_shot_detect(h, stage_number, reset=r),
+            fn=lambda h, sl=slug, r=reset: _run_shot_detect(h, sl, stage_number, reset=r),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -3851,6 +3832,7 @@ def create_app(
         return job
 
     def _apply_beep_override(
+        slug: str,
         project: MatchProject,
         stage: StageEntry,
         video: StageVideo,
@@ -3902,10 +3884,10 @@ def create_app(
                 video.processed["shot_detect"] = False
 
         audio_helpers.invalidate_video_audit_trim(
-            state.project_root, stage.stage_number, video, project=project
+            state.shooter_root(slug), stage.stage_number, video, project=project
         )
 
-    def _maybe_chain_trim(stage: StageEntry, video: StageVideo) -> None:
+    def _maybe_chain_trim(slug: str, stage: StageEntry, video: StageVideo) -> None:
         """Auto-fire a trim job for ``video`` when conditions allow.
 
         Used after a beep override / candidate select: if the user just
@@ -3926,7 +3908,7 @@ def create_app(
             kind="trim",
             stage_number=stage.stage_number,
             video_id=video.video_id,
-            fn=lambda h, n=stage.stage_number, vid=video.video_id: _run_trim_for_video(h, n, vid),
+            fn=lambda h, sl=slug, n=stage.stage_number, vid=video.video_id: _run_trim_for_video(h, sl, n, vid),
         )
 
     def _select_candidate_on_video(video: StageVideo, time_value: float) -> None:
@@ -3974,8 +3956,9 @@ def create_app(
         if video.role == "primary":
             video.processed["shot_detect"] = False
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep")
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep")
     def override_beep_for_video(
+        slug: str,
         stage_number: int, video_id: str, req: BeepOverrideRequest
     ) -> JSONResponse:
         """Manually set or clear ``video``'s beep timestamp.
@@ -3985,19 +3968,19 @@ def create_app(
         with ``beep_source="manual"``. Same dedupe + auto-trim chain as
         the legacy primary endpoint, just keyed per video.
         """
-        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         if req.beep_time is not None and req.beep_time < 0.0:
             raise HTTPException(status_code=400, detail="beep_time must be >= 0")
-        _apply_beep_override(project, stage, video, req.beep_time)
-        project.save(state.project_root)
+        _apply_beep_override(slug, project, stage, video, req.beep_time)
+        project.save(state.shooter_root(slug))
         if req.beep_time is not None:
-            _maybe_chain_trim(stage, video)
+            _maybe_chain_trim(slug, stage, video)
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/stages/{stage_number}/beep")
-    def override_beep(stage_number: int, req: BeepOverrideRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/beep")
+    def override_beep(slug: str, stage_number: int, req: BeepOverrideRequest) -> JSONResponse:
         """Backward-compat shim: manually set / clear the primary's beep."""
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -4010,14 +3993,14 @@ def create_app(
             )
         if req.beep_time is not None and req.beep_time < 0.0:
             raise HTTPException(status_code=400, detail="beep_time must be >= 0")
-        _apply_beep_override(project, stage, primary, req.beep_time)
-        project.save(state.project_root)
+        _apply_beep_override(slug, project, stage, primary, req.beep_time)
+        project.save(state.shooter_root(slug))
         if req.beep_time is not None:
-            _maybe_chain_trim(stage, primary)
+            _maybe_chain_trim(slug, stage, primary)
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/stages/{stage_number}/time")
-    def set_stage_time(stage_number: int, req: StageTimeRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/time")
+    def set_stage_time(slug: str, stage_number: int, req: StageTimeRequest) -> JSONResponse:
         """Manually set or clear the stage duration.
 
         For projects without scoreboard data (the only source that
@@ -4030,7 +4013,7 @@ def create_app(
         Does NOT auto-chain a trim job -- the user clicks Trim
         themselves once they're satisfied with the duration.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -4046,11 +4029,11 @@ def create_app(
                 )
             stage.time_seconds = float(req.time_seconds)
             stage.time_seconds_manual = True
-        project.save(state.project_root)
+        project.save(state.shooter_root(slug))
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/snap")
-    def snap_beep_for_video(stage_number: int, video_id: str, req: BeepSnapRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/snap")
+    def snap_beep_for_video(slug: str, stage_number: int, video_id: str, req: BeepSnapRequest) -> JSONResponse:
         """Refine a user-placed beep marker by snapping it to the strongest
         tone in a tight window around the hint.
 
@@ -4065,8 +4048,8 @@ def create_app(
         criteria. The SPA surfaces that as "no beep found nearby; widen
         the window or move the marker".
         """
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
-        source = project.resolve_video_path(state.project_root, video.path)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
+        source = project.resolve_video_path(state.shooter_root(slug), video.path)
         _ensure_source_reachable(stage_number, source)
         if req.hint_time < 0.0:
             raise HTTPException(status_code=400, detail="hint_time must be >= 0")
@@ -4074,7 +4057,7 @@ def create_app(
             raise HTTPException(status_code=400, detail="window_s must be > 0")
 
         audio_path = audio_helpers.ensure_video_audio(
-            state.project_root, stage_number, video, source, project=project
+            state.shooter_root(slug), stage_number, video, source, project=project
         )
         audio, sr = beep_detect.load_audio(audio_path)
         duration_s = audio.size / sr if sr > 0 else 0.0
@@ -4141,22 +4124,23 @@ def create_app(
             ).model_dump()
         )
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/select")
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/select")
     def select_beep_candidate_for_video(
+        slug: str,
         stage_number: int, video_id: str, req: BeepSelectRequest
     ) -> JSONResponse:
         """Promote one of ``video``'s ranked candidates as authoritative."""
-        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         _select_candidate_on_video(video, req.time)
         audio_helpers.invalidate_video_audit_trim(
-            state.project_root, stage_number, video, project=project
+            state.shooter_root(slug), stage_number, video, project=project
         )
-        project.save(state.project_root)
-        _maybe_chain_trim(stage, video)
+        project.save(state.shooter_root(slug))
+        _maybe_chain_trim(slug, stage, video)
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/stages/{stage_number}/videos/{video_id}/beep/review")
-    def set_beep_reviewed(stage_number: int, video_id: str, req: BeepReviewRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/review")
+    def set_beep_reviewed(slug: str, stage_number: int, video_id: str, req: BeepReviewRequest) -> JSONResponse:
         """Flip ``video.beep_reviewed`` (issue #71).
 
         Setting True requires ``beep_time`` to be set; setting False is
@@ -4167,14 +4151,14 @@ def create_app(
         ensemble doesn't burn cycles on an unconfirmed beep, and we
         finally fire it here once the user has listened and approved).
         """
-        project, stage, video = _resolve_stage_video(stage_number, video_id)
+        project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         if req.reviewed and video.beep_time is None:
             raise HTTPException(
                 status_code=400,
                 detail="cannot mark a beep reviewed before one has been detected",
             )
         video.beep_reviewed = bool(req.reviewed)
-        project.save(state.project_root)
+        project.save(state.shooter_root(slug))
 
         # When the user confirms the primary's beep AND the trim is
         # already cached from the auto-detect chain, kick off the
@@ -4190,13 +4174,13 @@ def create_app(
             state.jobs.submit(
                 kind="shot_detect",
                 stage_number=stage_number,
-                fn=lambda h, n=stage_number: _run_shot_detect(h, n),
+                fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
             )
 
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.patch("/api/stages/{stage_number}/videos/{video_id}/camera-mount")
-    def set_camera_mount(stage_number: int, video_id: str, req: CameraMountRequest) -> JSONResponse:
+    @app.patch("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/camera-mount")
+    def set_camera_mount(slug: str, stage_number: int, video_id: str, req: CameraMountRequest) -> JSONResponse:
         """Override the heuristic ``camera_mount`` (issue #143).
 
         Validated against the fixture-schema ``CameraMount`` enum so
@@ -4204,7 +4188,7 @@ def create_app(
         override -- the next shot-detect run will use the artifact's
         default class instead of a per-class threshold.
         """
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
         from ..fixture_schema import CameraMount
 
         if req.mount is not None:
@@ -4219,11 +4203,11 @@ def create_app(
                     ),
                 ) from exc
         video.camera_mount = req.mount
-        project.save(state.project_root)
+        project.save(state.shooter_root(slug))
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.patch("/api/stages/{stage_number}/videos/{video_id}/camera-model")
-    def set_camera_model(stage_number: int, video_id: str, req: CameraModelRequest) -> JSONResponse:
+    @app.patch("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/camera-model")
+    def set_camera_model(slug: str, stage_number: int, video_id: str, req: CameraModelRequest) -> JSONResponse:
         """Override the ffprobed camera make + model (#303-followup).
 
         Used when ffprobe couldn't read the QuickTime tag (e.g. Meta
@@ -4243,10 +4227,10 @@ def create_app(
                 status_code=400,
                 detail="camera-model: 'make' and 'model' must be supplied together or both null",
             )
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
         video.camera_make = req.make
         video.camera_model = req.model
-        project.save(state.project_root)
+        project.save(state.shooter_root(slug))
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.get("/api/calibrated-camera-models")
@@ -4282,8 +4266,8 @@ def create_app(
         rows.sort(key=lambda r: (-r["amp_floor"], r["key"]))
         return JSONResponse({"models": rows})
 
-    @app.post("/api/stages/{stage_number}/beep/select")
-    def select_beep_candidate(stage_number: int, req: BeepSelectRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/beep/select")
+    def select_beep_candidate(slug: str, stage_number: int, req: BeepSelectRequest) -> JSONResponse:
         """Backward-compat shim: promote a ranked candidate on the primary.
 
         Lets the user fix a wrong auto-pick without typing a timestamp.
@@ -4291,7 +4275,7 @@ def create_app(
         from the detector -- we only changed which candidate the project
         trusts. Triggers a re-trim so the cached audit clip lines up.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -4304,14 +4288,14 @@ def create_app(
             )
         _select_candidate_on_video(primary, req.time)
         audio_helpers.invalidate_video_audit_trim(
-            state.project_root, stage_number, primary, project=project
+            state.shooter_root(slug), stage_number, primary, project=project
         )
-        project.save(state.project_root)
-        _maybe_chain_trim(stage, primary)
+        project.save(state.shooter_root(slug))
+        _maybe_chain_trim(slug, stage, primary)
         return JSONResponse(project.model_dump(mode="json"))
 
     def _resolve_audit_audio(
-        project: MatchProject, stage_number: int
+        slug: str, project: MatchProject, stage_number: int
     ) -> audio_helpers.AuditAudioResult:
         """Shared resolver for /audio + /peaks: prefers the trimmed clip's
         WAV, falls back to full primary on cache miss / no trim."""
@@ -4327,9 +4311,9 @@ def create_app(
             )
         try:
             return audio_helpers.ensure_audit_audio(
-                state.project_root,
+                state.shooter_root(slug),
                 stage_number,
-                project.resolve_video_path(state.project_root, primary.path),
+                project.resolve_video_path(state.shooter_root(slug), primary.path),
                 primary.beep_time,
                 project=project,
             )
@@ -4339,7 +4323,7 @@ def create_app(
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     def _resolve_video_audio(
-        project: MatchProject, stage_number: int, video: StageVideo
+        slug: str, project: MatchProject, stage_number: int, video: StageVideo
     ) -> audio_helpers.AuditAudioResult:
         """Per-video version of :func:`_resolve_audit_audio`.
 
@@ -4353,10 +4337,10 @@ def create_app(
         ``beep_in_clip`` is just ``video.beep_time``; the WAV is in source
         time so no trim offset applies.
         """
-        source = project.resolve_video_path(state.project_root, video.path)
+        source = project.resolve_video_path(state.shooter_root(slug), video.path)
         try:
             audio_path = audio_helpers.ensure_video_audio(
-                state.project_root,
+                state.shooter_root(slug),
                 stage_number,
                 video,
                 source,
@@ -4373,6 +4357,7 @@ def create_app(
         )
 
     def _serve_beep_preview(
+        slug: str,
         project: MatchProject,
         stage_number: int,
         video: StageVideo,
@@ -4383,7 +4368,7 @@ def create_app(
         Shared by the legacy primary endpoint and the per-video endpoint
         so both honour the same 404 / 424 / cache semantics.
         """
-        source = project.resolve_video_path(state.project_root, video.path)
+        source = project.resolve_video_path(state.shooter_root(slug), video.path)
         _ensure_source_reachable(stage_number, source)
         center = t if t is not None else video.beep_time
         if center is None:
@@ -4393,7 +4378,7 @@ def create_app(
             )
         if center < 0:
             raise HTTPException(status_code=400, detail="t must be >= 0")
-        thumbs_dir = project.thumbs_path(state.project_root)
+        thumbs_dir = project.thumbs_path(state.shooter_root(slug))
         try:
             clip = thumbnail_helpers.ensure_clip(
                 source,
@@ -4406,16 +4391,17 @@ def create_app(
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         return FileResponse(clip, media_type="video/mp4", filename=clip.name)
 
-    @app.get("/api/stages/{stage_number}/videos/{video_id}/beep-preview")
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep-preview")
     def video_beep_preview(
+        slug: str,
         stage_number: int, video_id: str, t: float | None = None
     ) -> FileResponse:
         """Serve a ~1 s MP4 around ``video``'s beep (or override ``t``)."""
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
-        return _serve_beep_preview(project, stage_number, video, t)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
+        return _serve_beep_preview(slug, project, stage_number, video, t)
 
-    @app.get("/api/stages/{stage_number}/beep-preview")
-    def stage_beep_preview(stage_number: int, t: float | None = None) -> FileResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/beep-preview")
+    def stage_beep_preview(slug: str, stage_number: int, t: float | None = None) -> FileResponse:
         """Serve a tiny MP4 around the primary's beep timestamp (#27, #22).
 
         Default center is the primary's persisted ``beep_time``. The
@@ -4424,7 +4410,7 @@ def create_app(
         promoting them first. Cache keys on (source mtime/size, center
         time, duration), so each distinct ``t`` gets its own cached clip.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -4435,10 +4421,10 @@ def create_app(
                 status_code=404,
                 detail=f"stage {stage_number} has no primary video",
             )
-        return _serve_beep_preview(project, stage_number, primary, t)
+        return _serve_beep_preview(slug, project, stage_number, primary, t)
 
-    @app.get("/api/stages/{stage_number}/audio")
-    def stage_audio(stage_number: int) -> FileResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/audio")
+    def stage_audio(slug: str, stage_number: int) -> FileResponse:
         """Serve the audit-clip WAV for ``stage_number``.
 
         Prefers the primary's audit WAV (extracted from the short-GOP trimmed
@@ -4447,16 +4433,17 @@ def create_app(
         when no trimmed clip exists yet -- the SPA surfaces this with a
         "trim required" hint.
         """
-        project = state.load()
-        result = _resolve_audit_audio(project, stage_number)
+        project = state.shooter_project(slug)
+        result = _resolve_audit_audio(slug, project, stage_number)
         return FileResponse(
             result.audio_path,
             media_type="audio/wav",
             filename=result.audio_path.name,
         )
 
-    @app.get("/api/stages/{stage_number}/peaks")
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/peaks")
     def stage_peaks(
+        slug: str,
         stage_number: int,
         bins: int = Query(default=1200, ge=16, le=8192),
     ) -> JSONResponse:
@@ -4468,16 +4455,16 @@ def create_app(
         timeline + ``trimmed`` so the SPA can render the beep marker
         correctly and warn when the user is auditing an untrimmed source.
         """
-        project = state.load()
-        audit = _resolve_audit_audio(project, stage_number)
+        project = state.shooter_project(slug)
+        audit = _resolve_audit_audio(slug, project, stage_number)
         peaks = waveform_helpers.ensure_peaks(audit.audio_path, bins)
         payload = peaks.model_dump(mode="json")
         payload["beep_time"] = audit.beep_in_clip
         payload["trimmed"] = audit.trimmed
         return JSONResponse(payload)
 
-    @app.get("/api/stages/{stage_number}/videos/{video_id}/audio")
-    def video_audio(stage_number: int, video_id: str) -> FileResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/audio")
+    def video_audio(slug: str, stage_number: int, video_id: str) -> FileResponse:
         """Serve ``video``'s WAV for the per-video beep picker.
 
         Primary forwards to the legacy stage audio resolver so the
@@ -4487,16 +4474,17 @@ def create_app(
         the user can find the buzzer / first-shot regardless of where
         the current beep estimate is.
         """
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
-        result = _resolve_video_audio(project, stage_number, video)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
+        result = _resolve_video_audio(slug, project, stage_number, video)
         return FileResponse(
             result.audio_path,
             media_type="audio/wav",
             filename=result.audio_path.name,
         )
 
-    @app.get("/api/stages/{stage_number}/videos/{video_id}/peaks")
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/peaks")
     def video_peaks(
+        slug: str,
         stage_number: int,
         video_id: str,
         bins: int = Query(default=1200, ge=16, le=8192),
@@ -4507,16 +4495,16 @@ def create_app(
         picker can take the same path for primary + secondary -- the
         only thing that varies between roles is the URL.
         """
-        project, _stage, video = _resolve_stage_video(stage_number, video_id)
-        audit = _resolve_video_audio(project, stage_number, video)
+        project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
+        audit = _resolve_video_audio(slug, project, stage_number, video)
         peaks = waveform_helpers.ensure_peaks(audit.audio_path, bins)
         payload = peaks.model_dump(mode="json")
         payload["beep_time"] = audit.beep_in_clip
         payload["trimmed"] = audit.trimmed
         return JSONResponse(payload)
 
-    @app.get("/api/stages/{stage_number}/audit")
-    def get_stage_audit(stage_number: int) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/audit")
+    def get_stage_audit(slug: str, stage_number: int) -> JSONResponse:
         """Return the stage's audit JSON (issue #15) if one has been written.
 
         Lives at ``<project>/audit/stage<N>.json`` -- the same path the
@@ -4524,12 +4512,12 @@ def create_app(
         exists yet (the audit screen treats this as "fresh -- start from
         candidates if any, otherwise empty markers").
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_file = project.audit_path(state.project_root) / f"stage{stage_number}.json"
+        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
         if not audit_file.exists():
             raise HTTPException(
                 status_code=404,
@@ -4541,8 +4529,8 @@ def create_app(
             raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
         return JSONResponse(payload)
 
-    @app.put("/api/stages/{stage_number}/audit")
-    def put_stage_audit(stage_number: int, payload: dict[str, Any]) -> JSONResponse:
+    @app.put("/api/shooters/{slug}/stages/{stage_number}/audit")
+    def put_stage_audit(slug: str, stage_number: int, payload: dict[str, Any]) -> JSONResponse:
         """Atomically write the audit JSON for a stage.
 
         Layout follows the existing audit-prep / audit-apply convention plus
@@ -4557,12 +4545,12 @@ def create_app(
         rename ``.tmp`` to final. A crashed process never leaves the SPA
         without a readable JSON.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_dir = project.audit_path(state.project_root)
+        audit_dir = project.audit_path(state.shooter_root(slug))
         audit_dir.mkdir(parents=True, exist_ok=True)
         target = audit_dir / f"stage{stage_number}.json"
         tmp = target.with_suffix(target.suffix + ".tmp")
@@ -4580,8 +4568,8 @@ def create_app(
             raise HTTPException(status_code=500, detail=f"audit write failed: {exc}") from exc
         return JSONResponse(payload)
 
-    @app.get("/api/stages/{stage_number}/anomalies")
-    def get_stage_anomalies(stage_number: int) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/anomalies")
+    def get_stage_anomalies(slug: str, stage_number: int) -> JSONResponse:
         """Return structured anomalies for the saved audit JSON (issue #42).
 
         Single source of truth for ``report.detect_anomalies_structured``:
@@ -4595,13 +4583,13 @@ def create_app(
         beep yet, or an empty ``shots[]`` -- the SPA renders these as
         "no anomalies" / "no shots audited yet" depending on context.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stg = project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-        audit_file = project.audit_path(state.project_root) / f"stage{stage_number}.json"
+        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
         if not audit_file.exists():
             return JSONResponse({"anomalies": []})
         try:
@@ -4627,6 +4615,7 @@ def create_app(
     # ----------------------------------------------------------------------
 
     def _video_beep_in_clip(
+        slug: str,
         project: MatchProject,
         stage_number: int,
         video: StageVideo,
@@ -4644,13 +4633,13 @@ def create_app(
         if video.beep_time is None:
             return None
         trimmed = audio_helpers.trimmed_video_path(
-            state.project_root, stage_number, video, project=project
+            state.shooter_root(slug), stage_number, video, project=project
         )
         if trimmed.exists() and trimmed.stat().st_size > 0:
             return min(video.beep_time, project.trim_pre_buffer_seconds)
         return video.beep_time
 
-    def _coach_video_entries(project: MatchProject, stg: Any) -> list[dict[str, Any]]:
+    def _coach_video_entries(slug: str, project: MatchProject, stg: Any) -> list[dict[str, Any]]:
         """Per-video metadata the SPA needs to seek every synced camera.
 
         Order mirrors VideoPanel's expectation: primary first, then
@@ -4670,23 +4659,24 @@ def create_app(
                 {
                     "path": str(v.path),
                     "role": v.role,
-                    "beep_in_clip": _video_beep_in_clip(project, stg.stage_number, v),
+                    "beep_in_clip": _video_beep_in_clip(slug, project, stg.stage_number, v),
                 }
             )
         return out
 
     def _load_audit_for_coach(
+        slug: str,
         stage_number: int,
     ) -> tuple[dict[str, Any], Path, float | None, Any, MatchProject]:
         """Shared loader: validates the stage, reads the audit JSON,
         returns (payload, path, primary_beep_in_clip, stage, project).
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stg = project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_file = project.audit_path(state.project_root) / f"stage{stage_number}.json"
+        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
         if not audit_file.exists():
             raise HTTPException(
                 status_code=404,
@@ -4698,7 +4688,7 @@ def create_app(
             raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
         prim = stg.primary()
         primary_beep_in_clip = (
-            _video_beep_in_clip(project, stage_number, prim) if prim is not None else None
+            _video_beep_in_clip(slug, project, stage_number, prim) if prim is not None else None
         )
         return payload, audit_file, primary_beep_in_clip, stg, project
 
@@ -4718,6 +4708,7 @@ def create_app(
             raise HTTPException(status_code=500, detail=f"coach write failed: {exc}") from exc
 
     def _build_coach_response(
+        slug: str,
         payload: dict[str, Any],
         primary_beep_in_clip: float | None,
         stg: Any,
@@ -4776,12 +4767,12 @@ def create_app(
             # secondaries (each ``videos[i].beep_in_clip`` mirrors this
             # field for that camera's served clip).
             "beep_time": clip_anchor,
-            "videos": _coach_video_entries(project, stg),
+            "videos": _coach_video_entries(slug, project, stg),
             "shots": coach_shots,
         }
 
-    @app.get("/api/stages/{stage_number}/coach")
-    def get_stage_coach(stage_number: int) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/coach")
+    def get_stage_coach(slug: str, stage_number: int) -> JSONResponse:
         """Return the per-shot coach view for a stage.
 
         Read-only: the stored ``interval_class`` is surfaced as-is, plus a
@@ -4789,17 +4780,17 @@ def create_app(
         client can call ``POST /coach/reclassify`` to persist the rule's
         verdict onto unset/auto entries.
         """
-        payload, _audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
+        payload, _audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
-        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
+        return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
-    @app.post("/api/stages/{stage_number}/coach/reclassify")
-    def reclassify_stage_coach(stage_number: int) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/coach/reclassify")
+    def reclassify_stage_coach(slug: str, stage_number: int) -> JSONResponse:
         """Force the auto-classifier to (re)write ``interval_class`` for
         every shot whose source is unset or ``"auto"``. Manual entries are
         preserved. Idempotent.
         """
-        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
+        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -4815,10 +4806,11 @@ def create_app(
         )
         payload["audit_events"] = events
         _coach_atomic_write(audit_file, payload)
-        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
+        return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
-    @app.patch("/api/stages/{stage_number}/shots/{shot_number}/coach")
+    @app.patch("/api/shooters/{slug}/stages/{stage_number}/shots/{shot_number}/coach")
     def patch_stage_shot_coach(
+        slug: str,
         stage_number: int,
         shot_number: int,
         body: CoachShotPatchRequest,
@@ -4826,7 +4818,7 @@ def create_app(
         """Patch the coaching annotation fields on one shot. Returns the
         updated coach response for the stage so the client can refresh.
         """
-        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(stage_number)
+        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -4870,17 +4862,17 @@ def create_app(
         )
         payload["audit_events"] = events
         _coach_atomic_write(audit_file, payload)
-        return JSONResponse(_build_coach_response(payload, beep_in_clip, stg, project, cfg))
+        return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
-    @app.get("/api/stages/{stage_number}/coach/distributions")
-    def get_stage_coach_distributions(stage_number: int) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/stages/{stage_number}/coach/distributions")
+    def get_stage_coach_distributions(slug: str, stage_number: int) -> JSONResponse:
         """Histograms + summary stats for one stage's coach annotations.
 
         Unset interval classes are computed in memory; nothing persists.
         Empty classes still appear in the response with count=0 so the
         UI can render an empty histogram without a special case.
         """
-        payload, _audit_file, _beep_in_clip, stg, _project = _load_audit_for_coach(stage_number)
+        payload, _audit_file, _beep_in_clip, stg, _project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -4893,15 +4885,15 @@ def create_app(
         )
         return JSONResponse(result.model_dump())
 
-    @app.get("/api/coach/distributions")
-    def get_match_coach_distributions() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/coach/distributions")
+    def get_match_coach_distributions(slug: str) -> JSONResponse:
         """Match-level distributions across every stage with an audit
         JSON. Stages without an audit are silently skipped -- they
         haven't been audited yet so they'd just dilute the average.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         cfg = CoachAutoClassifyConfig()
-        audit_dir = project.audit_path(state.project_root)
+        audit_dir = project.audit_path(state.shooter_root(slug))
         triples: list[tuple[int, str, list[dict[str, Any]]]] = []
         for stg in project.stages:
             audit_file = audit_dir / f"stage{stg.stage_number}.json"
@@ -5032,8 +5024,9 @@ def create_app(
         media_type = "video/mp4" if target.suffix.lower() == ".mp4" else "application/octet-stream"
         return FileResponse(target, media_type=media_type, filename=target.name)
 
-    @app.get("/api/videos/stream")
+    @app.get("/api/shooters/{slug}/videos/stream")
     def stream_video(
+        slug: str,
         path: str = Query(...),
         kind: Literal["auto", "trim", "source"] = Query("auto"),
     ) -> FileResponse:
@@ -5061,7 +5054,8 @@ def create_app(
         (any stage, any role, or unassigned) so the endpoint cannot be
         used as a generic file-read primitive.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         located = project.find_video(Path(path))
         if located is None:
             raise HTTPException(
@@ -5076,7 +5070,7 @@ def create_app(
             # its own scrub clip cut around its own beep, so dragging
             # the audit playhead doesn't stall on a 4K MOV from a phone.
             trimmed = audio_helpers.trimmed_video_path(
-                state.project_root, stage.stage_number, video, project=project
+                root, stage.stage_number, video, project=project
             )
             if trimmed.exists():
                 served_path = trimmed.resolve()
@@ -5086,7 +5080,7 @@ def create_app(
                     status_code=404,
                     detail=f"trimmed clip not built yet for {path}",
                 )
-            served_path = project.resolve_video_path(state.project_root, video.path).resolve()
+            served_path = project.resolve_video_path(root, video.path).resolve()
             # Same structured shape as detect-beep / trim / preview so
             # the SPA's "reconnect external storage" surface is uniform.
             _ensure_source_reachable(stage.stage_number if stage is not None else None, served_path)
@@ -5096,8 +5090,9 @@ def create_app(
         )
         return FileResponse(served_path, media_type=media_type, filename=served_path.name)
 
-    @app.get("/api/fs/list", response_model=FsListing)
+    @app.get("/api/shooters/{slug}/fs/list", response_model=FsListing)
     def fs_list(
+        slug: str,
         path: str | None = Query(default=None),
         probe: bool = Query(default=False),
     ) -> FsListing:
@@ -5117,7 +5112,7 @@ def create_app(
           probes / thumbnails always populate -- the budget only gates the
           first-time work.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         target = Path(path).expanduser() if path else _default_start(project.last_scanned_dir)
         try:
             target = target.resolve(strict=True)
@@ -5132,8 +5127,8 @@ def create_app(
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
 
-        probes_dir = project.probes_path(state.project_root)
-        thumbs_dir = project.thumbs_path(state.project_root)
+        probes_dir = project.probes_path(state.shooter_root(slug))
+        thumbs_dir = project.thumbs_path(state.shooter_root(slug))
         budget_deadline = time.monotonic() + 5.0  # wall-clock budget for new probes
 
         for child in children:
@@ -5151,6 +5146,7 @@ def create_app(
                     if is_video:
                         duration, thumbnail_url = _video_metadata_for(
                             child,
+            slug=slug,
                             probes_dir=probes_dir,
                             thumbs_dir=thumbs_dir,
                             allow_new=probe and time.monotonic() < budget_deadline,
@@ -5181,8 +5177,8 @@ def create_app(
             suggested_starts=suggested,
         )
 
-    @app.get("/api/fs/probe")
-    def fs_probe(path: str = Query(...)) -> JSONResponse:
+    @app.get("/api/shooters/{slug}/fs/probe")
+    def fs_probe(slug: str, path: str = Query(...)) -> JSONResponse:
         """Probe a single video file on demand: ffprobe + thumbnail extraction.
 
         Used by the SPA when a picker row came back with null fields (the
@@ -5191,11 +5187,11 @@ def create_app(
         surfaces resolution/codec/size so the unassigned-tray rows can show
         enough metadata for the user to identify which clip is which.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         # StageVideo.path is project-relative for default projects, so resolve
         # via the project root rather than process CWD before strict-resolving.
         raw_target = Path(path).expanduser()
-        target = project.resolve_video_path(state.project_root, raw_target)
+        target = project.resolve_video_path(state.shooter_root(slug), raw_target)
         try:
             target = target.resolve(strict=True)
         except (FileNotFoundError, OSError) as exc:
@@ -5205,10 +5201,11 @@ def create_app(
         if target.suffix.lower() not in VIDEO_EXTENSIONS:
             raise HTTPException(status_code=400, detail=f"not a video: {target}")
 
-        probes_dir = project.probes_path(state.project_root)
-        thumbs_dir = project.thumbs_path(state.project_root)
+        probes_dir = project.probes_path(state.shooter_root(slug))
+        thumbs_dir = project.thumbs_path(state.shooter_root(slug))
         duration, thumbnail_url = _video_metadata_for(
             target,
+            slug=slug,
             probes_dir=probes_dir,
             thumbs_dir=thumbs_dir,
             allow_new=True,
@@ -5231,8 +5228,8 @@ def create_app(
             }
         )
 
-    @app.get("/api/thumbnails/{cache_key}.jpg", include_in_schema=False)
-    def serve_thumbnail(cache_key: str) -> FileResponse:
+    @app.get("/api/shooters/{slug}/thumbnails/{cache_key}.jpg", include_in_schema=False)
+    def serve_thumbnail(slug: str, cache_key: str) -> FileResponse:
         """Serve a cached thumbnail by its content-addressed key.
 
         Keys are 16-char hex from :func:`video_probe.source_cache_key`. We
@@ -5241,21 +5238,21 @@ def create_app(
         """
         if not cache_key.isalnum() or len(cache_key) > 32:
             raise HTTPException(status_code=400, detail="invalid thumbnail key")
-        project = state.load()
-        thumbs_dir = project.thumbs_path(state.project_root)
+        project = state.shooter_project(slug)
+        thumbs_dir = project.thumbs_path(state.shooter_root(slug))
         candidate = thumbs_dir / f"{cache_key}.jpg"
         if not candidate.exists():
             raise HTTPException(status_code=404, detail="thumbnail not cached")
         return FileResponse(candidate, media_type="image/jpeg", filename=candidate.name)
 
-    @app.post("/api/videos/auto-match")
-    def auto_match() -> JSONResponse:
-        project = state.load()
-        suggestions = project.auto_match(state.project_root)
+    @app.post("/api/shooters/{slug}/videos/auto-match")
+    def auto_match(slug: str) -> JSONResponse:
+        project = state.shooter_project(slug)
+        suggestions = project.auto_match(state.shooter_root(slug))
         return JSONResponse({str(stage_num): str(path) for stage_num, path in suggestions.items()})
 
-    @app.post("/api/videos/remove")
-    def remove_video(req: RemoveVideoRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/videos/remove")
+    def remove_video(slug: str, req: RemoveVideoRequest) -> JSONResponse:
         """Remove a registered video and clean up its caches.
 
         Walks the :class:`RemovalPlan` returned by the model: unlinks the
@@ -5267,11 +5264,12 @@ def create_app(
         the same stage with a different file picks up where the user left
         off.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             plan = project.remove_video(
                 Path(req.video_path),
-                state.project_root,
+                root,
                 reset_audit=req.reset_audit,
             )
         except KeyError as exc:
@@ -5286,7 +5284,7 @@ def create_app(
             elif plan.raw_link_path.exists():
                 # Treat as a copy splitsmith placed (link_mode="copy"). We
                 # only delete files inside raw_dir; never anything beyond.
-                raw_dir = project.raw_path(state.project_root).resolve()
+                raw_dir = project.raw_path(root).resolve()
                 try:
                     plan.raw_link_path.resolve().relative_to(raw_dir)
                     plan.raw_link_path.unlink()
@@ -5313,7 +5311,7 @@ def create_app(
             except OSError as exc:
                 logger.warning("could not remove audit %s: %s", plan.audit_path, exc)
 
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(
             {
                 "project": project.model_dump(mode="json"),
@@ -5321,8 +5319,9 @@ def create_app(
             }
         )
 
-    @app.get("/api/project/cleanup/plan")
+    @app.get("/api/shooters/{slug}/project/cleanup/plan")
     def cleanup_plan(
+        slug: str,
         categories: str = Query("", description="Comma-separated category list."),
     ) -> JSONResponse:
         """Preview a cleanup plan without deleting anything.
@@ -5331,7 +5330,7 @@ def create_app(
         the SPA can debounce-fetch as the user toggles checkboxes
         without worrying about partial selections.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         cats: set[cleanup_module.CleanupCategory] = set()
         for token in categories.split(","):
             token = token.strip()
@@ -5343,11 +5342,11 @@ def create_app(
                 # Skip unknown categories silently; the SPA only sends
                 # known ones, and a stale tab shouldn't crash here.
                 continue
-        plan = cleanup_module.plan_cleanup(project, state.project_root, cats)
+        plan = cleanup_module.plan_cleanup(project, state.shooter_root(slug), cats)
         return JSONResponse(plan.model_dump(mode="json"))
 
-    @app.post("/api/project/cleanup")
-    def cleanup_apply(req: CleanupRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/project/cleanup")
+    def cleanup_apply(slug: str, req: CleanupRequest) -> JSONResponse:
         """Apply a cleanup. Refuses while jobs are pending or running.
 
         Re-plans server-side: the client only sends categories, never
@@ -5369,10 +5368,11 @@ def create_app(
                     "kind": active.kind,
                 },
             )
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         cats = set(req.categories)
-        plan = cleanup_module.plan_cleanup(project, state.project_root, cats)
-        result = cleanup_module.apply_cleanup(plan, root=state.project_root)
+        plan = cleanup_module.plan_cleanup(project, root, cats)
+        result = cleanup_module.apply_cleanup(plan, root=root)
         return JSONResponse(
             {
                 "plan": plan.model_dump(mode="json"),
@@ -5380,9 +5380,10 @@ def create_app(
             }
         )
 
-    @app.post("/api/assignments/move")
-    def move_assignment(req: MoveRequest) -> JSONResponse:
-        project = state.load()
+    @app.post("/api/shooters/{slug}/assignments/move")
+    def move_assignment(slug: str, req: MoveRequest) -> JSONResponse:
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             project.assign_video(
                 Path(req.video_path),
@@ -5391,7 +5392,7 @@ def create_app(
             )
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        project.save(state.project_root)
+        project.save(root)
 
         # Auto-queue beep on assignment to a real stage (#67). Skip when
         # unassigning (to_stage_number=None) or marking ignored -- those
@@ -5400,12 +5401,12 @@ def create_app(
             stage = project.stage(req.to_stage_number)
             video = next((v for v in stage.videos if str(v.path) == req.video_path), None)
             if video is not None:
-                _auto_queue_beep_if_needed(project, req.to_stage_number, video)
+                _auto_queue_beep_if_needed(slug, project, req.to_stage_number, video)
 
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.post("/api/assignments/swap-primary")
-    def swap_primary(req: SwapPrimaryRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/assignments/swap-primary")
+    def swap_primary(slug: str, req: SwapPrimaryRequest) -> JSONResponse:
         """Promote ``video_path`` to primary on ``stage_number``.
 
         Audit-safe: when the stage has shots in its audit JSON, refuses with
@@ -5413,13 +5414,14 @@ def create_app(
         audit JSON is renamed to ``.bak`` so a bad swap is recoverable, and
         the new primary's processed flags are cleared so detection re-runs.
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(req.stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-        warns = project.primary_swap_warns(state.project_root, stage_number=req.stage_number)
+        warns = project.primary_swap_warns(root, stage_number=req.stage_number)
         if warns and not req.confirm:
             existing = stage.primary()
             raise HTTPException(
@@ -5439,13 +5441,13 @@ def create_app(
         try:
             project.swap_primary(
                 Path(req.video_path),
-                root=state.project_root,
+                root=root,
                 stage_number=req.stage_number,
                 backup_audit=warns,
             )
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        project.save(state.project_root)
+        project.save(root)
 
         # Auto-queue beep for the new primary (#67). swap_primary may
         # clear ``processed.beep`` to force re-detection on the new
@@ -5453,24 +5455,24 @@ def create_app(
         # accordingly. No-op when the video already had a current beep.
         new_primary = project.stage(req.stage_number).primary()
         if new_primary is not None:
-            _auto_queue_beep_if_needed(project, req.stage_number, new_primary)
+            _auto_queue_beep_if_needed(slug, project, req.stage_number, new_primary)
 
         return JSONResponse(project.model_dump(mode="json"))
 
-    @app.get("/api/exports/overview")
-    def export_overview() -> JSONResponse:
+    @app.get("/api/shooters/{slug}/exports/overview")
+    def export_overview(slug: str) -> JSONResponse:
         """Match-overview payload for the Analysis & Export screen.
 
         Returns one row per stage with audit + export status (shot count,
         pending candidates, file paths, last export time, ready-to-export
         flag). Pure stat: no detection, no rewriting of audit JSON.
         """
-        project = state.load()
-        rows = project.export_overview(state.project_root)
+        project = state.shooter_project(slug)
+        rows = project.export_overview(state.shooter_root(slug))
         return JSONResponse({"stages": [r.model_dump(mode="json") for r in rows]})
 
-    @app.post("/api/stages/{stage_number}/export")
-    def export_stage(stage_number: int, req: ExportStageRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/export")
+    def export_stage(slug: str, stage_number: int, req: ExportStageRequest) -> JSONResponse:
         """Submit a per-stage export job.
 
         Wraps the ``export_helpers.export_stage`` orchestrator (lossless trim
@@ -5485,7 +5487,7 @@ def create_app(
         errors up front so the SPA can show a clear error before queueing
         a useless job.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
@@ -5515,7 +5517,7 @@ def create_app(
         # message in the per-row anomaly list).
         if req.write_trim or req.write_fcpxml:
             _ensure_source_reachable(
-                stage_number, project.resolve_video_path(state.project_root, primary.path)
+                stage_number, project.resolve_video_path(state.shooter_root(slug), primary.path)
             )
 
         existing = state.jobs.find_active(kind="export", stage_number=stage_number)
@@ -5524,27 +5526,27 @@ def create_app(
         job = state.jobs.submit(
             kind="export",
             stage_number=stage_number,
-            fn=lambda h, n=stage_number, r=req: _run_export_for_stage(h, n, r),
+            fn=lambda h, sl=slug, n=stage_number, r=req: _run_export_for_stage(h, sl, n, r),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
     def _run_export_for_stage(
-        handle: JobHandle, stage_number: int, req: ExportStageRequest
+        handle: JobHandle, slug: str, stage_number: int, req: ExportStageRequest
     ) -> None:
         """Worker for /api/stages/{n}/export. Phases mirror the user's
         mental model so the JobsPanel message is meaningful."""
         from ..config import StageData as EngineStageData
 
         handle.update(progress=0.05, message="Loading project...")
-        proj = state.load()
+        proj = state.shooter_project(slug)
         stg = proj.stage(stage_number)
         prim = stg.primary()
         if prim is None or prim.beep_time is None:
             raise RuntimeError("primary or beep disappeared mid-flight")
 
-        audit_file = proj.audit_path(state.project_root) / f"stage{stage_number}.json"
-        exports_dir = proj.exports_path(state.project_root)
-        source_video = proj.resolve_video_path(state.project_root, prim.path)
+        audit_file = proj.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
+        exports_dir = proj.exports_path(state.shooter_root(slug))
+        source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
         engine_stage = EngineStageData(
             stage_number=stg.stage_number,
             stage_name=stg.stage_name,
@@ -5581,7 +5583,7 @@ def create_app(
                 continue
             if allowed_ids is not None and sv.video_id not in allowed_ids:
                 continue
-            sec_source = proj.resolve_video_path(state.project_root, sv.path)
+            sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
             secondaries.append(
                 export_helpers.SecondaryExport(
                     video_id=sv.video_id,
@@ -5623,7 +5625,7 @@ def create_app(
 
         handle.update(progress=0.95, message="Saving project...")
         proj.updated_at = datetime.now(UTC)
-        proj.save(state.project_root)
+        proj.save(state.shooter_root(slug))
 
         # Final message summarises what shipped + flags any skipped
         # artefacts (FCPXML without a trim, etc). The full list lives in
@@ -5670,22 +5672,21 @@ def create_app(
         ]
         return JSONResponse({"templates": payload})
 
-    @app.post("/api/match/export")
-    def export_match(req: MatchExportRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/export/match")
+    def export_match(slug: str, req: MatchExportRequest) -> JSONResponse:
         """Stitch N stages into one FCPXML (issue #171, #172).
 
         Job-queued: per-stage trims (and optional overlays) can take
         minutes for a real match, so the response is a Job snapshot the
-        SPA polls via ``/api/jobs/{id}``. The worker re-runs any missing
-        per-stage exports before invoking the match composer, so the user
-        doesn't have to click Generate on each stage first -- "Export
-        match" is a one-stop button.
+        SPA polls via ``/api/me/jobs/{id}``. The worker re-runs any
+        missing per-stage exports before invoking the match composer,
+        so the user doesn't have to click Generate on each stage first.
 
         Validation up-front (404 on unbound project, 400 on empty
         selection / unknown stage / missing primary or beep / padding out
         of range) so the SPA shows a clear error before queueing.
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         if not req.stage_numbers:
             raise HTTPException(status_code=400, detail="stage_numbers cannot be empty")
 
@@ -5736,10 +5737,10 @@ def create_app(
             # Source-reachability matters because the worker may have to
             # produce missing trims via ffmpeg. Surface up-front rather
             # than letting the worker fail mid-flight.
-            if not project.resolve_video_path(state.project_root, primary.path).exists():
+            if not project.resolve_video_path(state.shooter_root(slug), primary.path).exists():
                 _ensure_source_reachable(
                     stage_number,
-                    project.resolve_video_path(state.project_root, primary.path),
+                    project.resolve_video_path(state.shooter_root(slug), primary.path),
                 )
 
         existing = state.jobs.find_active(kind="match_export")
@@ -5747,12 +5748,12 @@ def create_app(
             return JSONResponse(existing.model_dump(mode="json"))
         job = state.jobs.submit(
             kind="match_export",
-            fn=lambda h, r=req: _run_match_export(h, r),
+            fn=lambda h, sl=slug, r=req: _run_match_export(h, sl, r),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
-    def _run_match_export(handle: JobHandle, req: MatchExportRequest) -> None:
-        """Worker for /api/match/export. Re-runs the per-stage exporter for
+    def _run_match_export(handle: JobHandle, slug: str, req: MatchExportRequest) -> None:
+        """Worker for the shooter's match-export job. Re-runs the per-stage exporter for
         any selected stage missing its lossless trim, then composes the
         match FCPXML.
         """
@@ -5760,9 +5761,9 @@ def create_app(
         from . import exports as exports_mod
 
         handle.update(progress=0.02, message="Loading project...")
-        proj = state.load()
-        exports_dir = proj.exports_path(state.project_root)
-        audit_dir = proj.audit_path(state.project_root)
+        proj = state.shooter_project(slug)
+        exports_dir = proj.exports_path(state.shooter_root(slug))
+        audit_dir = proj.audit_path(state.shooter_root(slug))
 
         n = len(req.stage_numbers)
         # Reserve the last 10% for the match compose step; the rest is
@@ -5826,7 +5827,7 @@ def create_app(
                     for sv in stg.videos:
                         if sv.role != "secondary" or sv.beep_time is None:
                             continue
-                        sec_source = proj.resolve_video_path(state.project_root, sv.path)
+                        sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
                         secondaries_in.append(
                             export_helpers.SecondaryExport(
                                 video_id=sv.video_id,
@@ -5835,7 +5836,7 @@ def create_app(
                                 label=f"Cam {sv.video_id}",
                             )
                         )
-                source_video = proj.resolve_video_path(state.project_root, prim.path)
+                source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
                 engine_stage = EngineStageData(
                     stage_number=stg.stage_number,
                     stage_name=stg.stage_name,
@@ -5882,7 +5883,7 @@ def create_app(
 
         # Re-load the project: the per-stage worker writes processed flags
         # via project.save() side-effects, so a fresh load picks those up.
-        proj = state.load()
+        proj = state.shooter_project(slug)
         stages_input: list[match_export_helpers.MatchStageInput] = []
         for stage_number in req.stage_numbers:
             stg = proj.stage(stage_number)
@@ -5980,11 +5981,11 @@ def create_app(
         except (OSError, FileNotFoundError) as exc:
             raise HTTPException(status_code=404, detail=f"not found: {target}") from exc
         try:
-            resolved.relative_to(state.project_root.resolve())
+            resolved.relative_to(state.bound_root.resolve())
         except ValueError as exc:
             raise HTTPException(
                 status_code=400,
-                detail="reveal path must be inside the project root",
+                detail="reveal path must be inside the bound project root",
             ) from exc
         try:
             if sys.platform == "darwin":
@@ -6002,8 +6003,8 @@ def create_app(
             ) from exc
         return JSONResponse({"revealed": str(resolved)})
 
-    @app.post("/api/videos/reveal")
-    def reveal_video(req: RevealRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/videos/reveal")
+    def reveal_video(slug: str, req: RevealRequest) -> JSONResponse:
         """Reveal a registered project video in the OS file manager.
 
         The generic ``/api/files/reveal`` requires the resolved path to be
@@ -6014,12 +6015,12 @@ def create_app(
         registering the source via the picker, so revealing the original
         location is the natural action for "open containing folder".
         """
-        project = state.load()
+        project = state.shooter_project(slug)
         located = project.find_video(Path(req.path))
         if located is None:
             raise HTTPException(status_code=404, detail=f"video not registered: {req.path}")
         _, video = located
-        target = project.resolve_video_path(state.project_root, Path(str(video.path)))
+        target = project.resolve_video_path(state.shooter_root(slug), Path(str(video.path)))
         try:
             resolved = target.resolve(strict=True)
         except (OSError, FileNotFoundError) as exc:
@@ -6038,21 +6039,22 @@ def create_app(
             ) from exc
         return JSONResponse({"revealed": str(resolved)})
 
-    @app.post("/api/stages/{stage_number}/skip")
-    def set_stage_skipped(stage_number: int, req: SkipStageRequest) -> JSONResponse:
+    @app.post("/api/shooters/{slug}/stages/{stage_number}/skip")
+    def set_stage_skipped(slug: str, stage_number: int, req: SkipStageRequest) -> JSONResponse:
         """Mark ``stage_number`` as skipped (or un-skip it).
 
         A skipped stage is excluded from "next step" gating in the ingest
         screen so the user can advance even when the stage has no videos
         (e.g. they didn't film stage 4).
         """
-        project = state.load()
+        root = state.shooter_root(slug)
+        project = state.shooter_project(slug)
         try:
             stage = project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         stage.skipped = req.skipped
-        project.save(state.project_root)
+        project.save(root)
         return JSONResponse(project.model_dump(mode="json"))
 
     # ----------------------------------------------------------------------
@@ -6845,14 +6847,18 @@ def create_app(
         every shooter's primary in that stage being ``beep_reviewed``.
         """
         match_root, match = _resolve_match_context()
-        # Resolve the low-confidence threshold from the active shooter's
-        # automation settings; per-shooter thresholds aren't supported.
-        try:
-            active_project = state.load()
-            resolved = automation_settings.resolve_automation(active_project)
-            threshold = resolved.settings.beep_low_confidence_threshold
-        except Exception:  # noqa: BLE001
-            threshold = 0.5
+        # Resolve the low-confidence threshold from any shooter's automation
+        # settings; per-shooter thresholds aren't supported, the gate is
+        # global to the match.
+        threshold = 0.5
+        for first_slug in match.shooters:
+            try:
+                proj_for_threshold = state.shooter_project(first_slug)
+                resolved = automation_settings.resolve_automation(proj_for_threshold)
+                threshold = resolved.settings.beep_low_confidence_threshold
+                break
+            except Exception:  # noqa: BLE001
+                continue
 
         stage_lookup = {s.stage_number: s.stage_name for s in match.stages}
         groups: dict[int, BeepQueueStageGroup] = {}
@@ -7121,14 +7127,14 @@ def create_app(
                     status_code=400,
                     detail="payload must include integer 'stage_number' and string 'slug'",
                 )
-            project = state.load()
+            project = state.shooter_project(slug)
             try:
                 stg = project.stage(stage_n)
             except KeyError as exc:
                 raise HTTPException(status_code=404, detail=str(exc)) from exc
-            audit_json = project.audit_path(state.project_root) / f"stage{stage_n}.json"
+            audit_json = project.audit_path(state.shooter_root(slug)) / f"stage{stage_n}.json"
             try:
-                audit_audio = _resolve_audit_audio(project, stage_n)
+                audit_audio = _resolve_audit_audio(slug, project, stage_n)
             except HTTPException:
                 raise
             audit_wav = audit_audio.audio_path
@@ -7199,7 +7205,7 @@ def create_app(
                         f"stage {stage_n} has no time_seconds; cannot " "compute the trim window."
                     ),
                 )
-            source_video_path = project.resolve_video_path(state.project_root, primary.path)
+            source_video_path = project.resolve_video_path(state.shooter_root(slug), primary.path)
             trim_start = max(0.0, float(primary.beep_time) - float(project.trim_pre_buffer_seconds))
             trim_end = (
                 float(primary.beep_time)
@@ -7615,7 +7621,7 @@ def create_app(
         # Project-aware secondary promotion (issue #125 follow-up)
         # ------------------------------------------------------------------
 
-        @app.post("/api/stages/{stage_number}/videos/{video_id}/promote-secondary")
+        @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/promote-secondary")
         def promote_secondary(
             stage_number: int,
             video_id: str,
@@ -7628,7 +7634,7 @@ def create_app(
             caller only has to supply ``mount`` + ``position``. Anchor
             fixture must already exist (run the primary promote first).
             """
-            project, stage, video = _resolve_stage_video(stage_number, video_id)
+            project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
             if video.role != "secondary":
                 raise HTTPException(
                     status_code=400,
@@ -7674,12 +7680,12 @@ def create_app(
                     detail=f"anchor WAV missing: {anchor_wav_path.name}",
                 )
 
-            source = project.resolve_video_path(state.project_root, video.path)
+            source = project.resolve_video_path(state.shooter_root(slug), video.path)
             _ensure_source_reachable(stage_number, source)
 
             try:
                 secondary_wav_path = audio_helpers.ensure_video_audio(
-                    state.project_root, stage_number, video, source, project=project
+                    state.shooter_root(slug), stage_number, video, source, project=project
                 )
             except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -7854,8 +7860,11 @@ def create_app(
         # in-project primary required, any video on the stage works.
         # ------------------------------------------------------------------
 
-        @app.post("/api/lab/projects/{stage_number}/videos/{video_id}/promote-against-fixture")
+        @app.post(
+            "/api/lab/projects/{slug}/{stage_number}/videos/{video_id}/promote-against-fixture"
+        )
         def lab_promote_against_fixture(
+            slug: str,
             stage_number: int,
             video_id: str,
             body: PromoteAgainstFixtureBody = Body(...),  # noqa: B008
@@ -7869,7 +7878,7 @@ def create_app(
             comes from ``body.anchor_slug`` (any fixture in
             ``tests/fixtures/``).
             """
-            project, _stage, video = _resolve_stage_video(stage_number, video_id)
+            project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
             if video.beep_time is None:
                 raise HTTPException(
                     status_code=409,
@@ -7893,12 +7902,12 @@ def create_app(
                     detail=f"anchor WAV missing: {anchor_wav_path.name}",
                 )
 
-            source = project.resolve_video_path(state.project_root, video.path)
+            source = project.resolve_video_path(state.shooter_root(slug), video.path)
             _ensure_source_reachable(stage_number, source)
 
             try:
                 secondary_wav_path = audio_helpers.ensure_video_audio(
-                    state.project_root, stage_number, video, source, project=project
+                    state.shooter_root(slug), stage_number, video, source, project=project
                 )
             except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -8573,6 +8582,7 @@ def _query_windows_drives() -> dict[str, tuple[int, str | None]]:
 def _video_metadata_for(
     source: Path,
     *,
+    slug: str,
     probes_dir: Path,
     thumbs_dir: Path,
     allow_new: bool,
@@ -8599,7 +8609,7 @@ def _video_metadata_for(
     thumbnail_url: str | None = None
     cached_thumb = thumbnail_helpers.cached(source, thumbs_dir)
     if cached_thumb is not None:
-        thumbnail_url = f"/api/thumbnails/{cached_thumb.stem}.jpg"
+        thumbnail_url = f"/api/shooters/{slug}/thumbnails/{cached_thumb.stem}.jpg"
     elif allow_new:
         try:
             t_dur = duration_for_thumb if duration_for_thumb is not None else duration
@@ -8608,7 +8618,7 @@ def _video_metadata_for(
                 cache_dir=thumbs_dir,
                 duration=t_dur,
             )
-            thumbnail_url = f"/api/thumbnails/{extracted.stem}.jpg"
+            thumbnail_url = f"/api/shooters/{slug}/thumbnails/{extracted.stem}.jpg"
         except thumbnail_helpers.ThumbnailError as exc:
             logger.debug("thumbnail failed for %s: %s", source, exc)
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -285,9 +285,7 @@ def _ensure_ui_built() -> None:
 
     npm = shutil.which("npm")
     if npm is None:
-        logger.warning(
-            "ui_static/dist appears stale but npm is not on PATH; serving whatever is in dist/"
-        )
+        logger.warning("ui_static/dist appears stale but npm is not on PATH; serving whatever is in dist/")
         return
 
     logger.info(
@@ -1667,8 +1665,7 @@ def _bind_project_to_state(
                 detail={
                     "code": "match_empty",
                     "message": (
-                        f"Match {resolved} has no shooters yet. "
-                        "Add a shooter or recreate the match."
+                        f"Match {resolved} has no shooters yet. " "Add a shooter or recreate the match."
                     ),
                 },
             )
@@ -1750,9 +1747,7 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
                 audited_total += sum(1 for s in shooter.stages if s.time_seconds > 0 or s.skipped)
                 shooter_names.append(shooter.name or slug)
             detail.shooter_names = shooter_names
-            detail.stages_audited = (
-                audited_total // max(len(match.shooters), 1) if match.shooters else 0
-            )
+            detail.stages_audited = audited_total // max(len(match.shooters), 1) if match.shooters else 0
             metadata_path = path / match_model.MATCH_FILE
         else:
             project = MatchProject.load(path)
@@ -1762,9 +1757,7 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
             detail.stage_count = len(project.stages)
             detail.match_date = project.match_date.isoformat() if project.match_date else None
             detail.manual = project.scoreboard_match_id is None
-            detail.stages_audited = sum(
-                1 for s in project.stages if s.time_seconds > 0 or s.skipped
-            )
+            detail.stages_audited = sum(1 for s in project.stages if s.time_seconds > 0 or s.skipped)
             if project.competitor_name:
                 detail.shooter_names = [project.competitor_name]
             metadata_path = path / "project.json"
@@ -1967,9 +1960,7 @@ def create_app(
             shutil.rmtree(tmp, ignore_errors=True)
 
         if bind:
-            _bind_project_to_state(
-                state, result.project_root, fallback_name=result.project_name
-            )
+            _bind_project_to_state(state, result.project_root, fallback_name=result.project_name)
 
         return JSONResponse(
             {
@@ -2091,11 +2082,7 @@ def create_app(
                     }
                 )
                 continue
-            if (
-                primary.beep_source == "auto"
-                and primary.beep_time is not None
-                and not primary.beep_reviewed
-            ):
+            if primary.beep_source == "auto" and primary.beep_time is not None and not primary.beep_reviewed:
                 # Either confidence is below the threshold OR the field
                 # predates layer 3a (None) -- both warrant review.
                 items.append(
@@ -2400,8 +2387,7 @@ def create_app(
                 detail={
                     "code": "competitor_not_in_match",
                     "message": (
-                        f"competitor {req.competitor_id} isn't in this match. "
-                        "Pick a different shooter."
+                        f"competitor {req.competitor_id} isn't in this match. " "Pick a different shooter."
                     ),
                 },
             )
@@ -2650,9 +2636,7 @@ def create_app(
                     video_id=entry.video_id,
                     name=entry.name,
                     link_path=str(entry.link_path),
-                    current_target=(
-                        str(entry.current_target) if entry.current_target is not None else None
-                    ),
+                    current_target=(str(entry.current_target) if entry.current_target is not None else None),
                     current_status=entry.current_status,
                     candidates=[str(p) for p in entry.candidates],
                     chosen_path=str(entry.chosen_path) if entry.chosen_path is not None else None,
@@ -2676,9 +2660,7 @@ def create_app(
         if not req.decisions:
             raise HTTPException(status_code=400, detail="decisions must be non-empty")
         project = state.shooter_project(slug)
-        infos = {
-            info.video_id: info for info in relink_mod.inspect_links(project, state.shooter_root(slug))
-        }
+        infos = {info.video_id: info for info in relink_mod.inspect_links(project, state.shooter_root(slug))}
         decisions: list[tuple[Path, Path]] = []
         id_for_link: dict[Path, str] = {}
         for video_id, target_str in req.decisions.items():
@@ -2887,12 +2869,8 @@ def create_app(
         primary = stage.primary()
         if primary is None or primary.beep_time is None:
             return None
-        primary_audio_path = audio_helpers.primary_audio_path(
-            root, stage.stage_number, project=proj
-        )
-        secondary_audio_path = audio_helpers.video_audio_path(
-            root, stage.stage_number, video, project=proj
-        )
+        primary_audio_path = audio_helpers.primary_audio_path(root, stage.stage_number, project=proj)
+        secondary_audio_path = audio_helpers.video_audio_path(root, stage.stage_number, video, project=proj)
         if not primary_audio_path.exists() or not secondary_audio_path.exists():
             # Either side missing means the user hasn't run beep-detect on
             # the primary yet, or the secondary's own audio extract failed
@@ -2920,9 +2898,7 @@ def create_app(
             return None
         return result
 
-    def _run_detect_beep_for_video(
-        handle: JobHandle, slug: str, stage_number: int, video_id: str
-    ) -> None:
+    def _run_detect_beep_for_video(handle: JobHandle, slug: str, stage_number: int, video_id: str) -> None:
         """Worker: detect ``video``'s beep, then auto-chain trim.
 
         Generic over role:
@@ -2992,9 +2968,7 @@ def create_app(
             if aligned is not None and aligned.confidence >= _align_confidence_floor:
                 handle.update(
                     progress=0.55,
-                    message=(
-                        f"Aligned to primary (conf {aligned.confidence:.2f}); " "verify on waveform"
-                    ),
+                    message=(f"Aligned to primary (conf {aligned.confidence:.2f}); " "verify on waveform"),
                 )
                 video.beep_time = aligned.secondary_beep_time
                 video.beep_source = "aligned"
@@ -3146,9 +3120,7 @@ def create_app(
                 )
         handle.update(progress=1.0, message="Done")
 
-    def _submit_detect_beep(
-        slug: str, stage_number: int, video: StageVideo
-    ) -> JSONResponse:
+    def _submit_detect_beep(slug: str, stage_number: int, video: StageVideo) -> JSONResponse:
         """Validate + dedupe + queue a detect-beep job for ``video``.
 
         Shared by the per-video endpoint and the primary-only legacy
@@ -3219,8 +3191,7 @@ def create_app(
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/detect-beep")
     def detect_beep_for_video(
-        slug: str,
-        stage_number: int, video_id: str, force: bool = False
+        slug: str, stage_number: int, video_id: str, force: bool = False
     ) -> JSONResponse:
         """Submit a beep-detection job for ``video_id`` on ``stage_number``.
 
@@ -3329,16 +3300,14 @@ def create_app(
                     "scoreboard or set the stage time before trimming"
                 ),
             )
-        existing = state.jobs.find_active(
-            kind="trim", stage_number=stage_number, video_id=video.video_id
-        )
+        existing = state.jobs.find_active(kind="trim", stage_number=stage_number, video_id=video.video_id)
         if existing is not None:
             return JSONResponse(existing.model_dump(mode="json"))
         job = state.jobs.submit(
             kind="trim",
             stage_number=stage_number,
             video_id=video.video_id,
-            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: _run_trim_for_video(h, sl, n, vid),
+            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: (_run_trim_for_video(h, sl, n, vid)),
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -3348,9 +3317,7 @@ def create_app(
         project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         return _submit_trim(slug, stage_number, stage, video, project)
 
-    def _run_trim_for_video(
-        handle: JobHandle, slug: str, stage_number: int, video_id: str
-    ) -> None:
+    def _run_trim_for_video(handle: JobHandle, slug: str, stage_number: int, video_id: str) -> None:
         """Worker for the audit-mode trim of a specific video.
 
         Auto-chains shot detection only when the trimmed video is the
@@ -3474,9 +3441,7 @@ def create_app(
             raise RuntimeError(f"stage {stage_number} has no primary mid-flight")
         _run_trim_for_video(handle, slug, stage_number, primary.video_id)
 
-    def _run_shot_detect(
-        handle: JobHandle, slug: str, stage_number: int, reset: bool = False
-    ) -> None:
+    def _run_shot_detect(handle: JobHandle, slug: str, stage_number: int, reset: bool = False) -> None:
         """Worker that runs the 4-voter ensemble on the stage's audit clip.
 
         Reads the trimmed clip's WAV (extracting it on demand if needed),
@@ -3582,9 +3547,7 @@ def create_app(
         # detection after a scoreboard refresh should pick up the new
         # round count without manual edits.
         if stg.stage_rounds is not None:
-            existing_json["stage_rounds"] = stg.stage_rounds.model_dump(
-                mode="json", exclude_none=True
-            )
+            existing_json["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
         expected_rounds: int | None = None
         sr_block = existing_json.get("stage_rounds")
         if isinstance(sr_block, dict):
@@ -3922,9 +3885,7 @@ def create_app(
         if video.beep_time is None or stage.time_seconds <= 0:
             return
         if (
-            state.jobs.find_active(
-                kind="trim", stage_number=stage.stage_number, video_id=video.video_id
-            )
+            state.jobs.find_active(kind="trim", stage_number=stage.stage_number, video_id=video.video_id)
             is not None
         ):
             return
@@ -3932,7 +3893,9 @@ def create_app(
             kind="trim",
             stage_number=stage.stage_number,
             video_id=video.video_id,
-            fn=lambda h, sl=slug, n=stage.stage_number, vid=video.video_id: _run_trim_for_video(h, sl, n, vid),
+            fn=lambda h, sl=slug, n=stage.stage_number, vid=video.video_id: (
+                _run_trim_for_video(h, sl, n, vid)
+            ),
         )
 
     def _select_candidate_on_video(video: StageVideo, time_value: float) -> None:
@@ -3982,8 +3945,7 @@ def create_app(
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep")
     def override_beep_for_video(
-        slug: str,
-        stage_number: int, video_id: str, req: BeepOverrideRequest
+        slug: str, stage_number: int, video_id: str, req: BeepOverrideRequest
     ) -> JSONResponse:
         """Manually set or clear ``video``'s beep timestamp.
 
@@ -4057,7 +4019,9 @@ def create_app(
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/snap")
-    def snap_beep_for_video(slug: str, stage_number: int, video_id: str, req: BeepSnapRequest) -> JSONResponse:
+    def snap_beep_for_video(
+        slug: str, stage_number: int, video_id: str, req: BeepSnapRequest
+    ) -> JSONResponse:
         """Refine a user-placed beep marker by snapping it to the strongest
         tone in a tight window around the hint.
 
@@ -4150,8 +4114,7 @@ def create_app(
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/select")
     def select_beep_candidate_for_video(
-        slug: str,
-        stage_number: int, video_id: str, req: BeepSelectRequest
+        slug: str, stage_number: int, video_id: str, req: BeepSelectRequest
     ) -> JSONResponse:
         """Promote one of ``video``'s ranked candidates as authoritative."""
         project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
@@ -4164,7 +4127,9 @@ def create_app(
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep/review")
-    def set_beep_reviewed(slug: str, stage_number: int, video_id: str, req: BeepReviewRequest) -> JSONResponse:
+    def set_beep_reviewed(
+        slug: str, stage_number: int, video_id: str, req: BeepReviewRequest
+    ) -> JSONResponse:
         """Flip ``video.beep_reviewed`` (issue #71).
 
         Setting True requires ``beep_time`` to be set; setting False is
@@ -4204,7 +4169,9 @@ def create_app(
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.patch("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/camera-mount")
-    def set_camera_mount(slug: str, stage_number: int, video_id: str, req: CameraMountRequest) -> JSONResponse:
+    def set_camera_mount(
+        slug: str, stage_number: int, video_id: str, req: CameraMountRequest
+    ) -> JSONResponse:
         """Override the heuristic ``camera_mount`` (issue #143).
 
         Validated against the fixture-schema ``CameraMount`` enum so
@@ -4231,7 +4198,9 @@ def create_app(
         return JSONResponse(project.model_dump(mode="json"))
 
     @app.patch("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/camera-model")
-    def set_camera_model(slug: str, stage_number: int, video_id: str, req: CameraModelRequest) -> JSONResponse:
+    def set_camera_model(
+        slug: str, stage_number: int, video_id: str, req: CameraModelRequest
+    ) -> JSONResponse:
         """Override the ffprobed camera make + model (#303-followup).
 
         Used when ffprobe couldn't read the QuickTime tag (e.g. Meta
@@ -4281,9 +4250,7 @@ def create_app(
                 {
                     "key": key,
                     "make": meta.get("make", key.split(" ", 1)[0].title()),
-                    "model": meta.get(
-                        "model", key.split(" ", 1)[1].title() if " " in key else key.title()
-                    ),
+                    "model": meta.get("model", key.split(" ", 1)[1].title() if " " in key else key.title()),
                     "amp_floor": float(floor),
                 }
             )
@@ -4417,8 +4384,7 @@ def create_app(
 
     @app.get("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/beep-preview")
     def video_beep_preview(
-        slug: str,
-        stage_number: int, video_id: str, t: float | None = None
+        slug: str, stage_number: int, video_id: str, t: float | None = None
     ) -> FileResponse:
         """Serve a ~1 s MP4 around ``video``'s beep (or override ``t``)."""
         project, _stage, video = _resolve_stage_video(slug, stage_number, video_id)
@@ -4622,9 +4588,7 @@ def create_app(
 
         prim = stg.primary()
         beep_time = prim.beep_time if prim is not None and prim.beep_time is not None else 0.0
-        shots = export_helpers.audit_shots_to_engine_shots(
-            audit_payload, beep_time_in_source=beep_time
-        )
+        shots = export_helpers.audit_shots_to_engine_shots(audit_payload, beep_time_in_source=beep_time)
         anomalies = report.detect_anomalies_structured(shots, beep_time, stg.time_seconds)
         return JSONResponse({"anomalies": [a.model_dump() for a in anomalies]})
 
@@ -4857,11 +4821,7 @@ def create_app(
         if not isinstance(shots, list):
             raise HTTPException(status_code=500, detail="audit shots is not a list")
         target = next(
-            (
-                s
-                for s in shots
-                if isinstance(s, dict) and int(s.get("shot_number", -1)) == shot_number
-            ),
+            (s for s in shots if isinstance(s, dict) and int(s.get("shot_number", -1)) == shot_number),
             None,
         )
         if target is None:
@@ -5102,9 +5062,7 @@ def create_app(
             # Per-video short-GOP trim is keyed per role: each angle has
             # its own scrub clip cut around its own beep, so dragging
             # the audit playhead doesn't stall on a 4K MOV from a phone.
-            trimmed = audio_helpers.trimmed_video_path(
-                root, stage.stage_number, video, project=project
-            )
+            trimmed = audio_helpers.trimmed_video_path(root, stage.stage_number, video, project=project)
             if trimmed.exists():
                 served_path = trimmed.resolve()
         if served_path is None:
@@ -5118,9 +5076,7 @@ def create_app(
             # the SPA's "reconnect external storage" surface is uniform.
             _ensure_source_reachable(stage.stage_number if stage is not None else None, served_path)
 
-        media_type = (
-            "video/mp4" if served_path.suffix.lower() == ".mp4" else "application/octet-stream"
-        )
+        media_type = "video/mp4" if served_path.suffix.lower() == ".mp4" else "application/octet-stream"
         return FileResponse(served_path, media_type=media_type, filename=served_path.name)
 
     @app.get("/api/shooters/{slug}/fs/list", response_model=FsListing)
@@ -5179,7 +5135,7 @@ def create_app(
                     if is_video:
                         duration, thumbnail_url = _video_metadata_for(
                             child,
-            slug=slug,
+                            slug=slug,
                             probes_dir=probes_dir,
                             thumbs_dir=thumbs_dir,
                             allow_new=probe and time.monotonic() < budget_deadline,
@@ -5538,8 +5494,7 @@ def create_app(
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"stage {stage_number} is a placeholder; import a real "
-                    "scoreboard before exporting"
+                    f"stage {stage_number} is a placeholder; import a real " "scoreboard before exporting"
                 ),
             )
         # Source-reachability surfaces as a structured 424 so the SPA
@@ -5826,8 +5781,7 @@ def create_app(
                     if sv.role == "secondary" and sv.beep_time is not None:
                         wanted_secondary_ids.add(sv.video_id)
             secondary_trims_present = all(
-                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists()
-                for vid in wanted_secondary_ids
+                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
             )
             # Treat any non-default overlay format option as "force re-render"
             # so the dialog's codec / max-height / max-fps choices actually
@@ -5843,15 +5797,11 @@ def create_app(
                 not overlay_target.exists() or overlay_format_overridden
             )
 
-            needs_per_stage = (
-                not trimmed_path.exists() or not secondary_trims_present or overlay_missing
-            )
+            needs_per_stage = not trimmed_path.exists() or not secondary_trims_present or overlay_missing
             if needs_per_stage:
                 handle.update(
                     progress=0.02 + idx * per_stage_share,
-                    message=(
-                        f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."
-                    ),
+                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."),
                 )
                 # Build the secondaries list for the per-stage exporter --
                 # mirrors the single-stage endpoint's logic.
@@ -5905,10 +5855,7 @@ def create_app(
             else:
                 handle.update(
                     progress=0.02 + idx * per_stage_share,
-                    message=(
-                        f"Stage {stage_number} ({idx + 1} of {n}): "
-                        "trim already present; skipping"
-                    ),
+                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "trim already present; skipping"),
                 )
 
         handle.check_cancel()
@@ -5993,10 +5940,7 @@ def create_app(
         anom_suffix = f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
         handle.update(
             progress=1.0,
-            message=(
-                f"Done: {result.stage_count} stages, "
-                f"{result.duration_seconds:.1f}s{anom_suffix}"
-            ),
+            message=(f"Done: {result.stage_count} stages, " f"{result.duration_seconds:.1f}s{anom_suffix}"),
         )
 
     @app.post("/api/files/reveal")
@@ -6031,9 +5975,7 @@ def create_app(
                 parent = resolved.parent if resolved.is_file() else resolved
                 subprocess.run(["xdg-open", str(parent)], check=False)
         except OSError as exc:
-            raise HTTPException(
-                status_code=500, detail=f"failed to launch file manager: {exc}"
-            ) from exc
+            raise HTTPException(status_code=500, detail=f"failed to launch file manager: {exc}") from exc
         return JSONResponse({"revealed": str(resolved)})
 
     @app.post("/api/shooters/{slug}/videos/reveal")
@@ -6067,9 +6009,7 @@ def create_app(
                 parent = resolved.parent if resolved.is_file() else resolved
                 subprocess.run(["xdg-open", str(parent)], check=False)
         except OSError as exc:
-            raise HTTPException(
-                status_code=500, detail=f"failed to launch file manager: {exc}"
-            ) from exc
+            raise HTTPException(status_code=500, detail=f"failed to launch file manager: {exc}") from exc
         return JSONResponse({"revealed": str(resolved)})
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/skip")
@@ -6210,10 +6150,7 @@ def create_app(
         shooter = match_model.Shooter(
             slug=shooter_slug,
             name=req.primary_shooter.name,
-            stages=[
-                match_model.ShooterStageData(stage_number=draft.stage_number)
-                for draft in req.stages
-            ],
+            stages=[match_model.ShooterStageData(stage_number=draft.stage_number) for draft in req.stages],
         )
         try:
             match.add_shooter(target, shooter)
@@ -6341,9 +6278,7 @@ def create_app(
                     continue
             except Exception:  # noqa: BLE001 -- defensive
                 continue
-            cache = audio_helpers.trimmed_video_path(
-                shooter_root, s.stage_number, prim, project=legacy
-            )
+            cache = audio_helpers.trimmed_video_path(shooter_root, s.stage_number, prim, project=legacy)
             if not cache.exists():
                 stages_missing_trim += 1
         # Camera grouping: ``(make, model, mount)`` -> [(role, count, stages)].
@@ -6412,9 +6347,7 @@ def create_app(
                 MergePlanStage(
                     stage_number=s.stage_number,
                     stage_name=s.stage_name,
-                    expected_rounds=(
-                        s.stage_rounds.expected if s.stage_rounds is not None else None
-                    ),
+                    expected_rounds=(s.stage_rounds.expected if s.stage_rounds is not None else None),
                     placeholder=s.placeholder,
                 )
                 for s in plan.stages
@@ -6542,9 +6475,7 @@ def create_app(
         shooter = match_model.Shooter(
             slug=slug,
             name=req.name,
-            stages=[
-                match_model.ShooterStageData(stage_number=s.stage_number) for s in match.stages
-            ],
+            stages=[match_model.ShooterStageData(stage_number=s.stage_number) for s in match.stages],
         )
         try:
             match.add_shooter(match_root, shooter)
@@ -6632,9 +6563,7 @@ def create_app(
             if not source.exists():
                 skipped.append({"stage": stage.stage_number, "reason": "source_missing"})
                 continue
-            cache = audio_helpers.trimmed_video_path(
-                shooter_root, stage.stage_number, primary, project=proj
-            )
+            cache = audio_helpers.trimmed_video_path(shooter_root, stage.stage_number, primary, project=proj)
             if cache.exists():
                 skipped.append({"stage": stage.stage_number, "reason": "already_cached"})
                 continue
@@ -6703,9 +6632,7 @@ def create_app(
                 None,
             )
             primary = (
-                next((v for v in stage.videos if v.role == "primary"), None)
-                if stage is not None
-                else None
+                next((v for v in stage.videos if v.role == "primary"), None) if stage is not None else None
             )
 
             beep_offset: float | None = None
@@ -6723,25 +6650,19 @@ def create_app(
                 stage_name = stage_def.stage_name
                 base = f"stage{stage_number}_{match_export_helpers._slugify(stage_name)}"
                 exports = (
-                    Path(legacy.exports_dir).expanduser()
-                    if legacy.exports_dir
-                    else shooter_root / "exports"
+                    Path(legacy.exports_dir).expanduser() if legacy.exports_dir else shooter_root / "exports"
                 )
                 if not exports.is_absolute():
                     exports = shooter_root / exports
                 trimmed = (
-                    Path(legacy.trimmed_dir).expanduser()
-                    if legacy.trimmed_dir
-                    else shooter_root / "trimmed"
+                    Path(legacy.trimmed_dir).expanduser() if legacy.trimmed_dir else shooter_root / "trimmed"
                 )
                 if not trimmed.is_absolute():
                     trimmed = shooter_root / trimmed
                 lossless = exports / f"{base}_trimmed.mp4"
                 audit_cache = trimmed / f"stage{stage_number}_cam_{primary.video_id}_trimmed.mp4"
                 resolved_trim = (
-                    lossless
-                    if lossless.exists()
-                    else (audit_cache if audit_cache.exists() else None)
+                    lossless if lossless.exists() else (audit_cache if audit_cache.exists() else None)
                 )
                 if resolved_trim is not None:
                     video_path = str(resolved_trim)
@@ -6771,9 +6692,7 @@ def create_app(
                                 CompareShotPoint(
                                     shot_number=int(shot.get("shot_number", 0)),
                                     time_after_beep=float(t) - float(audit_beep),
-                                    source=(
-                                        "manual" if shot.get("source") == "manual" else "detected"
-                                    ),
+                                    source=("manual" if shot.get("source") == "manual" else "detected"),
                                 )
                             )
 
@@ -7238,16 +7157,12 @@ def create_app(
             if stage_time_seconds is None:
                 raise HTTPException(
                     status_code=409,
-                    detail=(
-                        f"stage {stage_n} has no time_seconds; cannot " "compute the trim window."
-                    ),
+                    detail=(f"stage {stage_n} has no time_seconds; cannot " "compute the trim window."),
                 )
             source_video_path = project.resolve_video_path(state.shooter_root(slug), primary.path)
             trim_start = max(0.0, float(primary.beep_time) - float(project.trim_pre_buffer_seconds))
             trim_end = (
-                float(primary.beep_time)
-                + float(stage_time_seconds)
-                + float(project.trim_post_buffer_seconds)
+                float(primary.beep_time) + float(stage_time_seconds) + float(project.trim_post_buffer_seconds)
             )
             # Camera make/model (#303): use the values cached on the
             # StageVideo at register time -- those came from ffprobe and
@@ -7545,8 +7460,7 @@ def create_app(
                 fixtures_root.mkdir(parents=True, exist_ok=True)
                 tmp = target_json.with_suffix(".json.tmp")
                 tmp.write_text(
-                    __import__("json").dumps(result.fixture_data, indent=2, ensure_ascii=True)
-                    + "\n",
+                    __import__("json").dumps(result.fixture_data, indent=2, ensure_ascii=True) + "\n",
                     encoding="utf-8",
                 )
                 tmp.replace(target_json)
@@ -7556,8 +7470,7 @@ def create_app(
 
                 report_path = fixtures_root / f"{body.slug}-promotion-report.json"
                 report_path.write_text(
-                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True)
-                    + "\n",
+                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True) + "\n",
                     encoding="utf-8",
                 )
 
@@ -7595,9 +7508,7 @@ def create_app(
             try:
                 data = __import__("json").loads(report_path.read_text(encoding="utf-8"))
             except Exception as exc:
-                raise HTTPException(
-                    status_code=500, detail=f"failed to read report: {exc}"
-                ) from exc
+                raise HTTPException(status_code=500, detail=f"failed to read report: {exc}") from exc
             return JSONResponse(data)
 
         @app.delete("/api/lab/fixture")
@@ -7617,9 +7528,7 @@ def create_app(
             try:
                 payload = __import__("json").loads(json_path.read_text(encoding="utf-8"))
             except Exception as exc:
-                raise HTTPException(
-                    status_code=500, detail=f"failed to read fixture: {exc}"
-                ) from exc
+                raise HTTPException(status_code=500, detail=f"failed to read fixture: {exc}") from exc
             anchor_block = payload.get("anchor")
             if not isinstance(anchor_block, dict) or not anchor_block.get("fixture_slug"):
                 raise HTTPException(
@@ -7660,6 +7569,7 @@ def create_app(
 
         @app.post("/api/shooters/{slug}/stages/{stage_number}/videos/{video_id}/promote-secondary")
         def promote_secondary(
+            slug: str,
             stage_number: int,
             video_id: str,
             body: PromoteSecondaryBody = Body(...),  # noqa: B008
@@ -7690,15 +7600,11 @@ def create_app(
             if project.selected_shooter_id is None:
                 raise HTTPException(
                     status_code=400,
-                    detail=(
-                        "this project has no SSI shooter pinned; "
-                        "cannot resolve anchor fixture slug."
-                    ),
+                    detail=("this project has no SSI shooter pinned; " "cannot resolve anchor fixture slug."),
                 )
             anchor_token = lab_module.shooter_token(project.selected_shooter_id)
             primary_slug = (
-                f"stage-shots-{export_helpers._slugify(project.name)}-stage{stage_number}"
-                f"-{anchor_token}"
+                f"stage-shots-{export_helpers._slugify(project.name)}-stage{stage_number}" f"-{anchor_token}"
             )
             fixtures_root = lab_module.core.DEFAULT_FIXTURES_ROOT
             anchor_path = fixtures_root / f"{primary_slug}.json"
@@ -7728,24 +7634,22 @@ def create_app(
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
 
             probe = probe_camera_metadata(source)
-            camera_id = (
-                body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}"
-            ).strip()
+            camera_id = (body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}").strip()
             if not camera_id:
                 raise HTTPException(
                     status_code=400,
                     detail="camera_id could not be derived; please supply one",
                 )
 
-            slug = (body.slug or f"{primary_slug}-{camera_id}").strip()
-            target_json = fixtures_root / f"{slug}.json"
+            # ``slug`` (URL path param) names the shooter; ``fixture_slug``
+            # below names the derived fixture being written. Same string
+            # convention but different identities -- don't rebind ``slug``.
+            fixture_slug = (body.slug or f"{primary_slug}-{camera_id}").strip()
+            target_json = fixtures_root / f"{fixture_slug}.json"
             if target_json.exists() and not body.overwrite:
                 raise HTTPException(
                     status_code=409,
-                    detail=(
-                        f"fixture already exists: {target_json.name}"
-                        " (set overwrite=true to replace)"
-                    ),
+                    detail=(f"fixture already exists: {target_json.name}" " (set overwrite=true to replace)"),
                 )
 
             try:
@@ -7791,7 +7695,7 @@ def create_app(
                         secondary_sr=secondary_sr,
                         secondary_source_desc=secondary_source_desc,
                         camera=camera,
-                        slug=slug,
+                        slug=fixture_slug,
                         snap_window_ms=body.snap_window_ms,
                         min_spacing_ms=body.min_spacing_ms,
                         secondary_beep_time=known_secondary_beep,
@@ -7813,9 +7717,7 @@ def create_app(
                 fixture_data = dict(result.fixture_data)
                 secondary_beep = float(fixture_data.get("beep_time") or 0.0)
                 shot_times = [
-                    float(s["time"])
-                    for s in fixture_data.get("shots", [])
-                    if s.get("time") is not None
+                    float(s["time"]) for s in fixture_data.get("shots", []) if s.get("time") is not None
                 ]
                 trim_buffer = 5.0
                 trim_tail = 5.0
@@ -7825,7 +7727,7 @@ def create_app(
                 clip_end = max(clip_end, clip_end_floor)
 
                 fixtures_root.mkdir(parents=True, exist_ok=True)
-                target_wav = fixtures_root / f"{slug}.wav"
+                target_wav = fixtures_root / f"{fixture_slug}.wav"
                 handle.update(progress=0.88, message="trimming clip audio...")
                 _trim_wav_to_clip(secondary_wav_path, target_wav, clip_start, clip_end)
 
@@ -7862,10 +7764,9 @@ def create_app(
                 )
                 tmp.replace(target_json)
 
-                report_path = fixtures_root / f"{slug}-promotion-report.json"
+                report_path = fixtures_root / f"{fixture_slug}-promotion-report.json"
                 report_path.write_text(
-                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True)
-                    + "\n",
+                    __import__("json").dumps(result.promotion_report, indent=2, ensure_ascii=True) + "\n",
                     encoding="utf-8",
                 )
 
@@ -7883,7 +7784,7 @@ def create_app(
                     "job": job.model_dump(mode="json"),
                     "fixture_path": str(target_json),
                     "anchor_path": str(anchor_path),
-                    "slug": slug,
+                    "slug": fixture_slug,
                     "camera_id": camera_id,
                     "anchor_slug": primary_slug,
                 }
@@ -7897,9 +7798,7 @@ def create_app(
         # in-project primary required, any video on the stage works.
         # ------------------------------------------------------------------
 
-        @app.post(
-            "/api/lab/projects/{slug}/{stage_number}/videos/{video_id}/promote-against-fixture"
-        )
+        @app.post("/api/lab/projects/{slug}/{stage_number}/videos/{video_id}/promote-against-fixture")
         def lab_promote_against_fixture(
             slug: str,
             stage_number: int,
@@ -7950,9 +7849,7 @@ def create_app(
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
 
             probe = probe_camera_metadata(source)
-            camera_id = (
-                body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}"
-            ).strip()
+            camera_id = (body.camera_id or probe.suggested_id or f"cam-{video.video_id[:8]}").strip()
             if not camera_id:
                 raise HTTPException(
                     status_code=400,
@@ -7964,10 +7861,7 @@ def create_app(
             if target_json.exists() and not body.overwrite:
                 raise HTTPException(
                     status_code=409,
-                    detail=(
-                        f"fixture already exists: {target_json.name}"
-                        " (set overwrite=true to replace)"
-                    ),
+                    detail=(f"fixture already exists: {target_json.name}" " (set overwrite=true to replace)"),
                 )
 
             try:
@@ -8025,9 +7919,7 @@ def create_app(
                 fixture_data = dict(result.fixture_data)
                 secondary_beep = float(fixture_data.get("beep_time") or 0.0)
                 shot_times = [
-                    float(s["time"])
-                    for s in fixture_data.get("shots", [])
-                    if s.get("time") is not None
+                    float(s["time"]) for s in fixture_data.get("shots", []) if s.get("time") is not None
                 ]
                 trim_buffer = 5.0
                 trim_tail = 5.0
@@ -8171,11 +8063,7 @@ def create_app(
     def _shooter_from_slug(slug: str) -> str | None:
         # Shooter is encoded as ``s<8-hex-chars>`` (the slug hash).
         for tok in slug.split("-"):
-            if (
-                len(tok) == 9
-                and tok.startswith("s")
-                and all(c in "0123456789abcdef" for c in tok[1:])
-            ):
+            if len(tok) == 9 and tok.startswith("s") and all(c in "0123456789abcdef" for c in tok[1:]):
                 return tok
         return None
 
@@ -8769,8 +8657,7 @@ def _print_active_jobs(app: FastAPI) -> None:
         print("Shutting down (no background jobs running).", file=sys.stderr, flush=True)
         return
     print(
-        f"Shutting down -- waiting for {len(active)} background job"
-        f"{'' if len(active) == 1 else 's'}:",
+        f"Shutting down -- waiting for {len(active)} background job" f"{'' if len(active) == 1 else 's'}:",
         file=sys.stderr,
         flush=True,
     )

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -45,67 +45,55 @@ export function App() {
               their redesign issues ship. Ingest stays self-shelled
               (focused-task page, no sidebar).
 
-              Shooter-scoped routes (#353 phase 1): /audit /export /ingest
-              /coach take an explicit /:slug so the URL alone identifies
-              which shooter is in focus. Legacy slug-less forms remain
-              live as backwards-compat shims; ShooterScopedRoute redirects
-              them to the canonical /<page>/<bound-slug>/[:stage] form.
-              The /:slug routes use the slug as the React Router key so a
-              switch (chip-strip click -> Link -> URL change) remounts the
-              page cleanly instead of forcing a window.location.reload.
+              Shooter-scoped routes (#353): /audit /export /ingest /coach
+              take an explicit /:slug so the URL alone identifies which
+              shooter is in focus. Slugless visits redirect to /shooters.
+              ShooterScopedRoute keys on slug so the page remounts cleanly
+              when the chip strip switches shooters.
 
               /compare /shooters /beep-review stay slug-less: compare is
               inherently multi-shooter, /shooters is the shooter manager
               itself, beep-review is a cross-shooter queue. */}
           <Route
-            path="ingest"
-            element={<ShooterScopedRoute page="ingest" element={<Ingest />} />}
+            path="ingest/:slug"
+            element={<ShooterScopedRoute element={<Ingest />} />}
           />
           <Route
-            path="ingest/:slugOrStage"
-            element={<ShooterScopedRoute page="ingest" element={<Ingest />} />}
+            path="ingest"
+            element={<Navigate to="/shooters" replace />}
           />
           <Route element={<MatchShell />}>
             <Route index element={<Home />} />
             <Route
-              path="audit"
-              element={<ShooterScopedRoute page="audit" element={<Audit />} />}
-            />
-            <Route
-              path="audit/:slugOrStage"
-              element={<ShooterScopedRoute page="audit" element={<Audit />} />}
+              path="audit/:slug"
+              element={<ShooterScopedRoute element={<Audit />} />}
             />
             <Route
               path="audit/:slug/:stage"
-              element={<ShooterScopedRoute page="audit" element={<Audit />} />}
+              element={<ShooterScopedRoute element={<Audit />} />}
             />
+            <Route path="audit" element={<Navigate to="/shooters" replace />} />
             <Route path="compare/:stage" element={<Compare />} />
             <Route
-              path="coach"
-              element={<ShooterScopedRoute page="coach" element={<Coach />} />}
-            />
-            <Route
-              path="coach/:slugOrStage"
-              element={<ShooterScopedRoute page="coach" element={<Coach />} />}
+              path="coach/:slug"
+              element={<ShooterScopedRoute element={<Coach />} />}
             />
             <Route
               path="coach/:slug/:stage"
-              element={<ShooterScopedRoute page="coach" element={<Coach />} />}
+              element={<ShooterScopedRoute element={<Coach />} />}
             />
+            <Route path="coach" element={<Navigate to="/shooters" replace />} />
             <Route path="shooters" element={<Shooters />} />
             <Route path="beep-review" element={<BeepReview />} />
             <Route
-              path="export"
-              element={<ShooterScopedRoute page="export" element={<Export />} />}
-            />
-            <Route
-              path="export/:slugOrStage"
-              element={<ShooterScopedRoute page="export" element={<Export />} />}
+              path="export/:slug"
+              element={<ShooterScopedRoute element={<Export />} />}
             />
             <Route
               path="export/:slug/:stage"
-              element={<ShooterScopedRoute page="export" element={<Export />} />}
+              element={<ShooterScopedRoute element={<Export />} />}
             />
+            <Route path="export" element={<Navigate to="/shooters" replace />} />
           </Route>
           {/* Developer mode (#331). All four workflow steps + the
               retired Lab + fixture-editor surfaces sit under the

--- a/src/splitsmith/ui_static/src/components/AuditControls.tsx
+++ b/src/splitsmith/ui_static/src/components/AuditControls.tsx
@@ -85,7 +85,7 @@ function FilterChip({ label, glyph, active, count, onToggle }: FilterChipProps) 
 
 export interface FilterBarProps {
   filters: MarkerFilters;
-  counts: { detected: number; rejected: number; manual: number };
+  counts: { detected: number; rejected: number; manual: number; beep: number };
   onChange: (next: MarkerFilters) => void;
 }
 
@@ -118,7 +118,7 @@ export function FilterBar({ filters, counts, onChange }: FilterBarProps) {
         label="beep"
         glyph="beep"
         active={filters.beep}
-        count={1}
+        count={counts.beep}
         onToggle={() => onChange({ ...filters, beep: !filters.beep })}
       />
     </div>

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -1308,7 +1308,7 @@ function BeepPreview({
       )}
       {isPrimary ? (
         <Link
-          to={`/audit/${stageNumber}`}
+          to={`/audit/${slug}/${stageNumber}`}
           className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
           title="Open the audit screen to verify or correct this beep on the waveform"
         >

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -74,6 +74,7 @@ function ReleasingPreviewVideo(
 }
 
 interface Props {
+  slug: string;
   stageNumber: number;
   /** The video this section operates on. Beep fields, candidate lists and
    *  the preview clip are all read from / written to this video; the
@@ -88,6 +89,7 @@ interface Props {
 }
 
 export function BeepSection({
+  slug,
   stageNumber,
   video,
   onProjectUpdate,
@@ -172,7 +174,7 @@ export function BeepSection({
         try {
           const final = await api.pollJob(active.id, setJobStatus);
           if (cancelled) return;
-          if (final.status === "succeeded") onProjectUpdate(await api.getProject());
+          if (final.status === "succeeded") onProjectUpdate(await api.getProject(slug));
           else if (final.status === "failed") setError(final.error ?? "Beep detection failed");
         } finally {
           if (!cancelled) {
@@ -193,13 +195,13 @@ export function BeepSection({
     setBusy(true);
     setError(null);
     try {
-      const job = await api.detectBeepForVideo(stageNumber, videoId, force);
+      const job = await api.detectBeepForVideo(slug, stageNumber, videoId, force);
       setJobStatus(job);
       const final = await api.pollJob(job.id, setJobStatus);
       if (final.status === "failed") {
         setError(final.error ?? "Beep detection failed");
       } else {
-        onProjectUpdate(await api.getProject());
+        onProjectUpdate(await api.getProject(slug));
       }
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
@@ -237,12 +239,12 @@ export function BeepSection({
     setRedetecting(true);
     setError(null);
     try {
-      const job = await api.detectShots(stageNumber, { reset: true });
+      const job = await api.detectShots(slug, stageNumber, { reset: true });
       const final = await api.pollJob(job.id, () => {});
       if (final.status === "failed") {
         setError(final.error ?? "Shot detection failed");
       } else {
-        onProjectUpdate(await api.getProject());
+        onProjectUpdate(await api.getProject(slug));
       }
       setPendingShotRedetect(null);
     } catch (e) {
@@ -267,7 +269,7 @@ export function BeepSection({
     const prevHadShots = isPrimary && video.processed.shot_detect;
     setBusy(true);
     try {
-      const updated = await api.overrideBeepForVideo(stageNumber, videoId, value);
+      const updated = await api.overrideBeepForVideo(slug, stageNumber, videoId, value);
       onProjectUpdate(updated);
       setError(null);
       setEditing(false);
@@ -282,7 +284,7 @@ export function BeepSection({
   const clear = async () => {
     setBusy(true);
     try {
-      const updated = await api.overrideBeepForVideo(stageNumber, videoId, null);
+      const updated = await api.overrideBeepForVideo(slug, stageNumber, videoId, null);
       onProjectUpdate(updated);
       setError(null);
       setEditing(false);
@@ -298,7 +300,7 @@ export function BeepSection({
     const prevHadShots = isPrimary && video.processed.shot_detect;
     setBusy(true);
     try {
-      const updated = await api.selectBeepCandidateForVideo(stageNumber, videoId, time);
+      const updated = await api.selectBeepCandidateForVideo(slug, stageNumber, videoId, time);
       onProjectUpdate(updated);
       setError(null);
       queueShotRedetectIfNeeded(prevBeepTime, prevHadShots, time);
@@ -341,6 +343,7 @@ export function BeepSection({
           </Button>
         </div>
         <BeepWaveformPicker
+          slug={slug}
           stageNumber={stageNumber}
           videoId={videoId}
           videoBeepTime={video.beep_time}
@@ -465,7 +468,7 @@ export function BeepSection({
     setBusy(true);
     setError(null);
     try {
-      const updated = await api.setBeepReviewed(stageNumber, videoId, true);
+      const updated = await api.setBeepReviewed(slug, stageNumber, videoId, true);
       onProjectUpdate(updated);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -478,7 +481,7 @@ export function BeepSection({
     setBusy(true);
     setError(null);
     try {
-      const updated = await api.setBeepReviewed(stageNumber, videoId, false);
+      const updated = await api.setBeepReviewed(slug, stageNumber, videoId, false);
       onProjectUpdate(updated);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -601,6 +604,7 @@ export function BeepSection({
       </div>
       {disagreement && crossAlignSuggestion != null ? (
         <AlignmentDisagreement
+          slug={slug}
           stageNumber={stageNumber}
           videoId={videoId}
           inStreamTime={video.beep_time!}
@@ -613,6 +617,7 @@ export function BeepSection({
             setBusy(true);
             try {
               const updated = await api.overrideBeepForVideo(
+                slug,
                 stageNumber,
                 videoId,
                 crossAlignSuggestion,
@@ -630,6 +635,7 @@ export function BeepSection({
         />
       ) : null}
       <BeepCandidates
+        slug={slug}
         stageNumber={stageNumber}
         videoId={videoId}
         candidates={video.beep_candidates}
@@ -638,6 +644,7 @@ export function BeepSection({
         onSelect={selectCandidate}
       />
       <BeepPreview
+        slug={slug}
         stageNumber={stageNumber}
         videoId={videoId}
         beepTime={video.beep_time}
@@ -677,6 +684,7 @@ export function BeepSection({
  *  (`/api/stages/{n}/videos/{vid}/...`) so primary and secondary use the
  *  same component, the same controls, and the same snap-to-beep flow. */
 export function BeepWaveformPicker({
+  slug,
   stageNumber,
   videoId,
   videoBeepTime,
@@ -688,6 +696,7 @@ export function BeepWaveformPicker({
   instructions,
   ariaLabel,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   videoBeepTime: number | null;
@@ -724,7 +733,7 @@ export function BeepWaveformPicker({
     setLoading(true);
     setUnavailable(false);
     api
-      .getVideoPeaks(stageNumber, videoId)
+      .getVideoPeaks(slug, stageNumber, videoId)
       .then((p) => {
         if (cancelled) return;
         setPeaks(p);
@@ -739,7 +748,7 @@ export function BeepWaveformPicker({
     return () => {
       cancelled = true;
     };
-  }, [stageNumber, videoId]);
+  }, [slug, stageNumber, videoId]);
 
   // Source-time <-> clip-time bridge. Zero when the WAV is the full
   // source; equal to the trim window's start when an audit clip is
@@ -821,7 +830,7 @@ export function BeepWaveformPicker({
     setSnapping(true);
     setError(null);
     try {
-      const result = await api.snapBeepForVideo(stageNumber, videoId, draftSourceTime, 1.5);
+      const result = await api.snapBeepForVideo(slug, stageNumber, videoId, draftSourceTime, 1.5);
       setProposal(result);
     } catch (e) {
       if (e instanceof ApiError && e.status === 404) {
@@ -921,7 +930,7 @@ export function BeepWaveformPicker({
       />
       <audio
         ref={audioRef}
-        src={api.videoAudioUrl(stageNumber, videoId)}
+        src={api.videoAudioUrl(slug, stageNumber, videoId)}
         preload="metadata"
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
@@ -954,6 +963,7 @@ export function BeepWaveformPicker({
       </div>
       {proposal != null ? (
         <SnapProposal
+          slug={slug}
           stageNumber={stageNumber}
           videoId={videoId}
           proposal={proposal}
@@ -967,12 +977,14 @@ export function BeepWaveformPicker({
 
 
 function SnapProposal({
+  slug,
   stageNumber,
   videoId,
   proposal,
   onAccept,
   onDismiss,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   proposal: BeepSnapResult;
@@ -1010,6 +1022,7 @@ function SnapProposal({
         </div>
       </div>
       <ProposalPreview
+        slug={slug}
         stageNumber={stageNumber}
         videoId={videoId}
         time={proposal.snapped_time}
@@ -1025,11 +1038,13 @@ function SnapProposal({
  *  cross-align suggestions, etc. Smaller than BeepPreview so it can sit
  *  inside a confirmation banner without dominating the row. */
 function ProposalPreview({
+  slug,
   stageNumber,
   videoId,
   time,
   ariaLabel,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   time: number;
@@ -1050,7 +1065,7 @@ function ProposalPreview({
   return (
     <ReleasingPreviewVideo
       key={`${stageNumber}:${videoId}:${time.toFixed(3)}`}
-      src={api.videoBeepPreviewUrl(stageNumber, videoId, time)}
+      src={api.videoBeepPreviewUrl(slug, stageNumber, videoId, time)}
       className="h-32 w-56 rounded-md border border-border/60 bg-black object-cover"
       playsInline
       controls
@@ -1063,6 +1078,7 @@ function ProposalPreview({
 }
 
 function BeepCandidates({
+  slug,
   stageNumber,
   videoId,
   candidates,
@@ -1070,6 +1086,7 @@ function BeepCandidates({
   busy,
   onSelect,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   candidates: BeepCandidate[];
@@ -1161,6 +1178,7 @@ function BeepCandidates({
                 <ReleasingPreviewVideo
                   key={`${stageNumber}:${videoId}:${candidates[previewIndex].time.toFixed(3)}`}
                   src={api.videoBeepPreviewUrl(
+                    slug,
                     stageNumber,
                     videoId,
                     candidates[previewIndex].time,
@@ -1251,11 +1269,13 @@ function CandidateRow({
 }
 
 function BeepPreview({
+  slug,
   stageNumber,
   videoId,
   beepTime,
   isPrimary,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   beepTime: number;
@@ -1276,7 +1296,7 @@ function BeepPreview({
       ) : (
         <ReleasingPreviewVideo
           key={`${stageNumber}:${videoId}:${beepTime.toFixed(3)}`}
-          src={api.videoBeepPreviewUrl(stageNumber, videoId, beepTime)}
+          src={api.videoBeepPreviewUrl(slug, stageNumber, videoId, beepTime)}
           className="h-40 w-64 rounded-md border border-border/60 bg-black object-cover"
           playsInline
           controls
@@ -1309,6 +1329,7 @@ function BeepPreview({
  *  override -- in-stream has frequency-domain information cross-align
  *  doesn't -- but we offer the user a one-click swap. */
 function AlignmentDisagreement({
+  slug,
   stageNumber,
   videoId,
   inStreamTime,
@@ -1318,6 +1339,7 @@ function AlignmentDisagreement({
   onUseCrossAlign,
   busy,
 }: {
+  slug: string;
   stageNumber: number;
   videoId: string;
   inStreamTime: number;
@@ -1369,6 +1391,7 @@ function AlignmentDisagreement({
             Cross-align preview ({crossAlignTime.toFixed(3)}s)
           </span>
           <ProposalPreview
+            slug={slug}
             stageNumber={stageNumber}
             videoId={videoId}
             time={crossAlignTime}

--- a/src/splitsmith/ui_static/src/components/CameraModelSelect.tsx
+++ b/src/splitsmith/ui_static/src/components/CameraModelSelect.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils";
 const OTHER_VALUE = "__other__";
 
 interface Props {
+  slug: string;
   video: StageVideo;
   stageNumber: number;
   disabled?: boolean;
@@ -38,6 +39,7 @@ interface Props {
 }
 
 export function CameraModelSelect({
+  slug,
   video,
   stageNumber,
   disabled = false,
@@ -104,6 +106,7 @@ export function CameraModelSelect({
           setError?.(null);
           try {
             const updated = await api.setCameraModel(
+              slug,
               stageNumber,
               video.video_id,
               picked.make,

--- a/src/splitsmith/ui_static/src/components/CleanupDialog.tsx
+++ b/src/splitsmith/ui_static/src/components/CleanupDialog.tsx
@@ -86,6 +86,7 @@ function formatBytes(bytes: number): string {
 }
 
 interface CleanupDialogProps {
+  slug: string;
   onClose: () => void;
 }
 
@@ -95,7 +96,7 @@ type ApplyOutcome = {
   failed: number;
 } | null;
 
-export function CleanupDialog({ onClose }: CleanupDialogProps) {
+export function CleanupDialog({ slug, onClose }: CleanupDialogProps) {
   const [selected, setSelected] = useState<Set<CleanupCategory>>(new Set());
   const [plan, setPlan] = useState<CleanupPlan | null>(null);
   const [planLoading, setPlanLoading] = useState(false);
@@ -113,7 +114,7 @@ export function CleanupDialog({ onClose }: CleanupDialogProps) {
     const handle = window.setTimeout(async () => {
       setPlanLoading(true);
       try {
-        const fresh = await api.getCleanupPlan(Array.from(selected));
+        const fresh = await api.getCleanupPlan(slug, Array.from(selected));
         if (!cancelled) setPlan(fresh);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -147,7 +148,7 @@ export function CleanupDialog({ onClose }: CleanupDialogProps) {
     setBusy(true);
     setError(null);
     try {
-      const resp = await api.applyCleanup(Array.from(selected));
+      const resp = await api.applyCleanup(slug, Array.from(selected));
       setOutcome({
         bytesFreed: resp.result.bytes_freed,
         deleted: resp.result.deleted.length,

--- a/src/splitsmith/ui_static/src/components/FolderPicker.tsx
+++ b/src/splitsmith/ui_static/src/components/FolderPicker.tsx
@@ -41,6 +41,10 @@ import {
 import { cn } from "@/lib/utils";
 
 interface FolderPickerProps {
+  /** Shooter slug for shooter-scoped fs endpoints. The picker browses
+   *  the host filesystem boundary-checked against this shooter's project
+   *  root. */
+  slug: string;
   initialPath?: string | null;
   onSelect: (path: string) => void;
   /** Optional callback for multi-file selection. When provided, video rows
@@ -70,6 +74,7 @@ interface FolderPickerProps {
 }
 
 export function FolderPicker({
+  slug,
   initialPath,
   onSelect,
   onSelectFiles,
@@ -98,7 +103,7 @@ export function FolderPicker({
       setBusy(true);
       setError(null);
       try {
-        const data = await api.listFolder(next ?? undefined, { probe: wantMetadata });
+        const data = await api.listFolder(slug, next ?? undefined, { probe: wantMetadata });
         setListing(data);
         setPath(data.path);
         // Reset multi-file selection when navigating to a new directory.
@@ -109,7 +114,7 @@ export function FolderPicker({
         setBusy(false);
       }
     },
-    [wantMetadata],
+    [slug, wantMetadata],
   );
 
   useEffect(() => {
@@ -263,6 +268,7 @@ export function FolderPicker({
                     return (
                       <VideoRowMulti
                         key={`v-${entry.name}`}
+                        slug={slug}
                         entry={entry}
                         fullPath={fullPath}
                         checked={checked}
@@ -422,6 +428,7 @@ function SidebarIcon({ kind }: { kind: SuggestedStart["kind"] }) {
 }
 
 function VideoRowMulti({
+  slug,
   entry,
   fullPath,
   checked,
@@ -430,6 +437,7 @@ function VideoRowMulti({
   onToggle,
   onProbed,
 }: {
+  slug: string;
   entry: FsEntry;
   fullPath: string;
   checked: boolean;
@@ -447,14 +455,14 @@ function VideoRowMulti({
     if (probing) return;
     setProbing(true);
     try {
-      const r = await api.probeFile(fullPath);
+      const r = await api.probeFile(slug, fullPath);
       onProbed(r.duration, r.thumbnail_url);
     } catch {
       // Best effort; leave fields null so the row still shows what it can.
     } finally {
       setProbing(false);
     }
-  }, [entry.duration, entry.thumbnail_url, fullPath, onProbed, probing]);
+  }, [entry.duration, entry.thumbnail_url, fullPath, onProbed, probing, slug]);
 
   return (
     <li

--- a/src/splitsmith/ui_static/src/components/HitlQueuePanel.tsx
+++ b/src/splitsmith/ui_static/src/components/HitlQueuePanel.tsx
@@ -49,6 +49,7 @@ const KIND_VARIANTS: Record<HitlItemKind, "outline" | "destructive"> = {
 };
 
 export interface HitlQueuePanelProps {
+  slug: string;
   /** Optional: external trigger to refetch. Bumping the value forces
    *  a queue reload; useful when the Ingest page just promoted a
    *  candidate and wants the list to refresh without waiting for the
@@ -65,6 +66,7 @@ export interface HitlQueuePanelProps {
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 
 export function HitlQueuePanel({
+  slug,
   refreshKey = 0,
   onJumpToStage,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
@@ -75,7 +77,7 @@ export function HitlQueuePanel({
 
   const reload = useCallback(async () => {
     try {
-      const next = await api.getHitlQueue();
+      const next = await api.getHitlQueue(slug);
       setQueue(next);
       setError(null);
     } catch (e) {
@@ -83,7 +85,7 @@ export function HitlQueuePanel({
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [slug]);
 
   useEffect(() => {
     void reload();

--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -196,7 +196,7 @@ export function JobsPanel() {
           <span
             className={cn(
               "inline-flex min-w-[1.5rem] items-center justify-center rounded-full px-2 py-0.5 font-mono text-[0.625rem] font-bold tabular-nums",
-              unackedFailures > 0 ? "bg-led text-bg" : "bg-beep text-bg",
+              unackedFailures > 0 ? "bg-led-fill text-ink" : "bg-beep text-bg",
             )}
           >
             {unackedFailures > 0
@@ -408,7 +408,7 @@ function Group({
           className={cn(
             "inline-flex min-w-[1.5rem] items-center justify-center rounded-full px-1.5 py-0.5 font-mono text-[0.625rem] font-bold tabular-nums",
             tone === "running" && "bg-beep text-bg",
-            tone === "failed" && "bg-led text-bg",
+            tone === "failed" && "bg-led-fill text-ink",
             tone === "done" && "bg-done text-bg",
             !tone && "bg-surface-3 text-ink-2",
           )}

--- a/src/splitsmith/ui_static/src/components/MountSelect.tsx
+++ b/src/splitsmith/ui_static/src/components/MountSelect.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from "@/lib/utils";
 
 interface MountSelectProps {
+  slug: string;
   video: StageVideo;
   stageNumber: number;
   disabled?: boolean;
@@ -35,6 +36,7 @@ interface MountSelectProps {
 }
 
 export function MountSelect({
+  slug,
   video,
   stageNumber,
   disabled = false,
@@ -67,6 +69,7 @@ export function MountSelect({
           setError?.(null);
           try {
             const updated = await api.setCameraMount(
+              slug,
               stageNumber,
               video.video_id,
               next,

--- a/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
+++ b/src/splitsmith/ui_static/src/components/RelinkDialog.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/api";
 
 interface RelinkDialogProps {
+  slug: string;
   onClose: () => void;
   onApplied?: () => void;
 }
@@ -72,7 +73,7 @@ function statusBadgeClass(status: LinkStatus): string {
   }
 }
 
-export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
+export function RelinkDialog({ slug, onClose, onApplied }: RelinkDialogProps) {
   const [rows, setRows] = useState<RowState[]>([]);
   const [searchRoot, setSearchRoot] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -86,7 +87,7 @@ export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
     let cancelled = false;
     void (async () => {
       try {
-        const resp = await api.getLinkStatus();
+        const resp = await api.getLinkStatus(slug);
         if (cancelled) return;
         setRows(
           resp.entries.map((link) => ({ link, scan: null, picked: null })),
@@ -120,7 +121,7 @@ export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
     setBusy(true);
     setError(null);
     try {
-      const resp = await api.relinkScan(root);
+      const resp = await api.relinkScan(slug, root);
       setRows((prev) =>
         prev.map((row) => {
           const found = resp.entries.find((e) => e.video_id === row.link.video_id);
@@ -154,11 +155,11 @@ export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
       for (const row of eligibleForApply) {
         if (row.picked) decisions[row.link.video_id] = row.picked;
       }
-      const resp = await api.relinkApply(decisions);
+      const resp = await api.relinkApply(slug, decisions);
       setAppliedCount((c) => c + resp.applied.length);
       // Refresh statuses so applied rows flip to ``ok`` and the user
       // sees them turn green.
-      const fresh = await api.getLinkStatus();
+      const fresh = await api.getLinkStatus(slug);
       setRows((prev) =>
         fresh.entries.map((link) => {
           const old = prev.find((r) => r.link.video_id === link.video_id);
@@ -234,6 +235,7 @@ export function RelinkDialog({ onClose, onApplied }: RelinkDialogProps) {
           {pickerOpen ? (
             <div className="rounded-md border border-border p-2">
               <FolderPicker
+                slug={slug}
                 onSelect={async (path) => {
                   setPickerOpen(false);
                   await runScan(path);

--- a/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
+++ b/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
@@ -1,190 +1,27 @@
 /**
- * ShooterScopedRoute -- canonicalises shooter-bound URLs (#353 phase 1).
+ * ShooterScopedRoute -- shooter-bound pages live under /<page>/:slug[/...].
  *
- * The shooter-bound pages (Audit, Export, Ingest, Coach) accept three URL
- * shapes for backwards-compat reasons:
+ * The slug in the URL is the only source of truth for which shooter the
+ * page reads (#353). When the slug changes, the wrapped element remounts
+ * via the slug-derived key so each page's effects start fresh on the new
+ * shooter without page-specific reset plumbing.
  *
- *   /page                     -- no slug, no stage. Use bound shooter.
- *   /page/:slugOrStage        -- one param, ambiguous:
- *                                  - numeric  -> legacy /page/:stage
- *                                  - non-numeric -> new /page/:slug
- *   /page/:slug/:stage        -- canonical new form.
- *
- * This component sits between the route and the actual page. It resolves
- * which case applies, redirects legacy / ambiguous forms to the canonical
- * /:slug or /:slug/:stage URL, and renders the wrapped page with
- * key={slug} so a shooter switch (chip-strip Link -> URL change) remounts
- * the page cleanly instead of needing window.location.reload().
- *
- * When the URL slug differs from the server-bound shooter it also fires
- * api.selectActiveShooter(slug) so the legacy ``state.project_root`` on
- * the server points at the right shooter. Phases 2-3 of #353 will lift
- * the binding off the server singleton, at which point that side-effect
- * goes away.
+ * Slugless visits (e.g. ``/audit``) redirect to ``/shooters`` so the user
+ * picks one explicitly -- there is no "active shooter" fallback any more.
  */
 
-import { useEffect, useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
-import { api } from "@/lib/api";
-
-type Page = "audit" | "export" | "ingest" | "coach";
-
 interface Props {
-  page: Page;
   element: React.ReactElement;
 }
 
-export function ShooterScopedRoute({ page, element }: Props) {
-  const params = useParams<{
-    slug?: string;
-    stage?: string;
-    slugOrStage?: string;
-  }>();
-
-  // Step 1: figure out the canonical (slug, stage) pair from the matched
-  // URL shape. Cases:
-  //   /page                       -> {slug: undef,  stage: undef}
-  //   /page/<number>              -> legacy, treat as {slug: undef, stage: <number>}
-  //   /page/<non-number>          -> new slug-only, {slug: <non-number>, stage: undef}
-  //   /page/<slug>/<stage>        -> canonical, both set
-  const { slug, stage } = useMemo(() => {
-    if (params.slug !== undefined) {
-      return { slug: params.slug, stage: params.stage };
-    }
-    if (params.slugOrStage === undefined) {
-      return { slug: undefined, stage: undefined };
-    }
-    if (/^\d+$/.test(params.slugOrStage)) {
-      return { slug: undefined, stage: params.slugOrStage };
-    }
-    return { slug: params.slugOrStage, stage: undefined };
-  }, [params]);
-
-  // Step 2: when no slug is in the URL, resolve the bound shooter and
-  // redirect to the canonical URL.
-  const [boundSlug, setBoundSlug] = useState<string | null | undefined>(
-    undefined,
-  );
-  useEffect(() => {
-    if (slug !== undefined) return;
-    let alive = true;
-    api
-      .getHealth()
-      .then((h) => {
-        if (!alive) return;
-        // project_root ends with "shooters/<slug>" when bound inside a
-        // match; the slug is the last path segment. For legacy single-
-        // shooter projects there's no match -> no slug to fill in; we
-        // leave boundSlug=null and just render the page (it'll use
-        // whatever the server has bound).
-        const root = h.project_root ?? "";
-        const m = root.match(/[\\/]shooters[\\/]([^\\/]+)[\\/]?$/);
-        setBoundSlug(m ? m[1] : null);
-      })
-      .catch(() => {
-        if (alive) setBoundSlug(null);
-      });
-    return () => {
-      alive = false;
-    };
-  }, [slug]);
-
-  if (slug === undefined) {
-    if (boundSlug === undefined) {
-      // Health still loading. Nothing visible -- this is fast (a single
-      // /api/health round-trip already in-flight from MatchShell).
-      return null;
-    }
-    if (boundSlug === null) {
-      // Legacy single-shooter project (no Match folder). Just render the
-      // page without remounting -- nothing to canonicalise.
-      return element;
-    }
-    const target = stage ? `/${page}/${boundSlug}/${stage}` : `/${page}/${boundSlug}`;
-    return <Navigate to={target} replace />;
-  }
-
-  // Step 3: slug in URL. If it differs from the server-bound one, fire a
-  // selectActiveShooter side-effect so legacy endpoints read the right
-  // project root. Don't gate the render on it -- the page mounts fresh
-  // (we key on slug), so any in-flight reads land on the new shooter
-  // once selectActiveShooter resolves. That's a phase-1 compromise; #353
-  // phases 2-3 remove the round-trip entirely.
+export function ShooterScopedRoute({ element }: Props) {
+  const { slug } = useParams<{ slug: string }>();
+  if (!slug) return <Navigate to="/shooters" replace />;
   return (
-    <SlugBindWrapper slug={slug}>
-      {/* The slug key forces a fresh mount of `element` whenever the URL
-          slug changes -- replaces the previous reload-on-switch. */}
-      <ShooterKeyedElement slug={slug} element={element} />
-    </SlugBindWrapper>
+    <span key={slug} style={{ display: "contents" }}>
+      {element}
+    </span>
   );
-}
-
-function SlugBindWrapper({
-  slug,
-  children,
-}: {
-  slug: string;
-  children: React.ReactNode;
-}) {
-  // Gate the children render until the server's project_root matches the
-  // URL slug. Audit / Export / Coach all fire their own getProject on
-  // mount; without this gate they'd race the rebind and momentarily show
-  // the previous shooter's data. Phase 2 of #353 eliminates this by
-  // making the slug per-request instead of singleton state.
-  const [bound, setBound] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    setBound(false);
-    (async () => {
-      try {
-        const h = await api.getHealth();
-        if (!alive) return;
-        const root = h.project_root ?? "";
-        const m = root.match(/[\\/]shooters[\\/]([^\\/]+)[\\/]?$/);
-        const currentBound = m ? m[1] : null;
-        if (currentBound === slug) {
-          setBound(true);
-          return;
-        }
-        try {
-          await api.selectActiveShooter(slug);
-          if (alive) setBound(true);
-        } catch (err: unknown) {
-          // 404 = slug not in match; the page will render its own error.
-          // Any other failure: still let the page try -- the worst case
-          // is a stale-shooter flash, not a stuck UI.
-          // eslint-disable-next-line no-console
-          console.warn("selectActiveShooter failed", err);
-          if (alive) setBound(true);
-        }
-      } catch {
-        if (alive) setBound(true);
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [slug]);
-
-  if (!bound) {
-    // Render nothing while binding: tiny window in the common case
-    // (already-bound shooter), brief loading state on a real switch.
-    return null;
-  }
-  return <>{children}</>;
-}
-
-function ShooterKeyedElement({
-  slug,
-  element,
-}: {
-  slug: string;
-  element: React.ReactElement;
-}) {
-  // React's reconciler treats elements with different keys as distinct
-  // mounts. Cloning the element with a slug-derived key gives us a clean
-  // remount on shooter switch without each page having to thread reset
-  // logic through its many effects.
-  return <span key={slug} style={{ display: "contents" }}>{element}</span>;
 }

--- a/src/splitsmith/ui_static/src/components/StageTimeSection.tsx
+++ b/src/splitsmith/ui_static/src/components/StageTimeSection.tsx
@@ -35,6 +35,7 @@ import { cn } from "@/lib/utils";
 import { api, type MatchProject, type StageEntry, type StageVideo } from "@/lib/api";
 
 interface Props {
+  slug: string;
   stageNumber: number;
   stage: StageEntry;
   primary: StageVideo;
@@ -43,6 +44,7 @@ interface Props {
 }
 
 export function StageTimeSection({
+  slug,
   stageNumber,
   stage,
   primary,
@@ -86,7 +88,7 @@ export function StageTimeSection({
     setBusy(true);
     setError(null);
     try {
-      const updated = await api.setStageTime(stageNumber, draftDuration);
+      const updated = await api.setStageTime(slug, stageNumber, draftDuration);
       onProjectUpdate(updated);
       setEditing(false);
     } catch (e) {
@@ -100,7 +102,7 @@ export function StageTimeSection({
     setBusy(true);
     setError(null);
     try {
-      const updated = await api.setStageTime(stageNumber, null);
+      const updated = await api.setStageTime(slug, stageNumber, null);
       onProjectUpdate(updated);
       setEditing(false);
       setEndSourceTime(null);
@@ -184,6 +186,7 @@ export function StageTimeSection({
         {busy ? <Loader2 className="size-4 animate-spin text-muted-foreground" /> : null}
       </div>
       <BeepWaveformPicker
+        slug={slug}
         stageNumber={stageNumber}
         videoId={primary.video_id}
         videoBeepTime={beepTime}

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -13,7 +13,7 @@
 
 import { Bell, HelpCircle, Repeat, Settings } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { Navigate, Outlet, useNavigate } from "react-router-dom";
+import { Navigate, Outlet, useNavigate, useParams } from "react-router-dom";
 
 import { JobsPanel } from "@/components/JobsPanel";
 import {
@@ -43,6 +43,12 @@ export interface MatchShellOutletContext {
 
 export function MatchShell() {
   const navigate = useNavigate();
+  // The shell mounts above shooter-scoped routes (/audit/:slug, /coach/:slug,
+  // /export/:slug) and slug-less routes (/, /shooters, /beep-review,
+  // /compare/:stage). When a slug is in the URL we load that shooter's
+  // project so the sidebar reflects their progress; otherwise the sidebar
+  // shows match-level info without per-stage status.
+  const { slug } = useParams<{ slug?: string }>();
   const { mode, setMode } = useMode();
   const [didInitMode, setDidInitMode] = useState(false);
   useEffect(() => {
@@ -86,14 +92,18 @@ export function MatchShell() {
       .then((h) => {
         if (alive) setHealth(h);
         if (h?.bound) {
-          api
-            .getProject()
-            .then((p) => {
-              if (alive) setProject(p);
-            })
-            .catch(() => {
-              if (alive) setProject(null);
-            });
+          if (slug) {
+            api
+              .getProject(slug)
+              .then((p) => {
+                if (alive) setProject(p);
+              })
+              .catch(() => {
+                if (alive) setProject(null);
+              });
+          } else {
+            setProject(null);
+          }
           api
             .listMatchShooters()
             .then((r) => {
@@ -112,7 +122,7 @@ export function MatchShell() {
     return () => {
       alive = false;
     };
-  }, [refreshKey]);
+  }, [refreshKey, slug]);
 
   const stages: MatchSidebarStage[] = useMemo(() => {
     if (!project) return [];
@@ -254,7 +264,9 @@ export function MatchShell() {
           awaiting={
             stages.length > 0 && stages.every((s) => s.status === "todo")
           }
-          onStageClick={(n) => navigate(`/audit/${n}`)}
+          onStageClick={(n) =>
+            navigate(slug ? `/audit/${slug}/${n}` : "/shooters")
+          }
         />
         <div className={cn("min-w-0 flex-1")}>
           <Outlet

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -85,6 +85,19 @@ export function MatchShell() {
     };
   }, []);
 
+  // Server-state drift recovery: when ANY request returns 409 ``no_project``
+  // (typical cause: dev server restart wiped the in-memory bind state),
+  // ``api.ts`` fires this custom event. We bump ``refreshKey`` so the
+  // health-load effect re-runs, sees ``bound: false``, and the redirect
+  // below sends the user to /pick. Without this, the page sits with
+  // every endpoint failing and the JobsPanel silently empty.
+  useEffect(() => {
+    const onNoProject = () => setRefreshKey((k) => k + 1);
+    window.addEventListener("splitsmith:no-project", onNoProject);
+    return () =>
+      window.removeEventListener("splitsmith:no-project", onNoProject);
+  }, []);
+
   useEffect(() => {
     let alive = true;
     api

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -92,9 +92,14 @@ export function MatchShell() {
       .then((h) => {
         if (alive) setHealth(h);
         if (h?.bound) {
-          if (slug) {
+          // Sidebar stage list needs *some* shooter's project to render
+          // status. URL slug wins; otherwise fall back to the server's
+          // default shooter (alphabetically-first match shooter, or the
+          // legacy slug for single-shooter projects).
+          const fetchSlug = slug ?? h.default_shooter_slug ?? null;
+          if (fetchSlug) {
             api
-              .getProject(slug)
+              .getProject(fetchSlug)
               .then((p) => {
                 if (alive) setProject(p);
               })
@@ -264,9 +269,11 @@ export function MatchShell() {
           awaiting={
             stages.length > 0 && stages.every((s) => s.status === "todo")
           }
-          onStageClick={(n) =>
-            navigate(slug ? `/audit/${slug}/${n}` : "/shooters")
-          }
+          onStageClick={(n) => {
+            const target = slug ?? health?.default_shooter_slug;
+            navigate(target ? `/audit/${target}/${n}` : "/shooters");
+          }}
+          shooterSlug={slug ?? health?.default_shooter_slug ?? undefined}
         />
         <div className={cn("min-w-0 flex-1")}>
           <Outlet

--- a/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
@@ -16,6 +16,7 @@ import {
   ArrowDownToLine,
   ClipboardCheck,
   Crosshair,
+  Film,
   LayoutGrid,
   Users,
 } from "lucide-react";
@@ -117,6 +118,12 @@ export function MatchSidebar({
           count={shooterCount}
         >
           Shooters
+        </SidebarLink>
+        <SidebarLink
+          to={shooterSlug ? `/ingest/${shooterSlug}` : "/shooters"}
+          icon={<Film className="size-[15px]" />}
+        >
+          Videos
         </SidebarLink>
         <SidebarLink
           to={shooterSlug ? `/export/${shooterSlug}` : "/shooters"}

--- a/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
@@ -46,6 +46,13 @@ interface MatchSidebarProps {
   /** Per-stage click handler. Receives the stage number; the surface that
    *  owns the sidebar decides where to route (audit, compare, ...). */
   onStageClick?: (stage_number: number) => void;
+  /** Slug for the shooter currently in focus (when a shooter-scoped route
+   *  is active). Drives the per-shooter nav links so clicking Audit /
+   *  Coach / Export keeps the user on the same shooter instead of
+   *  bouncing to the shooter picker. ``undefined`` when no shooter is in
+   *  focus (e.g. /shooters, /); in that case the per-shooter nav rows
+   *  point at /shooters so the user picks one. */
+  shooterSlug?: string;
   className?: string;
 }
 
@@ -57,6 +64,7 @@ export function MatchSidebar({
   shooterCount,
   awaiting = false,
   onStageClick,
+  shooterSlug,
   className,
 }: MatchSidebarProps) {
   const audited = stages.filter((s) => s.status === "done").length;
@@ -84,19 +92,21 @@ export function MatchSidebar({
         )}
       </div>
 
-      {/* Cross-match nav */}
+      {/* Cross-match nav. Per-shooter rows include the in-focus slug
+       *  so navigation stays on the same shooter when one is active;
+       *  without a slug they point to /shooters so the user picks. */}
       <div className="mb-1 flex flex-col gap-px">
         <SidebarLink to="/" icon={<LayoutGrid className="size-[15px]" />} end>
           Overview
         </SidebarLink>
         <SidebarLink
-          to="/audit"
+          to={shooterSlug ? `/audit/${shooterSlug}` : "/shooters"}
           icon={<Crosshair className="size-[15px]" />}
         >
           Audit
         </SidebarLink>
         <SidebarLink
-          to="/coach"
+          to={shooterSlug ? `/coach/${shooterSlug}` : "/shooters"}
           icon={<ClipboardCheck className="size-[15px]" />}
         >
           Coach
@@ -109,7 +119,7 @@ export function MatchSidebar({
           Shooters
         </SidebarLink>
         <SidebarLink
-          to="/export"
+          to={shooterSlug ? `/export/${shooterSlug}` : "/shooters"}
           icon={<ArrowDownToLine className="size-[15px]" />}
         >
           Export

--- a/src/splitsmith/ui_static/src/components/match/ShooterChipStrip.tsx
+++ b/src/splitsmith/ui_static/src/components/match/ShooterChipStrip.tsx
@@ -1,0 +1,117 @@
+/**
+ * ShooterChipStrip -- shared shooter switcher for every shooter-scoped
+ * page (Audit, Ingest / Videos, Coach, Export).
+ *
+ * Each chip is a Link to the same page at the picked slug; the parent
+ * route's <ShooterScopedRoute> keys the rendered page on slug so the
+ * switch remounts cleanly (no manual cleanup of stage state, peaks,
+ * audit JSON, etc.). The active chip is non-interactive and styled
+ * with the LED ring.
+ *
+ * The strip only renders for multi-shooter matches. Single-shooter
+ * matches and legacy projects have nothing to switch between.
+ */
+
+import { Link } from "react-router-dom";
+
+import { Avatar } from "@/components/ui";
+import type { ShooterListEntry } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** All shooters in the bound match. Hides itself when length <= 1. */
+  shooters: ShooterListEntry[];
+  /** Slug of the shooter currently in focus (the URL's :slug). */
+  activeSlug: string | undefined;
+  /** Route base for the chip targets, without leading slash. Examples:
+   *  ``"audit"``, ``"ingest"``, ``"coach"``, ``"export"``. */
+  urlBase: "audit" | "ingest" | "coach" | "export";
+  /** Optional stage number to suffix on the chip target. When set, the
+   *  target becomes ``/<urlBase>/<slug>/<stage>``; when null, just
+   *  ``/<urlBase>/<slug>``. Audit + Coach + Export all support both
+   *  forms; Ingest is per-shooter (no stage), so callers pass null. */
+  stage?: number | null;
+  /** Verb label shown to the left of the chips. Each page picks one:
+   *  ``"Auditing"``, ``"Adding videos for"``, ``"Coaching"``,
+   *  ``"Exporting"``. */
+  label: string;
+  /** Per-chip secondary count format. Defaults to "audited/total"; pages
+   *  that surface a different metric (e.g. raw video count on Ingest)
+   *  pass a custom formatter. ``null`` hides the count. */
+  count?: ((s: ShooterListEntry) => string | null) | null;
+}
+
+const defaultCount = (s: ShooterListEntry): string =>
+  `${pad2(s.stages_audited)}/${pad2(s.stages_total)}`;
+
+export function ShooterChipStrip({
+  shooters,
+  activeSlug,
+  urlBase,
+  stage = null,
+  label,
+  count = defaultCount,
+}: Props) {
+  if (shooters.length <= 1) return null;
+  return (
+    <div className="-mt-1 mb-3 inline-flex flex-wrap items-center gap-2">
+      <span className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.14em] text-subtle">
+        {label}
+      </span>
+      {shooters.map((s) => {
+        const isActive = s.slug === activeSlug;
+        const target =
+          stage != null
+            ? `/${urlBase}/${s.slug}/${stage}`
+            : `/${urlBase}/${s.slug}`;
+        const secondary = count ? count(s) : null;
+        return (
+          <Link
+            key={s.slug}
+            to={target}
+            replace
+            aria-current={isActive ? "page" : undefined}
+            title={
+              isActive
+                ? `${s.name} -- currently in focus`
+                : `Switch to ${s.name}`
+            }
+            className={cn(
+              "inline-flex items-center gap-2 rounded-full border px-2 py-1 text-[0.8125rem] transition-colors no-underline",
+              isActive
+                ? "border-led shadow-[0_0_0_1px_var(--color-led-deep),0_0_14px_var(--color-led-glow)]"
+                : "border-rule bg-surface-2 text-ink-2 hover:border-rule-strong hover:bg-surface-3",
+              isActive && "pointer-events-none",
+            )}
+          >
+            <Avatar
+              size="xs"
+              initials={chipInitials(s.name)}
+              seed={s.slug}
+              name={s.name}
+            />
+            <span className="font-display text-[0.6875rem] font-semibold uppercase tracking-[0.06em]">
+              {s.name}
+            </span>
+            {secondary ? (
+              <span className="font-mono text-[0.625rem] uppercase tracking-[0.06em] text-muted">
+                {secondary}
+              </span>
+            ) : null}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function chipInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1089,6 +1089,17 @@ export interface ServerHealth {
   bound: boolean;
   project_name: string | null;
   project_root: string | null;
+  /** Discriminates the on-disk layout. ``"match"`` for the Match -> Shooter
+   *  folder layout; ``"legacy"`` for single-shooter projects that predate
+   *  the split; ``null`` when the server is unbound. */
+  kind: "match" | "legacy" | null;
+  /** Slug that the SPA can plug into ``/audit/<slug>/...`` URLs from any
+   *  slugless surface (Home, sidebar Audit/Coach/Export rows) so the
+   *  user lands somewhere sensible without picking a shooter first. For
+   *  a match this is the alphabetically-first registered shooter; for a
+   *  legacy project it's the deterministic legacy slug. Null when the
+   *  match is empty or the server is unbound. */
+  default_shooter_slug: string | null;
   schema_version: number | null;
 }
 

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1370,102 +1370,137 @@ async function request<T>(
 }
 
 export const api = {
-  getProject: () => request<MatchProject>("/api/project"),
+  getProject: (slug: string) =>
+    request<MatchProject>(`/api/shooters/${encodeURIComponent(slug)}/project`),
 
   /** Fetch the canonical match-window analysis (per-stage windows +
    *  per-video classification). Drives the ingest screen's timeline; SPA
    *  carries no policy of its own beyond rendering. */
-  getMatchAnalysis: () => request<MatchAnalysis>("/api/project/match-analysis"),
+  getMatchAnalysis: (slug: string) =>
+    request<MatchAnalysis>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/match-analysis`,
+    ),
 
-  listFolder: (path?: string, opts?: { probe?: boolean }) => {
+  listFolder: (slug: string, path?: string, opts?: { probe?: boolean }) => {
     const params = new URLSearchParams();
     if (path) params.set("path", path);
     if (opts?.probe) params.set("probe", "true");
     const qs = params.toString();
-    return request<FsListing>(`/api/fs/list${qs ? `?${qs}` : ""}`);
+    return request<FsListing>(
+      `/api/shooters/${encodeURIComponent(slug)}/fs/list${qs ? `?${qs}` : ""}`,
+    );
   },
 
-  probeFile: (path: string) =>
-    request<FsProbeResponse>(`/api/fs/probe?path=${encodeURIComponent(path)}`),
+  probeFile: (slug: string, path: string) =>
+    request<FsProbeResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/fs/probe?path=${encodeURIComponent(path)}`,
+    ),
 
-  removeVideo: (videoPath: string, resetAudit = false) =>
-    request<RemoveVideoResponse>("/api/videos/remove", {
-      method: "POST",
-      json: { video_path: videoPath, reset_audit: resetAudit },
-    }),
+  removeVideo: (slug: string, videoPath: string, resetAudit = false) =>
+    request<RemoveVideoResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/remove`,
+      {
+        method: "POST",
+        json: { video_path: videoPath, reset_audit: resetAudit },
+      },
+    ),
 
-  getCleanupPlan: (categories: CleanupCategory[]) => {
+  getCleanupPlan: (slug: string, categories: CleanupCategory[]) => {
     const qs = categories.length
       ? `?categories=${encodeURIComponent(categories.join(","))}`
       : "";
-    return request<CleanupPlan>(`/api/project/cleanup/plan${qs}`);
+    return request<CleanupPlan>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/cleanup/plan${qs}`,
+    );
   },
 
-  applyCleanup: (categories: CleanupCategory[]) =>
-    request<CleanupApplyResponse>("/api/project/cleanup", {
-      method: "POST",
-      json: { categories },
-    }),
+  applyCleanup: (slug: string, categories: CleanupCategory[]) =>
+    request<CleanupApplyResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/cleanup`,
+      {
+        method: "POST",
+        json: { categories },
+      },
+    ),
 
-  importScoreboard: (data: unknown, overwrite = false) =>
-    request<MatchProject>("/api/scoreboard/import", {
-      method: "POST",
-      json: { data, overwrite },
-    }),
+  importScoreboard: (slug: string, data: unknown, overwrite = false) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/import`,
+      {
+        method: "POST",
+        json: { data, overwrite },
+      },
+    ),
 
   // SSI Scoreboard v1 wiring (#50). The UI calls these without picking the
   // backend implementation -- the server resolves Local vs Http per request
   // based on whether ``<project>/scoreboard/match.json`` exists.
 
-  getScoreboardSource: () => request<ScoreboardSource>("/api/scoreboard/source"),
+  getScoreboardSource: (slug: string) =>
+    request<ScoreboardSource>(
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/source`,
+    ),
 
   /** Drop-and-populate: the SPA reads the file as text, parses JSON, and
    *  posts it here. Backend writes to ``<project>/scoreboard/match.json``
    *  and uses LocalJsonScoreboard so subsequent requests stay fully offline. */
-  uploadScoreboard: (data: unknown, overwrite = false) =>
-    request<MatchProject>("/api/scoreboard/upload", {
-      method: "POST",
-      json: { data, overwrite },
-    }),
+  uploadScoreboard: (slug: string, data: unknown, overwrite = false) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/upload`,
+      {
+        method: "POST",
+        json: { data, overwrite },
+      },
+    ),
 
   /** Free-text match search. In offline mode this hits the dropped match
    *  only; in online mode it goes to ``GET /api/v1/events?q=``. */
-  searchScoreboardMatches: (q: string) =>
+  searchScoreboardMatches: (slug: string, q: string) =>
     request<ScoreboardMatchRef[]>(
-      `/api/scoreboard/search?q=${encodeURIComponent(q)}`,
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/search?q=${encodeURIComponent(q)}`,
     ),
 
   /** Cache-first full match fetch -> populate project. */
   fetchScoreboardMatch: (
+    slug: string,
     contentType: number,
     matchId: number,
     overwrite = false,
   ) =>
-    request<MatchProject>("/api/scoreboard/fetch", {
-      method: "POST",
-      json: { content_type: contentType, match_id: matchId, overwrite },
-    }),
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/fetch`,
+      {
+        method: "POST",
+        json: { content_type: contentType, match_id: matchId, overwrite },
+      },
+    ),
 
   /** Resolve the current source's ``MatchData``. The SPA uses this to map
    *  a picked ``shooterId`` to a per-match ``competitor_id`` before
    *  pinning. 404 when the project has no match loaded. */
-  getScoreboardMatchData: () =>
-    request<ScoreboardMatchData>("/api/scoreboard/match-data"),
+  getScoreboardMatchData: (slug: string) =>
+    request<ScoreboardMatchData>(
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/match-data`,
+    ),
 
   /** Find shooters by name. Offline mode searches this match's competitor
    *  list only; online mode hits the live shooter index. */
-  searchScoreboardShooters: (q: string) =>
+  searchScoreboardShooters: (slug: string, q: string) =>
     request<ScoreboardShooterRef[]>(
-      `/api/scoreboard/shooter/search?q=${encodeURIComponent(q)}`,
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/shooter/search?q=${encodeURIComponent(q)}`,
     ),
 
   /** Pin (shooter, competitor) and merge stage times. The competitor id is
    *  resolved client-side from ``getScoreboardMatchData``; the server
    *  refuses to guess. The response carries the updated project plus a
    *  ``stage_times_merged`` count for the SPA to confirm. */
-  selectScoreboardShooter: (shooterId: number, competitorId: number) =>
+  selectScoreboardShooter: (
+    slug: string,
+    shooterId: number,
+    competitorId: number,
+  ) =>
     request<MatchProject & { stage_times_merged: number }>(
-      "/api/scoreboard/select-shooter",
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/select-shooter`,
       {
         method: "POST",
         json: { shooter_id: shooterId, competitor_id: competitorId },
@@ -1475,104 +1510,139 @@ export const api = {
   /** Re-pull and re-merge stage times for the pinned competitor. Used for
    *  in-progress matches where new scorecards land while the user is
    *  ingesting; clears the project-local cache for every cid in the match. */
-  refreshScoreboardTimes: () =>
+  refreshScoreboardTimes: (slug: string) =>
     request<MatchProject & { stage_times_merged: number }>(
-      "/api/scoreboard/refresh-times",
+      `/api/shooters/${encodeURIComponent(slug)}/scoreboard/refresh-times`,
       { method: "POST" },
     ),
 
 
-  createPlaceholderStages: (req: PlaceholderStagesRequest) =>
-    request<MatchProject>("/api/project/placeholder-stages", {
-      method: "POST",
-      json: req,
-    }),
+  createPlaceholderStages: (slug: string, req: PlaceholderStagesRequest) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/placeholder-stages`,
+      {
+        method: "POST",
+        json: req,
+      },
+    ),
 
   scanVideos: (
+    slug: string,
     sourceDir: string,
     autoAssignPrimary = true,
     linkMode: "symlink" | "copy" = "symlink",
   ) =>
-    request<ScanResponse>("/api/videos/scan", {
-      method: "POST",
-      json: {
-        source_dir: sourceDir,
-        auto_assign_primary: autoAssignPrimary,
-        link_mode: linkMode,
+    request<ScanResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/scan`,
+      {
+        method: "POST",
+        json: {
+          source_dir: sourceDir,
+          auto_assign_primary: autoAssignPrimary,
+          link_mode: linkMode,
+        },
       },
-    }),
+    ),
 
   scanFiles: (
+    slug: string,
     sourcePaths: string[],
     autoAssignPrimary = true,
     linkMode: "symlink" | "copy" = "symlink",
   ) =>
-    request<ScanResponse>("/api/videos/scan", {
-      method: "POST",
-      json: {
-        source_paths: sourcePaths,
-        auto_assign_primary: autoAssignPrimary,
-        link_mode: linkMode,
+    request<ScanResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/scan`,
+      {
+        method: "POST",
+        json: {
+          source_paths: sourcePaths,
+          auto_assign_primary: autoAssignPrimary,
+          link_mode: linkMode,
+        },
       },
-    }),
+    ),
 
   /** Per-video filesystem status of the ``raw/<name>`` symlinks. The
    *  Project page polls this so it can badge broken/missing entries
    *  outside the relink dialog. */
-  getLinkStatus: () => request<LinkStatusResponse>("/api/videos/link-status"),
+  getLinkStatus: (slug: string) =>
+    request<LinkStatusResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/link-status`,
+    ),
 
   /** Recursive dry-run: walk ``searchRoot`` and report per-video
    *  candidates by basename. Pure -- no filesystem mutations. */
-  relinkScan: (searchRoot: string) =>
-    request<RelinkScanResponse>("/api/videos/relink/scan", {
-      method: "POST",
-      json: { search_root: searchRoot },
-    }),
+  relinkScan: (slug: string, searchRoot: string) =>
+    request<RelinkScanResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/relink/scan`,
+      {
+        method: "POST",
+        json: { search_root: searchRoot },
+      },
+    ),
 
   /** Apply a confirmed set of symlink rewrites. ``decisions`` maps
    *  ``video_id`` -> absolute target path. Any video_id not listed is
    *  left untouched. */
-  relinkApply: (decisions: Record<string, string>) =>
-    request<RelinkApplyResponse>("/api/videos/relink/apply", {
-      method: "POST",
-      json: { decisions },
-    }),
+  relinkApply: (slug: string, decisions: Record<string, string>) =>
+    request<RelinkApplyResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/relink/apply`,
+      {
+        method: "POST",
+        json: { decisions },
+      },
+    ),
 
-  updateSettings: (patch: ProjectSettingsPatch) =>
-    request<MatchProject>("/api/project/settings", {
-      method: "POST",
-      json: patch,
-    }),
+  updateSettings: (slug: string, patch: ProjectSettingsPatch) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/settings`,
+      {
+        method: "POST",
+        json: patch,
+      },
+    ),
 
-  getAutomation: () =>
-    request<ResolvedAutomationResponse>("/api/automation"),
+  getAutomation: (slug: string) =>
+    request<ResolvedAutomationResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/automation`,
+    ),
 
   /** Project-level work queue: beeps the auto-trust gate (#219) didn't
    *  clear -- either missing (auto-detect found nothing) or below the
    *  ``beep_low_confidence_threshold``. The HITL panel polls this on
    *  the Ingest page; the MCP wrapper exposes it as a resource so an
    *  agent can drive the picks. */
-  getHitlQueue: () => request<HitlQueueResponse>("/api/hitl-queue"),
+  getHitlQueue: (slug: string) =>
+    request<HitlQueueResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/hitl-queue`,
+    ),
 
-  dismissNudge: (stageNumber: number, dismissed: boolean) =>
-    request<MatchProject>("/api/project/nudges/dismiss", {
-      method: "POST",
-      json: { stage_number: stageNumber, dismissed },
-    }),
+  dismissNudge: (slug: string, stageNumber: number, dismissed: boolean) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/project/nudges/dismiss`,
+      {
+        method: "POST",
+        json: { stage_number: stageNumber, dismissed },
+      },
+    ),
 
   moveAssignment: (
+    slug: string,
     videoPath: string,
     toStageNumber: number | null,
     role: VideoRole = "secondary",
   ) =>
-    request<MatchProject>("/api/assignments/move", {
-      method: "POST",
-      json: {
-        video_path: videoPath,
-        to_stage_number: toStageNumber,
-        role,
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/assignments/move`,
+      {
+        method: "POST",
+        json: {
+          video_path: videoPath,
+          to_stage_number: toStageNumber,
+          role,
+        },
       },
-    }),
+    ),
 
   /** Promote ``videoPath`` to primary on ``stageNumber``. The server
    *  refuses with a 409 (``code: "audit_exists"``) when the stage has
@@ -1586,12 +1656,13 @@ export const api = {
    *  override and fall back to the artifact's default class on the next
    *  shot-detect run. */
   setCameraMount: (
+    slug: string,
     stageNumber: number,
     videoId: string,
     mount: CameraMount | null,
   ) =>
     request<MatchProject>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-mount`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-mount`,
       {
         method: "PATCH",
         json: { mount },
@@ -1604,13 +1675,14 @@ export const api = {
    *  generic-headcam amplitude floor. ``make`` and ``model`` must be
    *  supplied together or both ``null``. */
   setCameraModel: (
+    slug: string,
     stageNumber: number,
     videoId: string,
     make: string | null,
     model: string | null,
   ) =>
     request<MatchProject>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-model`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/camera-model`,
       {
         method: "PATCH",
         json: { make, model },
@@ -1624,23 +1696,34 @@ export const api = {
       "/api/calibrated-camera-models",
     ),
 
-  swapPrimary: (videoPath: string, stageNumber: number, confirm = false) =>
-    request<MatchProject>("/api/assignments/swap-primary", {
-      method: "POST",
-      json: {
-        video_path: videoPath,
-        stage_number: stageNumber,
-        confirm,
+  swapPrimary: (
+    slug: string,
+    videoPath: string,
+    stageNumber: number,
+    confirm = false,
+  ) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/assignments/swap-primary`,
+      {
+        method: "POST",
+        json: {
+          video_path: videoPath,
+          stage_number: stageNumber,
+          confirm,
+        },
       },
-    }),
+    ),
 
   /** Toggle the ``skipped`` flag on a stage. Skipped stages don't block
    *  the "next step" gate even when they have no videos / no primary. */
-  setStageSkipped: (stageNumber: number, skipped: boolean) =>
-    request<MatchProject>(`/api/stages/${stageNumber}/skip`, {
-      method: "POST",
-      json: { skipped },
-    }),
+  setStageSkipped: (slug: string, stageNumber: number, skipped: boolean) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/skip`,
+      {
+        method: "POST",
+        json: { skipped },
+      },
+    ),
 
   /** Submit a beep-detection job for the stage's primary. Returns a Job
    *  snapshot; poll via {@link api.pollJob} (or read /api/me/jobs/{id})
@@ -1648,9 +1731,9 @@ export const api = {
    *  SPA should re-fetch /api/project to pick up the new beep_time +
    *  processed.trim. Backed by the per-video pipeline; identical to
    *  ``detectBeepForVideo(stage, primary.video_id)``. */
-  detectBeep: (stageNumber: number, force = false) =>
+  detectBeep: (slug: string, stageNumber: number, force = false) =>
     request<Job>(
-      `/api/stages/${stageNumber}/detect-beep${force ? "?force=true" : ""}`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/detect-beep${force ? "?force=true" : ""}`,
       { method: "POST" },
     ),
 
@@ -1659,41 +1742,57 @@ export const api = {
    *  audit-mode trim, and its own dedupe slot in the registry so
    *  primary + Cam 2 + Cam 3 can run in parallel. Shot detection
    *  auto-chains for primary results only. */
-  detectBeepForVideo: (stageNumber: number, videoId: string, force = false) =>
+  detectBeepForVideo: (
+    slug: string,
+    stageNumber: number,
+    videoId: string,
+    force = false,
+  ) =>
     request<Job>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/detect-beep${
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/detect-beep${
         force ? "?force=true" : ""
       }`,
       { method: "POST" },
     ),
 
-  overrideBeep: (stageNumber: number, beepTime: number | null) =>
-    request<MatchProject>(`/api/stages/${stageNumber}/beep`, {
-      method: "POST",
-      json: { beep_time: beepTime },
-    }),
+  overrideBeep: (slug: string, stageNumber: number, beepTime: number | null) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/beep`,
+      {
+        method: "POST",
+        json: { beep_time: beepTime },
+      },
+    ),
 
   /** Manually set or clear a stage's duration. Used for projects without
    *  scoreboard data, where ``time_seconds`` would otherwise stay 0 and
    *  block the trim / shot-detect gates. Pass ``null`` to clear back to
    *  placeholder. Does NOT chain a trim -- caller clicks Trim explicitly. */
-  setStageTime: (stageNumber: number, timeSeconds: number | null) =>
-    request<MatchProject>(`/api/stages/${stageNumber}/time`, {
-      method: "POST",
-      json: { time_seconds: timeSeconds },
-    }),
+  setStageTime: (
+    slug: string,
+    stageNumber: number,
+    timeSeconds: number | null,
+  ) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/time`,
+      {
+        method: "POST",
+        json: { time_seconds: timeSeconds },
+      },
+    ),
 
   /** Manually set or clear ``video``'s beep timestamp. ``beepTime=null``
    *  clears back to "no beep yet"; otherwise the value (>= 0) is taken
    *  as authoritative with ``beep_source="manual"``. Same auto-trim
    *  chain as the legacy primary endpoint, just keyed per video. */
   overrideBeepForVideo: (
+    slug: string,
     stageNumber: number,
     videoId: string,
     beepTime: number | null,
   ) =>
     request<MatchProject>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep`,
       { method: "POST", json: { beep_time: beepTime } },
     ),
 
@@ -1702,22 +1801,26 @@ export const api = {
    *  so the SPA can hold a slightly stale snapshot without breaking the
    *  click. The server keeps the candidate list intact so the user can
    *  switch again without re-running detection, and re-fires the trim job. */
-  selectBeepCandidate: (stageNumber: number, time: number) =>
-    request<MatchProject>(`/api/stages/${stageNumber}/beep/select`, {
-      method: "POST",
-      json: { time },
-    }),
+  selectBeepCandidate: (slug: string, stageNumber: number, time: number) =>
+    request<MatchProject>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/beep/select`,
+      {
+        method: "POST",
+        json: { time },
+      },
+    ),
 
   /** Per-video candidate select. Same matching semantics as the primary
    *  endpoint (1 ms epsilon) but targets the video carrying the candidate
    *  list, so secondaries can pick from their own ranked alternatives. */
   selectBeepCandidateForVideo: (
+    slug: string,
     stageNumber: number,
     videoId: string,
     time: number,
   ) =>
     request<MatchProject>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/select`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/select`,
       { method: "POST", json: { time } },
     ),
 
@@ -1727,13 +1830,14 @@ export const api = {
    *  duration / amplitude in that window"; widen ``windowS`` or move
    *  the marker. */
   snapBeepForVideo: (
+    slug: string,
     stageNumber: number,
     videoId: string,
     hintTime: number,
     windowS: number = 0.5,
   ) =>
     request<BeepSnapResult>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/snap`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/snap`,
       { method: "POST", json: { hint_time: hintTime, window_s: windowS } },
     ),
 
@@ -1741,24 +1845,32 @@ export const api = {
    *  endpoint -- no detection or trim chain runs. Setting ``true``
    *  requires ``beep_time`` to already be set; the server returns 400
    *  otherwise. */
-  setBeepReviewed: (stageNumber: number, videoId: string, reviewed: boolean) =>
+  setBeepReviewed: (
+    slug: string,
+    stageNumber: number,
+    videoId: string,
+    reviewed: boolean,
+  ) =>
     request<MatchProject>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/review`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep/review`,
       { method: "POST", json: { reviewed } },
     ),
 
   /** Submit an audit-mode short-GOP trim job. Returns a Job snapshot;
    *  idempotent on the worker side -- when the cached MP4 is fresh the
    *  job completes near-instantly without re-encoding. */
-  trimStage: (stageNumber: number) =>
-    request<Job>(`/api/stages/${stageNumber}/trim`, { method: "POST" }),
+  trimStage: (slug: string, stageNumber: number) =>
+    request<Job>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/trim`,
+      { method: "POST" },
+    ),
 
   /** Per-video audit-mode trim. Mirrors ``trimStage`` for primaries but
    *  targets one specific camera, so multi-cam ingest can refresh a
    *  single secondary's scrub clip without retriggering the primary. */
-  trimVideo: (stageNumber: number, videoId: string) =>
+  trimVideo: (slug: string, stageNumber: number, videoId: string) =>
     request<Job>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/trim`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/trim`,
       { method: "POST" },
     ),
 
@@ -1768,21 +1880,31 @@ export const api = {
    *  this endpoint is for manual retrigger.
    *  Pass ``reset: true`` to wipe ``shots[]`` first, discarding the user's
    *  keep / reject decisions so the next pass starts fresh. */
-  detectShots: (stageNumber: number, opts: { reset?: boolean } = {}) => {
+  detectShots: (
+    slug: string,
+    stageNumber: number,
+    opts: { reset?: boolean } = {},
+  ) => {
     const qs = opts.reset ? "?reset=true" : "";
-    return request<Job>(`/api/stages/${stageNumber}/shot-detect${qs}`, { method: "POST" });
+    return request<Job>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/shot-detect${qs}`,
+      { method: "POST" },
+    );
   },
 
   /** Submit shot detection on every eligible stage. A stage is eligible
    *  when it has a primary with confirmed beep + non-zero time_seconds.
    *  Returns the list of submitted (or already-active) jobs plus a
    *  ``skipped`` array describing why ineligible stages were left alone. */
-  detectShotsAll: (opts: { reset?: boolean } = {}) => {
+  detectShotsAll: (slug: string, opts: { reset?: boolean } = {}) => {
     const qs = opts.reset ? "?reset=true" : "";
     return request<{
       jobs: Job[];
       skipped: { stage_number: number; reason: string }[];
-    }>(`/api/stages/shot-detect${qs}`, { method: "POST" });
+    }>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/shot-detect${qs}`,
+      { method: "POST" },
+    );
   },
 
   /** Server-side feature flags (fetched once on app mount). Today this
@@ -1982,26 +2104,32 @@ export const api = {
     }
   },
 
-  stageAudioUrl: (stageNumber: number) => `/api/stages/${stageNumber}/audio`,
+  stageAudioUrl: (slug: string, stageNumber: number) =>
+    `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/audio`,
 
   /** Per-video WAV URL. Primary forwards to the legacy stage audio
    *  endpoint (trimmed audit clip preferred); secondary serves the full
    *  per-cam WAV so the picker has the whole clip to scrub. */
-  videoAudioUrl: (stageNumber: number, videoId: string) =>
-    `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/audio`,
+  videoAudioUrl: (slug: string, stageNumber: number, videoId: string) =>
+    `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/audio`,
 
   /** URL for a tiny MP4 around a beep timestamp (#27, #22). ``t`` is
    *  passed to the server (which centres the clip there) AND ms-rounded
    *  into the cache key, so each distinct ``t`` gets its own MP4. The
    *  candidate picker uses this with arbitrary candidate times; the
    *  default flow passes ``primary.beep_time``. */
-  stageBeepPreviewUrl: (stageNumber: number, beepTime: number) =>
-    `/api/stages/${stageNumber}/beep-preview?t=${beepTime.toFixed(3)}`,
+  stageBeepPreviewUrl: (slug: string, stageNumber: number, beepTime: number) =>
+    `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/beep-preview?t=${beepTime.toFixed(3)}`,
 
   /** Per-video beep preview URL. Same caching semantics as the primary
    *  endpoint (cached on source mtime/size + center time + duration). */
-  videoBeepPreviewUrl: (stageNumber: number, videoId: string, beepTime: number) =>
-    `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep-preview?t=${beepTime.toFixed(3)}`,
+  videoBeepPreviewUrl: (
+    slug: string,
+    stageNumber: number,
+    videoId: string,
+    beepTime: number,
+  ) =>
+    `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/beep-preview?t=${beepTime.toFixed(3)}`,
 
   /** Stream URL for a registered video.
    *
@@ -2012,23 +2140,39 @@ export const api = {
    *  ``<video>`` element (which fails its next Range request with
    *  "source not found"). Other callers default to ``auto``: trim if
    *  present, source otherwise. */
-  videoStreamUrl: (videoPath: string, kind: "auto" | "trim" | "source" = "auto") =>
-    `/api/videos/stream?path=${encodeURIComponent(videoPath)}&kind=${kind}`,
+  videoStreamUrl: (
+    slug: string,
+    videoPath: string,
+    kind: "auto" | "trim" | "source" = "auto",
+  ) =>
+    `/api/shooters/${encodeURIComponent(slug)}/videos/stream?path=${encodeURIComponent(videoPath)}&kind=${kind}`,
 
-  getStagePeaks: (stageNumber: number, bins = 1200) =>
-    request<PeaksResult>(`/api/stages/${stageNumber}/peaks?bins=${bins}`),
+  getStagePeaks: (slug: string, stageNumber: number, bins = 1200) =>
+    request<PeaksResult>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/peaks?bins=${bins}`,
+    ),
 
   /** Per-video peaks. Same payload shape as the stage endpoint so the
    *  waveform picker takes the same code path for every role. */
-  getVideoPeaks: (stageNumber: number, videoId: string, bins = 1200) =>
+  getVideoPeaks: (
+    slug: string,
+    stageNumber: number,
+    videoId: string,
+    bins = 1200,
+  ) =>
     request<PeaksResult>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/peaks?bins=${bins}`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/peaks?bins=${bins}`,
     ),
 
   /** Returns the saved audit JSON for a stage, or null when none exists yet. */
-  getStageAudit: async (stageNumber: number): Promise<StageAudit | null> => {
+  getStageAudit: async (
+    slug: string,
+    stageNumber: number,
+  ): Promise<StageAudit | null> => {
     try {
-      return await request<StageAudit>(`/api/stages/${stageNumber}/audit`);
+      return await request<StageAudit>(
+        `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/audit`,
+      );
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) return null;
       throw err;
@@ -2037,51 +2181,65 @@ export const api = {
 
   /** Atomically write the stage's audit JSON. The server keeps the prior
    *  version as ``stage<N>.json.bak`` so a bad save can be recovered. */
-  saveStageAudit: (stageNumber: number, payload: StageAudit) =>
-    request<StageAudit>(`/api/stages/${stageNumber}/audit`, {
-      method: "PUT",
-      json: payload,
-    }),
+  saveStageAudit: (slug: string, stageNumber: number, payload: StageAudit) =>
+    request<StageAudit>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/audit`,
+      {
+        method: "PUT",
+        json: payload,
+      },
+    ),
 
   /** Coach view: per-shot interval class + flags + notes (#161). The
    *  GET is read-only; ``stale=true`` means the rule disagrees with the
    *  stored class and the user can accept the recompute via reclassify. */
-  getStageCoach: async (stageNumber: number): Promise<CoachStageResponse | null> => {
+  getStageCoach: async (
+    slug: string,
+    stageNumber: number,
+  ): Promise<CoachStageResponse | null> => {
     try {
-      return await request<CoachStageResponse>(`/api/stages/${stageNumber}/coach`);
+      return await request<CoachStageResponse>(
+        `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/coach`,
+      );
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) return null;
       throw err;
     }
   },
 
-  reclassifyStageCoach: (stageNumber: number) =>
-    request<CoachStageResponse>(`/api/stages/${stageNumber}/coach/reclassify`, {
-      method: "POST",
-    }),
+  reclassifyStageCoach: (slug: string, stageNumber: number) =>
+    request<CoachStageResponse>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/coach/reclassify`,
+      {
+        method: "POST",
+      },
+    ),
 
   patchStageShotCoach: (
+    slug: string,
     stageNumber: number,
     shotNumber: number,
     patch: CoachShotPatch,
   ) =>
     request<CoachStageResponse>(
-      `/api/stages/${stageNumber}/shots/${shotNumber}/coach`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/shots/${shotNumber}/coach`,
       { method: "PATCH", json: patch },
     ),
 
   /** Per-stage histograms + summary stats for the Coach distributions
    *  panel (#163). Empty classes still appear with count=0 so the UI
    *  can render an empty histogram without a special case. */
-  getStageCoachDistributions: (stageNumber: number) =>
+  getStageCoachDistributions: (slug: string, stageNumber: number) =>
     request<CoachStageDistributions>(
-      `/api/stages/${stageNumber}/coach/distributions`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/coach/distributions`,
     ),
 
   /** Match-level histograms aggregated across every stage with an audit
    *  JSON. Stages without an audit are silently skipped server-side. */
-  getMatchCoachDistributions: () =>
-    request<CoachMatchDistributions>("/api/coach/distributions"),
+  getMatchCoachDistributions: (slug: string) =>
+    request<CoachMatchDistributions>(
+      `/api/shooters/${encodeURIComponent(slug)}/coach/distributions`,
+    ),
 
   /** Structured anomalies for the *saved* audit JSON (issue #42).
    *
@@ -2089,13 +2247,16 @@ export const api = {
    *  so the panel updates without a network round-trip on every keep /
    *  reject. This endpoint exists for external consumers + integration
    *  tests that want the same flags ``report.txt`` will produce. */
-  getStageAnomalies: (stageNumber: number) =>
+  getStageAnomalies: (slug: string, stageNumber: number) =>
     request<{ anomalies: import("./anomalies").Anomaly[] }>(
-      `/api/stages/${stageNumber}/anomalies`,
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/anomalies`,
     ),
 
   /** Match-overview payload for the Analysis & Export screen. */
-  getExportOverview: () => request<ExportOverview>("/api/exports/overview"),
+  getExportOverview: (slug: string) =>
+    request<ExportOverview>(
+      `/api/shooters/${encodeURIComponent(slug)}/exports/overview`,
+    ),
 
   /** Submit a stage export job. Returns a Job snapshot; poll
    *  ``/api/me/jobs/{id}`` (or {@link api.pollJob}) until it leaves the
@@ -2103,8 +2264,14 @@ export const api = {
    *  paths + ``last_export_at``. Idempotent on the worker side: the
    *  registry dedupes by (kind, stage_number) so double-clicking
    *  Generate returns the in-flight job instead of stacking. */
-  exportStage: (stageNumber: number, opts: ExportStageRequestPayload = {}) =>
-    request<Job>(`/api/stages/${stageNumber}/export`, {
+  exportStage: (
+    slug: string,
+    stageNumber: number,
+    opts: ExportStageRequestPayload = {},
+  ) =>
+    request<Job>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/export`,
+      {
       method: "POST",
       json: {
         write_trim: opts.write_trim ?? true,
@@ -2137,8 +2304,8 @@ export const api = {
    *  to "match FCPXML on disk" in one click. Returns a Job snapshot;
    *  poll via {@link api.pollJob} until terminal, then read the
    *  {@link MatchExportResult} from ``Job.result``. */
-  exportMatch: (payload: MatchExportRequestPayload) =>
-    request<Job>("/api/match/export", {
+  exportMatch: (slug: string, payload: MatchExportRequestPayload) =>
+    request<Job>(`/api/shooters/${encodeURIComponent(slug)}/export/match`, {
       method: "POST",
       json: {
         stage_numbers: payload.stage_numbers,
@@ -2213,11 +2380,14 @@ export const api = {
    *  it from). Use this for the per-video "open containing folder" button
    *  -- ``revealFile`` would refuse because the resolved target lives
    *  outside the project root. */
-  revealVideo: (videoPath: string) =>
-    request<{ revealed: string }>("/api/videos/reveal", {
-      method: "POST",
-      json: { path: videoPath },
-    }),
+  revealVideo: (slug: string, videoPath: string) =>
+    request<{ revealed: string }>(
+      `/api/shooters/${encodeURIComponent(slug)}/videos/reveal`,
+      {
+        method: "POST",
+        json: { path: videoPath },
+      },
+    ),
 
   // -----------------------------------------------------------------------
   // Fixture mode (closes #19): the /review SPA route reads + writes a single
@@ -2362,6 +2532,7 @@ export const api = {
     `/api/lab/sweeps/${encodeURIComponent(runId)}/plot/${encodeURIComponent(plotName)}.png`,
 
   promoteSecondary: (
+    shooterSlug: string,
     stageNumber: number,
     videoId: string,
     payload: {
@@ -2383,7 +2554,7 @@ export const api = {
       camera_id: string;
       anchor_slug: string;
     }>(
-      `/api/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/promote-secondary`,
+      `/api/shooters/${encodeURIComponent(shooterSlug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/promote-secondary`,
       { method: "POST", json: payload },
     ),
 
@@ -2392,6 +2563,7 @@ export const api = {
    *  as a fixture in ``tests/fixtures/`` and the project has a phone-cam
    *  primary that should be aligned against it. */
   promoteAgainstFixture: (
+    shooterSlug: string,
     stageNumber: number,
     videoId: string,
     payload: {
@@ -2414,7 +2586,7 @@ export const api = {
       camera_id: string;
       anchor_slug: string;
     }>(
-      `/api/lab/projects/${stageNumber}/videos/${encodeURIComponent(videoId)}/promote-against-fixture`,
+      `/api/lab/projects/${encodeURIComponent(shooterSlug)}/${stageNumber}/videos/${encodeURIComponent(videoId)}/promote-against-fixture`,
       { method: "POST", json: payload },
     ),
 
@@ -2422,19 +2594,22 @@ export const api = {
    *  tab / window to trigger a download; using a real URL (not fetch)
    *  lets the browser write to disk without buffering the whole archive
    *  in memory. */
-  exportProjectUrl: (opts?: {
-    includeTrimmed?: boolean;
-    includeExports?: boolean;
-    includeRaw?: boolean;
-    includeAudio?: boolean;
-  }) => {
+  exportProjectUrl: (
+    slug: string,
+    opts?: {
+      includeTrimmed?: boolean;
+      includeExports?: boolean;
+      includeRaw?: boolean;
+      includeAudio?: boolean;
+    },
+  ) => {
     const params = new URLSearchParams();
     if (opts?.includeTrimmed) params.set("include_trimmed", "true");
     if (opts?.includeExports) params.set("include_exports", "true");
     if (opts?.includeRaw) params.set("include_raw", "true");
     if (opts?.includeAudio) params.set("include_audio", "true");
     const qs = params.toString();
-    return `/api/project/export${qs ? `?${qs}` : ""}`;
+    return `/api/shooters/${encodeURIComponent(slug)}/project/export${qs ? `?${qs}` : ""}`;
   },
 
   /** Restore a previously exported project. The server extracts the
@@ -2454,7 +2629,7 @@ export const api = {
       project_root: string;
       project_name: string;
       manifest: Record<string, unknown> | null;
-    }>("/api/project/import", { method: "POST", body: form });
+    }>("/api/me/projects/import", { method: "POST", body: form });
   },
 };
 

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1374,6 +1374,23 @@ async function request<T>(
     } catch {
       /* ignore */
     }
+    // Server-state drift recovery: a 409 with ``code: "no_project"`` means
+    // the SPA's view of the world is stale -- the server has no bound
+    // project (dev-server restart, explicit unbind, etc.). Fire a custom
+    // event so the match shell can force a health refresh and redirect
+    // to /pick. Without this, the page just shows broken-everything with
+    // no explanation and the JobsPanel quietly disappears. ``not_a_match``
+    // doesn't trigger the redirect; that's a per-route concern (the
+    // bound project is fine, just legacy).
+    if (
+      resp.status === 409 &&
+      rawDetail &&
+      typeof rawDetail === "object" &&
+      (rawDetail as { code?: unknown }).code === "no_project" &&
+      typeof window !== "undefined"
+    ) {
+      window.dispatchEvent(new CustomEvent("splitsmith:no-project"));
+    }
     throw new ApiError(resp.status, detail, rawDetail);
   }
   if (resp.status === 204) return undefined as T;

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1173,7 +1173,6 @@ export interface ShooterCameraInfo {
 export interface ShooterListEntry {
   slug: string;
   name: string;
-  is_active: boolean;
   selected_shooter_id: number | null;
   selected_competitor_id: number | null;
   stages_audited: number;
@@ -1211,7 +1210,6 @@ export interface CompareShotPoint {
 export interface CompareShooterRecord {
   slug: string;
   name: string;
-  is_active: boolean;
   video_path: string | null;
   beep_offset_in_clip: number | null;
   duration_seconds: number | null;
@@ -1832,13 +1830,6 @@ export const api = {
   /** List every shooter in the currently-bound match (#324). */
   listMatchShooters: () =>
     request<ShooterListResponse>("/api/match/shooters"),
-
-  /** Re-bind the server to a different shooter inside the same match (#324). */
-  selectActiveShooter: (slug: string) =>
-    request<ServerHealth>(
-      `/api/match/shooters/${encodeURIComponent(slug)}/select`,
-      { method: "POST" },
-    ),
 
   /** Queue trim-cache rebuild jobs for every missing-but-rebuildable stage
    *  in the named shooter's project. Works against the shooter's project

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1009,7 +1009,7 @@ export type JobStatus = "pending" | "running" | "succeeded" | "failed" | "cancel
 
 /** Mirror of splitsmith.ui.jobs.Job. Long-running endpoints (detect-beep,
  *  trim, future shot-detect/export) submit a job and return a snapshot;
- *  the SPA polls /api/jobs/{id} until status leaves "pending" / "running". */
+ *  the SPA polls /api/me/jobs/{id} until status leaves "pending" / "running". */
 export interface Job {
   id: string;
   kind: string;
@@ -1023,12 +1023,12 @@ export interface Job {
   progress: number | null;
   message: string | null;
   error: string | null;
-  /** True after the SPA POSTed /api/jobs/{id}/cancel for this job. The flag
+  /** True after the SPA POSTed /api/me/jobs/{id}/cancel for this job. The flag
    *  stays True on the terminal snapshot so the row can be labelled
    *  "Cancelled by user" instead of "Aborted". */
   cancel_requested: boolean;
   /** True once the user has dismissed this failure via
-   *  /api/jobs/{id}/acknowledge (issue #73). Meaningful only on FAILED
+   *  /api/me/jobs/{id}/acknowledge (issue #73). Meaningful only on FAILED
    *  jobs; the JobsPanel badge counts failures with acknowledged=false
    *  and the registry rolls acknowledged failures off faster than
    *  unacknowledged ones. */
@@ -1093,7 +1093,7 @@ export interface ServerHealth {
 }
 
 /** Saved SSI Scoreboard identity for the operator. Returned by
- *  ``GET /api/user/scoreboard-identity``; null when nothing is pinned. */
+ *  ``GET /api/me/scoreboard-identity``; null when nothing is pinned. */
 export interface ScoreboardIdentity {
   shooter_id: number;
   display_name: string | null;
@@ -1102,7 +1102,7 @@ export interface ScoreboardIdentity {
   base_url: string | null;
 }
 
-/** One entry from ``GET /api/user/recent-projects``. ``last_opened_at``
+/** One entry from ``GET /api/me/recent-projects``. ``last_opened_at``
  *  is an ISO-8601 UTC timestamp the picker uses to sort. ``path`` is
  *  resolved server-side; we don't normalise it client-side. ``kind``
  *  was added in #320 -- ``null`` covers entries written before the
@@ -1643,7 +1643,7 @@ export const api = {
     }),
 
   /** Submit a beep-detection job for the stage's primary. Returns a Job
-   *  snapshot; poll via {@link api.pollJob} (or read /api/jobs/{id})
+   *  snapshot; poll via {@link api.pollJob} (or read /api/me/jobs/{id})
    *  until the status flips out of "pending"/"running". On success the
    *  SPA should re-fetch /api/project to pick up the new beep_time +
    *  processed.trim. Backed by the per-video pipeline; identical to
@@ -1799,7 +1799,7 @@ export const api = {
    *  or null when nothing has been pinned yet. The header chrome uses
    *  this to render the user badge; null hides it. */
   getScoreboardIdentity: () =>
-    request<ScoreboardIdentity>("/api/user/scoreboard-identity").catch(
+    request<ScoreboardIdentity>("/api/me/scoreboard-identity").catch(
       (err) => {
         if (err instanceof ApiError && err.status === 404) return null;
         throw err;
@@ -1808,7 +1808,7 @@ export const api = {
 
   /** Recent-projects list, most-recent first. Drives the picker. */
   getRecentProjects: () =>
-    request<{ projects: RecentProject[] }>("/api/user/recent-projects").then(
+    request<{ projects: RecentProject[] }>("/api/me/recent-projects").then(
       (r) => r.projects,
     ),
 
@@ -1816,7 +1816,7 @@ export const api = {
    *  stages, status). Used by the redesigned match picker (#322). */
   getRecentProjectsDetail: () =>
     request<{ projects: RecentProjectDetail[] }>(
-      "/api/user/recent-projects?detail=true",
+      "/api/me/recent-projects?detail=true",
     ).then((r) => r.projects),
 
   /** Create a new match from the manual variant of the create-match form
@@ -1895,7 +1895,7 @@ export const api = {
    *  list so the picker can re-render without a follow-up GET. */
   forgetRecentProject: (path: string) =>
     request<{ removed: boolean; projects: RecentProject[] }>(
-      "/api/user/recent-projects/forget",
+      "/api/me/recent-projects/forget",
       { method: "POST", json: { path } },
     ),
 
@@ -1907,7 +1907,7 @@ export const api = {
     name?: string,
     opts?: { create?: boolean },
   ) =>
-    request<ServerHealth>("/api/user/recent-projects/bind", {
+    request<ServerHealth>("/api/me/recent-projects/bind", {
       method: "POST",
       json: { path, name, create: opts?.create ?? false },
     }),
@@ -1915,12 +1915,12 @@ export const api = {
   /** Drop the bound project so the SPA returns to the picker (Cmd+P
    *  "Switch project..." path). */
   unbindProject: () =>
-    request<ServerHealth>("/api/user/recent-projects/unbind", { method: "POST" }),
+    request<ServerHealth>("/api/me/recent-projects/unbind", { method: "POST" }),
 
   listJobs: (opts?: { signal?: AbortSignal }) =>
-    request<Job[]>("/api/jobs", { signal: opts?.signal }),
+    request<Job[]>("/api/me/jobs", { signal: opts?.signal }),
   getJob: (jobId: string, opts?: { signal?: AbortSignal }) =>
-    request<Job>(`/api/jobs/${encodeURIComponent(jobId)}`, {
+    request<Job>(`/api/me/jobs/${encodeURIComponent(jobId)}`, {
       signal: opts?.signal,
     }),
 
@@ -1928,18 +1928,18 @@ export const api = {
    *  as-is. For a running trim job the server terminates the underlying
    *  ffmpeg subprocess so the cancel takes effect immediately. */
   cancelJob: (jobId: string) =>
-    request<Job>(`/api/jobs/${encodeURIComponent(jobId)}/cancel`, { method: "POST" }),
+    request<Job>(`/api/me/jobs/${encodeURIComponent(jobId)}/cancel`, { method: "POST" }),
 
   /** Mark a single failed job as seen (issue #73). The badge stops
    *  counting it and the registry rolls it off ahead of unacknowledged
    *  failures. No-op for non-failed / already-acknowledged jobs. */
   acknowledgeJob: (jobId: string) =>
-    request<Job>(`/api/jobs/${encodeURIComponent(jobId)}/acknowledge`, { method: "POST" }),
+    request<Job>(`/api/me/jobs/${encodeURIComponent(jobId)}/acknowledge`, { method: "POST" }),
 
   /** Bulk-dismiss every currently-unacknowledged failure. Returns the
    *  jobs that actually flipped to acknowledged. */
   acknowledgeAllFailures: () =>
-    request<Job[]>(`/api/jobs/acknowledge-failures`, { method: "POST" }),
+    request<Job[]>(`/api/me/jobs/acknowledge-failures`, { method: "POST" }),
 
   /** Poll a job until it leaves the running state. ``onUpdate`` fires on
    *  every snapshot (including the final one). Returns the terminal Job. */
@@ -1954,7 +1954,7 @@ export const api = {
     while (true) {
       if (signal?.aborted) throw new DOMException("aborted", "AbortError");
       const job = await request<Job>(
-        `/api/jobs/${encodeURIComponent(jobId)}`,
+        `/api/me/jobs/${encodeURIComponent(jobId)}`,
         { signal },
       );
       onUpdate(job);
@@ -2098,7 +2098,7 @@ export const api = {
   getExportOverview: () => request<ExportOverview>("/api/exports/overview"),
 
   /** Submit a stage export job. Returns a Job snapshot; poll
-   *  ``/api/jobs/{id}`` (or {@link api.pollJob}) until it leaves the
+   *  ``/api/me/jobs/{id}`` (or {@link api.pollJob}) until it leaves the
    *  running state, then re-fetch the export overview to see updated
    *  paths + ``last_export_at``. Idempotent on the worker side: the
    *  registry dedupes by (kind, stage_number) so double-clicking

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1930,14 +1930,11 @@ export const api = {
 
   /** Saved SSI Scoreboard identity for the operator running this install,
    *  or null when nothing has been pinned yet. The header chrome uses
-   *  this to render the user badge; null hides it. */
+   *  this to render the user badge; null hides it. The server returns
+   *  ``200 null`` for the "not pinned" case so it doesn't show up as a
+   *  failed request in DevTools. */
   getScoreboardIdentity: () =>
-    request<ScoreboardIdentity>("/api/me/scoreboard-identity").catch(
-      (err) => {
-        if (err instanceof ApiError && err.status === 404) return null;
-        throw err;
-      },
-    ),
+    request<ScoreboardIdentity | null>("/api/me/scoreboard-identity"),
 
   /** Recent-projects list, most-recent first. Drives the picker. */
   getRecentProjects: () =>
@@ -2175,20 +2172,13 @@ export const api = {
       `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/videos/${encodeURIComponent(videoId)}/peaks?bins=${bins}`,
     ),
 
-  /** Returns the saved audit JSON for a stage, or null when none exists yet. */
-  getStageAudit: async (
-    slug: string,
-    stageNumber: number,
-  ): Promise<StageAudit | null> => {
-    try {
-      return await request<StageAudit>(
-        `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/audit`,
-      );
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 404) return null;
-      throw err;
-    }
-  },
+  /** Returns the saved audit JSON for a stage, or null when none exists yet.
+   *  Server returns ``200 null`` for the "no audit yet" state so this
+   *  doesn't show up as a failed request in DevTools. */
+  getStageAudit: (slug: string, stageNumber: number) =>
+    request<StageAudit | null>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/audit`,
+    ),
 
   /** Atomically write the stage's audit JSON. The server keeps the prior
    *  version as ``stage<N>.json.bak`` so a bad save can be recovered. */
@@ -2203,20 +2193,12 @@ export const api = {
 
   /** Coach view: per-shot interval class + flags + notes (#161). The
    *  GET is read-only; ``stale=true`` means the rule disagrees with the
-   *  stored class and the user can accept the recompute via reclassify. */
-  getStageCoach: async (
-    slug: string,
-    stageNumber: number,
-  ): Promise<CoachStageResponse | null> => {
-    try {
-      return await request<CoachStageResponse>(
-        `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/coach`,
-      );
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 404) return null;
-      throw err;
-    }
-  },
+   *  stored class and the user can accept the recompute via reclassify.
+   *  Returns null when the stage has no audit JSON yet. */
+  getStageCoach: (slug: string, stageNumber: number) =>
+    request<CoachStageResponse | null>(
+      `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/coach`,
+    ),
 
   reclassifyStageCoach: (slug: string, stageNumber: number) =>
     request<CoachStageResponse>(

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -203,6 +203,10 @@ export function Audit() {
   }, []);
   const rafRef = useRef<number | null>(null);
 
+  // ShooterScopedRoute redirects to /shooters when slug is missing, so by
+  // the time this renders ``slugParam`` is always a non-empty string.
+  const slug = slugParam!;
+
   const stageNumber = useMemo(() => {
     if (stageParam == null) return null;
     const n = Number.parseInt(stageParam, 10);
@@ -213,7 +217,7 @@ export function Audit() {
   useEffect(() => {
     let alive = true;
     api
-      .getProject()
+      .getProject(slug)
       .then((p) => {
         if (alive) setProject(p);
       })
@@ -412,7 +416,7 @@ export function Audit() {
     setPeaksLoading(true);
     setPeaksError(null);
     api
-      .getStagePeaks(stageNumber, PEAK_BINS)
+      .getStagePeaks(slug, stageNumber, PEAK_BINS)
       .then((p) => {
         if (alive) setPeaks(p);
       })
@@ -428,7 +432,7 @@ export function Audit() {
     return () => {
       alive = false;
     };
-  }, [stageNumber, primary]);
+  }, [slug, stageNumber, primary]);
 
   // Load audit JSON. 404 means "no audit yet" -- start with empty markers.
   useEffect(() => {
@@ -440,7 +444,7 @@ export function Audit() {
     let alive = true;
     setAuditLoaded(false);
     api
-      .getStageAudit(stageNumber)
+      .getStageAudit(slug, stageNumber)
       .then((a) => {
         if (!alive) return;
         setAudit(a);
@@ -456,7 +460,7 @@ export function Audit() {
     return () => {
       alive = false;
     };
-  }, [stageNumber]);
+  }, [slug, stageNumber]);
 
   // Tab change: re-seek the new <video> to the audit-timeline position.
   useEffect(() => {
@@ -959,7 +963,7 @@ export function Audit() {
       }
       setSaveStatus({ kind: "saving" });
       try {
-        const saved = await api.saveStageAudit(stageNumber, payload);
+        const saved = await api.saveStageAudit(slug, stageNumber, payload);
         setAudit(saved);
         sessionEventsRef.current = [];
         isDirtyRef.current = false;
@@ -1231,9 +1235,9 @@ export function Audit() {
   // thing because the trim can't exist without a beep.
   const videoSrc = activeVideo
     ? peaks
-      ? api.videoStreamUrl(activeVideo.path, peaks.trimmed ? "trim" : "source")
+      ? api.videoStreamUrl(slug, activeVideo.path, peaks.trimmed ? "trim" : "source")
       : peaksError != null
-        ? api.videoStreamUrl(activeVideo.path)
+        ? api.videoStreamUrl(slug, activeVideo.path)
         : ""
     : "";
 
@@ -1415,6 +1419,7 @@ export function Audit() {
             </Button>
             {peaks && !peaks.trimmed ? (
               <TrimNowBadge
+                slug={slug}
                 stageNumber={stage.stage_number}
                 hasBeep={primary.beep_time != null}
                 hasStageTime={stage.time_seconds > 0}
@@ -1422,7 +1427,7 @@ export function Audit() {
                   setProject(p);
                   if (stageNumber != null) {
                     api
-                      .getStagePeaks(stageNumber, PEAK_BINS)
+                      .getStagePeaks(slug, stageNumber, PEAK_BINS)
                       .then((np) => setPeaks(np))
                       .catch(() => {});
                   }
@@ -1431,13 +1436,14 @@ export function Audit() {
             ) : null}
             {peaks && peaks.trimmed ? (
               <DetectShotsBadge
+                slug={slug}
                 stageNumber={stage.stage_number}
                 hasBeep={primary.beep_time != null}
                 hasStageTime={stage.time_seconds > 0}
                 hasCandidates={markers.length > 0}
                 onComplete={async () => {
                   if (stageNumber == null) return;
-                  const a = await api.getStageAudit(stageNumber);
+                  const a = await api.getStageAudit(slug, stageNumber);
                   setAudit(a);
                   setMarkers(deriveMarkers(a));
                 }}
@@ -1518,6 +1524,7 @@ export function Audit() {
             ) : null}
             {activeVideo && stageNumber != null ? (
               <MountSelect
+                slug={slug}
                 video={activeVideo}
                 stageNumber={stageNumber}
                 label="Mount"
@@ -2104,6 +2111,7 @@ const StageSelector = memo(function StageSelector({
 });
 
 interface DetectShotsBadgeProps {
+  slug: string;
   stageNumber: number;
   hasBeep: boolean;
   hasStageTime: boolean;
@@ -2112,6 +2120,7 @@ interface DetectShotsBadgeProps {
 }
 
 function DetectShotsBadge({
+  slug,
   stageNumber,
   hasBeep,
   hasStageTime,
@@ -2171,7 +2180,7 @@ function DetectShotsBadge({
     async (reset: boolean) => {
       setError(null);
       try {
-        const initial = await api.detectShots(stageNumber, { reset });
+        const initial = await api.detectShots(slug, stageNumber, { reset });
         setJob(initial);
         const final = await api.pollJob(initial.id, setJob);
         if (final.status === "failed") {
@@ -2185,7 +2194,7 @@ function DetectShotsBadge({
         setJob(null);
       }
     },
-    [stageNumber, onComplete],
+    [slug, stageNumber, onComplete],
   );
 
   const onClick = useCallback(() => void runDetect(false), [runDetect]);
@@ -2250,6 +2259,7 @@ function DetectShotsBadge({
 }
 
 interface TrimNowBadgeProps {
+  slug: string;
   stageNumber: number;
   hasBeep: boolean;
   hasStageTime: boolean;
@@ -2257,6 +2267,7 @@ interface TrimNowBadgeProps {
 }
 
 function TrimNowBadge({
+  slug,
   stageNumber,
   hasBeep,
   hasStageTime,
@@ -2300,7 +2311,7 @@ function TrimNowBadge({
         try {
           const final = await api.pollJob(active.id, setJob);
           if (cancelled) return;
-          if (final.status === "succeeded") onProjectUpdate(await api.getProject());
+          if (final.status === "succeeded") onProjectUpdate(await api.getProject(slug));
           else if (final.status === "failed") setError(final.error ?? "Trim failed");
         } finally {
           if (!cancelled) setJob(null);
@@ -2319,14 +2330,14 @@ function TrimNowBadge({
     try {
       // The server returns the existing active job if one is in flight,
       // so two clicks (or a click after reload) don't spawn parallels.
-      const initial = await api.trimStage(stageNumber);
+      const initial = await api.trimStage(slug, stageNumber);
       setJob(initial);
       const final = await api.pollJob(initial.id, setJob);
       if (final.status === "failed") {
         setError(final.error ?? "Trim failed");
         return;
       }
-      const fresh = await api.getProject();
+      const fresh = await api.getProject(slug);
       onProjectUpdate(fresh);
     } catch (err) {
       setError(err instanceof ApiError ? err.detail : String(err));

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -53,6 +53,7 @@ import {
   visibleKindsFromFilters,
   zoomToPixelsPerSecond,
 } from "@/components/AuditControls";
+import { BeepWaveformPicker } from "@/components/BeepSection";
 import { HelpOverlay } from "@/components/HelpOverlay";
 import { ListDrawer } from "@/components/ListDrawer";
 import { MarkerLayer, type AuditMarker } from "@/components/MarkerLayer";
@@ -141,6 +142,15 @@ export function Audit() {
   const [activeVideoIndex, setActiveVideoIndex] = useState(0);
   const [loopMode, setLoopMode] = useState(false);
   const [gridMode, setGridMode] = useState(true);
+  // Inline beep re-pick (opens via the Re-pick beep button in the audit
+  // toolbar). Draft is in *source* time -- the picker emits source-time
+  // values via onPick. Apply: overrideBeepForVideo on the primary, which
+  // clears shots[] server-side and chains a fresh trim + shot-detect.
+  // Fire-and-forget: we leave the user in audit; the JobsPanel surfaces
+  // progress and they reload audit data once the chain completes.
+  const [showRepickBeep, setShowRepickBeep] = useState(false);
+  const [repickDraft, setRepickDraft] = useState<number | null>(null);
+  const [repickBusy, setRepickBusy] = useState(false);
   // Stable refs used by grid-mode callbacks to avoid stale closures without
   // adding them to useCallback / useEffect dep arrays.
   const isPlayingRef = useRef(false);
@@ -1508,6 +1518,23 @@ export function Audit() {
                 no beep yet
               </span>
             )}
+            {/* Re-pick beep affordance. Stays out of the way until the
+             *  user notices the shots are mis-aligned in audit -- then a
+             *  single click opens an inline waveform picker so they
+             *  don't have to leave the page. Applying the new beep
+             *  clears shots[] and re-chains trim + shot-detect; we
+             *  confirm before doing that if there's work to discard. */}
+            {primary.beep_time != null && stageNumber != null ? (
+              <button
+                type="button"
+                onClick={() => setShowRepickBeep((v) => !v)}
+                aria-expanded={showRepickBeep}
+                aria-controls="audit-repick-beep-picker"
+                className="inline-flex items-center gap-1.5 rounded border border-rule bg-surface-2 px-2 py-0.5 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-ink-2 transition-colors hover:border-led-deep hover:bg-led-tint hover:text-led"
+              >
+                {showRepickBeep ? "Cancel re-pick" : "Re-pick beep"}
+              </button>
+            ) : null}
             {videos.length > 1 ? (
               <span className="rounded border border-rule-strong bg-surface-2 px-2 py-0.5 font-bold tabular-nums text-ink-2">
                 {videos.length} cams
@@ -1533,6 +1560,102 @@ export function Audit() {
               />
             ) : null}
           </div>
+
+          {/* Inline beep re-pick. Mounts under the toolbar so the user
+           *  who notices a mis-aligned beep mid-audit doesn't have to
+           *  leave the page. Fire-and-forget: Apply queues a trim +
+           *  shot-detect chain via the existing override endpoint; the
+           *  JobsPanel surfaces the progress. */}
+          {showRepickBeep && stageNumber != null && primary.beep_time != null ? (
+            <div
+              id="audit-repick-beep-picker"
+              className="rounded-2xl border border-led-deep/60 bg-surface p-4"
+            >
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                <div className="font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-muted">
+                  Re-pick beep
+                  <span className="ml-2 text-ink-2">
+                    current: <b className="tabular-nums">{primary.beep_time.toFixed(3)}s</b>
+                  </span>
+                  {repickDraft != null ? (
+                    <span className="ml-2 text-led">
+                      draft: <b className="tabular-nums">{repickDraft.toFixed(3)}s</b>
+                    </span>
+                  ) : null}
+                </div>
+                <div className="inline-flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setShowRepickBeep(false);
+                      setRepickDraft(null);
+                    }}
+                    disabled={repickBusy}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="bg-led-fill text-ink hover:bg-led hover:text-ink"
+                    disabled={
+                      repickBusy ||
+                      repickDraft == null ||
+                      Math.abs(repickDraft - (primary.beep_time ?? 0)) < 1e-3
+                    }
+                    onClick={async () => {
+                      if (repickDraft == null || stageNumber == null) return;
+                      const keptShots = audit?.shots.length ?? 0;
+                      if (keptShots > 0) {
+                        const ok = window.confirm(
+                          `Re-picking the beep will discard the ${keptShots} kept shot${
+                            keptShots === 1 ? "" : "s"
+                          } on this stage and re-run trim + shot detection. Continue?`,
+                        );
+                        if (!ok) return;
+                      }
+                      setRepickBusy(true);
+                      try {
+                        const updated = await api.overrideBeepForVideo(
+                          slug,
+                          stageNumber,
+                          primary.video_id,
+                          repickDraft,
+                        );
+                        setProject(updated);
+                        setShowRepickBeep(false);
+                        setRepickDraft(null);
+                        // Audit data will be stale until shot-detect
+                        // re-runs. The JobsPanel surfaces progress; the
+                        // user reloads when they see it land.
+                      } catch (e) {
+                        setProjectError(
+                          e instanceof ApiError ? e.detail : String(e),
+                        );
+                      } finally {
+                        setRepickBusy(false);
+                      }
+                    }}
+                  >
+                    Apply & re-process
+                  </Button>
+                </div>
+              </div>
+              <BeepWaveformPicker
+                slug={slug}
+                stageNumber={stageNumber}
+                videoId={primary.video_id}
+                videoBeepTime={primary.beep_time}
+                draftSourceTime={repickDraft}
+                onPick={(sourceTime) => setRepickDraft(sourceTime)}
+                setError={setProjectError}
+                instructions="Click on the waveform to mark the buzzer's rise. Apply to re-run trim + shot detection on the new beep."
+                ariaLabel={`Re-pick beep for stage ${stageNumber}`}
+              />
+            </div>
+          ) : null}
 
           {/* Video panel wrapped in instrument-panel frame */}
           <div className="overflow-hidden rounded-2xl border border-rule-strong bg-surface p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_18px_36px_-24px_rgba(0,0,0,0.6)]">

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1505,6 +1505,11 @@ export function Audit() {
                   detected: detectedCount,
                   rejected: rejectedCount,
                   manual: manualCount,
+                  // The audit waveform anchors on the primary; the beep
+                  // marker reflects ``auditBeep`` (= peaks.beep_time
+                  // falling back to primary.beep_time). 0 when the
+                  // primary has no beep yet.
+                  beep: auditBeep != null ? 1 : 0,
                 }}
                 onChange={setFilters}
               />

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1371,12 +1371,14 @@ export function Audit() {
           </div>
 
           {/* Shooter switcher: only renders for multi-shooter matches.
-              See #350 for the operator-vs-active-shooter discussion --
-              ``is_active`` here is "currently bound", not "this is you".
               Chip is a Link to /audit/:newSlug/:stage; ShooterScopedRoute
-              handles the rebind + remount (#353 phase 1). */}
+              keys the page on slug so the switch remounts cleanly (#353). */}
           {shooters.length > 1 && (
-            <ShooterChipStrip shooters={shooters} stage={stageNumber} />
+            <ShooterChipStrip
+              shooters={shooters}
+              stage={stageNumber}
+              activeSlug={slugParam}
+            />
           )}
 
           {/* Toolbar: Save + Undo + status badges + filter chips + zoom */}
@@ -1755,9 +1757,11 @@ function Readout({ label, value }: { label: string; value: string }) {
 function ShooterChipStrip({
   shooters,
   stage,
+  activeSlug,
 }: {
   shooters: ShooterListEntry[];
   stage: number | null;
+  activeSlug: string | undefined;
 }) {
   return (
     <div className="-mt-1 mb-3 inline-flex flex-wrap items-center gap-2">
@@ -1765,7 +1769,7 @@ function ShooterChipStrip({
         Auditing
       </span>
       {shooters.map((s) => {
-        const isActive = s.is_active;
+        const isActive = s.slug === activeSlug;
         const target = stage != null ? `/audit/${s.slug}/${stage}` : `/audit/${s.slug}`;
         return (
           <Link

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -28,7 +28,7 @@
  */
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   CheckCircle2,
   ChevronLeft,
@@ -53,11 +53,11 @@ import {
   visibleKindsFromFilters,
   zoomToPixelsPerSecond,
 } from "@/components/AuditControls";
-import { Avatar } from "@/components/ui";
 import { HelpOverlay } from "@/components/HelpOverlay";
 import { ListDrawer } from "@/components/ListDrawer";
 import { MarkerLayer, type AuditMarker } from "@/components/MarkerLayer";
 import { MountSelect } from "@/components/MountSelect";
+import { ShooterChipStrip } from "@/components/match/ShooterChipStrip";
 import { ShotStepper } from "@/components/ShotStepper";
 import { VideoPanel } from "@/components/VideoPanel";
 import { Waveform } from "@/components/Waveform";
@@ -1377,13 +1377,13 @@ export function Audit() {
           {/* Shooter switcher: only renders for multi-shooter matches.
               Chip is a Link to /audit/:newSlug/:stage; ShooterScopedRoute
               keys the page on slug so the switch remounts cleanly (#353). */}
-          {shooters.length > 1 && (
-            <ShooterChipStrip
-              shooters={shooters}
-              stage={stageNumber}
-              activeSlug={slugParam}
-            />
-          )}
+          <ShooterChipStrip
+            shooters={shooters}
+            stage={stageNumber}
+            activeSlug={slugParam}
+            urlBase="audit"
+            label="Auditing"
+          />
 
           {/* Toolbar: Save + Undo + status badges + filter chips + zoom */}
           <div className="flex flex-wrap items-center gap-2.5">
@@ -1759,68 +1759,6 @@ function Readout({ label, value }: { label: string; value: string }) {
       </span>
     </div>
   );
-}
-
-function ShooterChipStrip({
-  shooters,
-  stage,
-  activeSlug,
-}: {
-  shooters: ShooterListEntry[];
-  stage: number | null;
-  activeSlug: string | undefined;
-}) {
-  return (
-    <div className="-mt-1 mb-3 inline-flex flex-wrap items-center gap-2">
-      <span className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.14em] text-subtle">
-        Auditing
-      </span>
-      {shooters.map((s) => {
-        const isActive = s.slug === activeSlug;
-        const target = stage != null ? `/audit/${s.slug}/${stage}` : `/audit/${s.slug}`;
-        return (
-          <Link
-            key={s.slug}
-            to={target}
-            replace
-            aria-current={isActive ? "page" : undefined}
-            title={
-              isActive
-                ? `${s.name} -- currently auditing`
-                : `Switch to ${s.name}`
-            }
-            className={cn(
-              "inline-flex items-center gap-2 rounded-full border px-2 py-1 text-[0.8125rem] transition-colors no-underline",
-              isActive
-                ? "border-led shadow-[0_0_0_1px_var(--color-led-deep),0_0_14px_var(--color-led-glow)]"
-                : "border-rule bg-surface-2 text-ink-2 hover:border-rule-strong hover:bg-surface-3",
-              isActive && "pointer-events-none",
-            )}
-          >
-            <Avatar
-              size="xs"
-              initials={chipInitials(s.name)}
-              seed={s.slug}
-              name={s.name}
-            />
-            <span className="font-display text-[0.6875rem] font-semibold uppercase tracking-[0.06em]">
-              {s.name}
-            </span>
-            <span className="font-mono text-[0.625rem] uppercase tracking-[0.06em] text-muted">
-              {pad2(s.stages_audited)}/{pad2(s.stages_total)}
-            </span>
-          </Link>
-        );
-      })}
-    </div>
-  );
-}
-
-function chipInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[1][0]).toUpperCase();
 }
 
 function ShortcutsStrip() {

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -832,6 +832,45 @@ export function Audit() {
     [markers],
   );
 
+  // "Beep looks wrong" heuristic. Fires when the post-detection state
+  // has signals that strongly suggest the beep was placed on the wrong
+  // sound rather than e.g. the user missing shots. Surfacing this as a
+  // banner is the proactive counterpart to the always-visible 'Re-pick
+  // beep' button: catches the mistake even before the user manually
+  // compares shot count vs expected.
+  //
+  // Heuristic, conservative to avoid false alarms:
+  //   - "draw too long": first detected shot lands > 2.5s after beep
+  //     (typical IPSC draw is < 2s; > 2.5s means the beep is probably
+  //     before the actual buzzer).
+  //   - "stage time overshoot": the last detected shot lands more than
+  //     1s AFTER the official stage time. Stage time is the call from
+  //     beep to last shot; if our beep is too early, last shot's time-
+  //     from-beep exceeds stage_time.
+  //
+  // Only fires when there are enough shots to draw a conclusion (>= 3).
+  const beepDiagnostic = useMemo<{ reason: string } | null>(() => {
+    if (!stage || stage.time_seconds <= 0 || auditBeep == null) return null;
+    if (keptShots.length < 3) return null;
+    const sorted = keptShots.slice().sort((a, b) => a.time - b.time);
+    const first = sorted[0];
+    const last = sorted[sorted.length - 1];
+    const firstFromBeep = first.time - auditBeep;
+    const lastFromBeep = last.time - auditBeep;
+    const overshoot = lastFromBeep - stage.time_seconds;
+    if (firstFromBeep > 2.5) {
+      return {
+        reason: `First shot lands ${firstFromBeep.toFixed(2)}s after the beep -- typical draws are well under 2 s, so the beep is likely placed before the actual buzzer.`,
+      };
+    }
+    if (overshoot > 1.0) {
+      return {
+        reason: `Last shot lands ${overshoot.toFixed(2)}s after the official stage time (${stage.time_seconds.toFixed(2)}s) -- the beep may have been picked up too early.`,
+      };
+    }
+    return null;
+  }, [keptShots, auditBeep, stage]);
+
   // Whenever the kept-shot list shrinks (reject / delete), keep the index
   // in range. Don't change otherwise -- the user's position is sticky.
   useEffect(() => {
@@ -1560,6 +1599,45 @@ export function Audit() {
               />
             ) : null}
           </div>
+
+          {/* Proactive nudge: when the post-detection state has signals
+           *  the beep was wrong (draw too long, overshoot the official
+           *  stage time, etc.), surface a banner that opens the re-pick
+           *  picker in one click. Suppressed once the picker is open --
+           *  the user has clearly seen the affordance and doesn't need
+           *  another reminder underneath it. */}
+          {beepDiagnostic && !showRepickBeep ? (
+            <div
+              role="status"
+              className="flex flex-wrap items-start gap-3 rounded-2xl border border-live/40 bg-live/10 px-4 py-3 text-sm"
+            >
+              <span
+                aria-hidden
+                className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-live/60 bg-live-tint font-mono text-[0.625rem] font-bold text-live"
+              >
+                !
+              </span>
+              <div className="flex-1">
+                <div className="font-display text-[0.75rem] font-bold uppercase tracking-[0.08em] text-live">
+                  Looks like the beep is wrong
+                </div>
+                <p className="mt-1 text-[0.8125rem] leading-snug text-ink-2">
+                  {beepDiagnostic.reason}
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                className="bg-led-fill text-ink hover:bg-led hover:text-ink"
+                onClick={() => {
+                  setShowRepickBeep(true);
+                  setRepickDraft(null);
+                }}
+              >
+                Re-pick beep
+              </Button>
+            </div>
+          ) : null}
 
           {/* Inline beep re-pick. Mounts under the toolbar so the user
            *  who notices a mis-aligned beep mid-audit doesn't have to

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -1561,7 +1561,7 @@ export function Audit() {
                   onClick={togglePlay}
                   aria-label={isPlaying ? "Pause (Space)" : "Play (Space)"}
                   title={isPlaying ? "Pause (Space)" : "Play (Space)"}
-                  className="inline-flex size-11 items-center justify-center rounded-full bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
+                  className="inline-flex size-11 items-center justify-center rounded-full bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
                 >
                   {isPlaying ? (
                     <Pause className="size-5" />

--- a/src/splitsmith/ui_static/src/pages/BeepReview.tsx
+++ b/src/splitsmith/ui_static/src/pages/BeepReview.tsx
@@ -216,17 +216,9 @@ export function BeepReview() {
             onConfirm={() => void confirm(active)}
             onConfirmAlt={(t) => void confirm(active, t)}
             onSkip={skip}
-            onOpenAudit={() => {
-              // Switch to that shooter's audit page.
-              void (async () => {
-                try {
-                  await api.selectActiveShooter(active.slug);
-                  navigate(`/audit/${active.stage_number}`);
-                } catch {
-                  /* swallow */
-                }
-              })();
-            }}
+            onOpenAudit={() =>
+              navigate(`/audit/${active.slug}/${active.stage_number}`)
+            }
           />
         ) : (
           <div className="flex h-full items-center justify-center text-center text-sm text-muted">

--- a/src/splitsmith/ui_static/src/pages/BeepReview.tsx
+++ b/src/splitsmith/ui_static/src/pages/BeepReview.tsx
@@ -535,7 +535,7 @@ function ActiveDetail({
               type="button"
               onClick={onConfirm}
               disabled={busy || item.beep_time == null}
-              className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+              className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
             >
               <Check className="size-3.5" strokeWidth={3} />
               <span className="font-display uppercase tracking-[0.08em]">

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -1327,7 +1327,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
                 type="button"
                 onClick={togglePlay}
                 aria-label={isPlaying ? "Pause" : "Play"}
-                className="inline-flex size-10 items-center justify-center rounded-full bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
+                className="inline-flex size-10 items-center justify-center rounded-full bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
               >
                 {isPlaying ? (
                   <Pause className="size-4" />

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -39,7 +39,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
@@ -121,8 +121,14 @@ interface PerStageAggregate {
 
 function CoachMatch({ slug }: { slug?: string }) {
   const navigate = useNavigate();
-  const stagePrefix = slug ? `/coach/${slug}` : "/coach";
-  const auditPrefix = slug ? `/audit/${slug}` : "/audit";
+  if (!slug) {
+    // ShooterScopedRoute should keep this from rendering, but the
+    // Coach() wrapper still passes slugParam through when undefined;
+    // bounce back to the picker rather than 500ing on the API call.
+    return <Navigate to="/shooters" replace />;
+  }
+  const stagePrefix = `/coach/${slug}`;
+  const auditPrefix = `/audit/${slug}`;
   const [project, setProject] = useState<MatchProject | null>(null);
   const [perStage, setPerStage] = useState<PerStageAggregate[]>([]);
   const [distributions, setDistributions] =
@@ -147,7 +153,7 @@ function CoachMatch({ slug }: { slug?: string }) {
     setError(null);
     (async () => {
       try {
-        const proj = await api.getProject();
+        const proj = await api.getProject(slug);
         if (!alive) return;
         setProject(proj);
         const auditedStages = proj.stages.filter(
@@ -157,11 +163,11 @@ function CoachMatch({ slug }: { slug?: string }) {
           Promise.all(
             auditedStages.map((s) =>
               api
-                .getStageCoach(s.stage_number)
+                .getStageCoach(slug, s.stage_number)
                 .catch(() => null as CoachStageResponse | null),
             ),
           ),
-          api.getMatchCoachDistributions().catch(() => null),
+          api.getMatchCoachDistributions(slug).catch(() => null),
         ]);
         if (!alive) return;
         setDistributions(dist);
@@ -243,7 +249,7 @@ function CoachMatch({ slug }: { slug?: string }) {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [slug]);
 
   const auditedAggs = perStage.filter((s) => s.audited);
   const headline = useMemo(() => computeHeadline(auditedAggs), [auditedAggs]);
@@ -948,8 +954,11 @@ function AnnotationsCard({
 
 function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const navigate = useNavigate();
-  const coachPrefix = slug ? `/coach/${slug}` : "/coach";
-  const auditPrefix = slug ? `/audit/${slug}` : "/audit";
+  if (!slug) {
+    return <Navigate to="/shooters" replace />;
+  }
+  const coachPrefix = `/coach/${slug}`;
+  const auditPrefix = `/audit/${slug}`;
   const [project, setProject] = useState<MatchProject | null>(null);
   const [coach, setCoach] = useState<CoachStageResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -966,8 +975,8 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
     (async () => {
       try {
         const [p, c] = await Promise.all([
-          api.getProject(),
-          api.getStageCoach(stage),
+          api.getProject(slug),
+          api.getStageCoach(slug, stage),
         ]);
         if (!alive) return;
         setProject(p);
@@ -982,7 +991,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
     return () => {
       alive = false;
     };
-  }, [stage]);
+  }, [slug, stage]);
 
   useEffect(() => {
     if (!coach) return;
@@ -990,7 +999,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
     if (anyUnclassified && !reclassifying) {
       setReclassifying(true);
       api
-        .reclassifyStageCoach(stage)
+        .reclassifyStageCoach(slug, stage)
         .then((c) => setCoach(c))
         .catch(() => {})
         .finally(() => setReclassifying(false));
@@ -1048,28 +1057,28 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const reclassify = useCallback(async () => {
     setReclassifying(true);
     try {
-      const c = await api.reclassifyStageCoach(stage);
+      const c = await api.reclassifyStageCoach(slug, stage);
       setCoach(c);
     } catch (e) {
       setError(e instanceof ApiError ? e.detail : String(e));
     } finally {
       setReclassifying(false);
     }
-  }, [stage]);
+  }, [slug, stage]);
 
   const patchShot = useCallback(
     async (
       shotNumber: number,
-      patch: Parameters<typeof api.patchStageShotCoach>[2],
+      patch: Parameters<typeof api.patchStageShotCoach>[3],
     ) => {
       try {
-        const c = await api.patchStageShotCoach(stage, shotNumber, patch);
+        const c = await api.patchStageShotCoach(slug, stage, shotNumber, patch);
         setCoach(c);
       } catch (e) {
         setError(e instanceof ApiError ? e.detail : String(e));
       }
     },
-    [stage],
+    [slug, stage],
   );
 
   const seekToShot = useCallback((shot: CoachShot) => {
@@ -1112,7 +1121,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const activeShot =
     coach.shots.find((s) => s.shot_number === activeShotNumber) ?? null;
   const primary = coach.videos.find((v) => v.role === "primary");
-  const streamUrl = primary ? api.videoStreamUrl(primary.path) : null;
+  const streamUrl = primary ? api.videoStreamUrl(slug, primary.path) : null;
   const maxAbs =
     coach.shots.length > 0
       ? Math.max(...coach.shots.map((s) => s.time_absolute))

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -41,6 +41,7 @@ import {
 } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 
+import { ShooterChipStrip } from "@/components/match/ShooterChipStrip";
 import { Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import {
@@ -51,6 +52,7 @@ import {
   type CoachShot,
   type CoachStageResponse,
   type MatchProject,
+  type ShooterListEntry,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -130,6 +132,7 @@ function CoachMatch({ slug }: { slug?: string }) {
   const stagePrefix = `/coach/${slug}`;
   const auditPrefix = `/audit/${slug}`;
   const [project, setProject] = useState<MatchProject | null>(null);
+  const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
   const [perStage, setPerStage] = useState<PerStageAggregate[]>([]);
   const [distributions, setDistributions] =
     useState<CoachMatchDistributions | null>(null);
@@ -146,6 +149,17 @@ function CoachMatch({ slug }: { slug?: string }) {
       flagged: boolean;
     }[]
   >([]);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .listMatchShooters()
+      .then((r) => alive && setShooters(r.shooters))
+      .catch(() => alive && setShooters([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   useEffect(() => {
     let alive = true;
@@ -289,6 +303,12 @@ function CoachMatch({ slug }: { slug?: string }) {
 
   return (
     <div className="flex flex-col gap-5 px-7 py-5">
+      <ShooterChipStrip
+        shooters={shooters}
+        activeSlug={slug}
+        urlBase="coach"
+        label="Coaching"
+      />
       <div>
         <Kicker className="mb-2">Match analysis</Kicker>
         <h1 className="mb-2 font-display text-4xl font-bold uppercase leading-none tracking-tight text-ink">
@@ -960,6 +980,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const coachPrefix = `/coach/${slug}`;
   const auditPrefix = `/audit/${slug}`;
   const [project, setProject] = useState<MatchProject | null>(null);
+  const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
   const [coach, setCoach] = useState<CoachStageResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reclassifying, setReclassifying] = useState(false);
@@ -969,6 +990,17 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const [noteDraft, setNoteDraft] = useState("");
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const shotListRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .listMatchShooters()
+      .then((r) => alive && setShooters(r.shooters))
+      .catch(() => alive && setShooters([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   useEffect(() => {
     let alive = true;
@@ -1134,6 +1166,13 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
 
   return (
     <div className="flex flex-col gap-4 px-7 py-5">
+      <ShooterChipStrip
+        shooters={shooters}
+        activeSlug={slug}
+        urlBase="coach"
+        stage={stage}
+        label="Coaching"
+      />
       {/* Compact stage header */}
       <div className="flex flex-wrap items-center gap-4 border-b border-rule pb-4">
         <div className="flex items-center gap-1.5">

--- a/src/splitsmith/ui_static/src/pages/Compare.tsx
+++ b/src/splitsmith/ui_static/src/pages/Compare.tsx
@@ -78,15 +78,22 @@ export function Compare() {
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
   const rafRef = useRef<number | null>(null);
 
-  // Load project + compare data.
+  // Load project + compare data. Stage definitions are identical across
+  // every shooter in a match, so we lift them from whichever shooter is
+  // alphabetically first. Compare itself is slug-less (multi-shooter view).
   useEffect(() => {
     let alive = true;
-    api
-      .getProject()
-      .then((p) => {
+    (async () => {
+      try {
+        const shooters = await api.listMatchShooters();
+        const first = shooters.shooters[0]?.slug;
+        if (!first) return;
+        const p = await api.getProject(first);
         if (alive) setProject(p);
-      })
-      .catch(() => {});
+      } catch {
+        /* compare bundle below covers the no-shooter case */
+      }
+    })();
     return () => {
       alive = false;
     };

--- a/src/splitsmith/ui_static/src/pages/Compare.tsx
+++ b/src/splitsmith/ui_static/src/pages/Compare.tsx
@@ -314,7 +314,13 @@ export function Compare() {
         >
           <button
             type="button"
-            onClick={() => navigate(`/audit/${stageNumber}`)}
+            onClick={() => {
+              // Compare is multi-shooter; pick the audio source (the
+              // primary shown in this view) as the target shooter so
+              // the user lands on the same camera they were watching.
+              const target = audioSlug ?? orderedShooters[0]?.slug;
+              if (target) navigate(`/audit/${target}/${stageNumber}`);
+            }}
             className="inline-flex min-h-9 items-center rounded-md px-3.5 font-sans text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-muted hover:text-ink-2"
           >
             Audit
@@ -324,7 +330,10 @@ export function Compare() {
           </span>
           <button
             type="button"
-            onClick={() => navigate(`/coach/${stageNumber}`)}
+            onClick={() => {
+              const target = audioSlug ?? orderedShooters[0]?.slug;
+              if (target) navigate(`/coach/${target}/${stageNumber}`);
+            }}
             className="inline-flex min-h-9 items-center rounded-md px-3.5 font-sans text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-muted hover:text-ink"
           >
             Coach
@@ -379,6 +388,21 @@ export function Compare() {
         </Button>
       </div>
 
+      {/* Unfinished banner: when at least one shooter is playable, the
+       *  grid renders the playable subset. Shooters without a cached
+       *  trim are surfaced here so the user can rebuild the cache (when
+       *  audit is done) or jump into audit (when nothing has run yet)
+       *  without having to leave the page. */}
+      {visibleShooters.length > 0 &&
+      orderedShooters.some((s) => !s.video_path) ? (
+        <UnfinishedShootersBanner
+          unfinished={orderedShooters.filter((s) => !s.video_path)}
+          onOpenInAudit={(slug) =>
+            navigate(`/audit/${slug}/${stageNumber}`)
+          }
+        />
+      ) : null}
+
       {/* Video grid */}
       <div className={layoutClass(layout)}>
         {visibleShooters.length === 0 ? (
@@ -428,6 +452,104 @@ export function Compare() {
 /* -------------------------------------------------------------------------- */
 /* Empty state -- no shooter has a usable trim for this stage yet             */
 /* -------------------------------------------------------------------------- */
+
+function UnfinishedShootersBanner({
+  unfinished,
+  onOpenInAudit,
+}: {
+  unfinished: CompareShooterRecord[];
+  onOpenInAudit: (slug: string) => void | Promise<void>;
+}) {
+  const [busySlug, setBusySlug] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [doneSlugs, setDoneSlugs] = useState<Set<string>>(() => new Set());
+
+  // A shooter with shots[] but no video_path has finished audit; just
+  // the trim cache is missing. Offer to rebuild it in-place. A shooter
+  // with neither needs to be audited first.
+  const rebuild = async (slug: string) => {
+    setErrorMsg(null);
+    setBusySlug(slug);
+    try {
+      const res = await api.buildShooterTrimCaches(slug);
+      // The server queues jobs but the bundle won't see the new trim
+      // until the worker finishes. Tell the user to refresh once jobs
+      // settle rather than polling the bundle here (Compare's polling
+      // story is "reload the page"; the JobsPanel surfaces progress).
+      if (res.jobs_submitted.length === 0) {
+        setErrorMsg(
+          `${slug}: nothing to rebuild -- either no stage qualifies or every cache is already on disk. Open the shooter in audit to see why.`,
+        );
+        return;
+      }
+      setDoneSlugs((prev) => new Set(prev).add(slug));
+    } catch (e) {
+      setErrorMsg(e instanceof ApiError ? e.detail : String(e));
+    } finally {
+      setBusySlug(null);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-rule bg-surface px-5 py-3 text-sm text-muted">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-display text-[0.6875rem] font-bold uppercase tracking-[0.08em] text-ink-2">
+          Missing footage
+        </span>
+        <span className="text-ink-2">{unfinished.length}</span>
+        <span>
+          {unfinished.length === 1 ? "shooter has" : "shooters have"} no
+          cached trim for this stage.
+        </span>
+      </div>
+      <div className="mt-2.5 flex flex-wrap items-center gap-2">
+        {unfinished.map((s) => {
+          const auditedButUncached = s.shots.length > 0;
+          const queued = doneSlugs.has(s.slug);
+          return (
+            <div
+              key={s.slug}
+              className="inline-flex items-center gap-2 rounded-lg border border-rule-strong bg-surface-2 px-3 py-1.5 text-xs"
+            >
+              <span className="font-semibold text-ink-2">{s.name}</span>
+              {auditedButUncached ? (
+                queued ? (
+                  <span className="text-[0.6875rem] uppercase tracking-[0.08em] text-done">
+                    Build queued -- check Jobs
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => rebuild(s.slug)}
+                    disabled={busySlug === s.slug}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-rule-strong bg-surface px-2 py-1 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-ink hover:border-led hover:text-led disabled:opacity-50"
+                  >
+                    {busySlug === s.slug ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : null}
+                    Build trim cache
+                  </button>
+                )
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onOpenInAudit(s.slug)}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-rule-strong bg-surface px-2 py-1 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-ink hover:border-led hover:text-led"
+                >
+                  <ArrowRight className="size-3" />
+                  Open in audit
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {errorMsg ? (
+        <div className="mt-2 text-xs text-led">{errorMsg}</div>
+      ) : null}
+    </div>
+  );
+}
 
 function CompareEmptyState({
   unfinished,

--- a/src/splitsmith/ui_static/src/pages/Compare.tsx
+++ b/src/splitsmith/ui_static/src/pages/Compare.tsx
@@ -103,8 +103,7 @@ export function Compare() {
         if (!alive) return;
         setBundle(b);
         if (b.shooters.length > 0) {
-          const active = b.shooters.find((s) => s.is_active) ?? b.shooters[0];
-          setAudioSlug(active.slug);
+          setAudioSlug(b.shooters[0].slug);
           setVisibleSlugs(
             new Set(b.shooters.filter((s) => s.video_path).map((s) => s.slug)),
           );
@@ -379,9 +378,6 @@ export function Compare() {
           <CompareEmptyState
             unfinished={orderedShooters.filter((s) => !s.video_path)}
             onOpenInAudit={(slug) => {
-              // #353 phase 1: target the slug-scoped audit URL directly.
-              // ShooterScopedRoute handles the rebind before mounting
-              // the page, so we don't need to await it here.
               navigate(`/audit/${slug}/${stageNumber}`);
             }}
           />
@@ -501,7 +497,7 @@ function ShooterChip({
       <Avatar
         size="xs"
         initials={initials(shooter.name)}
-        tone={shooter.is_active ? "you" : undefined}
+        tone={undefined}
         seed={shooter.slug}
         name={shooter.name}
       />
@@ -598,18 +594,13 @@ function VideoTile({
         <Avatar
           size="xs"
           initials={initials(shooter.name)}
-          tone={shooter.is_active ? "you" : undefined}
+          tone={undefined}
           seed={shooter.slug}
           name={shooter.name}
         />
         <span className="font-display text-[0.75rem] font-bold uppercase tracking-[0.06em] text-ink">
           {shooter.name}
         </span>
-        {shooter.is_active && (
-          <span className="rounded border border-led-deep bg-led/10 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-led">
-            You
-          </span>
-        )}
         {isAudio && (
           <span className="ml-auto inline-flex items-center gap-1 rounded border border-led-deep bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_8px_var(--color-led-glow)]">
             <Volume2 className="size-2.5" />
@@ -959,27 +950,19 @@ function RankingTable({ shooters }: { shooters: CompareShooterRecord[] }) {
       {rows.map((row) => (
         <div
           key={row.shooter.slug}
-          className={cn(
-            "grid grid-cols-[48px_1fr_120px_120px_120px_80px] items-center gap-3 border-b border-rule px-5 py-3 last:border-b-0",
-            row.shooter.is_active && "bg-led/[0.05]",
-          )}
+          className="grid grid-cols-[48px_1fr_120px_120px_120px_80px] items-center gap-3 border-b border-rule px-5 py-3 last:border-b-0"
         >
           <RankPill rank={row.rank} />
           <div className="inline-flex items-center gap-2.5">
             <Avatar
               size="sm"
               initials={initials(row.shooter.name)}
-              tone={row.shooter.is_active ? "you" : undefined}
+              tone={undefined}
               seed={row.shooter.slug}
             />
             <span className="font-display text-sm font-bold uppercase tracking-[0.04em] text-ink">
               {row.shooter.name}
             </span>
-            {row.shooter.is_active && (
-              <span className="rounded border border-led-deep bg-led/10 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-led">
-                You
-              </span>
-            )}
           </div>
           <span
             className={cn(

--- a/src/splitsmith/ui_static/src/pages/Compare.tsx
+++ b/src/splitsmith/ui_static/src/pages/Compare.tsx
@@ -646,7 +646,7 @@ function ShooterChip({
         className={cn(
           "inline-flex size-6 items-center justify-center rounded-full transition-colors",
           isAudio
-            ? "bg-led text-bg shadow-[0_0_10px_var(--color-led-glow)]"
+            ? "bg-led-fill text-ink shadow-[0_0_10px_var(--color-led-glow)]"
             : "bg-surface-3 text-subtle hover:text-ink",
         )}
       >
@@ -731,7 +731,7 @@ function VideoTile({
           {shooter.name}
         </span>
         {isAudio && (
-          <span className="ml-auto inline-flex items-center gap-1 rounded border border-led-deep bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_8px_var(--color-led-glow)]">
+          <span className="ml-auto inline-flex items-center gap-1 rounded border border-led-deep bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-ink shadow-[0_0_8px_var(--color-led-glow)]">
             <Volume2 className="size-2.5" />
             Audio
           </span>
@@ -810,7 +810,7 @@ function Transport({
         type="button"
         onClick={onTogglePlay}
         aria-label={isPlaying ? "Pause" : "Play"}
-        className="inline-flex size-11 items-center justify-center rounded-full bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
+        className="inline-flex size-11 items-center justify-center rounded-full bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] transition-colors hover:bg-led-soft"
       >
         {isPlaying ? <Pause className="size-5" /> : <Play className="size-5" />}
       </button>
@@ -1119,7 +1119,7 @@ function RankingTable({ shooters }: { shooters: CompareShooterRecord[] }) {
 function RankPill({ rank }: { rank: number }) {
   const tone =
     rank === 1
-      ? "border-led bg-led text-bg shadow-[0_0_10px_var(--color-led-glow)]"
+      ? "border-led bg-led-fill text-ink shadow-[0_0_10px_var(--color-led-glow)]"
       : rank === 2
         ? "border-ink-2 bg-surface-3 text-ink"
         : "border-rule bg-surface-3 text-muted";

--- a/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
+++ b/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
@@ -442,7 +442,7 @@ function ScoreboardVariant({
                 disabled={
                   creating || !shooterName.trim() || !projectFolder.trim()
                 }
-                className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_16px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+                className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_16px_var(--color-led-glow)] hover:bg-led hover:text-ink"
               >
                 <span className="font-display uppercase tracking-[0.08em]">
                   {creating ? "Creating..." : "Create match"}
@@ -486,7 +486,7 @@ function ResultRow({
         className={cn(
           "inline-flex size-7 items-center justify-center rounded-md",
           selected
-            ? "bg-led text-bg shadow-[0_0_10px_var(--color-led-glow)]"
+            ? "bg-led-fill text-ink shadow-[0_0_10px_var(--color-led-glow)]"
             : "bg-surface-3 text-muted",
         )}
       >
@@ -545,7 +545,7 @@ function ResultRow({
         )}
       </div>
       {selected ? (
-        <span className="inline-flex size-5 items-center justify-center rounded-full bg-led text-bg shadow-[0_0_10px_var(--color-led-glow)]">
+        <span className="inline-flex size-5 items-center justify-center rounded-full bg-led-fill text-ink shadow-[0_0_10px_var(--color-led-glow)]">
           <Check className="size-3" strokeWidth={3} />
         </span>
       ) : (
@@ -836,7 +836,7 @@ function ManualVariant({
               !shooterName.trim() ||
               stages.length === 0
             }
-            className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_16px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+            className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_16px_var(--color-led-glow)] hover:bg-led hover:text-ink"
           >
             <span className="font-display uppercase tracking-[0.08em]">
               {creating ? "Creating..." : "Create match"}

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -39,6 +39,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { Navigate, useParams } from "react-router-dom";
+
 import { Button } from "@/components/ui/button";
 import {
   ApiError,
@@ -111,6 +113,12 @@ const TITLE_STYLES: {
 ];
 
 export function Export() {
+  const { slug } = useParams<{ slug: string }>();
+  if (!slug) return <Navigate to="/shooters" replace />;
+  return <ExportInner slug={slug} />;
+}
+
+function ExportInner({ slug }: { slug: string }) {
   const [project, setProject] = useState<MatchProject | null>(null);
   const [overview, setOverview] = useState<ExportOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -120,8 +128,8 @@ export function Export() {
   const reload = useCallback(async () => {
     try {
       const [proj, ov] = await Promise.all([
-        api.getProject(),
-        api.getExportOverview(),
+        api.getProject(slug),
+        api.getExportOverview(slug),
       ]);
       setProject(proj);
       setOverview(ov);
@@ -129,7 +137,7 @@ export function Export() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, []);
+  }, [slug]);
 
   useEffect(() => {
     void reload();
@@ -266,7 +274,7 @@ export function Export() {
     setError(null);
     setResult(null);
     try {
-      const submitted = await api.exportMatch({
+      const submitted = await api.exportMatch(slug, {
         stage_numbers: orderedSelection,
         head_pad_seconds: headPad,
         tail_pad_seconds: tailPad,

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -41,6 +41,7 @@ import {
 
 import { Navigate, useParams } from "react-router-dom";
 
+import { ShooterChipStrip } from "@/components/match/ShooterChipStrip";
 import { Button } from "@/components/ui/button";
 import {
   ApiError,
@@ -50,6 +51,7 @@ import {
   type MatchExportResult,
   type MatchProject,
   type OverlayCodec,
+  type ShooterListEntry,
   type StageExportStatus,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -121,6 +123,7 @@ export function Export() {
 function ExportInner({ slug }: { slug: string }) {
   const [project, setProject] = useState<MatchProject | null>(null);
   const [overview, setOverview] = useState<ExportOverview | null>(null);
+  const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [job, setJob] = useState<Job | null>(null);
   const [result, setResult] = useState<MatchExportResult | null>(null);
@@ -142,6 +145,17 @@ function ExportInner({ slug }: { slug: string }) {
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .listMatchShooters()
+      .then((r) => alive && setShooters(r.shooters))
+      .catch(() => alive && setShooters([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   // === Form state ===
   const [mode, setMode] = useState<OutputMode>("single");
@@ -323,6 +337,12 @@ function ExportInner({ slug }: { slug: string }) {
 
   return (
     <div className="px-7 py-5">
+      <ShooterChipStrip
+        shooters={shooters}
+        activeSlug={slug}
+        urlBase="export"
+        label="Exporting"
+      />
       <div className="mb-5">
         <Kicker className="mb-2">Final cut &middot; bundle</Kicker>
         <h1 className="mb-2 font-display text-4xl font-bold uppercase leading-none tracking-tight text-ink">

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -668,7 +668,7 @@ function ExportInner({ slug }: { slug: string }) {
                 type="button"
                 onClick={() => void submitExport()}
                 disabled={!canExport}
-                className="w-full bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+                className="w-full bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
               >
                 {busy ? (
                   <Loader2 className="size-3.5 animate-spin" />
@@ -1037,7 +1037,7 @@ function FormatRow({
           className={cn(
             "mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded border-[1.5px]",
             selected
-              ? "border-led bg-led text-bg"
+              ? "border-led bg-led-fill text-ink"
               : "border-rule-strong bg-surface",
           )}
         >

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -55,6 +55,10 @@ export function Home() {
   const navigate = useNavigate();
   const ctx = useOutletContext<MatchShellOutletContext>();
   const project = ctx?.project ?? null;
+  // Slug used for slug-bearing nav links from this page. Lifted off the
+  // health snapshot the shell already loaded, so Home doesn't need its
+  // own fetch. Falls back to "/shooters" routing when no default exists.
+  const navSlug = ctx?.health?.default_shooter_slug ?? null;
   const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
 
   useEffect(() => {
@@ -176,7 +180,12 @@ export function Home() {
           )}
         </div>
         <div className="mt-4 inline-flex gap-2.5">
-          <Button variant="outline" onClick={() => navigate("/export")}>
+          <Button
+            variant="outline"
+            onClick={() =>
+              navigate(navSlug ? `/export/${navSlug}` : "/shooters")
+            }
+          >
             <ArrowDownToLine className="size-3.5" />
             <span className="font-display uppercase tracking-[0.08em]">
               Export Match
@@ -197,6 +206,7 @@ export function Home() {
             project={project}
             stageViews={stageViews}
             shooters={shooters}
+            navSlug={navSlug}
           />
         ) : (
           <ActiveVariant
@@ -206,6 +216,7 @@ export function Home() {
             nextUp={nextUp ?? null}
             totalsByTone={totalsByTone}
             auditedPct={auditedPct}
+            navSlug={navSlug}
           />
         )}
       </div>
@@ -224,6 +235,7 @@ function ActiveVariant({
   nextUp,
   totalsByTone,
   auditedPct,
+  navSlug,
 }: {
   project: MatchProject;
   stageViews: StageView[];
@@ -231,8 +243,11 @@ function ActiveVariant({
   nextUp: StageView | null;
   totalsByTone: Record<StagePillTone, number>;
   auditedPct: number;
+  navSlug: string | null;
 }) {
   const navigate = useNavigate();
+  const stageHref = (n: number) =>
+    navSlug ? `/audit/${navSlug}/${n}` : "/shooters";
   return (
     <>
       {/* Resume hero */}
@@ -301,7 +316,7 @@ function ActiveVariant({
           <div className="relative z-10">
             <button
               type="button"
-              onClick={() => navigate(`/audit/${nextUp.stage.stage_number}`)}
+              onClick={() => navigate(stageHref(nextUp.stage.stage_number))}
               className="inline-flex min-h-[60px] items-center gap-3.5 rounded-[11px] border border-led bg-led px-6 py-4 font-display text-base font-bold uppercase tracking-[0.06em] text-bg shadow-[0_0_0_1px_var(--color-led),0_0_32px_var(--color-led-glow),inset_0_1px_0_rgba(255,255,255,0.2)] transition-all hover:bg-led-soft hover:-translate-y-0.5"
             >
               <div className="flex flex-col items-start gap-1">
@@ -387,7 +402,7 @@ function ActiveVariant({
           <StageTile
             key={v.stage.stage_number}
             view={v}
-            onClick={() => navigate(`/audit/${v.stage.stage_number}`)}
+            onClick={() => navigate(stageHref(v.stage.stage_number))}
           />
         ))}
       </div>
@@ -403,12 +418,15 @@ function EmptyVariant({
   project,
   stageViews,
   shooters,
+  navSlug,
 }: {
   project: MatchProject;
   stageViews: StageView[];
   shooters: ShooterListEntry[];
+  navSlug: string | null;
 }) {
   const navigate = useNavigate();
+  const ingestHref = navSlug ? `/ingest/${navSlug}` : "/shooters";
   return (
     <>
       <section
@@ -445,7 +463,7 @@ function EmptyVariant({
         </p>
         <div className="inline-flex gap-2.5">
           <Button
-            onClick={() => navigate("/ingest")}
+            onClick={() => navigate(ingestHref)}
             className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
           >
             <ArrowDownToLine className="size-3.5" />
@@ -496,7 +514,7 @@ function EmptyVariant({
                   : "No footage yet"
               }
               addLink={s.video_count === 0 ? "Add footage" : undefined}
-              onAddLink={() => navigate("/ingest")}
+              onAddLink={() => navigate(ingestHref)}
             />
           ))
         ) : (
@@ -505,7 +523,7 @@ function EmptyVariant({
             name={project.competitor_name ?? "Shooter"}
             stats="No footage yet"
             addLink="Add footage"
-            onAddLink={() => navigate("/ingest")}
+            onAddLink={() => navigate(ingestHref)}
           />
         )}
         <div
@@ -545,7 +563,7 @@ function EmptyVariant({
           title="Drop your SD card"
           desc="Drag a folder of head-cam videos. Splitsmith auto-matches each video to a stage by recording time."
           cta="Start ingest"
-          onClick={() => navigate("/ingest")}
+          onClick={() => navigate(ingestHref)}
         />
         <HelpCard
           icon={<Users className="size-4" />}

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -317,7 +317,7 @@ function ActiveVariant({
             <button
               type="button"
               onClick={() => navigate(stageHref(nextUp.stage.stage_number))}
-              className="inline-flex min-h-[60px] items-center gap-3.5 rounded-[11px] border border-led bg-led px-6 py-4 font-display text-base font-bold uppercase tracking-[0.06em] text-bg shadow-[0_0_0_1px_var(--color-led),0_0_32px_var(--color-led-glow),inset_0_1px_0_rgba(255,255,255,0.2)] transition-all hover:bg-led-soft hover:-translate-y-0.5"
+              className="inline-flex min-h-[60px] items-center gap-3.5 rounded-[11px] border border-led-deep bg-led-fill px-6 py-4 font-display text-base font-bold uppercase tracking-[0.06em] text-ink shadow-[0_0_0_1px_var(--color-led),0_0_32px_var(--color-led-glow),inset_0_1px_0_rgba(255,255,255,0.2)] transition-all hover:bg-led hover:-translate-y-0.5"
             >
               <div className="flex flex-col items-start gap-1">
                 <span className="font-mono text-[0.5625rem] font-bold uppercase tracking-[0.18em] opacity-70">
@@ -464,7 +464,7 @@ function EmptyVariant({
         <div className="inline-flex gap-2.5">
           <Button
             onClick={() => navigate(ingestHref)}
-            className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+            className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
           >
             <ArrowDownToLine className="size-3.5" />
             <span className="font-display uppercase tracking-[0.1em]">
@@ -772,7 +772,7 @@ function StageTile({
             className={cn(
               "inline-flex size-7 items-center justify-center rounded-md font-mono text-xs font-bold tabular-nums",
               isNextUp
-                ? "bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_8px_var(--color-led-glow)]"
+                ? "bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_8px_var(--color-led-glow)]"
                 : "bg-surface-3 text-ink-2",
             )}
           >

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -419,7 +419,7 @@ function DropZone({ onPickFolder }: { onPickFolder: () => void }) {
       <div className="inline-flex gap-2.5">
         <Button
           onClick={onPickFolder}
-          className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+          className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
         >
           <Folder className="size-3.5" />
           <span className="font-display uppercase tracking-[0.1em]">
@@ -667,7 +667,7 @@ function StorageOption({
         className={cn(
           "relative mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full border-[1.5px]",
           selected
-            ? "border-led bg-led shadow-[0_0_10px_var(--color-led-glow)]"
+            ? "border-led-deep bg-led-fill shadow-[0_0_10px_var(--color-led-glow)]"
             : "border-rule-strong bg-surface",
         )}
       >
@@ -682,7 +682,7 @@ function StorageOption({
         >
           {title}
           {badge && (
-            <span className="rounded border border-led-deep bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_8px_var(--color-led-glow)]">
+            <span className="rounded border border-led-deep bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-ink shadow-[0_0_8px_var(--color-led-glow)]">
               {badge}
             </span>
           )}
@@ -784,7 +784,7 @@ function ReviewState({
             aria-hidden
             className="absolute inset-y-0 left-0 w-0.5 bg-led shadow-[0_0_12px_var(--color-led-glow)]"
           />
-          <span className="inline-flex size-11 items-center justify-center rounded-[10px] bg-led text-bg shadow-[0_0_16px_var(--color-led-glow)]">
+          <span className="inline-flex size-11 items-center justify-center rounded-[10px] bg-led-fill text-ink shadow-[0_0_16px_var(--color-led-glow)]">
             <Package className="size-5" strokeWidth={2.2} />
           </span>
           <div className="flex-1">
@@ -894,7 +894,7 @@ function ReviewState({
             type="button"
             onClick={onConfirm}
             disabled={busy || willProcess === 0}
-            className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+            className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
           >
             <span className="font-display uppercase tracking-[0.08em]">
               Confirm &amp; start processing

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -34,6 +34,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { FolderPicker } from "@/components/FolderPicker";
+import { RelinkDialog } from "@/components/RelinkDialog";
 import { Brand, Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,6 +64,7 @@ function IngestInner({ slug }: { slug: string }) {
   const [error, setError] = useState<string | null>(null);
   const [storage, setStorage] = useState<StorageMode>("symlink");
   const [showFolderPicker, setShowFolderPicker] = useState(false);
+  const [showRelinkDialog, setShowRelinkDialog] = useState(false);
   const [scanning, setScanning] = useState(false);
   const [busy, setBusy] = useState(false);
   const [lastScannedDir, setLastScannedDir] = useState<string | null>(null);
@@ -216,6 +218,38 @@ function IngestInner({ slug }: { slug: string }) {
         </div>
 
         <ShooterBanner project={project} />
+
+        {/* Top-level actions. The relink dialog handles the "I moved my
+         *  source videos and the project's symlinks are now broken"
+         *  JTBD. It scans a folder recursively, matches by basename, and
+         *  rewrites the per-video symlinks. Reachable here so the user
+         *  doesn't have to dig through Settings or the CLI. */}
+        {!isEmpty && (
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowRelinkDialog(true)}
+            >
+              <Folder className="size-3.5" />
+              <span className="font-display uppercase tracking-[0.08em]">
+                Find moved videos
+              </span>
+            </Button>
+            <span className="text-[0.6875rem] uppercase tracking-[0.06em] text-muted">
+              Use this when source files have moved and the project's symlinks are broken.
+            </span>
+          </div>
+        )}
+
+        {showRelinkDialog && (
+          <RelinkDialog
+            slug={slug}
+            onClose={() => setShowRelinkDialog(false)}
+            onApplied={() => void reload()}
+          />
+        )}
 
         {error && (
           <div className="mb-4 rounded-md border border-led/40 bg-led/10 px-3 py-2 text-sm text-led">

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -35,6 +35,7 @@ import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { FolderPicker } from "@/components/FolderPicker";
 import { RelinkDialog } from "@/components/RelinkDialog";
+import { ShooterChipStrip } from "@/components/match/ShooterChipStrip";
 import { Brand, Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import {
@@ -43,6 +44,7 @@ import {
   type CameraMount,
   type MatchProject,
   type ServerHealth,
+  type ShooterListEntry,
   type StageEntry,
   type StageVideo,
   type VideoRole,
@@ -61,6 +63,7 @@ function IngestInner({ slug }: { slug: string }) {
   const navigate = useNavigate();
   const [project, setProject] = useState<MatchProject | null>(null);
   const [health, setHealth] = useState<ServerHealth | null>(null);
+  const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [storage, setStorage] = useState<StorageMode>("symlink");
   const [showFolderPicker, setShowFolderPicker] = useState(false);
@@ -68,6 +71,24 @@ function IngestInner({ slug }: { slug: string }) {
   const [scanning, setScanning] = useState(false);
   const [busy, setBusy] = useState(false);
   const [lastScannedDir, setLastScannedDir] = useState<string | null>(null);
+
+  // Match-level shooter list drives the chip-strip switcher. 409
+  // (legacy single-shooter project) collapses to an empty list, which
+  // hides the strip without surfacing as an error to the user.
+  useEffect(() => {
+    let alive = true;
+    api
+      .listMatchShooters()
+      .then((r) => {
+        if (alive) setShooters(r.shooters);
+      })
+      .catch(() => {
+        if (alive) setShooters([]);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   async function reload() {
     setError(null);
@@ -217,7 +238,21 @@ function IngestInner({ slug }: { slug: string }) {
           </p>
         </div>
 
-        <ShooterBanner project={project} />
+        {/* Switch which shooter you're managing videos for. Same chip
+         *  pattern as Audit / Coach / Export so the user has one mental
+         *  model for moving between shooters. Hides itself in
+         *  single-shooter matches and legacy projects. */}
+        <div className="mb-5">
+          <ShooterChipStrip
+            shooters={shooters}
+            activeSlug={slug}
+            urlBase="ingest"
+            label="Adding footage for"
+            count={(s) =>
+              `${s.video_count} video${s.video_count === 1 ? "" : "s"}`
+            }
+          />
+        </div>
 
         {/* Top-level actions. The relink dialog handles the "I moved my
          *  source videos and the project's symlinks are now broken"
@@ -685,50 +720,6 @@ function StorageOption({
         </div>
       </div>
     </button>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* Shooter banner                                                             */
-/* -------------------------------------------------------------------------- */
-
-function ShooterBanner({ project }: { project: MatchProject | null }) {
-  const name = project?.competitor_name ?? "You";
-  return (
-    <div className="relative mb-5 flex items-center gap-3.5 overflow-hidden rounded-xl border border-rule-strong bg-gradient-to-b from-surface to-surface-2 px-4.5 py-3.5">
-      <span
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-[3px] bg-led shadow-[0_0_12px_var(--color-led-glow)]"
-      />
-      <span
-        aria-hidden
-        className="inline-flex size-10 items-center justify-center rounded-full font-mono text-[0.8125rem] font-bold text-ink"
-        style={{
-          background:
-            "linear-gradient(135deg, var(--color-led), var(--color-led-deep))",
-          boxShadow:
-            "0 0 0 1px rgba(255,45,45,0.4), 0 0 14px var(--color-led-glow)",
-        }}
-      >
-        {initials(name)}
-      </span>
-      <div className="flex-1">
-        <div className="mb-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.2em] text-subtle">
-          Adding footage for
-        </div>
-        <div className="inline-flex items-center gap-2.5 font-display text-base font-bold uppercase tracking-[0.04em] text-ink">
-          {name}
-          <span className="rounded bg-led px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_8px_var(--color-led-glow)]">
-            YOU
-          </span>
-        </div>
-        {project?.match_date && (
-          <div className="mt-0.5 font-mono text-[0.625rem] uppercase tracking-[0.06em] text-muted">
-            Match {project.match_date}
-          </div>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -1276,11 +1267,4 @@ function CameraCard({ camera }: { camera: CameraGroup }) {
 
 function pad2(n: number): string {
   return n.toString().padStart(2, "0");
-}
-
-function initials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 0 || !parts[0]) return "??";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -335,6 +335,7 @@ function IngestInner({ slug }: { slug: string }) {
             onConfirm={() => navigate("/", { replace: true })}
             busy={busy}
             lastScannedDir={lastScannedDir}
+            onError={setError}
           />
         ) : null}
       </main>
@@ -738,6 +739,7 @@ function ReviewState({
   onConfirm,
   busy,
   lastScannedDir,
+  onError,
 }: {
   slug: string;
   project: MatchProject;
@@ -753,6 +755,7 @@ function ReviewState({
   onConfirm: () => void;
   busy: boolean;
   lastScannedDir: string | null;
+  onError: (msg: string | null) => void;
 }) {
   const assignedVideos: { video: StageVideo; stage: StageEntry }[] = useMemo(
     () =>
@@ -855,6 +858,7 @@ function ReviewState({
             return (
               <StageBlock
                 key={stage.stage_number}
+                slug={slug}
                 stage={stage}
                 allStages={project.stages}
                 videos={videos}
@@ -862,18 +866,21 @@ function ReviewState({
                 onMove={onMoveAssignment}
                 onRemove={onRemoveVideo}
                 busy={busy}
+                onError={onError}
               />
             );
           })}
 
           {unassignedVideos.length > 0 && (
             <UnassignedBlock
+              slug={slug}
               videos={unassignedVideos}
               allStages={project.stages}
               cameras={cameras}
               onMove={onMoveAssignment}
               onRemove={onRemoveVideo}
               busy={busy}
+              onError={onError}
             />
           )}
         </div>
@@ -962,6 +969,7 @@ function groupByCamera(
 }
 
 function StageBlock({
+  slug,
   stage,
   allStages,
   videos,
@@ -969,7 +977,9 @@ function StageBlock({
   onMove,
   onRemove,
   busy,
+  onError,
 }: {
+  slug: string;
   stage: StageEntry;
   allStages: StageEntry[];
   videos: StageVideo[];
@@ -981,6 +991,7 @@ function StageBlock({
   ) => Promise<void>;
   onRemove: (videoPath: string) => Promise<void>;
   busy: boolean;
+  onError: (msg: string | null) => void;
 }) {
   const primaryCount = videos.filter((v) => v.role === "primary").length;
   const status: "ok" | "warn" =
@@ -1020,6 +1031,7 @@ function StageBlock({
       {videos.map((v) => (
         <VideoRow
           key={v.video_id}
+          slug={slug}
           video={v}
           camera={cameras.find((c) => c.videoPaths.has(v.path))}
           currentStage={stage.stage_number}
@@ -1027,6 +1039,7 @@ function StageBlock({
           onMove={onMove}
           onRemove={onRemove}
           busy={busy}
+          onError={onError}
         />
       ))}
     </div>
@@ -1034,13 +1047,16 @@ function StageBlock({
 }
 
 function UnassignedBlock({
+  slug,
   videos,
   allStages,
   cameras,
   onMove,
   onRemove,
   busy,
+  onError,
 }: {
+  slug: string;
   videos: StageVideo[];
   allStages: StageEntry[];
   cameras: CameraGroup[];
@@ -1051,6 +1067,7 @@ function UnassignedBlock({
   ) => Promise<void>;
   onRemove: (videoPath: string) => Promise<void>;
   busy: boolean;
+  onError: (msg: string | null) => void;
 }) {
   return (
     <div className="border-y border-live/30 bg-gradient-to-r from-live/[0.06] to-transparent">
@@ -1071,6 +1088,7 @@ function UnassignedBlock({
       {videos.map((v) => (
         <VideoRow
           key={v.video_id}
+          slug={slug}
           video={v}
           camera={cameras.find((c) => c.videoPaths.has(v.path))}
           currentStage={null}
@@ -1078,6 +1096,7 @@ function UnassignedBlock({
           onMove={onMove}
           onRemove={onRemove}
           busy={busy}
+          onError={onError}
         />
       ))}
     </div>
@@ -1085,6 +1104,7 @@ function UnassignedBlock({
 }
 
 function VideoRow({
+  slug,
   video,
   camera,
   currentStage,
@@ -1092,7 +1112,9 @@ function VideoRow({
   onMove,
   onRemove,
   busy,
+  onError,
 }: {
+  slug: string;
   video: StageVideo;
   camera?: CameraGroup;
   currentStage: number | null;
@@ -1104,7 +1126,30 @@ function VideoRow({
   ) => Promise<void>;
   onRemove: (videoPath: string) => Promise<void>;
   busy: boolean;
+  onError: (msg: string | null) => void;
 }) {
+  const [detecting, setDetecting] = useState(false);
+  const needsBeep =
+    video.role !== "ignored" &&
+    video.beep_time == null &&
+    currentStage != null;
+
+  async function detectBeep() {
+    if (currentStage == null) return;
+    setDetecting(true);
+    onError(null);
+    try {
+      // Server-side dedupe: if a detect_beep job is already in flight for
+      // this video, ``_submit_detect_beep`` returns the existing job
+      // without spawning a parallel one. JobsPanel surfaces progress;
+      // we leave the user here.
+      await api.detectBeepForVideo(slug, currentStage, video.video_id);
+    } catch (e) {
+      onError(e instanceof ApiError ? e.detail : String(e));
+    } finally {
+      setDetecting(false);
+    }
+  }
   const filename = video.path.split("/").pop() ?? video.path;
   const cameraLabel = camera?.label ?? "Camera";
   const cameraDetail = [
@@ -1135,7 +1180,7 @@ function VideoRow({
 
   return (
     <div
-      className="grid grid-cols-[36px_minmax(0,1.6fr)_120px_180px_220px_36px] items-center gap-3.5 border-b border-rule px-5 py-2.5 last:border-b-0 hover:bg-surface-2"
+      className="grid grid-cols-[36px_minmax(0,1.6fr)_120px_180px_220px_minmax(160px,auto)_36px] items-center gap-3.5 border-b border-rule px-5 py-2.5 last:border-b-0 hover:bg-surface-2"
     >
       <span
         aria-hidden
@@ -1176,6 +1221,34 @@ function VideoRow({
         ))}
       </select>
       <RoleToggles value={video.role} onChange={(r) => void setRole(r)} disabled={busy} />
+      {/* Beep status + manual retry. Auto-queue fires at scan / move /
+       *  swap-primary time; if a job never ran or failed silently, the
+       *  user needs an explicit affordance to kick detection. Clicking
+       *  hits ``detectBeepForVideo``; the server dedupes against an
+       *  in-flight job so double-clicks are safe. JobsPanel surfaces
+       *  progress; on success the row re-renders via project reload. */}
+      <div className="flex items-center justify-end gap-2">
+        {video.beep_time != null ? (
+          <span className="inline-flex items-center gap-1.5 rounded border border-beep/40 bg-beep-tint px-2 py-0.5 font-mono text-[0.625rem] font-bold tabular-nums text-beep">
+            beep {video.beep_time.toFixed(2)}s
+          </span>
+        ) : video.role === "ignored" ? (
+          <span className="font-mono text-[0.625rem] uppercase tracking-[0.06em] text-muted">
+            ignored
+          </span>
+        ) : null}
+        {needsBeep ? (
+          <button
+            type="button"
+            onClick={() => void detectBeep()}
+            disabled={busy || detecting}
+            title="Detect beep on this video"
+            className="inline-flex items-center gap-1.5 rounded-md border border-rule-strong bg-surface-2 px-2.5 py-1.5 font-display text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-ink-2 transition-colors hover:border-led-deep hover:bg-led-tint hover:text-led disabled:opacity-50"
+          >
+            {detecting ? "Queuing..." : "Detect beep"}
+          </button>
+        ) : null}
+      </div>
       <button
         type="button"
         onClick={() => void onRemove(video.path)}

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -256,6 +256,7 @@ function IngestInner({ slug }: { slug: string }) {
           />
         ) : project ? (
           <ReviewState
+            slug={slug}
             project={project}
             storage={storage}
             onStorageChange={setStorage}
@@ -702,6 +703,7 @@ function ShooterBanner({ project }: { project: MatchProject | null }) {
 /* -------------------------------------------------------------------------- */
 
 function ReviewState({
+  slug,
   project,
   storage,
   onStorageChange,
@@ -712,6 +714,7 @@ function ReviewState({
   busy,
   lastScannedDir,
 }: {
+  slug: string;
   project: MatchProject;
   storage: StorageMode;
   onStorageChange: (s: StorageMode) => void;
@@ -883,7 +886,7 @@ function ReviewState({
         Background jobs queue immediately (audio extract + beep detect per
         video). Stages with confirmed beeps become available for audit.
         Continue to <Link to="/" className="text-led hover:text-led-soft">match overview</Link>{" "}
-        or open the <Link to="/audit" className="text-led hover:text-led-soft">audit</Link>{" "}
+        or open the <Link to={`/audit/${slug}`} className="text-led hover:text-led-soft">audit</Link>{" "}
         page to start reviewing.
       </div>
     </>

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -31,7 +31,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { FolderPicker } from "@/components/FolderPicker";
 import { Brand, Kicker } from "@/components/ui";
@@ -51,6 +51,12 @@ import { cn } from "@/lib/utils";
 type StorageMode = "symlink" | "copy";
 
 export function Ingest() {
+  const { slug } = useParams<{ slug: string }>();
+  if (!slug) return <Navigate to="/shooters" replace />;
+  return <IngestInner slug={slug} />;
+}
+
+function IngestInner({ slug }: { slug: string }) {
   const navigate = useNavigate();
   const [project, setProject] = useState<MatchProject | null>(null);
   const [health, setHealth] = useState<ServerHealth | null>(null);
@@ -65,7 +71,7 @@ export function Ingest() {
     setError(null);
     try {
       const [p, h] = await Promise.all([
-        api.getProject(),
+        api.getProject(slug),
         api.getHealth(),
       ]);
       setProject(p);
@@ -91,7 +97,7 @@ export function Ingest() {
     setScanning(true);
     setError(null);
     try {
-      await api.scanVideos(path, true, storage);
+      await api.scanVideos(slug, path, true, storage);
       setLastScannedDir(path);
       await reload();
     } catch (e: unknown) {
@@ -106,7 +112,7 @@ export function Ingest() {
     setScanning(true);
     setError(null);
     try {
-      await api.scanFiles(files.map((f) => f.path), true, storage);
+      await api.scanFiles(slug, files.map((f) => f.path), true, storage);
       await reload();
     } catch (e: unknown) {
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -123,7 +129,7 @@ export function Ingest() {
     setBusy(true);
     setError(null);
     try {
-      await api.moveAssignment(videoPath, toStage, role);
+      await api.moveAssignment(slug, videoPath, toStage, role);
       await reload();
     } catch (e: unknown) {
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -136,7 +142,7 @@ export function Ingest() {
     setBusy(true);
     setError(null);
     try {
-      await api.removeVideo(videoPath, false);
+      await api.removeVideo(slug, videoPath, false);
       await reload();
     } catch (e: unknown) {
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -220,6 +226,7 @@ export function Ingest() {
         {showFolderPicker && (
           <div className="mb-5 rounded-2xl border border-rule-strong bg-surface p-4">
             <FolderPicker
+              slug={slug}
               initialPath={lastScannedDir ?? undefined}
               onSelect={(path) => void scanFolder(path)}
               onSelectFiles={(files) => void scanFiles(files)}

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -1674,9 +1674,19 @@ function PromoteAllStagesButton({
     setLoading(true);
     setLoadError(null);
     try {
+      // Lab is process-scoped (legacy dev tool). Pull stage definitions
+      // off whichever shooter is alphabetically first; in match mode they
+      // share the same stage list, and in single-shooter mode there's
+      // only one shooter to pick.
+      const shooters = await api.listMatchShooters();
+      const first = shooters.shooters[0]?.slug;
+      if (!first) {
+        setRows([]);
+        return;
+      }
       const [proj, ov] = await Promise.all([
-        api.getProject(),
-        api.getExportOverview(),
+        api.getProject(first),
+        api.getExportOverview(first),
       ]);
       setProject(proj);
       setRows(buildBatchRows(proj, ov.stages, catalog));

--- a/src/splitsmith/ui_static/src/pages/MergeMatches.tsx
+++ b/src/splitsmith/ui_static/src/pages/MergeMatches.tsx
@@ -300,7 +300,7 @@ function SelectStep({
                     className={cn(
                       "inline-flex size-5 items-center justify-center rounded border",
                       checked
-                        ? "border-led bg-led text-bg"
+                        ? "border-led bg-led-fill text-ink"
                         : "border-rule-strong bg-surface-2",
                     )}
                   >

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -857,8 +857,8 @@ function MatchRow({
           className={cn(
             "inline-flex min-h-[40px] items-center gap-2 rounded-lg border px-4 py-2.5 font-display text-xs font-bold uppercase tracking-[0.1em] leading-none transition-all",
             archived
-              ? "border-rule-strong bg-transparent text-ink hover:border-led hover:bg-led hover:text-bg"
-              : "border-ink bg-ink text-bg hover:border-led hover:bg-led",
+              ? "border-rule-strong bg-transparent text-ink hover:border-led hover:bg-led-fill hover:text-ink"
+              : "border-ink bg-ink text-bg hover:border-led-deep hover:bg-led-fill hover:text-ink",
           )}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/splitsmith/ui_static/src/pages/Review.tsx
+++ b/src/splitsmith/ui_static/src/pages/Review.tsx
@@ -741,6 +741,7 @@ export function Review() {
                     detected: detectedCount,
                     rejected: rejectedCount,
                     manual: manualCount,
+                    beep: peaks.beep_time != null ? 1 : 0,
                   }}
                   onChange={setFilters}
                 />

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -18,6 +18,7 @@
 
 import {
   ArrowRight,
+  Camera,
   CheckCircle2,
   Plus,
   RefreshCw,

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -18,7 +18,6 @@
 
 import {
   ArrowRight,
-  Camera,
   CheckCircle2,
   Plus,
   RefreshCw,
@@ -119,18 +118,6 @@ export function Shooters() {
     void reload();
   }, [reload]);
 
-  async function activate(slug: string) {
-    setBusy(slug);
-    try {
-      await api.selectActiveShooter(slug);
-      await reload();
-    } catch (e) {
-      setError(e instanceof ApiError ? e.detail : String(e));
-    } finally {
-      setBusy(null);
-    }
-  }
-
   async function remove(slug: string, name: string) {
     if (
       !window.confirm(
@@ -224,9 +211,8 @@ export function Shooters() {
               shooter={shooter}
               stagesTotal={stagesTotal}
               busy={busy === shooter.slug}
-              onActivate={() => void activate(shooter.slug)}
               onRemove={() => void remove(shooter.slug, shooter.name)}
-              onOpenAudit={() => navigate("/audit")}
+              onOpenAudit={() => navigate(`/audit/${shooter.slug}`)}
               onRebuildTrims={() =>
                 void rebuildTrims(
                   shooter.slug,
@@ -310,7 +296,6 @@ function ShooterCard({
   shooter,
   stagesTotal,
   busy,
-  onActivate,
   onRemove,
   onOpenAudit,
   onRebuildTrims,
@@ -318,12 +303,11 @@ function ShooterCard({
   shooter: ShooterListEntry;
   stagesTotal: number;
   busy: boolean;
-  onActivate: () => void;
   onRemove: () => void;
   onOpenAudit: () => void;
   onRebuildTrims: () => void;
 }) {
-  const palette = pickPalette(shooter.slug, shooter.is_active);
+  const palette = pickPalette(shooter.slug, false);
   const style = PALETTE_STYLE[palette];
   const progress =
     stagesTotal > 0 ? shooter.stages_audited / stagesTotal : 0;
@@ -342,10 +326,7 @@ function ShooterCard({
 
   return (
     <article
-      className={cn(
-        "relative overflow-hidden rounded-2xl border border-rule-strong bg-gradient-to-b from-surface to-surface-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_18px_36px_-24px_rgba(0,0,0,0.6)]",
-        shooter.is_active && style.glow,
-      )}
+      className="relative overflow-hidden rounded-2xl border border-rule-strong bg-gradient-to-b from-surface to-surface-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_18px_36px_-24px_rgba(0,0,0,0.6)]"
     >
       <span
         aria-hidden
@@ -364,11 +345,6 @@ function ShooterCard({
         <div className="min-w-0 flex-1">
           <div className="inline-flex items-center gap-2.5 font-display text-base font-bold uppercase tracking-[0.04em] text-ink">
             {shooter.name}
-            {shooter.is_active && (
-              <span className="rounded border border-led-deep bg-led/10 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.14em] text-led">
-                Active
-              </span>
-            )}
           </div>
           <div className="mt-0.5 font-mono text-[0.6875rem] uppercase tracking-[0.06em] text-muted">
             {shooter.cameras.length} camera
@@ -413,38 +389,20 @@ function ShooterCard({
               Rebuild ({shooter.stages_missing_trim})
             </button>
           )}
-          {!shooter.is_active && (
-            <button
-              type="button"
-              onClick={onActivate}
-              disabled={busy}
-              title={`Switch to ${shooter.name}`}
-              aria-label={`Switch to ${shooter.name}`}
-              className="inline-flex size-9 items-center justify-center rounded-md border border-rule bg-surface-2 text-ink-2 transition-colors hover:border-led hover:bg-led/10 hover:text-led disabled:opacity-50"
-            >
-              <ArrowRight className="size-4" />
-            </button>
-          )}
-          {shooter.is_active && (
-            <button
-              type="button"
-              onClick={onOpenAudit}
-              title="Open audit"
-              aria-label="Open audit"
-              className="inline-flex size-9 items-center justify-center rounded-md border border-rule bg-surface-2 text-ink-2 transition-colors hover:bg-surface-3 hover:text-ink"
-            >
-              <Camera className="size-4" />
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={onOpenAudit}
+            title={`Open ${shooter.name}'s audit`}
+            aria-label={`Open ${shooter.name}'s audit`}
+            className="inline-flex size-9 items-center justify-center rounded-md border border-rule bg-surface-2 text-ink-2 transition-colors hover:border-led hover:bg-led/10 hover:text-led"
+          >
+            <ArrowRight className="size-4" />
+          </button>
           <button
             type="button"
             onClick={onRemove}
-            disabled={busy || shooter.is_active}
-            title={
-              shooter.is_active
-                ? "Switch to another shooter before removing this one"
-                : `Remove ${shooter.name}`
-            }
+            disabled={busy}
+            title={`Remove ${shooter.name}`}
             aria-label="Remove shooter"
             className="inline-flex size-9 items-center justify-center rounded-md border border-rule bg-surface-2 text-subtle transition-colors hover:border-led/40 hover:bg-led/10 hover:text-led disabled:opacity-30 disabled:hover:bg-surface-2 disabled:hover:text-subtle"
           >

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -275,7 +275,7 @@ export function Shooters() {
               type="button"
               onClick={() => void add()}
               disabled={adding || !newName.trim()}
-              className="bg-led text-bg shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led-soft hover:text-bg"
+              className="bg-led-fill text-ink shadow-[0_0_0_1px_var(--color-led),0_0_18px_var(--color-led-glow)] hover:bg-led hover:text-ink"
             >
               <Plus className="size-3.5" />
               <span className="font-display uppercase tracking-[0.08em]">

--- a/src/splitsmith/ui_static/src/pages/dev/DevReviewQueue.tsx
+++ b/src/splitsmith/ui_static/src/pages/dev/DevReviewQueue.tsx
@@ -255,7 +255,7 @@ function QueueItem({
         {item.status === "done" ? (
           <CheckCircle2 className="size-4 text-done" />
         ) : item.status === "flagged" ? (
-          <span className="inline-flex size-5 items-center justify-center rounded-full bg-led text-bg font-mono text-[0.625rem] font-bold">
+          <span className="inline-flex size-5 items-center justify-center rounded-full bg-led-fill text-ink font-mono text-[0.625rem] font-bold">
             !
           </span>
         ) : (

--- a/src/splitsmith/video_match.py
+++ b/src/splitsmith/video_match.py
@@ -38,9 +38,7 @@ from .config import StageData, VideoMatchConfig, VideoMatchResult, VideoStageMat
 VideoClassification = Literal["in_window", "contested", "orphan", "no_timestamp"]
 
 
-def match_window(
-    scorecard_updated_at: datetime, tolerance_minutes: int
-) -> tuple[datetime, datetime]:
+def match_window(scorecard_updated_at: datetime, tolerance_minutes: int) -> tuple[datetime, datetime]:
     """Return ``(lower, upper)`` for a stage's match window.
 
     Asymmetric: the upper bound is ``scorecard_updated_at`` itself because the
@@ -104,9 +102,7 @@ def match_videos_to_stages(
     candidates_per_stage: dict[int, list[Path]] = {}
     for stage in stages:
         lower, upper = match_window(stage.scorecard_updated_at, config.tolerance_minutes)
-        candidates_per_stage[stage.stage_number] = [
-            p for p, ts in timestamps.items() if lower <= ts <= upper
-        ]
+        candidates_per_stage[stage.stage_number] = [p for p, ts in timestamps.items() if lower <= ts <= upper]
 
     # And inversely, which stages does each video belong to?
     stages_per_video: dict[Path, list[int]] = defaultdict(list)

--- a/src/splitsmith/video_probe.py
+++ b/src/splitsmith/video_probe.py
@@ -108,9 +108,7 @@ def probe(
     except subprocess.TimeoutExpired as exc:
         raise ProbeError(f"ffprobe timed out on {path}") from exc
     except subprocess.CalledProcessError as exc:
-        raise ProbeError(
-            f"ffprobe failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise ProbeError(f"ffprobe failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
 
     try:
         payload = json.loads(completed.stdout)
@@ -121,9 +119,7 @@ def probe(
     key = source_cache_key(path)
     if key:
         cache_dir.mkdir(parents=True, exist_ok=True)
-        (cache_dir / f"{key}.json").write_text(
-            result.model_dump_json(indent=2) + "\n", encoding="utf-8"
-        )
+        (cache_dir / f"{key}.json").write_text(result.model_dump_json(indent=2) + "\n", encoding="utf-8")
     return result
 
 

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -52,9 +52,7 @@ def test_automation_settings_malformed_yaml_falls_back(tmp_path: Path) -> None:
     assert loaded.shot_detect_on_beep_verified is True
 
 
-def test_automation_settings_env_var_overrides_yaml(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_automation_settings_env_var_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``SPLITSMITH_AUTOMATION_*`` env vars trump the YAML default
     (pydantic-settings precedence). Env init args we pass in
     (the YAML block) lose to environment by design."""
@@ -121,9 +119,7 @@ def test_resolve_project_override_with_none_field_falls_through() -> None:
     assert resolved.provenance["shot_detect_on_beep_verified"].source == "global"
 
 
-def test_resolve_no_args_loads_global_from_disk(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_resolve_no_args_loads_global_from_disk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Without ``global_settings`` the resolver loads from the
     user-config directory. SPLITSMITH_HOME points to a tmp dir so the
     test doesn't read the real user's config."""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -207,7 +207,7 @@ def test_export_endpoint_streams_archive(tmp_path: Path) -> None:
     app = create_app(project_root=src, project_name="HTTP Match")
     client = TestClient(app)
 
-    resp = client.get("/api/project/export")
+    resp = client.get("/api/shooters/me/project/export")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/gzip"
     assert "match-backup-" in resp.headers.get(
@@ -236,7 +236,7 @@ def test_import_endpoint_extracts_and_optionally_binds(tmp_path: Path) -> None:
 
     with archive.open("rb") as fh:
         resp = client.post(
-            "/api/project/import",
+            "/api/me/projects/import",
             files={"archive": ("backup.tar.gz", fh, "application/gzip")},
             data={"dest_root": str(dest), "bind": "true"},
         )
@@ -263,7 +263,7 @@ def test_import_endpoint_refuses_overwrite(tmp_path: Path) -> None:
     # First import succeeds.
     with archive.open("rb") as fh:
         first = client.post(
-            "/api/project/import",
+            "/api/me/projects/import",
             files={"archive": ("backup.tar.gz", fh, "application/gzip")},
             data={"dest_root": str(dest)},
         )
@@ -272,7 +272,7 @@ def test_import_endpoint_refuses_overwrite(tmp_path: Path) -> None:
     # Second one without overwrite=true is rejected.
     with archive.open("rb") as fh:
         second = client.post(
-            "/api/project/import",
+            "/api/me/projects/import",
             files={"archive": ("backup.tar.gz", fh, "application/gzip")},
             data={"dest_root": str(dest)},
         )

--- a/tests/test_beep_detect.py
+++ b/tests/test_beep_detect.py
@@ -75,9 +75,7 @@ def test_detect_beep_returns_ranked_candidates() -> None:
     def _stamp(at_s: float, amp: float, dur_s: float = 0.300) -> None:
         n = int(sr * dur_s)
         t = np.arange(n) / sr
-        audio[int(sr * at_s) : int(sr * at_s) + n] += amp * np.sin(2 * np.pi * 3000 * t).astype(
-            np.float32
-        )
+        audio[int(sr * at_s) : int(sr * at_s) + n] += amp * np.sin(2 * np.pi * 3000 * t).astype(np.float32)
 
     _stamp(1.0, 0.6)  # the "real" beep -- preceded by ~1 s of silence
     _stamp(3.0, 0.4)  # competing transient further into the clip

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -161,9 +161,7 @@ def test_apply_handles_missing_files(tmp_path: Path) -> None:
     assert result.bytes_freed == 256
 
 
-def test_apply_records_failures_without_raising(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_apply_records_failures_without_raising(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     project, root = _project(tmp_path)
     audio = project.audio_path(root)
     audio.mkdir(parents=True, exist_ok=True)

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -145,9 +145,7 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
     trimmed_dir = project.trimmed_path(root)
     trimmed_dir.mkdir(parents=True, exist_ok=True)
     primary_id = project.stages[0].videos[0].video_id
-    (trimmed_dir / f"stage1_cam_{primary_id}_trimmed.mp4").write_bytes(
-        b"not really a video, but non-empty"
-    )
+    (trimmed_dir / f"stage1_cam_{primary_id}_trimmed.mp4").write_bytes(b"not really a video, but non-empty")
 
     app = create_app(project_root=root, project_name="Trimmed Match")
     client = TestClient(app)

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -188,7 +188,10 @@ def test_get_match_distributions_aggregates(tmp_path: Path) -> None:
     assert body["first_shot_seconds"] == pytest.approx([1.5])
 
 
-def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
+def test_get_coach_returns_null_when_no_audit(tmp_path: Path) -> None:
+    """No audit JSON yet -> 200 null. "Stage exists but isn't audited"
+    is a normal pre-audit state and shouldn't surface as a failed
+    request in DevTools. 404 is reserved for unknown stage numbers."""
     root = tmp_path / "match"
     project = MatchProject.init(root, name="Empty")
     project.stages = [StageEntry(stage_number=1, stage_name="x", time_seconds=10.0, videos=[])]
@@ -196,7 +199,8 @@ def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="Empty")
     client = TestClient(app)
     resp = client.get("/api/shooters/me/stages/1/coach")
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -68,7 +68,7 @@ def _read(audit_file: Path) -> dict[str, Any]:
 
 def test_get_coach_returns_shots_with_stale_when_unset(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
-    resp = client.get("/api/stages/1/coach")
+    resp = client.get("/api/shooters/me/stages/1/coach")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["stage_number"] == 1
@@ -94,7 +94,7 @@ def test_get_coach_returns_shots_with_stale_when_unset(tmp_path: Path) -> None:
 
 def test_get_coach_returns_videos_with_beep_in_clip(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
-    resp = client.get("/api/stages/1/coach")
+    resp = client.get("/api/shooters/me/stages/1/coach")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert "videos" in body
@@ -151,7 +151,7 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
 
     app = create_app(project_root=root, project_name="Trimmed Match")
     client = TestClient(app)
-    resp = client.get("/api/stages/1/coach")
+    resp = client.get("/api/shooters/me/stages/1/coach")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     # Default trim_pre_buffer_seconds is 5.0; beep clamps to that.
@@ -162,7 +162,7 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
 
 def test_get_stage_distributions(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
-    resp = client.get("/api/stages/1/coach/distributions")
+    resp = client.get("/api/shooters/me/stages/1/coach/distributions")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["stage_number"] == 1
@@ -178,7 +178,7 @@ def test_get_stage_distributions(tmp_path: Path) -> None:
 
 def test_get_match_distributions_aggregates(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
-    resp = client.get("/api/coach/distributions")
+    resp = client.get("/api/shooters/me/coach/distributions")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["stage_count"] == 1
@@ -195,7 +195,7 @@ def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
     project.save(root)
     app = create_app(project_root=root, project_name="Empty")
     client = TestClient(app)
-    resp = client.get("/api/stages/1/coach")
+    resp = client.get("/api/shooters/me/stages/1/coach")
     assert resp.status_code == 404
 
 
@@ -207,7 +207,7 @@ def test_get_coach_404_when_no_audit(tmp_path: Path) -> None:
 def test_reclassify_persists_auto_classes(tmp_path: Path) -> None:
     client, audit_file = _bootstrap(tmp_path)
 
-    resp = client.post("/api/stages/1/coach/reclassify")
+    resp = client.post("/api/shooters/me/stages/1/coach/reclassify")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     classes = [s["interval_class"] for s in body["shots"]]
@@ -229,13 +229,13 @@ def test_reclassify_preserves_manual(tmp_path: Path) -> None:
 
     # Set a manual override on shot 4 first.
     resp = client.patch(
-        "/api/stages/1/shots/4/coach",
+        "/api/shooters/me/stages/1/shots/4/coach",
         json={"interval_class": "reload", "interval_class_source": "manual"},
     )
     assert resp.status_code == 200, resp.text
 
     # Reclassify -- should leave shot 4 alone.
-    resp = client.post("/api/stages/1/coach/reclassify")
+    resp = client.post("/api/shooters/me/stages/1/coach/reclassify")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["shots"][3]["interval_class"] == "reload"
@@ -253,7 +253,7 @@ def test_patch_set_class_and_note_and_flag(tmp_path: Path) -> None:
     client, audit_file = _bootstrap(tmp_path)
 
     resp = client.patch(
-        "/api/stages/1/shots/2/coach",
+        "/api/shooters/me/stages/1/shots/2/coach",
         json={
             "interval_class": "split",
             "interval_class_source": "manual",
@@ -278,10 +278,10 @@ def test_patch_set_class_and_note_and_flag(tmp_path: Path) -> None:
 def test_patch_clear_class_drops_pair(tmp_path: Path) -> None:
     client, audit_file = _bootstrap(tmp_path)
     client.patch(
-        "/api/stages/1/shots/2/coach",
+        "/api/shooters/me/stages/1/shots/2/coach",
         json={"interval_class": "reload", "interval_class_source": "manual"},
     )
-    resp = client.patch("/api/stages/1/shots/2/coach", json={"clear_class": True})
+    resp = client.patch("/api/shooters/me/stages/1/shots/2/coach", json={"clear_class": True})
     assert resp.status_code == 200
     body = resp.json()
     assert body["shots"][1]["interval_class"] is None
@@ -291,7 +291,7 @@ def test_patch_clear_class_drops_pair(tmp_path: Path) -> None:
 def test_patch_class_without_source_rejected(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
     resp = client.patch(
-        "/api/stages/1/shots/2/coach",
+        "/api/shooters/me/stages/1/shots/2/coach",
         json={"interval_class": "split"},
     )
     assert resp.status_code == 400
@@ -300,7 +300,7 @@ def test_patch_class_without_source_rejected(tmp_path: Path) -> None:
 def test_patch_unknown_shot_404(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
     resp = client.patch(
-        "/api/stages/1/shots/999/coach",
+        "/api/shooters/me/stages/1/shots/999/coach",
         json={"improvement_flag": True},
     )
     assert resp.status_code == 404
@@ -309,10 +309,10 @@ def test_patch_unknown_shot_404(tmp_path: Path) -> None:
 def test_patch_clear_note(tmp_path: Path) -> None:
     client, _audit = _bootstrap(tmp_path)
     client.patch(
-        "/api/stages/1/shots/2/coach",
+        "/api/shooters/me/stages/1/shots/2/coach",
         json={"coaching_note": "old note"},
     )
-    resp = client.patch("/api/stages/1/shots/2/coach", json={"clear_note": True})
+    resp = client.patch("/api/shooters/me/stages/1/shots/2/coach", json={"clear_note": True})
     assert resp.status_code == 200
     assert resp.json()["shots"][1]["coaching_note"] is None
 
@@ -320,7 +320,7 @@ def test_patch_clear_note(tmp_path: Path) -> None:
 def test_patch_emits_audit_event(tmp_path: Path) -> None:
     client, audit_file = _bootstrap(tmp_path)
     client.patch(
-        "/api/stages/1/shots/2/coach",
+        "/api/shooters/me/stages/1/shots/2/coach",
         json={"improvement_flag": True, "coaching_note": "fix me"},
     )
     saved = _read(audit_file)
@@ -338,7 +338,7 @@ def test_patch_emits_audit_event(tmp_path: Path) -> None:
 def test_stale_after_audit_edit(tmp_path: Path) -> None:
     client, audit_file = _bootstrap(tmp_path)
     # First persist auto classes.
-    client.post("/api/stages/1/coach/reclassify")
+    client.post("/api/shooters/me/stages/1/coach/reclassify")
 
     # Simulate an Audit-side timestamp move: shot 2 drifts from 0.30 -> 0.70 s gap.
     saved = _read(audit_file)
@@ -349,7 +349,7 @@ def test_stale_after_audit_edit(tmp_path: Path) -> None:
 
     # GET surfaces stale=True; the stored class is "split" but the rule
     # would now say "transition".
-    resp = client.get("/api/stages/1/coach")
+    resp = client.get("/api/shooters/me/stages/1/coach")
     assert resp.status_code == 200
     body = resp.json()
     moved = body["shots"][1]
@@ -357,7 +357,7 @@ def test_stale_after_audit_edit(tmp_path: Path) -> None:
     assert moved["stale"] is True
 
     # Reclassify clears stale.
-    resp = client.post("/api/stages/1/coach/reclassify")
+    resp = client.post("/api/shooters/me/stages/1/coach/reclassify")
     body = resp.json()
     moved = body["shots"][1]
     assert moved["interval_class"] == "transition"

--- a/tests/test_compare_emitter.py
+++ b/tests/test_compare_emitter.py
@@ -236,9 +236,7 @@ def test_beep_alignment_offsets_smaller_beep_later(tmp_path: Path) -> None:
     m = _manifest(out, "Mathias", ["Anders", "Mathias"])
     emit_compare_fcpxml(manifest=m, shooters=[a, b], output_path=out, runner=_stub_ffmpeg_runner())
     root = ET.fromstring(out.read_bytes())
-    by_name = {
-        c.attrib["name"]: c for c in root.findall("./resources/media/sequence/spine/asset-clip")
-    }
+    by_name = {c.attrib["name"]: c for c in root.findall("./resources/media/sequence/spine/asset-clip")}
     # delta = round((5.1 - 4.0)/0.0333...) = 33
     assert by_name["Anders"].attrib["offset"] == "33/30s"
     assert by_name["Anders"].attrib["start"] == "0s"

--- a/tests/test_compare_merged_match.py
+++ b/tests/test_compare_merged_match.py
@@ -221,11 +221,16 @@ def test_load_shooter_from_match_skips_stages_with_missing_trims(tmp_path: Path)
     plan = plan_merge([anton_root, martin_root], merged_root)
     execute_merge(plan, move=False)
 
+    # Resolve the opaque slug Anton was assigned in the merge plan.
+    anton_slug = next(m.slug for m in plan.shooter_moves if m.source_root == anton_root)
+
     # Delete one shooter's stage-1 trim post-merge.
-    victim = merged_root / "shooters" / "anton" / "exports" / "stage1_egg-grab_trimmed.mp4"
+    victim = (
+        merged_root / "shooters" / anton_slug / "exports" / "stage1_egg-grab_trimmed.mp4"
+    )
     assert victim.exists()
     victim.unlink()
 
-    bundle = load_shooter_from_match(merged_root, "anton", label="Anton", probe=_stub_probe)
+    bundle = load_shooter_from_match(merged_root, anton_slug, label="Anton", probe=_stub_probe)
     assert 1 not in bundle.stages_by_number
     assert 2 in bundle.stages_by_number

--- a/tests/test_compare_merged_match.py
+++ b/tests/test_compare_merged_match.py
@@ -142,9 +142,7 @@ def test_compare_via_manifest_and_via_merged_match_produce_same_structure(
             CompareShooter(project=martin_root, label="Martin"),
         ],
     )
-    bundles_via_manifest = [
-        load_shooter(s.project, s.label, probe=_stub_probe) for s in manifest.shooters
-    ]
+    bundles_via_manifest = [load_shooter(s.project, s.label, probe=_stub_probe) for s in manifest.shooters]
     emit_compare_fcpxml(
         manifest=manifest,
         shooters=bundles_via_manifest,
@@ -201,12 +199,10 @@ def test_compare_via_manifest_and_via_merged_match_produce_same_structure(
         return len(list(root.iter("asset")))
 
     assert _count_assets(via_manifest) == _count_assets(via_match), (
-        "merged-match render should reference the same number of source assets "
-        "as the manifest render"
+        "merged-match render should reference the same number of source assets " "as the manifest render"
     )
     assert _count_asset_refs(via_manifest) == _count_asset_refs(via_match), (
-        "merged-match render should place the same number of clips on tiles "
-        "as the manifest render"
+        "merged-match render should place the same number of clips on tiles " "as the manifest render"
     )
 
 
@@ -225,9 +221,7 @@ def test_load_shooter_from_match_skips_stages_with_missing_trims(tmp_path: Path)
     anton_slug = next(m.slug for m in plan.shooter_moves if m.source_root == anton_root)
 
     # Delete one shooter's stage-1 trim post-merge.
-    victim = (
-        merged_root / "shooters" / anton_slug / "exports" / "stage1_egg-grab_trimmed.mp4"
-    )
+    victim = merged_root / "shooters" / anton_slug / "exports" / "stage1_egg-grab_trimmed.mp4"
     assert victim.exists()
     victim.unlink()
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -276,9 +276,7 @@ def test_render_fcpxml_match_path_matches_generate_match_fcpxml(tmp_path: Path) 
             tail_pad_seconds=2.0,
         ),
     ]
-    generate_match_fcpxml(
-        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
-    )
+    generate_match_fcpxml(stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig())
 
     comp = composition.from_stage_compositions(stages, project_name="match")
     composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
@@ -334,9 +332,7 @@ def test_render_fcpxml_match_with_pip_secondaries_matches(tmp_path: Path) -> Non
             ),
         ),
     ]
-    generate_match_fcpxml(
-        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
-    )
+    generate_match_fcpxml(stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig())
 
     comp = composition.from_stage_compositions(stages, project_name="match")
     composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())
@@ -372,9 +368,7 @@ def test_render_fcpxml_match_with_overlay_matches(tmp_path: Path) -> None:
             tail_pad_seconds=5.0,
         ),
     ]
-    generate_match_fcpxml(
-        stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig()
-    )
+    generate_match_fcpxml(stages=stages, output_path=legacy_out, project_name="match", config=OutputConfig())
 
     comp = composition.from_stage_compositions(stages, project_name="match")
     composition.render_fcpxml(comp, output_path=ir_out, config=OutputConfig())

--- a/tests/test_cross_align.py
+++ b/tests/test_cross_align.py
@@ -53,9 +53,7 @@ def _stage_audio(
         if 0 <= s < n:
             e = min(e, n)
             envelope = np.exp(-np.linspace(0, 5, e - s)).astype(np.float32)
-            audio[s:e] += (
-                shot_amp * envelope * rng.choice([-1.0, 1.0], size=e - s).astype(np.float32)
-            )
+            audio[s:e] += shot_amp * envelope * rng.choice([-1.0, 1.0], size=e - s).astype(np.float32)
     return audio
 
 
@@ -65,9 +63,7 @@ def test_aligner_recovers_known_offset_within_5ms() -> None:
     sr = 48000
     primary_beep_t = 5.0
     shift = 3.7
-    primary = _stage_audio(
-        sr, duration_s=15.0, beep_at=primary_beep_t, shots_at=[6.5, 7.0, 7.6, 8.3], seed=1
-    )
+    primary = _stage_audio(sr, duration_s=15.0, beep_at=primary_beep_t, shots_at=[6.5, 7.0, 7.6, 8.3], seed=1)
     secondary = _stage_audio(
         sr,
         duration_s=20.0,

--- a/tests/test_csv_gen.py
+++ b/tests/test_csv_gen.py
@@ -37,12 +37,8 @@ def test_write_then_read_round_trip(tmp_path: Path) -> None:
     beep = 5.000
     shots = [
         _make_shot(1, beep + 1.420, beep_time=beep, peak=0.55, confidence=0.92, notes="draw"),
-        _make_shot(
-            2, beep + 1.630, beep_time=beep, prev_t=beep + 1.420, peak=0.48, confidence=0.81
-        ),
-        _make_shot(
-            3, beep + 1.820, beep_time=beep, prev_t=beep + 1.630, peak=0.42, confidence=0.74
-        ),
+        _make_shot(2, beep + 1.630, beep_time=beep, prev_t=beep + 1.420, peak=0.48, confidence=0.81),
+        _make_shot(3, beep + 1.820, beep_time=beep, prev_t=beep + 1.630, peak=0.42, confidence=0.74),
     ]
     out = tmp_path / "splits.csv"
     write_splits_csv(shots, out)

--- a/tests/test_dtd_validation.py
+++ b/tests/test_dtd_validation.py
@@ -273,9 +273,7 @@ def test_fcpxml_match_with_titles_validates(tmp_path: Path) -> None:
         project_name="match",
         config=OutputConfig(),
         titles=[
-            fcpxml_gen.StageTitle(
-                stage_index=0, text="Stage A", style="slate", duration_seconds=1.0
-            ),
+            fcpxml_gen.StageTitle(stage_index=0, text="Stage A", style="slate", duration_seconds=1.0),
             fcpxml_gen.StageTitle(
                 stage_index=1,
                 text="Stage B",
@@ -315,12 +313,8 @@ def test_fcpxml_match_with_intro_outro_validates(tmp_path: Path) -> None:
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        intro=fcpxml_gen.IntroOutroSegment(
-            video_path=intro_path, video=_meta_30fps(), name="Intro"
-        ),
-        outro=fcpxml_gen.IntroOutroSegment(
-            video_path=outro_path, video=_meta_30fps(), name="Outro"
-        ),
+        intro=fcpxml_gen.IntroOutroSegment(video_path=intro_path, video=_meta_30fps(), name="Intro"),
+        outro=fcpxml_gen.IntroOutroSegment(video_path=outro_path, video=_meta_30fps(), name="Outro"),
     )
     validate_against_dtd(out, dtd=fcpxml_dtd_path())
 
@@ -351,9 +345,7 @@ def test_fcpxml_match_with_chapter_markers_validates(tmp_path: Path) -> None:
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        intro=fcpxml_gen.IntroOutroSegment(
-            video_path=intro_path, video=_meta_30fps(), name="Intro"
-        ),
+        intro=fcpxml_gen.IntroOutroSegment(video_path=intro_path, video=_meta_30fps(), name="Intro"),
         chapter_markers=True,
     )
     validate_against_dtd(out, dtd=fcpxml_dtd_path())
@@ -406,8 +398,7 @@ def test_invalid_fcpxml_fails_validation(tmp_path: Path) -> None:
     ignored)."""
     out = tmp_path / "bad.fcpxml"
     out.write_bytes(
-        b'<?xml version="1.0"?>\n<!DOCTYPE fcpxml>\n'
-        b'<fcpxml version="1.10"><nonsense/></fcpxml>\n'
+        b'<?xml version="1.0"?>\n<!DOCTYPE fcpxml>\n' b'<fcpxml version="1.10"><nonsense/></fcpxml>\n'
     )
     with pytest.raises(AssertionError, match="DTD validation failed"):
         validate_against_dtd(out, dtd=fcpxml_dtd_path())

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -115,19 +115,15 @@ def test_vote_c_adaptive_confidence_override_recovers_high_scoring_outsiders() -
     # stable argsort), so the override doesn't add anything new here.
     # The cleaner functional check: a sub-K confidence_override floor
     # below all scores keeps everyone.
-    out_zero = vote_c_adaptive(
-        probs, expected_rounds=2, slack_min=0, slack_frac=0.0, confidence_override=0.0
-    )
+    out_zero = vote_c_adaptive(probs, expected_rounds=2, slack_min=0, slack_frac=0.0, confidence_override=0.0)
     assert int(out_zero.sum()) == probs.size
     # And confidence_override above the max keeps only top-(K+slack).
-    out_high = vote_c_adaptive(
-        probs, expected_rounds=2, slack_min=0, slack_frac=0.0, confidence_override=2.0
-    )
+    out_high = vote_c_adaptive(probs, expected_rounds=2, slack_min=0, slack_frac=0.0, confidence_override=2.0)
     assert int(out_high.sum()) == 2
     # The two outputs are bitwise consistent in the always-in-top-K case.
-    assert np.array_equal(out_with_override, out_no_override) or int(
-        out_with_override.sum()
-    ) >= int(out_no_override.sum())
+    assert np.array_equal(out_with_override, out_no_override) or int(out_with_override.sum()) >= int(
+        out_no_override.sum()
+    )
 
 
 def test_vote_c_adaptive_zero_rounds_returns_all_zero() -> None:
@@ -467,9 +463,7 @@ def test_detect_shots_ensemble_full_universe_with_stubs(monkeypatch) -> None:
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -529,9 +523,7 @@ def test_detect_shots_ensemble_apriori_boost_lifts_top_k(monkeypatch) -> None:
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.zeros(
-            (len(times), len(CLAP_PROMPTS)), dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.zeros((len(times), len(CLAP_PROMPTS)), dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -586,9 +578,7 @@ def test_detect_shots_ensemble_within_stage_amp_floor_drops_quiet_headcam(
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -639,9 +629,7 @@ def test_detect_shots_ensemble_within_stage_amp_floor_skipped_on_handheld(
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -701,9 +689,7 @@ def test_detect_shots_ensemble_within_stage_amp_floor_uses_per_model_override(
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -782,9 +768,7 @@ def test_detect_shots_ensemble_skips_voter_e_when_disabled(monkeypatch) -> None:
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -851,9 +835,7 @@ def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, t
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -864,9 +846,7 @@ def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, t
     monkeypatch.setattr(
         ensemble_visual,
         "compute_visual_features",
-        lambda video_path, source_times, runtime, **_: np.zeros(
-            (len(source_times), 1), dtype=np.float32
-        ),
+        lambda video_path, source_times, runtime, **_: np.zeros((len(source_times), 1), dtype=np.float32),
     )
 
     audio = np.zeros(48_000 * 20, dtype=np.float32)
@@ -878,9 +858,7 @@ def test_detect_shots_ensemble_voter_e_e_required_drops_low_score(monkeypatch, t
         beep_time=5.0,
         stage_time=10.0,
         runtime=runtime,
-        ensemble_config=EnsembleConfig(
-            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=None
-        ),
+        ensemble_config=EnsembleConfig(enable_voter_e=True, e_required=True, e_audio_strong_min_votes=None),
         video_path=fake_video,
         source_beep_time=5.0,
     )
@@ -937,9 +915,7 @@ def test_detect_shots_ensemble_voter_e_audio_strong_skips_veto(monkeypatch, tmp_
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -949,9 +925,7 @@ def test_detect_shots_ensemble_voter_e_audio_strong_skips_veto(monkeypatch, tmp_
     monkeypatch.setattr(
         ensemble_visual,
         "compute_visual_features",
-        lambda video_path, source_times, runtime, **_: np.zeros(
-            (len(source_times), 1), dtype=np.float32
-        ),
+        lambda video_path, source_times, runtime, **_: np.zeros((len(source_times), 1), dtype=np.float32),
     )
 
     audio = np.zeros(48_000 * 20, dtype=np.float32)
@@ -967,9 +941,7 @@ def test_detect_shots_ensemble_voter_e_audio_strong_skips_veto(monkeypatch, tmp_
         beep_time=5.0,
         stage_time=10.0,
         runtime=runtime,
-        ensemble_config=EnsembleConfig(
-            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=3
-        ),
+        ensemble_config=EnsembleConfig(enable_voter_e=True, e_required=True, e_audio_strong_min_votes=3),
         video_path=fake_video,
         source_beep_time=5.0,
     )
@@ -986,9 +958,7 @@ def test_detect_shots_ensemble_voter_e_audio_strong_skips_veto(monkeypatch, tmp_
         beep_time=5.0,
         stage_time=10.0,
         runtime=runtime,
-        ensemble_config=EnsembleConfig(
-            enable_voter_e=True, e_required=True, e_audio_strong_min_votes=4
-        ),
+        ensemble_config=EnsembleConfig(enable_voter_e=True, e_required=True, e_audio_strong_min_votes=4),
         video_path=fake_video,
         source_beep_time=5.0,
     )
@@ -1197,9 +1167,7 @@ def test_detect_shots_ensemble_uses_per_class_thresholds(monkeypatch) -> None:
     monkeypatch.setattr(
         ensemble_features,
         "compute_clap_similarities",
-        lambda audio, sr, times, runtime: np.full(
-            (len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32
-        ),
+        lambda audio, sr, times, runtime: np.full((len(times), len(CLAP_PROMPTS)), 0.5, dtype=np.float32),
     )
     monkeypatch.setattr(
         ensemble_features,
@@ -1210,9 +1178,7 @@ def test_detect_shots_ensemble_uses_per_class_thresholds(monkeypatch) -> None:
     audio = np.zeros(48_000 * 20, dtype=np.float32)
 
     # Headcam class (default): floor 0.05 -> confidence 0.07 passes voter A.
-    result_head = detect_shots_ensemble(
-        audio, 48_000, beep_time=5.0, stage_time=10.0, runtime=runtime
-    )
+    result_head = detect_shots_ensemble(audio, 48_000, beep_time=5.0, stage_time=10.0, runtime=runtime)
     assert result_head.candidates[0].vote_a == 1
 
     # Handheld class: floor 0.20 -> 0.07 rejected by voter A.

--- a/tests/test_extract_full_fixture_audio.py
+++ b/tests/test_extract_full_fixture_audio.py
@@ -122,9 +122,7 @@ def test_run_ffmpeg_extract_builds_mono_48k_command(tmp_path: Path) -> None:
     assert "-y" in cmd  # overwrite=True
 
 
-def test_extract_one_writes_sidecar_with_window(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_extract_one_writes_sidecar_with_window(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     fixtures_dir = tmp_path / "fixtures"
     full_dir = fixtures_dir / "full"
     fixtures_dir.mkdir()
@@ -143,9 +141,7 @@ def test_extract_one_writes_sidecar_with_window(
     src.write_bytes(b"")
     sources = {"video_dir": str(tmp_path), "fixtures": {"stage-shots-x": "VID_X.mp4"}}
 
-    monkeypatch.setattr(
-        extractor, "probe", lambda path, cache_dir: type("R", (), {"duration": 180.0})()
-    )
+    monkeypatch.setattr(extractor, "probe", lambda path, cache_dir: type("R", (), {"duration": 180.0})())
     runner = _RecordingRunner()
     sidecar = extractor.extract_one(
         "stage-shots-x",

--- a/tests/test_fcp7xml_render.py
+++ b/tests/test_fcp7xml_render.py
@@ -109,9 +109,7 @@ def _render(stages: list[StageComposition], tmp_path: Path) -> ET.Element:
         (24000, 1001, 24, True),
     ],
 )
-def test_fcp7_rate_conversion(
-    num: int, den: int, expected_timebase: int, expected_ntsc: bool
-) -> None:
+def test_fcp7_rate_conversion(num: int, den: int, expected_timebase: int, expected_ntsc: bool) -> None:
     timebase, ntsc = fcp7xml_render._fcp7_rate(num, den)
     assert timebase == expected_timebase
     assert ntsc is expected_ntsc
@@ -437,9 +435,7 @@ def test_pip_y_axis_flips_for_bottom_corners(tmp_path: Path) -> None:
         )
     ]
     root = _render(stages, tmp_path)
-    vert = root.find(
-        ".//track[2]/clipitem/filter/effect/parameter[parameterid='center']/value/vert"
-    )
+    vert = root.find(".//track[2]/clipitem/filter/effect/parameter[parameterid='center']/value/vert")
     assert vert is not None
     assert float(vert.text) > 0  # type: ignore[arg-type]
 

--- a/tests/test_fcpxml_gen.py
+++ b/tests/test_fcpxml_gen.py
@@ -35,9 +35,7 @@ from splitsmith.fcpxml_gen import (
 )
 
 
-def _shot(
-    n: int, time_from_beep: float, split: float, peak: float = 0.5, conf: float = 0.8
-) -> Shot:
+def _shot(n: int, time_from_beep: float, split: float, peak: float = 0.5, conf: float = 0.8) -> Shot:
     return Shot(
         shot_number=n,
         time_absolute=10.0 + time_from_beep,
@@ -1627,9 +1625,7 @@ def test_secondary_with_pip_emits_corner_transform(corner: str, tmp_path: Path) 
     transform = cam_clip.find("adjust-transform")
     assert transform is not None
     assert list(cam_clip)[0] is transform  # transform must precede markers / nested clips
-    expected = _expected_pip_attrs(
-        seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner=corner
-    )
+    expected = _expected_pip_attrs(seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner=corner)
     assert transform.attrib == expected
 
 
@@ -1661,13 +1657,9 @@ def test_pip_position_is_resolution_independent(tmp_path: Path) -> None:
             )
         ],
     )
-    transform = ET.fromstring(out.read_bytes()).find(
-        ".//spine/asset-clip/asset-clip/adjust-transform"
-    )
+    transform = ET.fromstring(out.read_bytes()).find(".//spine/asset-clip/asset-clip/adjust-transform")
     assert transform is not None
-    expected = _expected_pip_attrs(
-        seq_w=3840, seq_h=2160, scale=0.30, margin_pct=2.0, corner="top-right"
-    )
+    expected = _expected_pip_attrs(seq_w=3840, seq_h=2160, scale=0.30, margin_pct=2.0, corner="top-right")
     assert transform.attrib == expected
     # Resolution-independent: the same PiP at 1080p emits the same
     # normalized position string.
@@ -1719,9 +1711,7 @@ def test_apply_pip_corner_cycle_preserves_explicit() -> None:
         beep_offset_seconds=5.0,
         label="Aux cam",
     )
-    laid_out = fcpxml_mod.apply_pip_corner_cycle(
-        (explicit, auto), default=fcpxml_mod.PipPlacement()
-    )
+    laid_out = fcpxml_mod.apply_pip_corner_cycle((explicit, auto), default=fcpxml_mod.PipPlacement())
     assert laid_out[0] is explicit  # untouched
     assert laid_out[1].pip is not None
     assert laid_out[1].pip.corner == "bottom-left"  # cycle starts at BL
@@ -1772,13 +1762,9 @@ def test_match_fcpxml_secondary_pip_uses_sequence_dims(tmp_path: Path) -> None:
         project_name="match",
         config=OutputConfig(),
     )
-    transform = ET.fromstring(out.read_bytes()).find(
-        ".//spine/asset-clip/asset-clip/adjust-transform"
-    )
+    transform = ET.fromstring(out.read_bytes()).find(".//spine/asset-clip/asset-clip/adjust-transform")
     assert transform is not None
-    expected = _expected_pip_attrs(
-        seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner="top-right"
-    )
+    expected = _expected_pip_attrs(seq_w=1920, seq_h=1080, scale=0.30, margin_pct=2.0, corner="top-right")
     assert transform.attrib == expected
 
 
@@ -1823,9 +1809,7 @@ def test_match_with_transition_emits_effect_resource(tmp_path: Path) -> None:
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        transitions=[
-            fcpxml_mod.StageTransition(after_stage_index=0, kind="zoom", duration_seconds=0.5)
-        ],
+        transitions=[fcpxml_mod.StageTransition(after_stage_index=0, kind="zoom", duration_seconds=0.5)],
     )
     root = ET.fromstring(out.read_bytes())
     effects = root.findall("./resources/effect")
@@ -1850,9 +1834,7 @@ def test_transition_offset_centred_on_boundary(tmp_path: Path) -> None:
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        transitions=[
-            fcpxml_mod.StageTransition(after_stage_index=0, kind="zoom", duration_seconds=0.5)
-        ],
+        transitions=[fcpxml_mod.StageTransition(after_stage_index=0, kind="zoom", duration_seconds=0.5)],
     )
     root = ET.fromstring(out.read_bytes())
     # 20s clip, beep=5, last shot at +1.0s -> tail_avail=14s, tail_pad=5
@@ -1991,9 +1973,7 @@ def test_no_transitions_emits_unchanged_spine(tmp_path: Path) -> None:
     before -- absence of transitions must not change the output."""
     primary_a, primary_b, out = _two_stage_match(tmp_path)
     stages = _basic_match_stages(primary_a, primary_b)
-    generate_match_fcpxml(
-        stages=stages, output_path=out, project_name="match", config=OutputConfig()
-    )
+    generate_match_fcpxml(stages=stages, output_path=out, project_name="match", config=OutputConfig())
     root = ET.fromstring(out.read_bytes())
     assert root.find(".//spine/transition") is None
     assert root.find("./resources/effect") is None
@@ -2198,11 +2178,7 @@ def test_match_with_slate_title_emits_basic_title_effect(tmp_path: Path) -> None
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        titles=[
-            fcpxml_mod.StageTitle(
-                stage_index=0, text="Stage A", style="slate", duration_seconds=1.5
-            )
-        ],
+        titles=[fcpxml_mod.StageTitle(stage_index=0, text="Stage A", style="slate", duration_seconds=1.5)],
     )
     root = ET.fromstring(out.read_bytes())
     effects = root.findall("./resources/effect")
@@ -2222,11 +2198,7 @@ def test_slate_title_lands_on_spine_before_primary(tmp_path: Path) -> None:
         output_path=out,
         project_name="match",
         config=OutputConfig(),
-        titles=[
-            fcpxml_mod.StageTitle(
-                stage_index=0, text="Stage A", style="slate", duration_seconds=1.0
-            )
-        ],
+        titles=[fcpxml_mod.StageTitle(stage_index=0, text="Stage A", style="slate", duration_seconds=1.0)],
     )
     root = ET.fromstring(out.read_bytes())
     spine = root.find(".//spine")
@@ -2345,9 +2317,7 @@ def test_slate_with_transitions_raises(tmp_path: Path) -> None:
             project_name="match",
             config=OutputConfig(),
             transitions=[fcpxml_mod.StageTransition(after_stage_index=0)],
-            titles=[
-                fcpxml_mod.StageTitle(stage_index=0, text="A", style="slate", duration_seconds=1.0)
-            ],
+            titles=[fcpxml_mod.StageTitle(stage_index=0, text="A", style="slate", duration_seconds=1.0)],
         )
 
 
@@ -2362,11 +2332,7 @@ def test_lower_third_with_transitions_is_allowed(tmp_path: Path) -> None:
         project_name="match",
         config=OutputConfig(),
         transitions=[fcpxml_mod.StageTransition(after_stage_index=0)],
-        titles=[
-            fcpxml_mod.StageTitle(
-                stage_index=0, text="A", style="lower-third", duration_seconds=2.0
-            )
-        ],
+        titles=[fcpxml_mod.StageTitle(stage_index=0, text="A", style="lower-third", duration_seconds=2.0)],
     )
     root = ET.fromstring(out.read_bytes())
     assert root.find(".//spine/transition") is not None

--- a/tests/test_fixture_schema.py
+++ b/tests/test_fixture_schema.py
@@ -204,9 +204,7 @@ def test_backfill_adds_camera_venue_gun_and_history(tmp_path: Path) -> None:
 
 def test_backfill_idempotent(tmp_path: Path) -> None:
     f = tmp_path / "fixture.json"
-    _write_fixture(
-        f, {"shots": [], "camera": {"id": "go3s"}, "venue": {}, "gun": {}, "history": []}
-    )
+    _write_fixture(f, {"shots": [], "camera": {"id": "go3s"}, "venue": {}, "gun": {}, "history": []})
     changed = backfill_fixture(f, GO3S)
     assert not changed
 

--- a/tests/test_fixtures_registry.py
+++ b/tests/test_fixtures_registry.py
@@ -113,15 +113,9 @@ def test_audited_filter_drops_zero_shot_fixtures(tmp_path: Path) -> None:
 
 
 def test_filters_by_mount_and_shooter(tmp_path: Path, monkeypatch) -> None:
-    _write_audit(
-        tmp_path, "stage-shots-m-2026-stage1-saaaa1111", mount="head", shooter_id="saaaa1111"
-    )
-    _write_audit(
-        tmp_path, "stage-shots-m-2026-stage2-saaaa1111", mount="hand", shooter_id="saaaa1111"
-    )
-    _write_audit(
-        tmp_path, "stage-shots-m-2026-stage3-sbbbb2222", mount="head", shooter_id="sbbbb2222"
-    )
+    _write_audit(tmp_path, "stage-shots-m-2026-stage1-saaaa1111", mount="head", shooter_id="saaaa1111")
+    _write_audit(tmp_path, "stage-shots-m-2026-stage2-saaaa1111", mount="hand", shooter_id="saaaa1111")
+    _write_audit(tmp_path, "stage-shots-m-2026-stage3-sbbbb2222", mount="head", shooter_id="sbbbb2222")
     monkeypatch.setattr(registry, "FIXTURES_DIR", tmp_path)
     registry.all_fixtures.cache_clear()
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -345,8 +345,7 @@ def test_acknowledge_all_failures_marks_only_unacked_failures() -> None:
 
     def _all_done() -> bool:
         return all(
-            reg.get(j.id) is not None
-            and reg.get(j.id).status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
+            reg.get(j.id) is not None and reg.get(j.id).status in (JobStatus.SUCCEEDED, JobStatus.FAILED)
             for j in (fail_a, fail_b, ok)
         )
 

--- a/tests/test_lab_event_id.py
+++ b/tests/test_lab_event_id.py
@@ -64,8 +64,7 @@ def test_match_stage_from_slug_returns_none_for_non_matching() -> None:
 def test_event_id_from_payload_combines_match_stage_and_shooter() -> None:
     payload = {"shooter": {"id": "ssi-12345", "ssi_shooter_id": 12345}}
     assert (
-        event_id_from_payload("stage-shots-blacksmith-2026-stage6", payload)
-        == "blacksmith-2026:6:ssi-12345"
+        event_id_from_payload("stage-shots-blacksmith-2026-stage6", payload) == "blacksmith-2026:6:ssi-12345"
     )
 
 
@@ -119,8 +118,7 @@ def test_list_fixtures_groups_multi_cam_siblings_by_event_id(tmp_path: Path) -> 
     by_slug = {r.slug: r for r in records}
     assert by_slug["stage-shots-blacksmith-2026-stage6"].event_id == "blacksmith-2026:6:ssi-42"
     assert (
-        by_slug["stage-shots-blacksmith-2026-stage6-apple-iphone17pro"].event_id
-        == "blacksmith-2026:6:ssi-42"
+        by_slug["stage-shots-blacksmith-2026-stage6-apple-iphone17pro"].event_id == "blacksmith-2026:6:ssi-42"
     )
 
 
@@ -138,9 +136,7 @@ def test_list_fixtures_distinct_shooters_get_distinct_events(tmp_path: Path) -> 
     records = list_fixtures(fixtures)
     by_slug = {r.slug: r for r in records}
     assert by_slug["stage-shots-blacksmith-2026-stage6"].event_id == "blacksmith-2026:6:ssi-1"
-    assert (
-        by_slug["stage-shots-blacksmith-2026-stage6-friend"].event_id == "blacksmith-2026:6:ssi-2"
-    )
+    assert by_slug["stage-shots-blacksmith-2026-stage6-friend"].event_id == "blacksmith-2026:6:ssi-2"
     assert (
         by_slug["stage-shots-blacksmith-2026-stage6"].event_id
         != by_slug["stage-shots-blacksmith-2026-stage6-friend"].event_id

--- a/tests/test_lab_promote.py
+++ b/tests/test_lab_promote.py
@@ -251,9 +251,7 @@ def test_lab_promote_endpoint_400s_when_camera_mount_missing(tmp_path: Path) -> 
     assert "camera_mount" in resp.json()["detail"]
 
 
-def test_lab_promote_endpoint_writes_full_provenance(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_lab_promote_endpoint_writes_full_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Happy path: project has primary + camera_mount + beep -> the
     fixture lands with source_video / fixture_window_in_source / camera
     derived from project context."""

--- a/tests/test_match_model.py
+++ b/tests/test_match_model.py
@@ -300,9 +300,7 @@ def test_plan_merge_rejects_stage_name_disagreement(tmp_path: Path):
 
 def test_plan_merge_tolerates_placeholder_loss(tmp_path: Path):
     # One project has a placeholder stage; the other has the real name.
-    proj_a = _make_legacy(
-        tmp_path / "a", name="X", competitor="A", stage_names=["Stage 1", "S2", "S3"]
-    )
+    proj_a = _make_legacy(tmp_path / "a", name="X", competitor="A", stage_names=["Stage 1", "S2", "S3"])
     proj_a.stages[0].placeholder = True
     proj_a.save(tmp_path / "a")
     _make_legacy(tmp_path / "b", name="X", competitor="B", stage_names=["Egg Grab", "S2", "S3"])
@@ -404,9 +402,7 @@ def test_execute_merge_copy_creates_full_layout(tmp_path: Path):
     # User data carried across.
     raw_file = out / SHOOTERS_DIR / anton_slug / "raw" / "fake.mp4"
     assert raw_file.read_bytes() == b"raw-anton"
-    assert (
-        out / SHOOTERS_DIR / anton_slug / "audit" / "stage1.json"
-    ).read_text() == '{"shots": []}'
+    assert (out / SHOOTERS_DIR / anton_slug / "audit" / "stage1.json").read_text() == '{"shots": []}'
 
     # Sources untouched (copy mode).
     assert (tmp_path / "anton" / "raw" / "fake.mp4").exists()
@@ -457,9 +453,7 @@ def test_execute_merge_shooter_json_has_no_match_fields(tmp_path: Path):
     plan = plan_merge([tmp_path / "anton", tmp_path / "martin"], out)
     execute_merge(plan, move=False)
 
-    anton_slug = next(
-        m.slug for m in plan.shooter_moves if m.source_root == tmp_path / "anton"
-    )
+    anton_slug = next(m.slug for m in plan.shooter_moves if m.source_root == tmp_path / "anton")
     shooter_json = json.loads((out / SHOOTERS_DIR / anton_slug / SHOOTER_FILE).read_text())
     for forbidden in ("name", "scoreboard_match_id", "scoreboard_content_type", "match_date"):
         # ``name`` IS a Shooter field (the human-readable shooter name), so

--- a/tests/test_match_model.py
+++ b/tests/test_match_model.py
@@ -18,15 +18,15 @@ from splitsmith.match_model import (
     MergeConflictError,
     Shooter,
     ShooterStageData,
-    disambiguate_slug,
     execute_merge,
     from_path,
     is_legacy_project_folder,
     is_match_folder,
     legacy_to_match_view,
     load_match_or_legacy,
+    mint_shooter_slug,
     plan_merge,
-    slugify,
+    slugify_filename,
 )
 from splitsmith.ui.project import MatchProject, StageEntry
 
@@ -76,27 +76,37 @@ def _make_legacy(
 # ---------------------------------------------------------------------------
 
 
-def test_slugify_basic():
-    assert slugify("Mathias Axell") == "mathias-axell"
+def test_mint_shooter_slug_shape():
+    slug = mint_shooter_slug()
+    assert slug.startswith("s_")
+    assert len(slug) == 10  # "s_" + 8 hex chars
+    assert all(c in "0123456789abcdef" for c in slug[2:])
 
 
-def test_slugify_handles_accents():
-    assert slugify("Martin Engström") == "martin-engstrom"
+def test_mint_shooter_slug_avoids_taken():
+    """The minter retries until it gets a slug outside ``taken``."""
+    slug = mint_shooter_slug(taken={"s_00000000"})
+    assert slug != "s_00000000"
 
 
-def test_slugify_collapses_punctuation_and_strips_edges():
-    assert slugify("  Anders! Andersson??  ") == "anders-andersson"
+def test_mint_shooter_slug_uniqueness():
+    """Two calls without coordination still collide vanishingly rarely; the
+    primary safety is the ``taken`` set, which the helper consults."""
+    slugs = {mint_shooter_slug() for _ in range(100)}
+    assert len(slugs) == 100
 
 
-def test_slugify_empty_falls_back():
-    assert slugify("") == "shooter"
-    assert slugify("---") == "shooter"
+def test_slugify_filename_basic():
+    assert slugify_filename("Stage 1: H1") == "stage-1-h1"
 
 
-def test_disambiguate_slug():
-    taken = {"anton", "anton-2"}
-    assert disambiguate_slug("anton", taken) == "anton-3"
-    assert disambiguate_slug("anton", set()) == "anton"
+def test_slugify_filename_handles_accents():
+    assert slugify_filename("Långvägen") == "langvagen"
+
+
+def test_slugify_filename_empty_falls_back():
+    assert slugify_filename("") == "name"
+    assert slugify_filename("---") == "name"
 
 
 # ---------------------------------------------------------------------------
@@ -195,14 +205,26 @@ def test_legacy_to_match_view_preserves_core_fields(tmp_path: Path):
     assert match.name == "VADS"
     assert match.scoreboard_match_id == "27242"
     assert match.match_date == date(2026, 4, 3)
-    assert match.shooters == ["anton-johansson"]
+    assert len(match.shooters) == 1
+    only_slug = match.shooters[0]
+    assert only_slug.startswith("s_")
     assert len(match.stages) == 3
     assert match.stages[0].stage_name == "Egg Grab"
 
-    assert shooter.slug == "anton-johansson"
+    assert shooter.slug == only_slug
     assert shooter.name == "Anton Johansson"
     assert shooter.selected_shooter_id == 55429
     assert shooter.stages[0].time_seconds == 11.0
+
+
+def test_legacy_to_match_view_slug_is_deterministic(tmp_path: Path):
+    """Same project metadata -> same opaque slug across reloads."""
+    root = tmp_path / "legacy"
+    project = _make_legacy(root, name="VADS", competitor="Anton Johansson")
+
+    match_a, _ = legacy_to_match_view(project)
+    match_b, _ = legacy_to_match_view(project)
+    assert match_a.shooters == match_b.shooters
 
 
 def test_load_match_or_legacy_legacy_path(tmp_path: Path):
@@ -211,8 +233,10 @@ def test_load_match_or_legacy_legacy_path(tmp_path: Path):
 
     match, roots = load_match_or_legacy(root)
 
-    assert match.shooters == ["anton-johansson"]
-    assert roots["anton-johansson"] == root
+    assert len(match.shooters) == 1
+    only_slug = match.shooters[0]
+    assert only_slug.startswith("s_")
+    assert roots[only_slug] == root
 
 
 def test_load_match_or_legacy_match_path(tmp_path: Path):
@@ -241,7 +265,9 @@ def test_plan_merge_happy_path(tmp_path: Path):
     assert plan.scoreboard_match_id == "27242"
     assert plan.match_date == date(2026, 4, 3)
     assert len(plan.stages) == 3
-    assert [m.slug for m in plan.shooter_moves] == ["anton-johansson", "martin-engstrom"]
+    slugs = [m.slug for m in plan.shooter_moves]
+    assert all(s.startswith("s_") for s in slugs), slugs
+    assert len(set(slugs)) == 2
     # Suppress unused-var warnings.
     assert a.name == b.name == "VADS"
 
@@ -325,13 +351,16 @@ def test_plan_merge_accepts_explicit_name_override(tmp_path: Path):
     assert plan.name == "VADS Easter 2026"
 
 
-def test_plan_merge_disambiguates_colliding_slugs(tmp_path: Path):
+def test_plan_merge_assigns_opaque_slugs(tmp_path: Path):
+    """Slugs are random opaque ids (``s_<hex>``), not derived from the
+    competitor names, so the on-disk layout doesn't leak PII."""
     _make_legacy(tmp_path / "a", name="X", competitor="Anton Johansson")
-    _make_legacy(tmp_path / "b", name="X", competitor="anton johansson")  # same after slugify
+    _make_legacy(tmp_path / "b", name="X", competitor="Martin Engström")
 
     plan = plan_merge([tmp_path / "a", tmp_path / "b"], tmp_path / "merged")
-    assert plan.shooter_moves[0].slug == "anton-johansson"
-    assert plan.shooter_moves[1].slug == "anton-johansson-2"
+    slugs = [m.slug for m in plan.shooter_moves]
+    assert all(s.startswith("s_") and len(s) == 10 for s in slugs), slugs
+    assert len(set(slugs)) == len(slugs), "slugs must be unique"
 
 
 # ---------------------------------------------------------------------------
@@ -351,12 +380,18 @@ def test_execute_merge_copy_creates_full_layout(tmp_path: Path):
     plan = plan_merge([tmp_path / "anton", tmp_path / "martin"], out)
     match = execute_merge(plan, move=False)
 
+    # Resolve the opaque slug for each source so the asserts below don't
+    # need to know the random ids.
+    moves_by_src = {m.source_root: m for m in plan.shooter_moves}
+    anton_slug = moves_by_src[tmp_path / "anton"].slug
+    martin_slug = moves_by_src[tmp_path / "martin"].slug
+
     # match.json present, shooters subdirs populated. project.json is kept
     # alongside shooter.json as a legacy compat shim (most server endpoints
     # still speak the legacy MatchProject schema); match-level fields are
     # stripped so match.json stays authoritative.
     assert (out / MATCH_FILE).is_file()
-    for slug in ("anton-johansson", "martin-engstrom"):
+    for slug in (anton_slug, martin_slug):
         sroot = out / SHOOTERS_DIR / slug
         assert (sroot / SHOOTER_FILE).is_file(), slug
         assert (sroot / "project.json").is_file(), slug
@@ -367,10 +402,10 @@ def test_execute_merge_copy_creates_full_layout(tmp_path: Path):
         assert legacy["match_date"] is None
 
     # User data carried across.
-    raw_file = out / SHOOTERS_DIR / "anton-johansson" / "raw" / "fake.mp4"
+    raw_file = out / SHOOTERS_DIR / anton_slug / "raw" / "fake.mp4"
     assert raw_file.read_bytes() == b"raw-anton"
     assert (
-        out / SHOOTERS_DIR / "anton-johansson" / "audit" / "stage1.json"
+        out / SHOOTERS_DIR / anton_slug / "audit" / "stage1.json"
     ).read_text() == '{"shots": []}'
 
     # Sources untouched (copy mode).
@@ -378,7 +413,7 @@ def test_execute_merge_copy_creates_full_layout(tmp_path: Path):
     assert (tmp_path / "anton" / "project.json").exists()
 
     # Returned Match is loadable.
-    assert match.shooters == ["anton-johansson", "martin-engstrom"]
+    assert sorted(match.shooters) == sorted([anton_slug, martin_slug])
     Match.load(out)  # raises if invalid
 
 
@@ -392,7 +427,10 @@ def test_execute_merge_move_relocates_sources(tmp_path: Path):
 
     assert not (tmp_path / "anton").exists()
     assert not (tmp_path / "martin").exists()
-    assert (out / SHOOTERS_DIR / "anton" / SHOOTER_FILE).is_file()
+    match = Match.load(out)
+    assert len(match.shooters) == 2
+    for slug in match.shooters:
+        assert (out / SHOOTERS_DIR / slug / SHOOTER_FILE).is_file()
 
 
 def test_execute_merge_refuses_existing_match(tmp_path: Path):
@@ -419,7 +457,10 @@ def test_execute_merge_shooter_json_has_no_match_fields(tmp_path: Path):
     plan = plan_merge([tmp_path / "anton", tmp_path / "martin"], out)
     execute_merge(plan, move=False)
 
-    shooter_json = json.loads((out / SHOOTERS_DIR / "anton" / SHOOTER_FILE).read_text())
+    anton_slug = next(
+        m.slug for m in plan.shooter_moves if m.source_root == tmp_path / "anton"
+    )
+    shooter_json = json.loads((out / SHOOTERS_DIR / anton_slug / SHOOTER_FILE).read_text())
     for forbidden in ("name", "scoreboard_match_id", "scoreboard_content_type", "match_date"):
         # ``name`` IS a Shooter field (the human-readable shooter name), so
         # only the *match*-flavored fields are forbidden. The shooter's own

--- a/tests/test_mcp_detect_tools.py
+++ b/tests/test_mcp_detect_tools.py
@@ -89,9 +89,7 @@ def _stage_with_primary(
     )
 
 
-def _fake_detection(
-    *, time: float = 5.5, confidence: float = 0.9, candidates: int = 2
-) -> BeepDetection:
+def _fake_detection(*, time: float = 5.5, confidence: float = 0.9, candidates: int = 2) -> BeepDetection:
     cands = [
         BeepCandidate(
             time=time + 0.5 * i,
@@ -249,9 +247,7 @@ def test_detect_beep_force_reruns(tmp_path: Path) -> None:
     with patch(
         "splitsmith.mcp.detect_tools.audio_helpers.detect_video_beep", return_value=fake
     ) as mock_detect:
-        detect_tools.detect_beep_for_video(
-            str(root), stage_number=1, video_id=primary_id, force=True
-        )
+        detect_tools.detect_beep_for_video(str(root), stage_number=1, video_id=primary_id, force=True)
 
     mock_detect.assert_called_once()
     after = MatchProject.load(root).stages[0].videos[0]

--- a/tests/test_mcp_sandbox.py
+++ b/tests/test_mcp_sandbox.py
@@ -87,9 +87,7 @@ def test_resolve_project_root_rejects_non_directory(tmp_path: Path) -> None:
         resolve_project_root(f)
 
 
-def test_resolve_project_root_honours_sandbox(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_project_root_honours_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Sandbox enforcement runs BEFORE the project.json check, so an
     out-of-sandbox project root errors with SandboxError, not a
     misleading FileNotFoundError pointing at project.json."""

--- a/tests/test_mcp_write_tools.py
+++ b/tests/test_mcp_write_tools.py
@@ -121,9 +121,7 @@ def test_set_beep_manual_pins_time_and_clamps_confidence(tmp_path: Path) -> None
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
 
     with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
-        result = write_tools.set_beep_manual(
-            str(root), stage_number=1, video_id=primary_id, time_seconds=4.5
-        )
+        result = write_tools.set_beep_manual(str(root), stage_number=1, video_id=primary_id, time_seconds=4.5)
     after = MatchProject.load(root)
     primary = after.stages[0].videos[0]
     assert primary.beep_time == 4.5
@@ -152,9 +150,7 @@ def test_set_beep_manual_clear_resets_state(tmp_path: Path) -> None:
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
 
     with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"):
-        write_tools.set_beep_manual(
-            str(root), stage_number=1, video_id=primary_id, time_seconds=None
-        )
+        write_tools.set_beep_manual(str(root), stage_number=1, video_id=primary_id, time_seconds=None)
     primary = MatchProject.load(root).stages[0].videos[0]
     assert primary.beep_time is None
     assert primary.beep_source is None
@@ -169,12 +165,8 @@ def test_set_beep_manual_invalidates_audit_trim(tmp_path: Path) -> None:
     _build_project(root, stages=[_stage_with_primary()])
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
 
-    with patch(
-        "splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim"
-    ) as mock_invalidate:
-        write_tools.set_beep_manual(
-            str(root), stage_number=1, video_id=primary_id, time_seconds=4.5
-        )
+    with patch("splitsmith.mcp.write_tools.audio_helpers.invalidate_video_audit_trim") as mock_invalidate:
+        write_tools.set_beep_manual(str(root), stage_number=1, video_id=primary_id, time_seconds=4.5)
     assert mock_invalidate.call_count == 1
 
 
@@ -183,9 +175,7 @@ def test_set_beep_manual_rejects_negative_time(tmp_path: Path) -> None:
     _build_project(root, stages=[_stage_with_primary()])
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
     with pytest.raises(ValueError, match=">= 0"):
-        write_tools.set_beep_manual(
-            str(root), stage_number=1, video_id=primary_id, time_seconds=-0.5
-        )
+        write_tools.set_beep_manual(str(root), stage_number=1, video_id=primary_id, time_seconds=-0.5)
 
 
 def test_set_beep_manual_unknown_stage_raises(tmp_path: Path) -> None:
@@ -323,9 +313,7 @@ def test_mark_beep_reviewed_flips_flag(tmp_path: Path) -> None:
     )
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
 
-    result = write_tools.mark_beep_reviewed(
-        str(root), stage_number=1, video_id=primary_id, reviewed=True
-    )
+    result = write_tools.mark_beep_reviewed(str(root), stage_number=1, video_id=primary_id, reviewed=True)
     after = MatchProject.load(root).stages[0].videos[0]
     assert after.beep_reviewed is True
     assert result["beep_reviewed"] is True
@@ -336,9 +324,7 @@ def test_mark_beep_reviewed_rejects_when_no_beep_yet(tmp_path: Path) -> None:
     _build_project(root, stages=[_stage_with_primary()])
     primary_id = MatchProject.load(root).stages[0].videos[0].video_id
     with pytest.raises(ValueError, match="before one has been detected"):
-        write_tools.mark_beep_reviewed(
-            str(root), stage_number=1, video_id=primary_id, reviewed=True
-        )
+        write_tools.mark_beep_reviewed(str(root), stage_number=1, video_id=primary_id, reviewed=True)
 
 
 def test_mark_beep_reviewed_unmark_allowed_without_beep(tmp_path: Path) -> None:

--- a/tests/test_mine_negatives.py
+++ b/tests/test_mine_negatives.py
@@ -94,9 +94,7 @@ def test_stage_window_handles_offset_full_extraction() -> None:
     assert stage_end_in_full == pytest.approx(70.5)
 
 
-def _write_wav_with_transients(
-    path: Path, sr: int, duration_s: float, peak_times_s: list[float]
-) -> None:
+def _write_wav_with_transients(path: Path, sr: int, duration_s: float, peak_times_s: list[float]) -> None:
     """Synthesize a near-silent mono WAV with sharp Hann-shaped clicks at given times."""
     n = int(round(sr * duration_s))
     audio = np.zeros(n, dtype=np.float32)
@@ -120,9 +118,7 @@ def _write_wav_with_transients(
         w.writeframes(pcm.tobytes())
 
 
-def test_mine_one_excludes_in_stage_and_tags_outside(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_mine_one_excludes_in_stage_and_tags_outside(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     fixtures_dir = tmp_path / "fixtures"
     full_dir = fixtures_dir / "full"
     cache_dir = fixtures_dir / ".cache"

--- a/tests/test_mp4_render.py
+++ b/tests/test_mp4_render.py
@@ -189,9 +189,7 @@ def test_plan_stage_negative_effective_raises(tmp_path: Path) -> None:
 def test_build_stage_command_minimal(tmp_path: Path) -> None:
     stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
     comp, plan = _build_plan(stage)
-    cmd = mp4_render._build_stage_command(
-        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
-    )
+    cmd = mp4_render._build_stage_command(plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4")
     # Sanity: the trim window matches the plan; the only video input is
     # the primary; no filter graph branch for cams or overlay.
     assert "-ss" in cmd and "-t" in cmd
@@ -213,9 +211,7 @@ def test_build_stage_command_pip_secondary(tmp_path: Path) -> None:
     )
     stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
     comp, plan = _build_plan(stage)
-    cmd = mp4_render._build_stage_command(
-        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
-    )
+    cmd = mp4_render._build_stage_command(plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4")
     fg = cmd[cmd.index("-filter_complex") + 1]
     # Cam scaled to 30% of 1920x1080 -> 576x324.
     assert "scale=576:324" in fg
@@ -230,9 +226,7 @@ def test_build_stage_command_overlay_emits_top_overlay(tmp_path: Path) -> None:
     overlay = _make_video(tmp_path, "overlay.mov")
     stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", overlay_path=overlay)
     comp, plan = _build_plan(stage)
-    cmd = mp4_render._build_stage_command(
-        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
-    )
+    cmd = mp4_render._build_stage_command(plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4")
     fg = cmd[cmd.index("-filter_complex") + 1]
     # The overlay input lives at index 1 (no cams) and lands as the
     # final layer at (0,0) with full-frame coverage.
@@ -252,9 +246,7 @@ def test_build_stage_command_pip_full_frame_when_no_transform(tmp_path: Path) ->
     )
     stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4", secondaries=(sec,))
     comp, plan = _build_plan(stage)
-    cmd = mp4_render._build_stage_command(
-        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
-    )
+    cmd = mp4_render._build_stage_command(plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4")
     fg = cmd[cmd.index("-filter_complex") + 1]
     assert "overlay=x=0:y=0" in fg
     # No ``scale=`` filter when the cam runs at native size (default
@@ -326,9 +318,7 @@ def test_render_mp4_propagates_ffmpeg_error(tmp_path: Path) -> None:
     comp = composition.from_stage_compositions([stage], project_name="m")
 
     def fail(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
-        raise subprocess.CalledProcessError(
-            returncode=1, cmd=args[0], stderr="boom: invalid argument"
-        )
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0], stderr="boom: invalid argument")
 
     with pytest.raises(mp4_render.FFmpegError, match="boom"):
         mp4_render.render_mp4(
@@ -375,9 +365,7 @@ def test_default_encode_args_match_today(tmp_path: Path) -> None:
     consumers."""
     stage = _basic_stage(tmp_path=tmp_path, name="A", primary_name="a.mp4")
     comp, plan = _build_plan(stage)
-    cmd = mp4_render._build_stage_command(
-        plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4"
-    )
+    cmd = mp4_render._build_stage_command(plan, sequence=comp.sequence, output_path=tmp_path / "stage.mp4")
     assert "-crf" in cmd and cmd[cmd.index("-crf") + 1] == "20"
     assert "-preset" in cmd and cmd[cmd.index("-preset") + 1] == "fast"
     assert cmd[cmd.index("-b:a") + 1] == "192k"

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -502,9 +502,7 @@ def _write_audit(tmp_path: Path) -> Path:
     return audit
 
 
-def test_codec_hevc_alpha_emits_videotoolbox_cmd(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_codec_hevc_alpha_emits_videotoolbox_cmd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Asking for ``hevc-alpha`` produces a ``hevc_videotoolbox`` cmd
     with ``hvc1`` tagging and yuva420p (the only alpha pix-fmt the
     encoder accepts)."""
@@ -523,9 +521,7 @@ def test_codec_hevc_alpha_emits_videotoolbox_cmd(
     assert "prores_ks" not in cmd
 
 
-def test_codec_auto_falls_back_to_prores_off_darwin(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_codec_auto_falls_back_to_prores_off_darwin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``auto`` resolves to ``prores-4444`` when the host isn't macOS,
     so non-Mac CI doesn't try to call ``hevc_videotoolbox``."""
     monkeypatch.setattr(overlay_render.platform, "system", lambda: "Linux")
@@ -582,9 +578,7 @@ def test_max_height_downscales_canvas_aspect_preserved(
     """Capping height shrinks the canvas (and therefore the bytes piped
     to ffmpeg) while keeping the aspect ratio."""
     # 1920x1080 source -> cap at 720 -> 1280x720.
-    probe = VideoMetadata(
-        width=1920, height=1080, duration_seconds=0.1, frame_rate_num=30, frame_rate_den=1
-    )
+    probe = VideoMetadata(width=1920, height=1080, duration_seconds=0.1, frame_rate_num=30, frame_rate_den=1)
     cmd, byte_count = _capture_render_cmd(
         monkeypatch,
         audit_path=_write_audit(tmp_path),
@@ -616,9 +610,7 @@ def test_max_height_above_source_is_noop(tmp_path: Path, monkeypatch: pytest.Mon
 
 def test_max_fps_caps_frame_count_and_rate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Capping fps drops the frame count and quotes the rate as a rational."""
-    probe = VideoMetadata(
-        width=320, height=180, duration_seconds=1.0, frame_rate_num=60, frame_rate_den=1
-    )
+    probe = VideoMetadata(width=320, height=180, duration_seconds=1.0, frame_rate_num=60, frame_rate_den=1)
     cmd, byte_count = _capture_render_cmd(
         monkeypatch,
         audit_path=_write_audit(tmp_path),

--- a/tests/test_overlay_theme.py
+++ b/tests/test_overlay_theme.py
@@ -26,11 +26,7 @@ def test_clean_preset_matches_legacy_hardcoded_values() -> None:
 def test_splitsmith_preset_loads_from_packaged_json() -> None:
     """The ``splitsmith`` preset must round-trip through the JSON mirror so
     a regenerate step actually flows into runtime."""
-    with (
-        resources.files("splitsmith.data")
-        .joinpath("overlay_theme.json")
-        .open("r", encoding="utf-8") as fh
-    ):
+    with resources.files("splitsmith.data").joinpath("overlay_theme.json").open("r", encoding="utf-8") as fh:
         data = json.load(fh)
 
     t = overlay_theme.load_theme("splitsmith")
@@ -156,9 +152,7 @@ def test_clean_theme_leaves_font_resolution_to_system_fallback() -> None:
     clean = overlay_theme.load_theme("clean")
     tmpl = overlay_render.DefaultTemplate(width=320, height=180, theme=clean)
     family, _ = tmpl.font_big.getname()
-    assert (
-        family != "JetBrains Mono"
-    ), f"clean theme should not auto-wire bundled font; got family={family!r}"
+    assert family != "JetBrains Mono", f"clean theme should not auto-wire bundled font; got family={family!r}"
 
 
 def test_available_font_names_includes_bundled_presets() -> None:

--- a/tests/test_relink.py
+++ b/tests/test_relink.py
@@ -36,9 +36,7 @@ def _project_with_videos(root: Path, names: list[str]) -> MatchProject:
         link = raw / name
         link.symlink_to(original)
         videos.append(StageVideo(path=Path("raw") / name, role="primary"))
-    project.stages = [
-        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)
-    ]
+    project.stages = [StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)]
     project.save(root)
     return project
 

--- a/tests/test_relink_api.py
+++ b/tests/test_relink_api.py
@@ -48,7 +48,7 @@ def _setup_project(tmp_path: Path, names: list[str]) -> tuple[Path, dict[str, st
 def test_link_status_reports_ok_for_intact_links(tmp_path: Path) -> None:
     root, ids = _setup_project(tmp_path, ["a.mp4"])
     client = TestClient(create_app(project_root=root, project_name="x"))
-    resp = client.get("/api/videos/link-status")
+    resp = client.get("/api/shooters/me/videos/link-status")
     assert resp.status_code == 200
     [entry] = resp.json()["entries"]
     assert entry["video_id"] == ids["a.mp4"]
@@ -60,7 +60,7 @@ def test_link_status_reports_broken_after_target_removed(tmp_path: Path) -> None
     root, _ = _setup_project(tmp_path, ["a.mp4"])
     (tmp_path / "originals" / "a.mp4").unlink()
     client = TestClient(create_app(project_root=root, project_name="x"))
-    [entry] = client.get("/api/videos/link-status").json()["entries"]
+    [entry] = client.get("/api/shooters/me/videos/link-status").json()["entries"]
     assert entry["status"] == "broken"
 
 
@@ -70,7 +70,7 @@ def test_relink_scan_reports_unique_candidate(tmp_path: Path) -> None:
     share.mkdir(parents=True)
     (share / "a.mp4").write_bytes(b"")
     client = TestClient(create_app(project_root=root, project_name="x"))
-    resp = client.post("/api/videos/relink/scan", json={"search_root": str(tmp_path / "share")})
+    resp = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(tmp_path / "share")})
     assert resp.status_code == 200
     body = resp.json()
     [entry] = body["entries"]
@@ -88,7 +88,7 @@ def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
     (share / "x" / "a.mp4").write_bytes(b"")
     (share / "y" / "a.mp4").write_bytes(b"")
     client = TestClient(create_app(project_root=root, project_name="x"))
-    [entry] = client.post("/api/videos/relink/scan", json={"search_root": str(share)}).json()[
+    [entry] = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(share)}).json()[
         "entries"
     ]
     assert entry["ambiguous"]
@@ -99,7 +99,7 @@ def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
 def test_relink_scan_400_on_missing_root(tmp_path: Path) -> None:
     root, _ = _setup_project(tmp_path, ["a.mp4"])
     client = TestClient(create_app(project_root=root, project_name="x"))
-    resp = client.post("/api/videos/relink/scan", json={"search_root": str(tmp_path / "nope")})
+    resp = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(tmp_path / "nope")})
     assert resp.status_code == 400
 
 
@@ -110,7 +110,7 @@ def test_relink_apply_rewrites_symlinks(tmp_path: Path) -> None:
     new_target.write_bytes(b"")
     client = TestClient(create_app(project_root=root, project_name="x"))
     resp = client.post(
-        "/api/videos/relink/apply",
+        "/api/shooters/me/videos/relink/apply",
         json={"decisions": {ids["a.mp4"]: str(new_target)}},
     )
     assert resp.status_code == 200
@@ -126,7 +126,7 @@ def test_relink_apply_rejects_missing_target(tmp_path: Path) -> None:
     root, ids = _setup_project(tmp_path, ["a.mp4"])
     client = TestClient(create_app(project_root=root, project_name="x"))
     resp = client.post(
-        "/api/videos/relink/apply",
+        "/api/shooters/me/videos/relink/apply",
         json={"decisions": {ids["a.mp4"]: str(tmp_path / "nope.mp4")}},
     )
     assert resp.status_code == 400
@@ -137,7 +137,7 @@ def test_relink_apply_rejects_unknown_video_id(tmp_path: Path) -> None:
     target = tmp_path / "originals" / "a.mp4"
     client = TestClient(create_app(project_root=root, project_name="x"))
     resp = client.post(
-        "/api/videos/relink/apply",
+        "/api/shooters/me/videos/relink/apply",
         json={"decisions": {"deadbeefcafe": str(target)}},
     )
     assert resp.status_code == 400

--- a/tests/test_relink_api.py
+++ b/tests/test_relink_api.py
@@ -38,9 +38,7 @@ def _setup_project(tmp_path: Path, names: list[str]) -> tuple[Path, dict[str, st
         sv = StageVideo(path=Path("raw") / name, role="primary")
         videos.append(sv)
         ids[name] = sv.video_id
-    project.stages = [
-        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)
-    ]
+    project.stages = [StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=0.0, videos=videos)]
     project.save(root)
     return root, ids
 
@@ -70,7 +68,10 @@ def test_relink_scan_reports_unique_candidate(tmp_path: Path) -> None:
     share.mkdir(parents=True)
     (share / "a.mp4").write_bytes(b"")
     client = TestClient(create_app(project_root=root, project_name="x"))
-    resp = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(tmp_path / "share")})
+    resp = client.post(
+        "/api/shooters/me/videos/relink/scan",
+        json={"search_root": str(tmp_path / "share")},
+    )
     assert resp.status_code == 200
     body = resp.json()
     [entry] = body["entries"]
@@ -88,9 +89,10 @@ def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
     (share / "x" / "a.mp4").write_bytes(b"")
     (share / "y" / "a.mp4").write_bytes(b"")
     client = TestClient(create_app(project_root=root, project_name="x"))
-    [entry] = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(share)}).json()[
-        "entries"
-    ]
+    [entry] = client.post(
+        "/api/shooters/me/videos/relink/scan",
+        json={"search_root": str(share)},
+    ).json()["entries"]
     assert entry["ambiguous"]
     assert entry["chosen_path"] is None
     assert len(entry["candidates"]) == 2
@@ -99,7 +101,10 @@ def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
 def test_relink_scan_400_on_missing_root(tmp_path: Path) -> None:
     root, _ = _setup_project(tmp_path, ["a.mp4"])
     client = TestClient(create_app(project_root=root, project_name="x"))
-    resp = client.post("/api/shooters/me/videos/relink/scan", json={"search_root": str(tmp_path / "nope")})
+    resp = client.post(
+        "/api/shooters/me/videos/relink/scan",
+        json={"search_root": str(tmp_path / "nope")},
+    )
     assert resp.status_code == 400
 
 

--- a/tests/test_scoreboard_cache.py
+++ b/tests/test_scoreboard_cache.py
@@ -50,9 +50,7 @@ def _load_match_payload(*, scoring_completed: float) -> dict:
 
 
 @respx.mock
-def test_first_call_hits_network_second_does_not(
-    tmp_path: Path, http_client: SsiHttpClient
-) -> None:
+def test_first_call_hits_network_second_does_not(tmp_path: Path, http_client: SsiHttpClient) -> None:
     cache = CachingScoreboardClient(http_client, tmp_path / "cache")
     payload = _load_match_payload(scoring_completed=100.0)
     route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
@@ -69,9 +67,7 @@ def test_first_call_hits_network_second_does_not(
 
 
 @respx.mock
-def test_in_progress_match_does_not_serve_from_cache(
-    tmp_path: Path, http_client: SsiHttpClient
-) -> None:
+def test_in_progress_match_does_not_serve_from_cache(tmp_path: Path, http_client: SsiHttpClient) -> None:
     cache = CachingScoreboardClient(http_client, tmp_path / "cache")
     payload = _load_match_payload(scoring_completed=42.0)
     route = respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
@@ -130,9 +126,7 @@ def test_cache_survives_across_instances(tmp_path: Path, http_client: SsiHttpCli
 
 
 @respx.mock
-def test_project_portability_copy_cache_to_new_path(
-    tmp_path: Path, http_client: SsiHttpClient
-) -> None:
+def test_project_portability_copy_cache_to_new_path(tmp_path: Path, http_client: SsiHttpClient) -> None:
     project_a = tmp_path / "project_a" / "scoreboard" / "cache"
     project_b = tmp_path / "project_b" / "scoreboard" / "cache"
     payload = _load_match_payload(scoring_completed=100.0)
@@ -155,9 +149,7 @@ def test_project_portability_copy_cache_to_new_path(
 @respx.mock
 def test_for_project_resolves_conventional_path(tmp_path: Path, http_client: SsiHttpClient) -> None:
     payload = _load_match_payload(scoring_completed=100.0)
-    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
-        return_value=httpx.Response(200, json=payload)
-    )
+    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(return_value=httpx.Response(200, json=payload))
 
     cache = CachingScoreboardClient.for_project(http_client, tmp_path)
     cache.get_match(22, 27190)
@@ -166,9 +158,7 @@ def test_for_project_resolves_conventional_path(tmp_path: Path, http_client: Ssi
 
 
 @respx.mock
-def test_unrelated_endpoints_pass_through_uncached(
-    tmp_path: Path, http_client: SsiHttpClient
-) -> None:
+def test_unrelated_endpoints_pass_through_uncached(tmp_path: Path, http_client: SsiHttpClient) -> None:
     cache = CachingScoreboardClient(http_client, tmp_path / "cache")
     route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=[]))
 
@@ -188,9 +178,7 @@ def test_corrupt_cache_file_falls_back_to_inner(tmp_path: Path, http_client: Ssi
 
     payload = _load_match_payload(scoring_completed=100.0)
     with respx.mock() as mock:
-        mock.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
-            return_value=httpx.Response(200, json=payload)
-        )
+        mock.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(return_value=httpx.Response(200, json=payload))
         cache.get_match(22, 27190)
 
     # After the fetch, the corrupt file should be replaced with a valid envelope.

--- a/tests/test_scoreboard_http.py
+++ b/tests/test_scoreboard_http.py
@@ -84,9 +84,7 @@ def test_bearer_header_sent(client: SsiHttpClient) -> None:
 @respx.mock
 def test_get_match_returns_parsed_match_data(client: SsiHttpClient) -> None:
     payload = _load(MATCH_FIXTURE)
-    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(
-        return_value=httpx.Response(200, json=payload)
-    )
+    respx.get(f"{DEFAULT_BASE_URL}/match/22/27190").mock(return_value=httpx.Response(200, json=payload))
     match = client.get_match(22, 27190)
     assert isinstance(match, MatchData)
     assert match.name == payload["name"]
@@ -105,9 +103,7 @@ def test_get_match_404_maps_to_match_not_found(client: SsiHttpClient) -> None:
 @respx.mock
 def test_search_matches_passes_query(client: SsiHttpClient) -> None:
     payload = _load(EVENTS_FIXTURE)
-    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(
-        return_value=httpx.Response(200, json=payload)
-    )
+    route = respx.get(f"{DEFAULT_BASE_URL}/events").mock(return_value=httpx.Response(200, json=payload))
     hits = client.search_matches("SPSK")
     assert all(isinstance(h, MatchRef) for h in hits)
     assert route.calls.last.request.url.params["q"] == "SPSK"
@@ -123,9 +119,7 @@ def test_search_matches_empty_query_omits_param(client: SsiHttpClient) -> None:
 @respx.mock
 def test_find_shooter(client: SsiHttpClient) -> None:
     payload = _load(SHOOTER_SEARCH_FIXTURE)
-    respx.get(f"{DEFAULT_BASE_URL}/shooter/search").mock(
-        return_value=httpx.Response(200, json=payload)
-    )
+    respx.get(f"{DEFAULT_BASE_URL}/shooter/search").mock(return_value=httpx.Response(200, json=payload))
     hits = client.find_shooter("Axell")
     assert hits, "fixture must have at least one shooter"
     assert all(isinstance(h, ShooterRef) for h in hits)

--- a/tests/test_scoreboard_models.py
+++ b/tests/test_scoreboard_models.py
@@ -103,9 +103,7 @@ def test_protocol_is_runtime_checkable() -> None:
         def get_shooter(self, shooter_id: int):  # noqa: ANN201
             raise NotImplementedError
 
-        def get_stage_times(  # noqa: ANN201
-            self, content_type: int, match_id: int, competitor_id: int
-        ):
+        def get_stage_times(self, content_type: int, match_id: int, competitor_id: int):  # noqa: ANN201
             raise NotImplementedError
 
     assert isinstance(_Stub(), ScoreboardClient)

--- a/tests/test_shot_detect.py
+++ b/tests/test_shot_detect.py
@@ -71,9 +71,7 @@ def test_audited_shots_are_well_formed(fixtures_dir: Path, fixture_stem: str) ->
     reference a real candidate_number, and drag distances are within a sane
     bound (100 ms; anything beyond that suggests a mistaken candidate pick)."""
     _, _, truth = _load_fixture(fixtures_dir, fixture_stem)
-    cands_by_num = {
-        c["candidate_number"]: c for c in truth["_candidates_pending_audit"]["candidates"]
-    }
+    cands_by_num = {c["candidate_number"]: c for c in truth["_candidates_pending_audit"]["candidates"]}
     audited = truth.get("shots", [])
     if not audited:
         pytest.skip(f"{fixture_stem}: no audited shots yet")
@@ -106,16 +104,12 @@ def test_detect_shots_constrains_to_search_window(fixtures_dir: Path) -> None:
     assert shots, "expected at least some shots in the stage window"
     for s in shots:
         assert s.time_absolute >= beep, f"shot before beep: {s.time_absolute}"
-        assert (
-            s.time_absolute <= beep + stage_time + 1.0
-        ), f"shot beyond stage_time + 1s: {s.time_absolute}"
+        assert s.time_absolute <= beep + stage_time + 1.0, f"shot beyond stage_time + 1s: {s.time_absolute}"
 
 
 def test_detect_shots_fields_are_consistent(fixtures_dir: Path) -> None:
     audio, sr, truth = _load_fixture(fixtures_dir)
-    shots = detect_shots(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig()
-    )
+    shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig())
     assert shots
     # shot_number is 1-indexed and dense
     assert [s.shot_number for s in shots] == list(range(1, len(shots) + 1))
@@ -246,18 +240,14 @@ def test_detect_shots_min_confidence_filter(fixtures_dir: Path) -> None:
     found. With the filter at 0.0 the count must equal the unfiltered count;
     raising it must monotonically reduce (never increase) the count."""
     audio, sr, truth = _load_fixture(fixtures_dir)
-    base = detect_shots(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig()
-    )
+    base = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig())
     last_n = len(base)
     for cap in [0.0, 0.05, 0.10, 0.20, 0.50, 0.99]:
         cfg = ShotDetectConfig(min_confidence=cap)
         out = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg)
         assert len(out) <= last_n, f"min_confidence={cap}: count rose ({last_n} -> {len(out)})"
         for s in out:
-            assert (
-                s.confidence >= cap - 1e-9
-            ), f"min_confidence={cap}: kept shot with conf={s.confidence}"
+            assert s.confidence >= cap - 1e-9, f"min_confidence={cap}: kept shot with conf={s.confidence}"
         # shot_number must remain dense even after filtering
         assert [s.shot_number for s in out] == list(range(1, len(out) + 1))
         last_n = len(out)
@@ -268,9 +258,7 @@ def test_detect_shots_recall_fallback_cwt_idempotent_on_calm_audio(fixtures_dir:
     zero candidates -- the suspicious-gap trigger should not fire on a stage
     where pass 1 already covers everything at typical inter-shot pacing."""
     audio, sr, truth = _load_fixture(fixtures_dir, "stage-shots-tallmilan-2026-stage3-s97dcec94")
-    base = detect_shots(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig()
-    )
+    base = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig())
     with_cwt = detect_shots(
         audio,
         sr,
@@ -289,9 +277,7 @@ def test_detect_shots_recall_fallback_recovers_known_miss(fixtures_dir: Path) ->
     within 75 ms of the known librosa miss at t=6.6399s, while leaving all
     pass-1 candidates intact."""
     audio, sr, truth = _load_fixture(fixtures_dir, "stage-shots-tallmilan-2026-stage7-s97dcec94")
-    base = detect_shots(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig()
-    )
+    base = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], ShotDetectConfig())
     with_cwt = detect_shots(
         audio,
         sr,
@@ -304,9 +290,7 @@ def test_detect_shots_recall_fallback_recovers_known_miss(fixtures_dir: Path) ->
     cwt_times = sorted(s.time_absolute for s in with_cwt)
     for b in base_times:
         nearest = min(abs(c - b) for c in cwt_times)
-        assert (
-            nearest < 1.0 / sr + 1e-9
-        ), f"pass-1 candidate at {b:.4f} disappeared after CWT fallback"
+        assert nearest < 1.0 / sr + 1e-9, f"pass-1 candidate at {b:.4f} disappeared after CWT fallback"
     # The known miss is now covered.
     assert any(abs(c - 6.6399) * 1000.0 < 75.0 for c in cwt_times), (
         f"CWT fallback failed to recover Stage 7 t=6.6399 miss; nearest cand "

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -130,9 +130,7 @@ def test_ensure_clip_extracts_and_caches(tmp_path: Path) -> None:
     ):
         first = thumbnail.ensure_clip(source, cache_dir=cache_dir, center_time=12.5, duration_s=1.0)
         # Same key -> cache hit, ffmpeg not invoked again.
-        second = thumbnail.ensure_clip(
-            source, cache_dir=cache_dir, center_time=12.5, duration_s=1.0
-        )
+        second = thumbnail.ensure_clip(source, cache_dir=cache_dir, center_time=12.5, duration_s=1.0)
 
     assert first.exists()
     assert first.suffix == ".mp4"
@@ -202,6 +200,4 @@ def test_ensure_clip_raises_on_timeout(tmp_path: Path) -> None:
 def test_cached_clip_returns_none_on_miss(tmp_path: Path) -> None:
     source = tmp_path / "clip.mp4"
     source.write_bytes(b"fake")
-    assert (
-        thumbnail.cached_clip(source, tmp_path / "thumbs", center_time=5.0, duration_s=1.0) is None
-    )
+    assert thumbnail.cached_clip(source, tmp_path / "thumbs", center_time=5.0, duration_s=1.0) is None

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -289,9 +289,7 @@ def test_select_audit_encoder_explicit_override_when_unsupported(monkeypatch) ->
     import splitsmith.trim as trim_module
 
     trim_module._probe_available_encoders.cache_clear()
-    monkeypatch.setattr(
-        trim_module, "_probe_available_encoders", lambda *a, **kw: frozenset({"libx264"})
-    )
+    monkeypatch.setattr(trim_module, "_probe_available_encoders", lambda *a, **kw: frozenset({"libx264"}))
 
     assert select_audit_encoder("h264_nvenc") == "libx264"
 
@@ -383,6 +381,5 @@ def test_trim_audit_mode_emits_short_gop(tmp_path: Path, fixtures_dir: Path) -> 
     assert len(keyframe_times) >= 2, f"expected multiple keyframes, got {keyframe_times}"
     gaps = [b - a for a, b in zip(keyframe_times, keyframe_times[1:], strict=False)]
     assert max(gaps) <= 0.6, (
-        f"keyframe gaps exceed 0.5s tolerance: max={max(gaps):.3f}s, "
-        f"gaps={[round(g, 3) for g in gaps]}"
+        f"keyframe gaps exceed 0.5s tolerance: max={max(gaps):.3f}s, " f"gaps={[round(g, 3) for g in gaps]}"
     )

--- a/tests/test_tta_agreement.py
+++ b/tests/test_tta_agreement.py
@@ -39,9 +39,7 @@ def test_tta_agreement_empty_input_returns_empty() -> None:
 def test_tta_agreement_in_expected_range_and_length() -> None:
     audio = _synthesise_shot_audio()
     base = np.array([1.5])
-    out = compute_tta_agreement(
-        audio, 48000, beep_time=0.0, stage_time=2.0, base_candidate_times=base
-    )
+    out = compute_tta_agreement(audio, 48000, beep_time=0.0, stage_time=2.0, base_candidate_times=base)
     assert out.shape == (1,)
     # Original always counts (1.0 floor); 4 perturbations cap us at 5.0.
     assert 1.0 <= float(out[0]) <= 5.0
@@ -53,7 +51,5 @@ def test_tta_agreement_unmatched_candidate_stays_at_floor() -> None:
     # Pick a time far away from the synthesised impulse so no perturbation
     # reproduces a candidate within the 15 ms tolerance.
     base = np.array([0.5])
-    out = compute_tta_agreement(
-        audio, 48000, beep_time=0.0, stage_time=2.0, base_candidate_times=base
-    )
+    out = compute_tta_agreement(audio, 48000, beep_time=0.0, stage_time=2.0, base_candidate_times=base)
     assert float(out[0]) == 1.0

--- a/tests/test_ui_exports.py
+++ b/tests/test_ui_exports.py
@@ -356,12 +356,8 @@ def test_export_stage_trims_secondaries_and_records_paths(
         beep_time_in_source=10.0,
         config=Config(),
         secondaries=[
-            exports_mod.SecondaryExport(
-                video_id="aaaaaa", source_path=cam_a_src, beep_time_in_source=11.0
-            ),
-            exports_mod.SecondaryExport(
-                video_id="bbbbbb", source_path=cam_b_src, beep_time_in_source=9.5
-            ),
+            exports_mod.SecondaryExport(video_id="aaaaaa", source_path=cam_a_src, beep_time_in_source=11.0),
+            exports_mod.SecondaryExport(video_id="bbbbbb", source_path=cam_b_src, beep_time_in_source=9.5),
         ],
     )
 

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -1165,9 +1165,7 @@ def test_swap_primary_warns_when_shots_audited(tmp_path: Path) -> None:
             {
                 "stage_number": 1,
                 "stage_name": "S1",
-                "shots": [
-                    {"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}
-                ],
+                "shots": [{"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}],
             }
         )
     )
@@ -1218,16 +1216,12 @@ def test_swap_primary_backs_up_audit_and_clears_processed(tmp_path: Path) -> Non
             {
                 "stage_number": 1,
                 "stage_name": "S1",
-                "shots": [
-                    {"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}
-                ],
+                "shots": [{"shot_number": 1, "candidate_number": 1, "time": 1.0, "ms_after_beep": 100}],
             }
         )
     )
 
-    new_primary = project.swap_primary(
-        Path("raw/b.mp4"), root=root, stage_number=1, backup_audit=True
-    )
+    new_primary = project.swap_primary(Path("raw/b.mp4"), root=root, stage_number=1, backup_audit=True)
 
     assert new_primary.role == "primary"
     assert new_primary.path == Path("raw/b.mp4")

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -84,7 +84,7 @@ def test_get_project_returns_full_dump(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored, project already exists")
     client = TestClient(app)
 
-    resp = client.get("/api/project")
+    resp = client.get("/api/shooters/me/project")
     assert resp.status_code == 200
     body = resp.json()
     # The project name from disk wins, not the create_app argument.
@@ -150,7 +150,7 @@ def test_import_scoreboard_endpoint(tmp_path: Path) -> None:
             }
         ],
     }
-    resp = client.post("/api/scoreboard/import", json={"data": sb})
+    resp = client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     assert resp.status_code == 200
     body = resp.json()
     assert body["name"] == "Imported Match"
@@ -180,12 +180,12 @@ def test_import_scoreboard_409_on_conflict(tmp_path: Path) -> None:
             }
         ],
     }
-    assert client.post("/api/scoreboard/import", json={"data": sb}).status_code == 200
-    resp = client.post("/api/scoreboard/import", json={"data": sb})
+    assert client.post("/api/shooters/me/scoreboard/import", json={"data": sb}).status_code == 200
+    resp = client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     assert resp.status_code == 409
 
     # overwrite=True succeeds.
-    resp = client.post("/api/scoreboard/import", json={"data": sb, "overwrite": True})
+    resp = client.post("/api/shooters/me/scoreboard/import", json={"data": sb, "overwrite": True})
     assert resp.status_code == 200
 
 
@@ -220,7 +220,7 @@ def test_scoreboard_loads_token_from_project_env_local(
     )
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
-    src = client.get("/api/scoreboard/source").json()
+    src = client.get("/api/shooters/me/scoreboard/source").json()
     assert src["http_token_set"] is True
 
 
@@ -239,14 +239,14 @@ def test_scoreboard_loads_token_from_cwd_env(
     monkeypatch.chdir(launch_dir)
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
-    src = client.get("/api/scoreboard/source").json()
+    src = client.get("/api/shooters/me/scoreboard/source").json()
     assert src["http_token_set"] is True
 
 
 def test_scoreboard_source_reports_online_when_no_local_file(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.get("/api/scoreboard/source")
+    resp = client.get("/api/shooters/me/scoreboard/source")
     assert resp.status_code == 200
     assert resp.json()["mode"] == "online"
     assert resp.json()["local_match_json_path"] is None
@@ -258,7 +258,7 @@ def test_scoreboard_upload_writes_local_json_and_populates_project(tmp_path: Pat
     client = TestClient(app)
 
     fixture = _load_v1_match_fixture()
-    resp = client.post("/api/scoreboard/upload", json={"data": fixture})
+    resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
     assert resp.status_code == 200
     body = resp.json()
     assert body["name"] == "SPSK Open 2026"
@@ -273,7 +273,7 @@ def test_scoreboard_upload_writes_local_json_and_populates_project(tmp_path: Pat
     assert local_path.exists()
 
     # Source endpoint now reports local mode (the offline path is active).
-    src = client.get("/api/scoreboard/source").json()
+    src = client.get("/api/shooters/me/scoreboard/source").json()
     assert src["mode"] == "local"
     assert src["local_match_json_path"] == str(local_path)
 
@@ -284,7 +284,7 @@ def test_scoreboard_upload_rejects_non_v1_payload(tmp_path: Path) -> None:
     # Legacy ``examples/`` shape is *not* MatchData -- the upload endpoint
     # should bounce it with a 400 rather than silently misparsing.
     legacy = {"match": {"id": "1", "name": "Legacy"}, "competitors": []}
-    resp = client.post("/api/scoreboard/upload", json={"data": legacy})
+    resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": legacy})
     assert resp.status_code == 400
 
 
@@ -296,11 +296,11 @@ def test_scoreboard_search_uses_local_when_match_json_present(tmp_path: Path) ->
     client = TestClient(app)
 
     fixture = _load_v1_match_fixture()
-    assert client.post("/api/scoreboard/upload", json={"data": fixture}).status_code == 200
+    assert client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture}).status_code == 200
 
     # No SPLITSMITH_SSI_TOKEN env var; must still work because the local
     # JSON path doesn't go through SsiHttpClient.
-    resp = client.get("/api/scoreboard/search", params={"q": "SPSK"})
+    resp = client.get("/api/shooters/me/scoreboard/search", params={"q": "SPSK"})
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
@@ -318,7 +318,7 @@ def test_scoreboard_search_returns_401_when_no_token_and_no_local(
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
 
-    resp = client.get("/api/scoreboard/search", params={"q": "anything"})
+    resp = client.get("/api/shooters/me/scoreboard/search", params={"q": "anything"})
     assert resp.status_code == 401
     detail = resp.json()["detail"]
     assert detail["code"] == "scoreboard_auth"
@@ -338,7 +338,7 @@ def test_scoreboard_upload_legacy_examples_auto_merges_stage_times(tmp_path: Pat
     legacy = _json.loads(
         (_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8")
     )
-    resp = client.post("/api/scoreboard/upload", json={"data": legacy})
+    resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": legacy})
     assert resp.status_code == 200
     body = resp.json()
     assert body["stage_times_merged"] == 8
@@ -355,7 +355,7 @@ def test_scoreboard_upload_pure_v1_does_not_auto_merge(tmp_path: Path) -> None:
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    resp = client.post("/api/scoreboard/upload", json={"data": fixture})
+    resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
     assert resp.status_code == 200
     body = resp.json()
     assert body["stage_times_merged"] == 0
@@ -376,7 +376,7 @@ def test_scoreboard_upload_combined_v1_auto_merges_when_single_competitor(
     combined = _json.loads(
         (_SCOREBOARD_FIXTURES_DIR / "match_22_27190_with_stages.json").read_text(encoding="utf-8")
     )
-    resp = client.post("/api/scoreboard/upload", json={"data": combined})
+    resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": combined})
     assert resp.status_code == 200
     body = resp.json()
     assert body["stage_times_merged"] == 10
@@ -394,16 +394,16 @@ def test_scoreboard_select_shooter_blocked_on_pure_v1(tmp_path: Path) -> None:
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
 
     resp = client.post(
-        "/api/scoreboard/select-shooter",
+        "/api/shooters/me/scoreboard/select-shooter",
         json={"shooter_id": 40821, "competitor_id": 727562},
     )
     assert resp.status_code == 400
     detail = resp.json()["detail"]
     assert detail["code"] == "stage_times_offline_pure_matchdata"
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     assert proj["selected_shooter_id"] == 40821
     assert proj["selected_competitor_id"] == 727562
 
@@ -419,8 +419,8 @@ def test_scoreboard_refresh_times_re_merges(tmp_path: Path) -> None:
     legacy = _json.loads(
         (_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8")
     )
-    client.post("/api/scoreboard/upload", json={"data": legacy})
-    resp = client.post("/api/scoreboard/refresh-times")
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": legacy})
+    resp = client.post("/api/shooters/me/scoreboard/refresh-times")
     assert resp.status_code == 200
     assert resp.json()["stage_times_merged"] == 8
 
@@ -432,9 +432,9 @@ def test_scoreboard_match_data_endpoint_exposes_competitors(tmp_path: Path) -> N
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
 
-    resp = client.get("/api/scoreboard/match-data")
+    resp = client.get("/api/shooters/me/scoreboard/match-data")
     assert resp.status_code == 200
     md = resp.json()
     assert md["name"] == "SPSK Open 2026"
@@ -446,7 +446,7 @@ def test_scoreboard_match_data_endpoint_exposes_competitors(tmp_path: Path) -> N
 def test_scoreboard_match_data_404_when_no_match_loaded(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.get("/api/scoreboard/match-data")
+    resp = client.get("/api/shooters/me/scoreboard/match-data")
     assert resp.status_code == 404
 
 
@@ -454,7 +454,7 @@ def test_scoreboard_select_shooter_409_when_no_match(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/scoreboard/select-shooter",
+        "/api/shooters/me/scoreboard/select-shooter",
         json={"shooter_id": 1, "competitor_id": 1},
     )
     assert resp.status_code == 409
@@ -465,8 +465,8 @@ def test_scoreboard_refresh_times_409_when_no_pin(tmp_path: Path) -> None:
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
-    resp = client.post("/api/scoreboard/refresh-times")
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
+    resp = client.post("/api/shooters/me/scoreboard/refresh-times")
     assert resp.status_code == 409
 
 
@@ -487,7 +487,7 @@ def test_scoreboard_select_shooter_rejects_competitor_not_in_match(
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
     (project_root / "scoreboard" / "match.json").unlink()
 
     # Mock the live API: get_match returns the fixture so the validate
@@ -519,13 +519,13 @@ def test_scoreboard_select_shooter_rejects_competitor_not_in_match(
 
     # 999999 is not in the fixture's competitors -- pre-validation should reject.
     resp = client.post(
-        "/api/scoreboard/select-shooter",
+        "/api/shooters/me/scoreboard/select-shooter",
         json={"shooter_id": 1, "competitor_id": 999999},
     )
     assert resp.status_code == 404
     assert resp.json()["detail"]["code"] == "competitor_not_in_match"
     assert stage_calls["count"] == 0  # never reached the stages endpoint
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     assert proj["selected_shooter_id"] is None
     assert proj["selected_competitor_id"] is None
 
@@ -545,7 +545,7 @@ def test_scoreboard_select_shooter_uses_live_stage_times_when_available(
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
     (project_root / "scoreboard" / "match.json").unlink()
 
     stage_results = {
@@ -587,7 +587,7 @@ def test_scoreboard_select_shooter_uses_live_stage_times_when_available(
     monkeypatch.setattr(http_mod.SsiHttpClient, "__init__", mocked_init)
 
     resp = client.post(
-        "/api/scoreboard/select-shooter",
+        "/api/shooters/me/scoreboard/select-shooter",
         json={"shooter_id": 40821, "competitor_id": 727562},
     )
     assert resp.status_code == 200
@@ -608,10 +608,10 @@ def test_scoreboard_fetch_uses_local_match_when_present(tmp_path: Path) -> None:
     client = TestClient(app)
 
     fixture = _load_v1_match_fixture()
-    client.post("/api/scoreboard/upload", json={"data": fixture})
+    client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
 
     resp = client.post(
-        "/api/scoreboard/fetch",
+        "/api/shooters/me/scoreboard/fetch",
         json={"content_type": 22, "match_id": 27190, "overwrite": True},
     )
     assert resp.status_code == 200
@@ -623,7 +623,7 @@ def test_placeholder_stages_endpoint_creates_stages(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/project/placeholder-stages",
+        "/api/shooters/me/project/placeholder-stages",
         json={"stage_count": 5, "match_name": "Test Match", "match_date": "2026-04-12"},
     )
     assert resp.status_code == 200
@@ -655,9 +655,9 @@ def test_placeholder_stages_endpoint_409_when_real_stages_exist(tmp_path: Path) 
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     resp = client.post(
-        "/api/project/placeholder-stages",
+        "/api/shooters/me/project/placeholder-stages",
         json={"stage_count": 5},
     )
     assert resp.status_code == 409
@@ -692,7 +692,7 @@ def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
 
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
@@ -702,7 +702,7 @@ def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
     _os.utime(vid, (target_ts, target_ts))
 
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": True},
     )
     assert resp.status_code == 200
@@ -711,7 +711,7 @@ def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
     assert body["auto_assigned"] == {"1": "raw/VID.mp4"}
 
     # Verify project state.
-    project = client.get("/api/project").json()
+    project = client.get("/api/shooters/me/project").json()
     assert project["stages"][0]["videos"][0]["role"] == "primary"
     assert project["unassigned_videos"] == []
 
@@ -719,7 +719,7 @@ def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
 def test_scan_videos_400_on_missing_dir(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.post("/api/videos/scan", json={"source_dir": str(tmp_path / "does-not-exist")})
+    resp = client.post("/api/shooters/me/videos/scan", json={"source_dir": str(tmp_path / "does-not-exist")})
     assert resp.status_code == 400
 
 
@@ -747,24 +747,24 @@ def test_move_assignment_endpoint(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
 
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     vid = src_dir / "VID.mp4"
     vid.write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
 
     # Should have one unassigned video.
-    project = client.get("/api/project").json()
+    project = client.get("/api/shooters/me/project").json()
     assert len(project["unassigned_videos"]) == 1
 
     # Move to stage 1 as primary.
     resp = client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={
             "video_path": "raw/VID.mp4",
             "to_stage_number": 1,
@@ -778,7 +778,7 @@ def test_move_assignment_endpoint(tmp_path: Path) -> None:
 
     # Mark as ignored (still on stage 1).
     resp = client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={
             "video_path": "raw/VID.mp4",
             "to_stage_number": 1,
@@ -790,7 +790,7 @@ def test_move_assignment_endpoint(tmp_path: Path) -> None:
 
     # Back to unassigned.
     resp = client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": None},
     )
     assert resp.status_code == 200
@@ -803,7 +803,7 @@ def test_move_assignment_404_on_unknown_video(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/nope.mp4", "to_stage_number": None},
     )
     assert resp.status_code == 404
@@ -822,7 +822,7 @@ def test_fs_list_returns_directory_entries(tmp_path: Path) -> None:
     (listing_root / "notes.txt").write_text("hi")
     (listing_root / ".hidden").mkdir()  # filtered out
 
-    resp = client.get("/api/fs/list", params={"path": str(listing_root)})
+    resp = client.get("/api/shooters/me/fs/list", params={"path": str(listing_root)})
     assert resp.status_code == 200
     body = resp.json()
     assert body["path"] == str(listing_root.resolve())
@@ -848,7 +848,7 @@ def test_fs_list_video_count_for_directories(tmp_path: Path) -> None:
     (inner / "v2.mov").write_bytes(b"")
     (inner / "notes.txt").write_text("hi")
 
-    resp = client.get("/api/fs/list", params={"path": str(parent)})
+    resp = client.get("/api/shooters/me/fs/list", params={"path": str(parent)})
     assert resp.status_code == 200
     entries = {e["name"]: e for e in resp.json()["entries"]}
     assert entries["match-day"]["kind"] == "dir"
@@ -867,7 +867,7 @@ def test_fs_list_default_path_uses_last_scanned_dir(tmp_path: Path) -> None:
     project.last_scanned_dir = str(seeded.resolve())
     project.save(project_root)
 
-    resp = client.get("/api/fs/list")
+    resp = client.get("/api/shooters/me/fs/list")
     assert resp.status_code == 200
     body = resp.json()
     assert body["path"] == str(seeded.resolve())
@@ -880,7 +880,7 @@ def test_fs_list_default_path_uses_last_scanned_dir(tmp_path: Path) -> None:
 def test_fs_list_404_on_missing_path(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.get("/api/fs/list", params={"path": str(tmp_path / "nope")})
+    resp = client.get("/api/shooters/me/fs/list", params={"path": str(tmp_path / "nope")})
     assert resp.status_code == 404
 
 
@@ -894,12 +894,12 @@ def test_scan_persists_last_scanned_dir(tmp_path: Path) -> None:
     (src_dir / "VID.mp4").write_bytes(b"")
 
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
     assert resp.status_code == 200
 
-    project = client.get("/api/project").json()
+    project = client.get("/api/shooters/me/project").json()
     assert project["last_scanned_dir"] == str(src_dir.resolve())
 
 
@@ -947,17 +947,17 @@ def _seed_project_with_primary(tmp_path: Path) -> tuple[TestClient, Path]:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     src = src_dir / "VID.mp4"
     src.write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     return client, src
@@ -1003,13 +1003,13 @@ def test_detect_beep_persists_auto_result(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     job = resp.json()
     assert job["kind"] == "detect_beep"
     final = _wait_for_job(client, job["id"])
     assert final["status"] == "succeeded", final
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 12.453
     assert primary["beep_source"] == "auto"
     assert primary["beep_peak_amplitude"] == 0.42
@@ -1020,21 +1020,21 @@ def test_detect_beep_persists_auto_result(tmp_path: Path, monkeypatch) -> None:
 def test_detect_beep_409_over_manual_unless_forced(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     # User has already set a manual override.
-    client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 12.5})
     _stub_detect(monkeypatch, beep_time=99.0)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 409
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 12.5
     assert primary["beep_source"] == "manual"
 
     # ?force=true replaces it.
-    resp = client.post("/api/stages/1/detect-beep?force=true")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep?force=true")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 99.0
     assert primary["beep_source"] == "auto"
 
@@ -1060,14 +1060,14 @@ def test_detect_beep_400_when_no_primary(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
-    resp = client.post("/api/stages/1/detect-beep")
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 400
 
 
 def test_override_beep_sets_manual_source(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 12.5})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 12.5
@@ -1078,9 +1078,9 @@ def test_override_beep_sets_manual_source(tmp_path: Path) -> None:
 def test_override_beep_clears_with_null(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=10.0)
-    client.post("/api/stages/1/detect-beep")
+    client.post("/api/shooters/me/stages/1/detect-beep")
 
-    resp = client.post("/api/stages/1/beep", json={"beep_time": None})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": None})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_time"] is None
@@ -1090,7 +1090,7 @@ def test_override_beep_clears_with_null(tmp_path: Path, monkeypatch) -> None:
 
 def test_override_beep_400_on_negative(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/stages/1/beep", json={"beep_time": -1.0})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": -1.0})
     assert resp.status_code == 400
 
 
@@ -1101,10 +1101,10 @@ def test_set_stage_time_manual_unblocks_no_scoreboard_project(tmp_path: Path) ->
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     client.post(
-        "/api/project/placeholder-stages",
+        "/api/shooters/me/project/placeholder-stages",
         json={"stage_count": 1, "match_name": "Manual Times"},
     )
-    resp = client.post("/api/stages/1/time", json={"time_seconds": 18.42})
+    resp = client.post("/api/shooters/me/stages/1/time", json={"time_seconds": 18.42})
     assert resp.status_code == 200
     stage = resp.json()["stages"][0]
     assert stage["time_seconds"] == 18.42
@@ -1114,9 +1114,9 @@ def test_set_stage_time_manual_unblocks_no_scoreboard_project(tmp_path: Path) ->
 def test_set_stage_time_null_clears_back_to_placeholder(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    client.post("/api/project/placeholder-stages", json={"stage_count": 1})
-    client.post("/api/stages/1/time", json={"time_seconds": 12.0})
-    resp = client.post("/api/stages/1/time", json={"time_seconds": None})
+    client.post("/api/shooters/me/project/placeholder-stages", json={"stage_count": 1})
+    client.post("/api/shooters/me/stages/1/time", json={"time_seconds": 12.0})
+    resp = client.post("/api/shooters/me/stages/1/time", json={"time_seconds": None})
     assert resp.status_code == 200
     stage = resp.json()["stages"][0]
     assert stage["time_seconds"] == 0.0
@@ -1126,9 +1126,9 @@ def test_set_stage_time_null_clears_back_to_placeholder(tmp_path: Path) -> None:
 def test_set_stage_time_400_on_non_positive(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    client.post("/api/project/placeholder-stages", json={"stage_count": 1})
+    client.post("/api/shooters/me/project/placeholder-stages", json={"stage_count": 1})
     for bad in (0.0, -1.0):
-        resp = client.post("/api/stages/1/time", json={"time_seconds": bad})
+        resp = client.post("/api/shooters/me/stages/1/time", json={"time_seconds": bad})
         assert resp.status_code == 400, f"expected 400 for {bad}, got {resp.status_code}"
 
 
@@ -1184,11 +1184,11 @@ def test_detect_beep_persists_candidate_list(tmp_path: Path, monkeypatch) -> Non
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert len(primary["beep_candidates"]) == 3
     assert primary["beep_candidates"][0]["time"] == 12.453
     assert primary["beep_candidates"][1]["time"] == 8.100
@@ -1197,10 +1197,10 @@ def test_detect_beep_persists_candidate_list(tmp_path: Path, monkeypatch) -> Non
 def test_select_beep_candidate_promotes_alternate(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
-    final = _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+    final = _wait_for_job(client, client.post("/api/shooters/me/stages/1/detect-beep").json()["id"])
     assert final["status"] == "succeeded"
 
-    resp = client.post("/api/stages/1/beep/select", json={"time": 8.100})
+    resp = client.post("/api/shooters/me/stages/1/beep/select", json={"time": 8.100})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 8.100
@@ -1220,9 +1220,9 @@ def test_select_beep_candidate_tolerates_sub_ms_drift(tmp_path: Path, monkeypatc
     keeps the click working."""
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
-    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+    _wait_for_job(client, client.post("/api/shooters/me/stages/1/detect-beep").json()["id"])
 
-    resp = client.post("/api/stages/1/beep/select", json={"time": 8.1004})
+    resp = client.post("/api/shooters/me/stages/1/beep/select", json={"time": 8.1004})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 8.100
@@ -1230,16 +1230,16 @@ def test_select_beep_candidate_tolerates_sub_ms_drift(tmp_path: Path, monkeypatc
 
 def test_select_beep_candidate_400_when_no_candidates(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/stages/1/beep/select", json={"time": 0.0})
+    resp = client.post("/api/shooters/me/stages/1/beep/select", json={"time": 0.0})
     assert resp.status_code == 400
 
 
 def test_select_beep_candidate_400_when_time_no_match(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
-    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+    _wait_for_job(client, client.post("/api/shooters/me/stages/1/detect-beep").json()["id"])
 
-    resp = client.post("/api/stages/1/beep/select", json={"time": 99.999})
+    resp = client.post("/api/shooters/me/stages/1/beep/select", json={"time": 99.999})
     assert resp.status_code == 400
     detail = resp.json()["detail"]
     # The server lists what's available so the user can copy a real time.
@@ -1272,12 +1272,12 @@ def test_snap_beep_refines_user_hint_to_truth(tmp_path: Path, monkeypatch) -> No
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_video_audio_with_fixture(monkeypatch)
 
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
 
     hint = _BEEP_FIXTURE_TRUTH + 0.072
     resp = client.post(
-        f"/api/stages/1/videos/{video_id}/beep/snap",
+        f"/api/shooters/me/stages/1/videos/{video_id}/beep/snap",
         json={"hint_time": hint, "window_s": 0.5},
     )
     assert resp.status_code == 200, resp.text
@@ -1292,9 +1292,9 @@ def test_snap_beep_refines_user_hint_to_truth(tmp_path: Path, monkeypatch) -> No
 def test_snap_beep_400_on_negative_hint(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_video_audio_with_fixture(monkeypatch)
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     resp = client.post(
-        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        f"/api/shooters/me/stages/1/videos/{primary['video_id']}/beep/snap",
         json={"hint_time": -0.1, "window_s": 0.5},
     )
     assert resp.status_code == 400
@@ -1303,9 +1303,9 @@ def test_snap_beep_400_on_negative_hint(tmp_path: Path, monkeypatch) -> None:
 def test_snap_beep_400_on_zero_window(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_video_audio_with_fixture(monkeypatch)
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     resp = client.post(
-        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        f"/api/shooters/me/stages/1/videos/{primary['video_id']}/beep/snap",
         json={"hint_time": 4.0, "window_s": 0.0},
     )
     assert resp.status_code == 400
@@ -1316,11 +1316,11 @@ def test_snap_beep_404_when_window_excludes_beep(tmp_path: Path, monkeypatch) ->
     so the SPA can prompt the user to widen the window or move the marker."""
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_video_audio_with_fixture(monkeypatch)
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     # Place the hint into the post-beep silence; 50 ms half-window has
     # nothing crossing the run-duration threshold.
     resp = client.post(
-        f"/api/stages/1/videos/{primary['video_id']}/beep/snap",
+        f"/api/shooters/me/stages/1/videos/{primary['video_id']}/beep/snap",
         json={"hint_time": 0.30, "window_s": 0.05},
     )
     assert resp.status_code == 404
@@ -1329,9 +1329,9 @@ def test_snap_beep_404_when_window_excludes_beep(tmp_path: Path, monkeypatch) ->
 def test_manual_override_clears_candidate_list(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=_three_candidates())
-    _wait_for_job(client, client.post("/api/stages/1/detect-beep").json()["id"])
+    _wait_for_job(client, client.post("/api/shooters/me/stages/1/detect-beep").json()["id"])
 
-    resp = client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 12.5})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_source"] == "manual"
@@ -1356,7 +1356,7 @@ def test_audio_endpoint_serves_cached_wav(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", fake_ensure)
 
-    resp = client.get("/api/stages/1/audio")
+    resp = client.get("/api/shooters/me/stages/1/audio")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "audio/wav"
     assert resp.content.startswith(b"RIFF")
@@ -1394,7 +1394,7 @@ def test_beep_preview_serves_cached_clip(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(server_module.thumbnail_helpers, "ensure_clip", fake_ensure_clip)
 
-    resp = client.get("/api/stages/1/beep-preview")
+    resp = client.get("/api/shooters/me/stages/1/beep-preview")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "video/mp4"
     assert resp.content.startswith(b"\x00\x00\x00\x18ftyp")
@@ -1430,11 +1430,11 @@ def test_beep_preview_t_query_overrides_center(tmp_path: Path, monkeypatch) -> N
 
     monkeypatch.setattr(server_module.thumbnail_helpers, "ensure_clip", fake_ensure_clip)
 
-    resp = client.get("/api/stages/1/beep-preview?t=27.5")
+    resp = client.get("/api/shooters/me/stages/1/beep-preview?t=27.5")
     assert resp.status_code == 200
     assert captured["center_time"] == pytest.approx(27.5)
     # primary.beep_time is unchanged.
-    after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    after = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert after["beep_time"] == 12.5
     # ``src`` is the seeded source video; sanity-check it exists.
     assert src.exists()
@@ -1449,7 +1449,7 @@ def test_beep_preview_400_on_negative_t(tmp_path: Path) -> None:
     primary.beep_time = 5.0
     project.save(project_root)
 
-    resp = client.get("/api/stages/1/beep-preview?t=-1")
+    resp = client.get("/api/shooters/me/stages/1/beep-preview?t=-1")
     assert resp.status_code == 400
 
 
@@ -1457,7 +1457,7 @@ def test_beep_preview_404_when_no_beep(tmp_path: Path) -> None:
     """No beep_time yet -> 404 with a clear detail. The SPA hides the preview
     until detection has run."""
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/stages/1/beep-preview")
+    resp = client.get("/api/shooters/me/stages/1/beep-preview")
     assert resp.status_code == 404
     assert "beep_time" in resp.json()["detail"]
 
@@ -1484,8 +1484,8 @@ def test_beep_preview_404_when_no_primary(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
-    resp = client.get("/api/stages/1/beep-preview")
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
+    resp = client.get("/api/shooters/me/stages/1/beep-preview")
     assert resp.status_code == 404
 
 
@@ -1507,7 +1507,7 @@ def test_beep_preview_500_on_ffmpeg_failure(tmp_path: Path, monkeypatch) -> None
         raise thumbnail.ThumbnailError("ffmpeg exploded")
 
     monkeypatch.setattr(server_module.thumbnail_helpers, "ensure_clip", boom)
-    resp = client.get("/api/stages/1/beep-preview")
+    resp = client.get("/api/shooters/me/stages/1/beep-preview")
     assert resp.status_code == 500
     assert "ffmpeg exploded" in resp.json()["detail"]
 
@@ -1552,7 +1552,7 @@ def test_peaks_endpoint_uses_trimmed_audio_when_present(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(audio_helpers, "_extract_audio", fake_extract)
 
-    resp = client.get("/api/stages/1/peaks?bins=64")
+    resp = client.get("/api/shooters/me/stages/1/peaks?bins=64")
     assert resp.status_code == 200
     body = resp.json()
     assert body["trimmed"] is True
@@ -1589,12 +1589,12 @@ def test_video_peaks_endpoint_serves_secondary_full_wav(tmp_path: Path, monkeypa
     monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
 
     # Set a beep_time on the secondary so beep_time is reflected in the payload.
-    proj = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": 0.42}).json()
+    proj = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": 0.42}).json()
     assert next(v for v in proj["stages"][0]["videos"] if v["video_id"] == sec_id)[
         "beep_time"
     ] == pytest.approx(0.42)
 
-    resp = client.get(f"/api/stages/1/videos/{sec_id}/peaks?bins=64")
+    resp = client.get(f"/api/shooters/me/stages/1/videos/{sec_id}/peaks?bins=64")
     assert resp.status_code == 200
     body = resp.json()
     assert body["bins"] == 64
@@ -1622,7 +1622,7 @@ def test_video_audio_endpoint_serves_secondary_wav(tmp_path: Path, monkeypatch) 
 
     monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
 
-    resp = client.get(f"/api/stages/1/videos/{sec_id}/audio")
+    resp = client.get(f"/api/shooters/me/stages/1/videos/{sec_id}/audio")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "audio/wav"
     assert resp.content.startswith(b"RIFF")
@@ -1647,7 +1647,7 @@ def test_video_peaks_endpoint_serves_primary_full_wav_even_when_trimmed_exists(
     audio_dir = project_root / "audio"
     audio_dir.mkdir(parents=True, exist_ok=True)
 
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     primary_id = primary["video_id"]
 
     # Cache both the trimmed audit WAV (short) and the full primary WAV
@@ -1668,7 +1668,7 @@ def test_video_peaks_endpoint_serves_primary_full_wav_even_when_trimmed_exists(
 
     monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
 
-    resp = client.get(f"/api/stages/1/videos/{primary_id}/peaks?bins=64")
+    resp = client.get(f"/api/shooters/me/stages/1/videos/{primary_id}/peaks?bins=64")
     assert resp.status_code == 200
     body = resp.json()
     assert body["trimmed"] is False
@@ -1679,7 +1679,7 @@ def test_video_peaks_endpoint_404_for_unknown_video(tmp_path: Path) -> None:
     """The per-video endpoint 404s when video_id isn't on the stage --
     same shape as the per-video beep endpoints."""
     client, _ = _seed_project_with_secondary(tmp_path)
-    resp = client.get("/api/stages/1/videos/deadbeef0000/peaks")
+    resp = client.get("/api/shooters/me/stages/1/videos/deadbeef0000/peaks")
     assert resp.status_code == 404
 
 
@@ -1705,7 +1705,7 @@ def test_peaks_endpoint_falls_back_to_full_when_no_trim(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", fake_ensure)
 
-    resp = client.get("/api/stages/1/peaks?bins=64")
+    resp = client.get("/api/shooters/me/stages/1/peaks?bins=64")
     assert resp.status_code == 200
     body = resp.json()
     assert body["trimmed"] is False
@@ -1729,7 +1729,7 @@ def test_stream_video_serves_trimmed_for_primary(tmp_path: Path) -> None:
     _full, _audit, trimmed_mp4 = _primary_cache_paths(project_root)
     trimmed_mp4.write_bytes(b"TRIMMED_MP4")
 
-    resp = client.get(f"/api/videos/stream?path={primary.path}")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={primary.path}")
     assert resp.status_code == 200
     assert resp.content == b"TRIMMED_MP4"
 
@@ -1753,7 +1753,7 @@ def test_stream_video_kind_pins_source_even_when_trim_exists(tmp_path: Path) -> 
     _full, _audit, trimmed_mp4 = _primary_cache_paths(project_root)
     trimmed_mp4.write_bytes(b"TRIMMED_MP4")
 
-    resp = client.get(f"/api/videos/stream?path={primary.path}&kind=source")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={primary.path}&kind=source")
     assert resp.status_code == 200
     assert resp.content == b"SOURCE_MP4"
 
@@ -1771,7 +1771,7 @@ def test_stream_video_kind_trim_404_when_not_built(tmp_path: Path) -> None:
     resolved.parent.mkdir(parents=True, exist_ok=True)
     resolved.write_bytes(b"SOURCE_MP4")
 
-    resp = client.get(f"/api/videos/stream?path={primary.path}&kind=trim")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={primary.path}&kind=trim")
     assert resp.status_code == 404
     assert "trimmed clip not built" in resp.json()["detail"]
 
@@ -1801,7 +1801,7 @@ def test_peaks_endpoint_returns_normalized_bins(tmp_path: Path, monkeypatch) -> 
 
     monkeypatch.setattr(audio_helpers, "ensure_primary_audio", fake_ensure)
 
-    resp = client.get("/api/stages/1/peaks?bins=64")
+    resp = client.get("/api/shooters/me/stages/1/peaks?bins=64")
     assert resp.status_code == 200
     body = resp.json()
     assert body["bins"] == 64
@@ -1819,7 +1819,7 @@ def test_peaks_endpoint_404_when_no_primary(tmp_path: Path) -> None:
     project.init_placeholder_stages(2)
     project.save(project_root)
 
-    resp = client.get("/api/stages/1/peaks")
+    resp = client.get("/api/shooters/me/stages/1/peaks")
     assert resp.status_code == 404
     assert "no primary" in resp.json()["detail"]
 
@@ -1864,11 +1864,11 @@ def test_detect_beep_auto_trims(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(trim, "trim_video", fake_trim_video)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
-    project_after = client.get("/api/project").json()
+    project_after = client.get("/api/shooters/me/project").json()
     assert project_after["stages"][0]["videos"][0]["beep_time"] == pytest.approx(6.5)
     assert project_after["stages"][0]["videos"][0]["processed"]["trim"] is True
     _full, _audit, expected_trim = _primary_cache_paths(project_root)
@@ -1915,10 +1915,10 @@ def test_detect_beep_high_confidence_auto_trusts_into_beep_reviewed(
     )
     Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     _wait_for_job(client, resp.json()["id"])
-    primary_after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary_after = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary_after["beep_confidence"] == pytest.approx(0.96)
     assert primary_after["beep_reviewed"] is True
 
@@ -1957,14 +1957,14 @@ def test_detect_beep_low_confidence_leaves_beep_for_hitl(tmp_path: Path, monkeyp
     )
     Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     _wait_for_job(client, resp.json()["id"])
-    primary_after = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary_after = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary_after["beep_confidence"] == pytest.approx(0.45)
     assert primary_after["beep_reviewed"] is False
     # And it should now show up in the HITL queue.
-    queue = client.get("/api/hitl-queue").json()
+    queue = client.get("/api/shooters/me/hitl-queue").json()
     assert len(queue["items"]) == 1
     assert queue["items"][0]["kind"] == "beep_low_confidence"
 
@@ -2001,11 +2001,11 @@ def test_detect_beep_skips_trim_when_stage_time_zero(tmp_path: Path, monkeypatch
     called = []
     monkeypatch.setattr(trim, "trim_video", lambda **kw: called.append(kw))
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
-    project_after = client.get("/api/project").json()
+    project_after = client.get("/api/shooters/me/project").json()
     assert project_after["stages"][0]["videos"][0]["beep_time"] == pytest.approx(4.0)
     assert project_after["stages"][0]["videos"][0]["processed"]["trim"] is False
     assert called == []
@@ -2032,11 +2032,11 @@ def test_post_trim_endpoint_produces_clip(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(trim, "trim_video", fake_trim_video)
 
-    resp = client.post("/api/stages/1/trim")
+    resp = client.post("/api/shooters/me/stages/1/trim")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
-    project_after = client.get("/api/project").json()
+    project_after = client.get("/api/shooters/me/project").json()
     assert project_after["stages"][0]["videos"][0]["processed"]["trim"] is True
     _full, _audit, expected_trim = _primary_cache_paths(project_root)
     assert expected_trim.exists()
@@ -2070,20 +2070,20 @@ def test_trim_invalidates_when_beep_changes(tmp_path: Path, monkeypatch) -> None
     monkeypatch.setattr(trim, "trim_video", fake_trim_video)
 
     # Run #1: cold cache, ffmpeg fires.
-    resp = client.post("/api/stages/1/trim")
+    resp = client.post("/api/shooters/me/stages/1/trim")
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded"
     assert len(invocations) == 1
 
     # Run #2: same params -> cache hit, ffmpeg does NOT fire again.
-    resp = client.post("/api/stages/1/trim")
+    resp = client.post("/api/shooters/me/stages/1/trim")
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded"
     assert len(invocations) == 1, "second run should be a cache hit"
 
     # Change beep_time via manual override. override_beep clears the trim
     # cache and auto-fires a re-trim job; we wait for it to finish.
-    resp = client.post("/api/stages/1/beep", json={"beep_time": 7.5})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 7.5})
     assert resp.status_code == 200
     # The auto-fired job is the active trim job.
     jobs = client.get("/api/me/jobs").json()
@@ -2123,7 +2123,7 @@ def test_trim_partial_filename_keeps_mp4_extension(tmp_path: Path, monkeypatch) 
 
     monkeypatch.setattr(trim, "trim_video", fake_trim_video)
 
-    resp = client.post("/api/stages/1/trim")
+    resp = client.post("/api/shooters/me/stages/1/trim")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
@@ -2168,8 +2168,8 @@ def test_trim_endpoint_returns_existing_job_when_one_is_running(
 
     monkeypatch.setattr(trim, "trim_video", slow_trim)
 
-    first = client.post("/api/stages/1/trim").json()
-    second = client.post("/api/stages/1/trim").json()
+    first = client.post("/api/shooters/me/stages/1/trim").json()
+    second = client.post("/api/shooters/me/stages/1/trim").json()
     assert first["id"] == second["id"], "second submit should return the same job"
     proceed.set()
     final = _wait_for_job(client, first["id"])
@@ -2221,7 +2221,7 @@ def test_cancel_endpoint_aborts_running_trim(tmp_path: Path, monkeypatch) -> Non
 
     monkeypatch.setattr(trim, "trim_video", slow_trim)
 
-    job = client.post("/api/stages/1/trim").json()
+    job = client.post("/api/shooters/me/stages/1/trim").json()
     assert started.wait(timeout=3.0), "worker should have started by now"
 
     cancel_resp = client.post(f"/api/me/jobs/{job['id']}/cancel")
@@ -2319,7 +2319,7 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     )
     monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", lambda *a, **kw: fake_result)
 
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
@@ -2343,7 +2343,7 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     assert shots[0]["source"] == "detected"
     assert shots[0]["ensemble_votes"] == 3
     # processed.shot_detect flips on the primary so the SPA can show status.
-    proj_after = client.get("/api/project").json()
+    proj_after = client.get("/api/shooters/me/project").json()
     assert proj_after["stages"][0]["videos"][0]["processed"]["shot_detect"] is True
 
 
@@ -2394,7 +2394,7 @@ def test_shot_detect_endpoint_ensures_trim_before_detection(tmp_path: Path, monk
         lambda *a, **kw: _fake_ensemble_result([]),
     )
 
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
@@ -2408,7 +2408,7 @@ def test_shot_detect_endpoint_ensures_trim_before_detection(tmp_path: Path, monk
     assert stage_t == pytest.approx(10.0)
 
     # processed.trim flips on the primary so the SPA reflects the rebuilt cache.
-    proj_after = client.get("/api/project").json()
+    proj_after = client.get("/api/shooters/me/project").json()
     assert proj_after["stages"][0]["videos"][0]["processed"].get("trim") is True
 
 
@@ -2462,7 +2462,7 @@ def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
 
     monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", _fake_detect)
 
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 200
     _wait_for_job(client, resp.json()["id"])
     assert captured.get("camera_class") == "handheld"
@@ -2515,7 +2515,7 @@ def test_shot_detect_endpoint_passes_default_class_when_mount_missing(
 
     monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", _fake_detect)
 
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 200
     _wait_for_job(client, resp.json()["id"])
     # ``camera_class_from_mount(None)`` -> ``headcam`` (the default class).
@@ -2591,7 +2591,7 @@ def test_shot_detect_all_endpoint_submits_per_eligible_stage(tmp_path: Path, mon
         lambda *a, **kw: _fake_ensemble_result([]),
     )
 
-    resp = client.post("/api/stages/shot-detect")
+    resp = client.post("/api/shooters/me/stages/shot-detect")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     submitted = sorted(j["stage_number"] for j in body["jobs"])
@@ -2658,7 +2658,7 @@ def test_shot_detect_endpoint_writes_stage_rounds_into_audit_json(
 
     monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", _fake_detect)
 
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 200
     _wait_for_job(client, resp.json()["id"])
 
@@ -2679,17 +2679,17 @@ def test_camera_mount_patch_endpoint_round_trips(tmp_path: Path) -> None:
     video_id = primary.video_id
 
     # Override.
-    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": "hand"})
+    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": "hand"})
     assert resp.status_code == 200, resp.text
     refreshed = MatchProject.load(project_root)
     assert refreshed.stages[0].primary().camera_mount == "hand"
 
     # Bad value rejected.
-    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": "shoulder"})
+    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": "shoulder"})
     assert resp.status_code == 400, resp.text
 
     # Clear back to None.
-    resp = client.patch(f"/api/stages/1/videos/{video_id}/camera-mount", json={"mount": None})
+    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": None})
     assert resp.status_code == 200
     refreshed = MatchProject.load(project_root)
     assert refreshed.stages[0].primary().camera_mount is None
@@ -2705,7 +2705,7 @@ def test_camera_model_patch_endpoint_round_trips(tmp_path: Path) -> None:
     video_id = primary.video_id
 
     resp = client.patch(
-        f"/api/stages/1/videos/{video_id}/camera-model",
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-model",
         json={"make": "Meta", "model": "Vanguard"},
     )
     assert resp.status_code == 200, resp.text
@@ -2716,7 +2716,7 @@ def test_camera_model_patch_endpoint_round_trips(tmp_path: Path) -> None:
 
     # Clear back to None on both fields.
     resp = client.patch(
-        f"/api/stages/1/videos/{video_id}/camera-model",
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-model",
         json={"make": None, "model": None},
     )
     assert resp.status_code == 200, resp.text
@@ -2736,14 +2736,14 @@ def test_camera_model_patch_rejects_half_filled_pair(tmp_path: Path) -> None:
     video_id = primary.video_id
 
     resp = client.patch(
-        f"/api/stages/1/videos/{video_id}/camera-model",
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-model",
         json={"make": "Meta", "model": None},
     )
     assert resp.status_code == 400, resp.text
     assert "supplied together" in resp.json()["detail"]
 
     resp = client.patch(
-        f"/api/stages/1/videos/{video_id}/camera-model",
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-model",
         json={"make": None, "model": "Vanguard"},
     )
     assert resp.status_code == 400, resp.text
@@ -2777,7 +2777,7 @@ def test_shot_detect_endpoint_400_when_no_beep(tmp_path: Path) -> None:
     project = MatchProject.load(project_root)
     project.stages[0].time_seconds = 10.0
     project.save(project_root)
-    resp = client.post("/api/stages/1/shot-detect")
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
     assert resp.status_code == 400
     assert "beep_time" in resp.json()["detail"]
 
@@ -2826,8 +2826,8 @@ def test_shot_detect_endpoint_dedupes_active_jobs(tmp_path: Path, monkeypatch) -
 
     monkeypatch.setattr(ensemble_module, "detect_shots_ensemble", slow_detect)
 
-    first = client.post("/api/stages/1/shot-detect").json()
-    second = client.post("/api/stages/1/shot-detect").json()
+    first = client.post("/api/shooters/me/stages/1/shot-detect").json()
+    second = client.post("/api/shooters/me/stages/1/shot-detect").json()
     assert first["id"] == second["id"]
     proceed.set()
     final = _wait_for_job(client, first["id"])
@@ -2869,7 +2869,7 @@ def test_jobs_endpoints_list_and_get(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(trim, "trim_video", fake_trim)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     job_id = resp.json()["id"]
     final = _wait_for_job(client, job_id)
@@ -2900,7 +2900,7 @@ def test_detect_beep_job_records_failure_when_ffmpeg_blows_up(tmp_path: Path, mo
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
     monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "failed"
@@ -2921,7 +2921,7 @@ def test_acknowledge_endpoint_marks_failed_job_as_seen(tmp_path: Path, monkeypat
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
     monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
 
-    submit = client.post("/api/stages/1/detect-beep")
+    submit = client.post("/api/shooters/me/stages/1/detect-beep")
     assert submit.status_code == 200
     job_id = submit.json()["id"]
     final = _wait_for_job(client, job_id)
@@ -2969,7 +2969,7 @@ def test_acknowledge_endpoint_noop_for_succeeded_job(tmp_path: Path, monkeypatch
     monkeypatch.setattr(beep_detect, "load_audio", lambda p: ([0.0] * 100, 48_000))
     monkeypatch.setattr(beep_detect, "detect_beep", lambda *a, **kw: FakeBeep())
 
-    submit = client.post("/api/stages/1/detect-beep")
+    submit = client.post("/api/shooters/me/stages/1/detect-beep")
     job_id = submit.json()["id"]
     assert _wait_for_job(client, job_id)["status"] == "succeeded"
     resp = client.post(f"/api/me/jobs/{job_id}/acknowledge")
@@ -2992,7 +2992,7 @@ def test_acknowledge_failures_bulk_endpoint(tmp_path: Path, monkeypatch) -> None
 
     ids: list[str] = []
     for _ in range(2):
-        submit = client.post("/api/stages/1/detect-beep")
+        submit = client.post("/api/shooters/me/stages/1/detect-beep")
         jid = submit.json()["id"]
         assert _wait_for_job(client, jid)["status"] == "failed"
         ids.append(jid)
@@ -3017,7 +3017,7 @@ def test_post_trim_400_when_no_beep(tmp_path: Path) -> None:
     project = MatchProject.load(project_root)
     project.stages[0].time_seconds = 10.0
     project.save(project_root)
-    resp = client.post("/api/stages/1/trim")
+    resp = client.post("/api/shooters/me/stages/1/trim")
     assert resp.status_code == 400
     assert "beep_time" in resp.json()["detail"]
 
@@ -3038,7 +3038,7 @@ def test_get_stage_audit_returns_payload_when_file_exists(tmp_path: Path) -> Non
     }
     (audit_dir / "stage1.json").write_text(json.dumps(payload), encoding="utf-8")
 
-    resp = client.get("/api/stages/1/audit")
+    resp = client.get("/api/shooters/me/stages/1/audit")
     assert resp.status_code == 200
     assert resp.json()["shots"][0]["candidate_number"] == 4
 
@@ -3046,14 +3046,14 @@ def test_get_stage_audit_returns_payload_when_file_exists(tmp_path: Path) -> Non
 def test_get_stage_audit_404_when_missing(tmp_path: Path) -> None:
     """No audit JSON yet -> 404. The SPA treats this as 'start fresh'."""
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/stages/1/audit")
+    resp = client.get("/api/shooters/me/stages/1/audit")
     assert resp.status_code == 404
     assert "no audit" in resp.json()["detail"]
 
 
 def test_get_stage_audit_404_when_stage_unknown(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/stages/99/audit")
+    resp = client.get("/api/shooters/me/stages/99/audit")
     assert resp.status_code == 404
 
 
@@ -3077,7 +3077,7 @@ def test_put_stage_audit_writes_payload_and_returns_it(tmp_path: Path) -> None:
             {"ts": "2026-05-02T12:00:00Z", "kind": "marker_kept", "payload": {"id": "cand-4"}}
         ],
     }
-    resp = client.put("/api/stages/1/audit", json=payload)
+    resp = client.put("/api/shooters/me/stages/1/audit", json=payload)
     assert resp.status_code == 200
     body = resp.json()
     assert body["shots"][0]["candidate_number"] == 4
@@ -3095,8 +3095,8 @@ def test_put_stage_audit_keeps_previous_version_as_bak(tmp_path: Path) -> None:
     second = {"stage_number": 1, "shots": [{"shot_number": 1, "time": 1.5}]}
     audit_path = tmp_path / "match" / "audit"
 
-    assert client.put("/api/stages/1/audit", json=first).status_code == 200
-    assert client.put("/api/stages/1/audit", json=second).status_code == 200
+    assert client.put("/api/shooters/me/stages/1/audit", json=first).status_code == 200
+    assert client.put("/api/shooters/me/stages/1/audit", json=second).status_code == 200
 
     import json as _json
 
@@ -3108,7 +3108,7 @@ def test_put_stage_audit_keeps_previous_version_as_bak(tmp_path: Path) -> None:
 
 def test_put_stage_audit_404_when_stage_unknown(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.put("/api/stages/99/audit", json={"stage_number": 99, "shots": []})
+    resp = client.put("/api/shooters/me/stages/99/audit", json={"stage_number": 99, "shots": []})
     assert resp.status_code == 404
 
 
@@ -3119,7 +3119,7 @@ def test_get_stage_anomalies_empty_when_no_audit_file(tmp_path: Path) -> None:
     useful to flag, so the panel renders the "looks clean" empty state.
     """
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/stages/1/anomalies")
+    resp = client.get("/api/shooters/me/stages/1/anomalies")
     assert resp.status_code == 200
     assert resp.json() == {"anomalies": []}
 
@@ -3146,7 +3146,7 @@ def test_get_stage_anomalies_flags_double_detection_with_shot_number(
     }
     (audit_dir / "stage1.json").write_text(_json.dumps(payload), encoding="utf-8")
 
-    resp = client.get("/api/stages/1/anomalies")
+    resp = client.get("/api/shooters/me/stages/1/anomalies")
     assert resp.status_code == 200
     anomalies = resp.json()["anomalies"]
     kinds = {a["kind"] for a in anomalies}
@@ -3159,7 +3159,7 @@ def test_get_stage_anomalies_flags_double_detection_with_shot_number(
 
 def test_get_stage_anomalies_404_when_stage_unknown(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/stages/99/anomalies")
+    resp = client.get("/api/shooters/me/stages/99/anomalies")
     assert resp.status_code == 404
 
 
@@ -3271,7 +3271,7 @@ def test_stream_video_serves_registered_file(tmp_path: Path) -> None:
     resolved.parent.mkdir(parents=True, exist_ok=True)
     resolved.write_bytes(b"FAKE_MP4_BYTES")
 
-    resp = client.get(f"/api/videos/stream?path={primary.path}")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={primary.path}")
     assert resp.status_code == 200
     assert resp.content == b"FAKE_MP4_BYTES"
     assert resp.headers["content-type"].startswith("video/")
@@ -3282,7 +3282,7 @@ def test_stream_video_404_on_unregistered_path(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     secret = tmp_path / "secret.mp4"
     secret.write_bytes(b"SECRET")
-    resp = client.get(f"/api/videos/stream?path={secret}")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={secret}")
     assert resp.status_code == 404
     assert "not registered" in resp.json()["detail"]
 
@@ -3300,7 +3300,7 @@ def test_stream_video_424_when_target_missing(tmp_path: Path) -> None:
     resolved = project.resolve_video_path(tmp_path / "match", primary.path).resolve()
     if resolved.exists() or resolved.is_symlink():
         resolved.unlink()
-    resp = client.get(f"/api/videos/stream?path={primary.path}")
+    resp = client.get(f"/api/shooters/me/videos/stream?path={primary.path}")
     assert resp.status_code == 424
     body = resp.json()
     assert body["detail"]["code"] == "source_unreachable"
@@ -3309,8 +3309,8 @@ def test_stream_video_424_when_target_missing(tmp_path: Path) -> None:
 
 def test_peaks_endpoint_rejects_extreme_bins(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    assert client.get("/api/stages/1/peaks?bins=8").status_code == 422
-    assert client.get("/api/stages/1/peaks?bins=999999").status_code == 422
+    assert client.get("/api/shooters/me/stages/1/peaks?bins=8").status_code == 422
+    assert client.get("/api/shooters/me/stages/1/peaks?bins=999999").status_code == 422
 
 
 def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
@@ -3336,7 +3336,7 @@ def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
 
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
@@ -3347,7 +3347,7 @@ def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
         f.write_bytes(b"")
 
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={
             "source_paths": [str(keep1), str(keep2)],
             "auto_assign_primary": False,
@@ -3356,7 +3356,7 @@ def test_scan_videos_with_explicit_source_paths(tmp_path: Path) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert sorted(body["registered"]) == ["raw/keep1.mp4", "raw/keep2.mp4"]
-    project = client.get("/api/project").json()
+    project = client.get("/api/shooters/me/project").json()
     assert len(project["unassigned_videos"]) == 2
     # last_scanned_dir set to the parent of the first picked file.
     assert project["last_scanned_dir"] == str(src_dir.resolve())
@@ -3381,7 +3381,7 @@ def test_scan_videos_walks_subdirectories(tmp_path: Path) -> None:
     (src_dir / "notes.txt").write_text("hi")
 
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
     assert resp.status_code == 200
@@ -3392,7 +3392,7 @@ def test_scan_videos_walks_subdirectories(tmp_path: Path) -> None:
 def test_scan_400_when_neither_source_dir_nor_paths(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.post("/api/videos/scan", json={"auto_assign_primary": False})
+    resp = client.post("/api/shooters/me/videos/scan", json={"auto_assign_primary": False})
     assert resp.status_code == 400
 
 
@@ -3400,7 +3400,7 @@ def test_scan_400_when_both_source_dir_and_paths(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(tmp_path), "source_paths": [str(tmp_path / "a.mp4")]},
     )
     assert resp.status_code == 400
@@ -3410,7 +3410,7 @@ def test_settings_endpoint_persists_overrides(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={
             "audio_dir": str(tmp_path / "scratch" / "audio"),
             "trimmed_dir": str(tmp_path / "scratch" / "trimmed"),
@@ -3432,10 +3432,10 @@ def test_settings_empty_string_clears_override(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={"audio_dir": str(tmp_path / "audio-config")},
     )
-    body = client.post("/api/project/settings", json={"audio_dir": ""}).json()
+    body = client.post("/api/shooters/me/project/settings", json={"audio_dir": ""}).json()
     assert body["audio_dir"] is None
 
 
@@ -3453,7 +3453,7 @@ def test_settings_409_when_old_dir_non_empty(tmp_path: Path) -> None:
 
     new_audio = tmp_path / "scratch-audio"
     resp = client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={"audio_dir": str(new_audio)},
     )
     assert resp.status_code == 409
@@ -3468,7 +3468,7 @@ def test_settings_409_when_old_dir_non_empty(tmp_path: Path) -> None:
 
     # With confirm=true the change goes through, leaving old files behind.
     resp = client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={"audio_dir": str(new_audio), "confirm": True},
     )
     assert resp.status_code == 200
@@ -3483,7 +3483,7 @@ def test_settings_no_warning_when_old_dir_empty(tmp_path: Path) -> None:
     client = TestClient(app)
     # Default <project>/audio doesn't even exist yet.
     resp = client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={"audio_dir": str(tmp_path / "elsewhere")},
     )
     assert resp.status_code == 200
@@ -3502,7 +3502,7 @@ def test_remove_video_unassigned(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_paths": [str(src)], "auto_assign_primary": False},
     )
     assert resp.status_code == 200
@@ -3510,7 +3510,7 @@ def test_remove_video_unassigned(tmp_path: Path) -> None:
     raw_link = root / "raw" / "clip.mp4"
     assert raw_link.is_symlink()
 
-    resp = client.post("/api/videos/remove", json={"video_path": registered_path})
+    resp = client.post("/api/shooters/me/videos/remove", json={"video_path": registered_path})
     assert resp.status_code == 200
     body = resp.json()
     assert body["plan"]["was_primary"] is False
@@ -3545,9 +3545,9 @@ def test_remove_primary_clears_caches_and_keeps_audit(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_paths": [str(src)], "auto_assign_primary": False},
     )
     project = MatchProject.load(root)
@@ -3570,7 +3570,7 @@ def test_remove_primary_clears_caches_and_keeps_audit(tmp_path: Path) -> None:
     project.save(root)
 
     resp = client.post(
-        "/api/videos/remove",
+        "/api/shooters/me/videos/remove",
         json={"video_path": "raw/clip.mp4"},
     )
     assert resp.status_code == 200
@@ -3608,9 +3608,9 @@ def test_remove_primary_with_reset_audit_clears_audit(tmp_path: Path) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_paths": [str(src)], "auto_assign_primary": False},
     )
     project = MatchProject.load(root)
@@ -3621,7 +3621,7 @@ def test_remove_primary_with_reset_audit_clears_audit(tmp_path: Path) -> None:
     audit.write_text("{}")
 
     resp = client.post(
-        "/api/videos/remove",
+        "/api/shooters/me/videos/remove",
         json={"video_path": "raw/clip.mp4", "reset_audit": True},
     )
     assert resp.status_code == 200
@@ -3633,7 +3633,7 @@ def test_remove_video_404_when_unknown(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
     resp = client.post(
-        "/api/videos/remove",
+        "/api/shooters/me/videos/remove",
         json={"video_path": "raw/no-such.mp4"},
     )
     assert resp.status_code == 404
@@ -3666,14 +3666,14 @@ def test_fs_list_probe_populates_duration_and_thumbnail(tmp_path: Path) -> None:
         patch("splitsmith.ui.server.video_probe.probe", side_effect=_fake_probe),
         patch("splitsmith.ui.server.thumbnail_helpers.ensure", side_effect=_fake_thumb),
     ):
-        resp = client.get(f"/api/fs/list?path={folder}&probe=true")
+        resp = client.get(f"/api/shooters/me/fs/list?path={folder}&probe=true")
 
     assert resp.status_code == 200
     body = resp.json()
     [entry] = body["entries"]
     assert entry["kind"] == "video"
     assert entry["duration"] == 12.5
-    assert entry["thumbnail_url"].startswith("/api/thumbnails/")
+    assert entry["thumbnail_url"].startswith("/api/shooters/me/thumbnails/")
 
 
 def test_fs_probe_endpoint_runs_on_demand(tmp_path: Path) -> None:
@@ -3700,12 +3700,12 @@ def test_fs_probe_endpoint_runs_on_demand(tmp_path: Path) -> None:
         patch("splitsmith.ui.server.video_probe.probe", side_effect=_fake_probe),
         patch("splitsmith.ui.server.thumbnail_helpers.ensure", side_effect=_fake_thumb),
     ):
-        resp = client.get(f"/api/fs/probe?path={clip}")
+        resp = client.get(f"/api/shooters/me/fs/probe?path={clip}")
 
     assert resp.status_code == 200
     body = resp.json()
     assert body["duration"] == 8.0
-    assert body["thumbnail_url"].startswith("/api/thumbnails/")
+    assert body["thumbnail_url"].startswith("/api/shooters/me/thumbnails/")
 
 
 def test_videos_reveal_runs_on_registered_path(tmp_path: Path) -> None:
@@ -3722,7 +3722,7 @@ def test_videos_reveal_runs_on_registered_path(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="x")
     client = TestClient(app)
 
-    scan = client.post("/api/videos/scan", json={"source_paths": [str(src)]})
+    scan = client.post("/api/shooters/me/videos/scan", json={"source_paths": [str(src)]})
     assert scan.status_code == 200, scan.text
 
     calls: list[list[str]] = []
@@ -3736,7 +3736,7 @@ def test_videos_reveal_runs_on_registered_path(tmp_path: Path) -> None:
         return _R()
 
     with patch("splitsmith.ui.server.subprocess.run", side_effect=_fake_run):
-        resp = client.post("/api/videos/reveal", json={"path": "raw/VID.mp4"})
+        resp = client.post("/api/shooters/me/videos/reveal", json={"path": "raw/VID.mp4"})
 
     assert resp.status_code == 200, resp.text
     assert resp.json()["revealed"].endswith("VID.mp4")
@@ -3752,7 +3752,7 @@ def test_videos_reveal_404_on_unregistered_path(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="x")
     client = TestClient(app)
 
-    resp = client.post("/api/videos/reveal", json={"path": "raw/missing.mp4"})
+    resp = client.post("/api/shooters/me/videos/reveal", json={"path": "raw/missing.mp4"})
     assert resp.status_code == 404
 
 
@@ -3784,7 +3784,7 @@ def test_fs_probe_resolves_project_relative_paths(tmp_path: Path) -> None:
         patch("splitsmith.ui.server.video_probe.probe", side_effect=_fake_probe),
         patch("splitsmith.ui.server.thumbnail_helpers.ensure", side_effect=_fake_thumb),
     ):
-        resp = client.get("/api/fs/probe?path=raw/clip.mp4")
+        resp = client.get("/api/shooters/me/fs/probe?path=raw/clip.mp4")
 
     assert resp.status_code == 200
     assert resp.json()["duration"] == 4.0
@@ -3799,11 +3799,11 @@ def test_thumbnail_endpoint_serves_cached(tmp_path: Path) -> None:
     thumbs_dir.mkdir(parents=True, exist_ok=True)
     (thumbs_dir / "abc123.jpg").write_bytes(b"\xff\xd8\xff jpeg")
 
-    resp = client.get("/api/thumbnails/abc123.jpg")
+    resp = client.get("/api/shooters/me/thumbnails/abc123.jpg")
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("image/jpeg")
 
-    resp_404 = client.get("/api/thumbnails/missing.jpg")
+    resp_404 = client.get("/api/shooters/me/thumbnails/missing.jpg")
     assert resp_404.status_code == 404
 
 
@@ -3812,7 +3812,7 @@ def test_thumbnail_endpoint_rejects_path_traversal(tmp_path: Path) -> None:
     client = TestClient(app)
     # Slashes in the path component aren't possible thanks to FastAPI's
     # path matcher, but '..' as a key should be rejected by our shape check.
-    resp = client.get("/api/thumbnails/..jpg")
+    resp = client.get("/api/shooters/me/thumbnails/..jpg")
     assert resp.status_code == 400
 
 
@@ -3837,7 +3837,7 @@ def test_fs_list_probe_skipped_when_falsy(tmp_path: Path) -> None:
             side_effect=AssertionError("thumb must not run"),
         ),
     ):
-        resp = client.get(f"/api/fs/list?path={folder}")
+        resp = client.get(f"/api/shooters/me/fs/list?path={folder}")
 
     assert resp.status_code == 200
     [entry] = resp.json()["entries"]
@@ -3865,7 +3865,7 @@ def test_fs_list_probe_failure_swallowed(tmp_path: Path) -> None:
             side_effect=ThumbnailError("thumb fails too"),
         ),
     ):
-        resp = client.get(f"/api/fs/list?path={folder}&probe=true")
+        resp = client.get(f"/api/shooters/me/fs/list?path={folder}&probe=true")
 
     assert resp.status_code == 200
     [entry] = resp.json()["entries"]
@@ -3879,13 +3879,13 @@ def test_external_edit_visible_without_restart(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="External Edit Match")
     client = TestClient(app)
 
-    assert client.get("/api/project").json()["competitor_name"] is None
+    assert client.get("/api/shooters/me/project").json()["competitor_name"] is None
 
     project = MatchProject.load(root)
     project.competitor_name = "Edited Externally"
     project.save(root)
 
-    assert client.get("/api/project").json()["competitor_name"] == "Edited Externally"
+    assert client.get("/api/shooters/me/project").json()["competitor_name"] == "Edited Externally"
 
 
 # Per-video beep endpoints (multi-cam ingest) -------------------------------
@@ -3902,11 +3902,11 @@ def _seed_project_with_secondary(tmp_path: Path) -> tuple[TestClient, Path]:
     cam2 = src_dir / "CAM2.mp4"
     cam2.write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/CAM2.mp4", "to_stage_number": 1, "role": "secondary"},
     )
     return client, cam2
@@ -3914,7 +3914,7 @@ def _seed_project_with_secondary(tmp_path: Path) -> tuple[TestClient, Path]:
 
 def _video_id_for(client: TestClient, stage_number: int, role: str) -> str:
     """Pull the ``video_id`` for the first video matching ``role`` on a stage."""
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     stage = next(s for s in proj["stages"] if s["stage_number"] == stage_number)
     video = next(v for v in stage["videos"] if v["role"] == role)
     return video["video_id"]
@@ -3923,8 +3923,8 @@ def _video_id_for(client: TestClient, stage_number: int, role: str) -> str:
 def test_video_id_is_stable_and_exposed(tmp_path: Path) -> None:
     """The computed ``video_id`` is on the wire and identical across reloads."""
     client, _ = _seed_project_with_primary(tmp_path)
-    proj1 = client.get("/api/project").json()
-    proj2 = client.get("/api/project").json()
+    proj1 = client.get("/api/shooters/me/project").json()
+    proj2 = client.get("/api/shooters/me/project").json()
     vid1 = proj1["stages"][0]["videos"][0]["video_id"]
     vid2 = proj2["stages"][0]["videos"][0]["video_id"]
     assert vid1 == vid2
@@ -3939,14 +3939,14 @@ def test_per_video_detect_beep_runs_on_secondary(tmp_path: Path, monkeypatch) ->
     _stub_detect(monkeypatch, beep_time=7.250)
 
     sec_id = _video_id_for(client, 1, "secondary")
-    resp = client.post(f"/api/stages/1/videos/{sec_id}/detect-beep")
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep")
     assert resp.status_code == 200
     job = resp.json()
     assert job["video_id"] == sec_id
     final = _wait_for_job(client, job["id"])
     assert final["status"] == "succeeded", final
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     primary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "primary")
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert primary["beep_time"] is None  # primary untouched
@@ -3974,12 +3974,12 @@ def test_secondary_beep_not_found_soft_fails(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
 
     sec_id = _video_id_for(client, 1, "secondary")
-    resp = client.post(f"/api/stages/1/videos/{sec_id}/detect-beep")
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "succeeded", final
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] is None
     assert secondary["beep_source"] == "auto"
@@ -4002,7 +4002,7 @@ def test_primary_beep_not_found_still_fails_job(tmp_path: Path, monkeypatch) -> 
     monkeypatch.setattr(audio_helpers, "detect_primary_beep", boom)
     monkeypatch.setattr(audio_helpers, "detect_video_beep", boom)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     final = _wait_for_job(client, resp.json()["id"])
     assert final["status"] == "failed"
@@ -4026,7 +4026,7 @@ def test_secondary_falls_back_to_cross_align(tmp_path: Path, monkeypatch) -> Non
     primary_id = _video_id_for(client, 1, "primary")
     _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()["id"],
     )
 
     # Make the secondary's beep detection raise + the audio paths "exist"
@@ -4057,11 +4057,11 @@ def test_secondary_falls_back_to_cross_align(tmp_path: Path, monkeypatch) -> Non
     sec_id = _video_id_for(client, 1, "secondary")
     final = _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()["id"],
     )
     assert final["status"] == "succeeded", final
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] == pytest.approx(7.250)
     assert secondary["beep_source"] == "aligned"
@@ -4086,7 +4086,7 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     primary_id = _video_id_for(client, 1, "primary")
     _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()["id"],
     )
 
     def boom(*a, **kw):  # type: ignore[no-untyped-def]
@@ -4111,11 +4111,11 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     sec_id = _video_id_for(client, 1, "secondary")
     final = _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()["id"],
     )
     assert final["status"] == "succeeded"
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] is None
     assert secondary["beep_source"] == "auto"
@@ -4141,7 +4141,7 @@ def test_secondary_in_stream_success_runs_cross_align_sanity_check(
     primary_id = _video_id_for(client, 1, "primary")
     _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()["id"],
     )
 
     # Secondary in-stream succeeds at 7.250 s; cross-align lands within
@@ -4167,11 +4167,11 @@ def test_secondary_in_stream_success_runs_cross_align_sanity_check(
     sec_id = _video_id_for(client, 1, "secondary")
     final = _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()["id"],
     )
     assert final["status"] == "succeeded"
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] == pytest.approx(7.250)
     assert secondary["beep_source"] == "auto"
@@ -4196,7 +4196,7 @@ def test_secondary_in_stream_disagreement_flagged_not_overridden(
     primary_id = _video_id_for(client, 1, "primary")
     _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()["id"],
     )
 
     _stub_detect(monkeypatch, beep_time=10.000)
@@ -4219,11 +4219,11 @@ def test_secondary_in_stream_disagreement_flagged_not_overridden(
     sec_id = _video_id_for(client, 1, "secondary")
     final = _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()["id"],
     )
     assert final["status"] == "succeeded"
 
-    proj = client.get("/api/project").json()
+    proj = client.get("/api/shooters/me/project").json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     # In-stream wins -- not overridden.
     assert secondary["beep_time"] == pytest.approx(10.000)
@@ -4247,11 +4247,11 @@ def test_secondary_soft_fail_clears_on_manual_override(tmp_path: Path, monkeypat
     sec_id = _video_id_for(client, 1, "secondary")
     final = _wait_for_job(
         client,
-        client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()["id"],
+        client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()["id"],
     )
     assert final["status"] == "succeeded"
 
-    proj = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": 2.5}).json()
+    proj = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": 2.5}).json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] == pytest.approx(2.5)
     assert secondary["beep_source"] == "manual"
@@ -4271,9 +4271,9 @@ def test_per_video_detect_beep_dedupes_per_video(tmp_path: Path, monkeypatch) ->
 
     primary_id = _video_id_for(client, 1, "primary")
     sec_id = _video_id_for(client, 1, "secondary")
-    j1 = client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()
-    j2 = client.post(f"/api/stages/1/videos/{primary_id}/detect-beep").json()
-    j3 = client.post(f"/api/stages/1/videos/{sec_id}/detect-beep").json()
+    j1 = client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()
+    j2 = client.post(f"/api/shooters/me/stages/1/videos/{primary_id}/detect-beep").json()
+    j3 = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/detect-beep").json()
     assert j1["id"] == j2["id"]  # same video -> same job
     assert j1["id"] != j3["id"]  # different video -> different job
     gate.set()
@@ -4287,7 +4287,7 @@ def test_per_video_manual_override(tmp_path: Path) -> None:
     client, _ = _seed_project_with_secondary(tmp_path)
     sec_id = _video_id_for(client, 1, "secondary")
 
-    resp = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": 4.5})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": 4.5})
     assert resp.status_code == 200
     proj = resp.json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
@@ -4295,7 +4295,7 @@ def test_per_video_manual_override(tmp_path: Path) -> None:
     assert secondary["beep_source"] == "manual"
 
     # Clear flips back to "no beep yet" and resets processed.beep
-    resp = client.post(f"/api/stages/1/videos/{sec_id}/beep", json={"beep_time": None})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": None})
     assert resp.status_code == 200
     proj = resp.json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
@@ -4310,7 +4310,7 @@ def test_legacy_primary_endpoints_still_work(tmp_path: Path, monkeypatch) -> Non
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
 
-    resp = client.post("/api/stages/1/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/detect-beep")
     assert resp.status_code == 200
     job = resp.json()
     primary_id = _video_id_for(client, 1, "primary")
@@ -4321,7 +4321,7 @@ def test_legacy_primary_endpoints_still_work(tmp_path: Path, monkeypatch) -> Non
 
 def test_per_video_endpoint_404_for_unknown_video_id(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/stages/1/videos/deadbeef0000/detect-beep")
+    resp = client.post("/api/shooters/me/stages/1/videos/deadbeef0000/detect-beep")
     assert resp.status_code == 404
 
 
@@ -4373,18 +4373,18 @@ def test_auto_beep_queued_on_move_to_stage(tmp_path: Path, monkeypatch) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     (src_dir / "VID.mp4").write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
 
     # Move triggers auto-fire.
     resp = client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     assert resp.status_code == 200
@@ -4392,7 +4392,7 @@ def test_auto_beep_queued_on_move_to_stage(tmp_path: Path, monkeypatch) -> None:
     auto_beep_jobs = [j for j in jobs if j["kind"] == "detect_beep"]
     assert len(auto_beep_jobs) == 1
     assert auto_beep_jobs[0]["status"] == "succeeded"
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 8.42
     assert primary["beep_source"] == "auto"
     assert primary["processed"]["beep"] is True
@@ -4425,13 +4425,13 @@ def test_auto_beep_fires_for_secondaries_too(tmp_path: Path, monkeypatch) -> Non
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     (src_dir / "PRIMARY.mp4").write_bytes(b"")
     (src_dir / "SECONDARY.mp4").write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
 
@@ -4440,12 +4440,12 @@ def test_auto_beep_fires_for_secondaries_too(tmp_path: Path, monkeypatch) -> Non
     # writes it back on exit; concurrent saves would clobber each
     # other's ``processed.beep`` flag.
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/PRIMARY.mp4", "to_stage_number": 1, "role": "primary"},
     )
     _wait_for_jobs_to_drain(client)
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={
             "video_path": "raw/SECONDARY.mp4",
             "to_stage_number": 1,
@@ -4453,7 +4453,7 @@ def test_auto_beep_fires_for_secondaries_too(tmp_path: Path, monkeypatch) -> Non
         },
     )
     _wait_for_jobs_to_drain(client)
-    stage = client.get("/api/project").json()["stages"][0]
+    stage = client.get("/api/shooters/me/project").json()["stages"][0]
     assert all(v["processed"]["beep"] for v in stage["videos"])
 
 
@@ -4484,18 +4484,18 @@ def test_auto_beep_skipped_for_unassigned_destination(tmp_path: Path, monkeypatc
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     (src_dir / "VID.mp4").write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
 
     # Move to stage -> auto-beep
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     _wait_for_jobs_to_drain(client)
@@ -4504,7 +4504,7 @@ def test_auto_beep_skipped_for_unassigned_destination(tmp_path: Path, monkeypatc
     # Move back to tray -> no new job (idempotent on already-beeped is
     # also covered: the helper would skip even if we re-assigned).
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": None, "role": "secondary"},
     )
     assert len(client.get("/api/me/jobs").json()) == job_count_after_assign
@@ -4543,18 +4543,18 @@ def test_auto_beep_skipped_when_already_processed(tmp_path: Path, monkeypatch) -
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     (src_dir / "VID.mp4").write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
 
     # First move to stage 1 -> auto-fires.
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     _wait_for_jobs_to_drain(client)
@@ -4562,7 +4562,7 @@ def test_auto_beep_skipped_when_already_processed(tmp_path: Path, monkeypatch) -
 
     # Move to stage 2 -> processed.beep is already True, no new job.
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 2, "role": "primary"},
     )
     assert len(client.get("/api/me/jobs").json()) == jobs_before
@@ -4594,20 +4594,20 @@ def test_auto_beep_disabled_via_env_var(tmp_path: Path, monkeypatch) -> None:
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
     src_dir = tmp_path / "videos"
     src_dir.mkdir()
     (src_dir / "VID.mp4").write_bytes(b"")
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": False},
     )
     client.post(
-        "/api/assignments/move",
+        "/api/shooters/me/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     # No auto job; primary still un-beeped until the user clicks detect.
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["processed"]["beep"] is False
 
 
@@ -4638,7 +4638,7 @@ def test_auto_beep_queued_on_scan_auto_assign(tmp_path: Path, monkeypatch) -> No
             }
         ],
     }
-    client.post("/api/scoreboard/import", json={"data": sb})
+    client.post("/api/shooters/me/scoreboard/import", json={"data": sb})
 
     # Drop a video whose mtime matches the stage's scorecard window so
     # auto_match picks it up.
@@ -4652,11 +4652,11 @@ def test_auto_beep_queued_on_scan_auto_assign(tmp_path: Path, monkeypatch) -> No
     _os.utime(src, (target_mtime, target_mtime))
 
     client.post(
-        "/api/videos/scan",
+        "/api/shooters/me/videos/scan",
         json={"source_dir": str(src_dir), "auto_assign_primary": True},
     )
     _wait_for_jobs_to_drain(client)
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["role"] == "primary"
     assert primary["processed"]["beep"] is True
     assert primary["beep_time"] == 4.5
@@ -4675,10 +4675,10 @@ def test_beep_review_default_false_after_auto_detect(tmp_path: Path, monkeypatch
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
 
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     final = _wait_for_job(client, job["id"])
     assert final["status"] == "succeeded"
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 12.453
     assert primary["beep_source"] == "auto"
     assert primary["beep_reviewed"] is False
@@ -4688,7 +4688,7 @@ def test_beep_review_manual_entry_auto_marks_reviewed(tmp_path: Path) -> None:
     """Manual override implies the user looked at the waveform to type
     the value -- skip the review pill (#71)."""
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/stages/1/beep", json={"beep_time": 12.5})
+    resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 12.5})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_source"] == "manual"
@@ -4700,17 +4700,17 @@ def test_beep_review_endpoint_flips_flag(tmp_path: Path, monkeypatch) -> None:
     detection or trim."""
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job["id"])
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
     assert primary["beep_reviewed"] is False
 
-    resp = client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
     assert resp.status_code == 200
     assert resp.json()["stages"][0]["videos"][0]["beep_reviewed"] is True
 
-    resp = client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": False})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": False})
     assert resp.status_code == 200
     assert resp.json()["stages"][0]["videos"][0]["beep_reviewed"] is False
 
@@ -4720,10 +4720,10 @@ def test_beep_review_400_when_no_beep_yet(tmp_path: Path) -> None:
     server refuses with 400 so the SPA isn't tempted to show a green
     pill on a video with no beep_time."""
     client, _ = _seed_project_with_primary(tmp_path)
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
 
-    resp = client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
     assert resp.status_code == 400
 
 
@@ -4738,15 +4738,15 @@ def test_beep_review_resets_on_candidate_switch(tmp_path: Path, monkeypatch) -> 
     ]
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453, candidates=candidates)
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job["id"])
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
 
     # User reviews candidate #1.
-    client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
     # Then switches to candidate #2.
-    resp = client.post("/api/stages/1/beep/select", json={"time": 11.000})
+    resp = client.post("/api/shooters/me/stages/1/beep/select", json={"time": 11.000})
     assert resp.status_code == 200
     primary = resp.json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 11.000
@@ -4758,16 +4758,16 @@ def test_beep_review_resets_on_redetect(tmp_path: Path, monkeypatch) -> None:
     carry over."""
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job["id"])
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
-    client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
 
     _stub_detect(monkeypatch, beep_time=10.0)
-    job2 = client.post("/api/stages/1/detect-beep").json()
+    job2 = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job2["id"])
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["beep_time"] == 10.0
     assert primary["beep_reviewed"] is False
 
@@ -4779,7 +4779,7 @@ def test_shot_detect_gated_on_beep_review(tmp_path: Path, monkeypatch) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
 
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job["id"])
 
     # No shot_detect job queued -- the chain stops at trim until the
@@ -4807,16 +4807,16 @@ def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> 
 
     client, _ = _seed_project_with_primary(tmp_path)
     _stub_detect(monkeypatch, beep_time=12.453)
-    job = client.post("/api/stages/1/detect-beep").json()
+    job = client.post("/api/shooters/me/stages/1/detect-beep").json()
     _wait_for_job(client, job["id"])
 
-    primary = client.get("/api/project").json()["stages"][0]["videos"][0]
+    primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     assert primary["processed"]["trim"] is True  # trim cached
     video_id = primary["video_id"]
     jobs_before = client.get("/api/me/jobs").json()
     assert not any(j["kind"] == "shot_detect" for j in jobs_before)
 
-    resp = client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
     assert resp.status_code == 200
     jobs_after = client.get("/api/me/jobs").json()
     assert any(j["kind"] == "shot_detect" for j in jobs_after)
@@ -4896,7 +4896,7 @@ def test_unbound_project_endpoints_return_409_no_project(tmp_path: Path) -> None
     app = create_app()
     client = TestClient(app)
 
-    resp = client.get("/api/project")
+    resp = client.get("/api/shooters/me/project")
     assert resp.status_code == 409
     detail = resp.json()["detail"]
     assert detail["code"] == "no_project"
@@ -4927,7 +4927,7 @@ def test_bind_recent_project_switches_in_memory(tmp_path: Path, _user_config_hom
     assert body["project_name"] == "Alpha"
 
     # Subsequent project endpoints now work.
-    assert client.get("/api/project").status_code == 200
+    assert client.get("/api/shooters/me/project").status_code == 200
 
     # Recent-projects list bumped Alpha to the top.
     recent = user_config.get_recent_projects()
@@ -4993,7 +4993,7 @@ def test_unbind_returns_to_unbound_state(tmp_path: Path, _user_config_home: Path
     resp = client.post("/api/me/recent-projects/unbind")
     assert resp.status_code == 200
     assert resp.json()["bound"] is False
-    assert client.get("/api/project").status_code == 409
+    assert client.get("/api/shooters/me/project").status_code == 409
 
 
 def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5346,7 +5346,7 @@ def test_promote_against_fixture_endpoint_validates_anchor_exists(
     project.save(project_root)
 
     resp = client.post(
-        f"/api/lab/projects/1/videos/{primary.video_id}/promote-against-fixture",
+        f"/api/lab/projects/me/1/videos/{primary.video_id}/promote-against-fixture",
         json={
             "anchor_slug": "stage-shots-does-not-exist-2026-stage1",
             "mount": "hand",
@@ -5433,7 +5433,7 @@ def test_match_export_endpoint_writes_fcpxml(
     _stub_match_export_probe(monkeypatch)
 
     resp = client.post(
-        "/api/match/export",
+        "/api/shooters/me/export/match",
         json={
             "stage_numbers": [1, 2],
             "head_pad_seconds": 0.5,
@@ -5463,7 +5463,7 @@ def test_match_export_endpoint_writes_fcpxml(
 
 def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> None:
     client, _ = _seed_match_export_project(tmp_path, stage_count=1)
-    resp = client.post("/api/match/export", json={"stage_numbers": []})
+    resp = client.post("/api/shooters/me/export/match", json={"stage_numbers": []})
     assert resp.status_code == 400
     assert "stage_numbers cannot be empty" in resp.json()["detail"]
 
@@ -5471,7 +5471,7 @@ def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> Non
 def test_match_export_endpoint_400_on_padding_above_buffer(tmp_path: Path) -> None:
     client, _ = _seed_match_export_project(tmp_path, stage_count=1)
     resp = client.post(
-        "/api/match/export",
+        "/api/shooters/me/export/match",
         json={"stage_numbers": [1], "head_pad_seconds": 99.0},
     )
     assert resp.status_code == 400
@@ -5480,7 +5480,7 @@ def test_match_export_endpoint_400_on_padding_above_buffer(tmp_path: Path) -> No
 
 def test_match_export_endpoint_400_on_unknown_stage(tmp_path: Path) -> None:
     client, _ = _seed_match_export_project(tmp_path, stage_count=1)
-    resp = client.post("/api/match/export", json={"stage_numbers": [99]})
+    resp = client.post("/api/shooters/me/export/match", json={"stage_numbers": [99]})
     assert resp.status_code == 400
     assert "stage 99 not found" in resp.json()["detail"]
 
@@ -5501,7 +5501,7 @@ def test_match_export_endpoint_job_fails_when_trim_unrecoverable(
     # structured 424.
     (project_root / "raw" / "VID1.mp4").unlink()
     resp = client.post(
-        "/api/match/export",
+        "/api/shooters/me/export/match",
         json={"stage_numbers": [1], "include_overlay": False},
     )
     assert resp.status_code == 424
@@ -5537,7 +5537,7 @@ def _seed_cleanup_project(tmp_path: Path) -> tuple[TestClient, Path]:
 
 def test_cleanup_plan_returns_per_category_totals(tmp_path: Path) -> None:
     client, _ = _seed_cleanup_project(tmp_path)
-    resp = client.get("/api/project/cleanup/plan", params={"categories": "audio,exports-overlays"})
+    resp = client.get("/api/shooters/me/project/cleanup/plan", params={"categories": "audio,exports-overlays"})
     assert resp.status_code == 200
     body = resp.json()
     assert body["total_file_count"] == 2
@@ -5549,7 +5549,7 @@ def test_cleanup_plan_returns_per_category_totals(tmp_path: Path) -> None:
 
 def test_cleanup_plan_empty_categories_yields_empty_plan(tmp_path: Path) -> None:
     client, _ = _seed_cleanup_project(tmp_path)
-    resp = client.get("/api/project/cleanup/plan", params={"categories": ""})
+    resp = client.get("/api/shooters/me/project/cleanup/plan", params={"categories": ""})
     assert resp.status_code == 200
     assert resp.json()["total_file_count"] == 0
 
@@ -5557,7 +5557,7 @@ def test_cleanup_plan_empty_categories_yields_empty_plan(tmp_path: Path) -> None
 def test_cleanup_plan_unknown_category_silently_dropped(tmp_path: Path) -> None:
     client, _ = _seed_cleanup_project(tmp_path)
     resp = client.get(
-        "/api/project/cleanup/plan",
+        "/api/shooters/me/project/cleanup/plan",
         params={"categories": "audio,bogus-category"},
     )
     assert resp.status_code == 200
@@ -5567,7 +5567,7 @@ def test_cleanup_plan_unknown_category_silently_dropped(tmp_path: Path) -> None:
 def test_cleanup_apply_deletes_and_returns_result(tmp_path: Path) -> None:
     client, root = _seed_cleanup_project(tmp_path)
     resp = client.post(
-        "/api/project/cleanup",
+        "/api/shooters/me/project/cleanup",
         json={"categories": ["audio", "exports-overlays"]},
     )
     assert resp.status_code == 200
@@ -5582,7 +5582,7 @@ def test_cleanup_apply_deletes_and_returns_result(tmp_path: Path) -> None:
 
 def test_cleanup_apply_audit_data_destructive(tmp_path: Path) -> None:
     client, root = _seed_cleanup_project(tmp_path)
-    resp = client.post("/api/project/cleanup", json={"categories": ["audit-data"]})
+    resp = client.post("/api/shooters/me/project/cleanup", json={"categories": ["audit-data"]})
     assert resp.status_code == 200
     assert not (root / "audit" / "stage1.json").exists()
 
@@ -5607,7 +5607,7 @@ def test_cleanup_apply_refuses_while_jobs_active(tmp_path: Path) -> None:
     assert started.wait(timeout=2.0)
 
     try:
-        resp = client.post("/api/project/cleanup", json={"categories": ["audio"]})
+        resp = client.post("/api/shooters/me/project/cleanup", json={"categories": ["audio"]})
         assert resp.status_code == 409
         detail = resp.json()["detail"]
         assert detail["code"] == "jobs_active"
@@ -5626,7 +5626,7 @@ def test_cleanup_apply_refuses_while_jobs_active(tmp_path: Path) -> None:
         _time.sleep(0.02)
 
     # And once the job finishes, the endpoint goes through.
-    resp = client.post("/api/project/cleanup", json={"categories": ["audio"]})
+    resp = client.post("/api/shooters/me/project/cleanup", json={"categories": ["audio"]})
     assert resp.status_code == 200
 
 
@@ -5634,8 +5634,8 @@ def test_cleanup_endpoints_409_when_no_project_bound(tmp_path: Path) -> None:
     """Picker-mode (no bound project) -> both endpoints return 409 no_project."""
     app = create_app()  # unbound
     client = TestClient(app)
-    assert client.get("/api/project/cleanup/plan?categories=audio").status_code == 409
-    assert client.post("/api/project/cleanup", json={"categories": ["audio"]}).status_code == 409
+    assert client.get("/api/shooters/me/project/cleanup/plan?categories=audio").status_code == 409
+    assert client.post("/api/shooters/me/project/cleanup", json={"categories": ["audio"]}).status_code == 409
 
 
 # --- automation settings (#216) ---------------------------------------------
@@ -5650,7 +5650,7 @@ def test_get_automation_returns_resolved_settings_and_provenance(tmp_path: Path)
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/automation")
+    resp = client.get("/api/shooters/me/automation")
     assert resp.status_code == 200
     body = resp.json()
     assert body["settings"] == {
@@ -5677,7 +5677,7 @@ def test_get_automation_reports_project_provenance_when_overridden(
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/automation")
+    resp = client.get("/api/shooters/me/automation")
     assert resp.status_code == 200
     body = resp.json()
     assert body["settings"]["shot_detect_on_beep_verified"] is False
@@ -5705,7 +5705,7 @@ def test_dismiss_nudge_persists_stage_number(tmp_path: Path) -> None:
     client = TestClient(app)
 
     resp = client.post(
-        "/api/project/nudges/dismiss",
+        "/api/shooters/me/project/nudges/dismiss",
         json={"stage_number": 1, "dismissed": True},
     )
     assert resp.status_code == 200
@@ -5730,7 +5730,7 @@ def test_dismiss_nudge_idempotent(tmp_path: Path) -> None:
     client = TestClient(app)
 
     resp = client.post(
-        "/api/project/nudges/dismiss",
+        "/api/shooters/me/project/nudges/dismiss",
         json={"stage_number": 2, "dismissed": True},
     )
     assert resp.status_code == 200
@@ -5754,7 +5754,7 @@ def test_dismiss_nudge_clears_when_dismissed_false(tmp_path: Path) -> None:
     client = TestClient(app)
 
     resp = client.post(
-        "/api/project/nudges/dismiss",
+        "/api/shooters/me/project/nudges/dismiss",
         json={"stage_number": 3, "dismissed": False},
     )
     assert resp.status_code == 200
@@ -5768,7 +5768,7 @@ def test_dismiss_nudge_404_for_unknown_stage(tmp_path: Path) -> None:
     client = TestClient(app)
 
     resp = client.post(
-        "/api/project/nudges/dismiss",
+        "/api/shooters/me/project/nudges/dismiss",
         json={"stage_number": 99, "dismissed": True},
     )
     assert resp.status_code == 404
@@ -5816,7 +5816,7 @@ def test_hitl_queue_lists_low_confidence_auto_beep(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/hitl-queue")
+    resp = client.get("/api/shooters/me/hitl-queue")
     assert resp.status_code == 200
     body = resp.json()
     assert body["threshold"] == 0.95
@@ -5843,7 +5843,7 @@ def test_hitl_queue_lists_missing_beep(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/hitl-queue")
+    resp = client.get("/api/shooters/me/hitl-queue")
     item = resp.json()["items"][0]
     assert item["kind"] == "beep_missing"
     assert item["confidence"] is None
@@ -5864,7 +5864,7 @@ def test_hitl_queue_omits_high_confidence_reviewed_beep(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/hitl-queue")
+    resp = client.get("/api/shooters/me/hitl-queue")
     assert resp.json()["items"] == []
 
 
@@ -5881,7 +5881,7 @@ def test_hitl_queue_omits_manual_beep(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/hitl-queue")
+    resp = client.get("/api/shooters/me/hitl-queue")
     assert resp.json()["items"] == []
 
 
@@ -5906,7 +5906,7 @@ def test_hitl_queue_orders_by_stage_number(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    resp = client.get("/api/hitl-queue")
+    resp = client.get("/api/shooters/me/hitl-queue")
     stages = [item["stage_number"] for item in resp.json()["items"]]
     assert stages == [1, 2, 3]
 
@@ -5927,7 +5927,7 @@ def test_hitl_queue_threshold_respects_project_override(tmp_path: Path) -> None:
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)
 
-    body = client.get("/api/hitl-queue").json()
+    body = client.get("/api/shooters/me/hitl-queue").json()
     assert body["threshold"] == 0.9
     assert body["items"][0]["confidence"] == 0.65
 
@@ -5941,14 +5941,14 @@ def test_post_settings_patches_automation_override(tmp_path: Path) -> None:
     client = TestClient(app)
 
     resp = client.post(
-        "/api/project/settings",
+        "/api/shooters/me/project/settings",
         json={"automation": {"shot_detect_on_beep_verified": False}},
     )
     assert resp.status_code == 200
     body = resp.json()
     assert body["automation"]["shot_detect_on_beep_verified"] is False
 
-    auto = client.get("/api/automation").json()
+    auto = client.get("/api/shooters/me/automation").json()
     assert auto["settings"]["shot_detect_on_beep_verified"] is False
     assert auto["provenance"]["shot_detect_on_beep_verified"]["source"] == "project"
 

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5108,9 +5108,12 @@ def test_create_match_manual_scaffolds_match_and_binds_shooter(
     match = match_model.Match.load(target)
     assert len(match.stages) == 2
     assert match.match_date.isoformat() == "2026-05-14"
-    assert match.shooters == ["mathias-axell"]
+    # Slugs are opaque (PII-free): no name leakage on disk or in URLs.
+    assert len(match.shooters) == 1
+    only_slug = match.shooters[0]
+    assert only_slug.startswith("s_") and len(only_slug) == 10
 
-    shooter_root = match_model.Match.shooter_root(target, "mathias-axell")
+    shooter_root = match_model.Match.shooter_root(target, only_slug)
     assert (shooter_root / "shooter.json").exists()
     assert (shooter_root / "project.json").exists()
     legacy = MatchProject.load(shooter_root)
@@ -5230,8 +5233,10 @@ def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_ho
     assert resp.status_code == 200
     body = resp.json()
     slugs = [s["slug"] for s in body["shooters"]]
-    assert "johan-larsson" in slugs
-    new_root = match_model.Match.shooter_root(target, "johan-larsson")
+    assert len(slugs) == 2  # original "ma" + the new opaque slug
+    new_slug = next(s for s in slugs if s != "ma")
+    assert new_slug.startswith("s_") and len(new_slug) == 10
+    new_root = match_model.Match.shooter_root(target, new_slug)
     assert (new_root / "project.json").exists()
     assert (new_root / "shooter.json").exists()
 
@@ -6016,7 +6021,8 @@ def test_merge_plan_returns_reconciled_plan_for_legacy_inputs(tmp_path: Path) ->
     body = resp.json()
     assert body["name"] == "Bromma 2026"
     assert len(body["shooter_moves"]) == 2
-    assert {mv["slug"] for mv in body["shooter_moves"]} == {"proj-a", "proj-b"}
+    slugs = {mv["slug"] for mv in body["shooter_moves"]}
+    assert all(s.startswith("s_") and len(s) == 10 for s in slugs), slugs
     # Plan must not have written anything to disk.
     assert not (tmp_path / "merged").exists()
 
@@ -6068,9 +6074,10 @@ def test_merge_execute_writes_match_folder_and_binds_first_shooter(tmp_path: Pat
     # Bound shooter root sits under the merged match's shooters dir.
     assert str(out) in body["project_root"]
     assert (out / "match.json").exists()
-    # Two shooter subdirs.
+    # Two shooter subdirs, named with opaque ids (no PII on disk).
     shooter_names = sorted(p.name for p in (out / "shooters").iterdir())
-    assert shooter_names == ["proj-a", "proj-b"]
+    assert len(shooter_names) == 2
+    assert all(n.startswith("s_") and len(n) == 10 for n in shooter_names), shooter_names
 
 
 def test_merge_execute_refuses_destination_with_existing_match(tmp_path: Path) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -197,9 +197,7 @@ def _load_v1_match_fixture() -> dict:
     """Read the SSI v1 match fixture used by ``test_scoreboard_*``."""
     import json
 
-    return json.loads(
-        (_SCOREBOARD_FIXTURES_DIR / "match_22_27190.json").read_text(encoding="utf-8")
-    )
+    return json.loads((_SCOREBOARD_FIXTURES_DIR / "match_22_27190.json").read_text(encoding="utf-8"))
 
 
 def test_scoreboard_loads_token_from_project_env_local(
@@ -215,18 +213,14 @@ def test_scoreboard_loads_token_from_project_env_local(
     monkeypatch.delenv("SPLITSMITH_SSI_TOKEN", raising=False)
     project_root = tmp_path / "match"
     project_root.mkdir(parents=True)
-    (project_root / ".env.local").write_text(
-        "SPLITSMITH_SSI_TOKEN=token-from-env-local\n", encoding="utf-8"
-    )
+    (project_root / ".env.local").write_text("SPLITSMITH_SSI_TOKEN=token-from-env-local\n", encoding="utf-8")
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
     src = client.get("/api/shooters/me/scoreboard/source").json()
     assert src["http_token_set"] is True
 
 
-def test_scoreboard_loads_token_from_cwd_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_scoreboard_loads_token_from_cwd_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """An ``.env`` next to where the user *launched* the server (typically
     the repo root) is the most common spot. It must work even when the
     project lives somewhere else entirely."""
@@ -296,7 +290,8 @@ def test_scoreboard_search_uses_local_when_match_json_present(tmp_path: Path) ->
     client = TestClient(app)
 
     fixture = _load_v1_match_fixture()
-    assert client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture}).status_code == 200
+    upload = client.post("/api/shooters/me/scoreboard/upload", json={"data": fixture})
+    assert upload.status_code == 200
 
     # No SPLITSMITH_SSI_TOKEN env var; must still work because the local
     # JSON path doesn't go through SsiHttpClient.
@@ -335,9 +330,7 @@ def test_scoreboard_upload_legacy_examples_auto_merges_stage_times(tmp_path: Pat
     project_root = tmp_path / "match"
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
-    legacy = _json.loads(
-        (_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8")
-    )
+    legacy = _json.loads((_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8"))
     resp = client.post("/api/shooters/me/scoreboard/upload", json={"data": legacy})
     assert resp.status_code == 200
     body = resp.json()
@@ -416,9 +409,7 @@ def test_scoreboard_refresh_times_re_merges(tmp_path: Path) -> None:
     project_root = tmp_path / "match"
     app = create_app(project_root=project_root, project_name="x")
     client = TestClient(app)
-    legacy = _json.loads(
-        (_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8")
-    )
+    legacy = _json.loads((_EXAMPLES_DIR / "blacksmith-handgun-open-2026.json").read_text(encoding="utf-8"))
     client.post("/api/shooters/me/scoreboard/upload", json={"data": legacy})
     resp = client.post("/api/shooters/me/scoreboard/refresh-times")
     assert resp.status_code == 200
@@ -719,7 +710,10 @@ def test_scan_videos_registers_and_auto_assigns(tmp_path: Path) -> None:
 def test_scan_videos_400_on_missing_dir(tmp_path: Path) -> None:
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
-    resp = client.post("/api/shooters/me/videos/scan", json={"source_dir": str(tmp_path / "does-not-exist")})
+    resp = client.post(
+        "/api/shooters/me/videos/scan",
+        json={"source_dir": str(tmp_path / "does-not-exist")},
+    )
     assert resp.status_code == 400
 
 
@@ -1589,7 +1583,10 @@ def test_video_peaks_endpoint_serves_secondary_full_wav(tmp_path: Path, monkeypa
     monkeypatch.setattr(audio_helpers, "ensure_video_audio", fake_ensure_video)
 
     # Set a beep_time on the secondary so beep_time is reflected in the payload.
-    proj = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": 0.42}).json()
+    proj = client.post(
+        f"/api/shooters/me/stages/1/videos/{sec_id}/beep",
+        json={"beep_time": 0.42},
+    ).json()
     assert next(v for v in proj["stages"][0]["videos"] if v["video_id"] == sec_id)[
         "beep_time"
     ] == pytest.approx(0.42)
@@ -1879,9 +1876,7 @@ def test_detect_beep_auto_trims(tmp_path: Path, monkeypatch) -> None:
     assert trim_calls[0]["stage_time"] == pytest.approx(12.0)
 
 
-def test_detect_beep_high_confidence_auto_trusts_into_beep_reviewed(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_detect_beep_high_confidence_auto_trusts_into_beep_reviewed(tmp_path: Path, monkeypatch) -> None:
     """confidence >= threshold flips beep_reviewed to True without a click (#219)."""
     client, _ = _seed_project_with_primary(tmp_path)
     project_root = tmp_path / "match"
@@ -1909,9 +1904,7 @@ def test_detect_beep_high_confidence_auto_trusts_into_beep_reviewed(
     monkeypatch.setattr(
         trim,
         "trim_video",
-        lambda **kw: trim.TrimResult(
-            output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0
-        ),
+        lambda **kw: trim.TrimResult(output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0),
     )
     Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
 
@@ -1951,9 +1944,7 @@ def test_detect_beep_low_confidence_leaves_beep_for_hitl(tmp_path: Path, monkeyp
     monkeypatch.setattr(
         trim,
         "trim_video",
-        lambda **kw: trim.TrimResult(
-            output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0
-        ),
+        lambda **kw: trim.TrimResult(output_path=Path(kw["output_path"]), start_time=1.0, end_time=20.0),
     )
     Path(project_root / "trimmed").mkdir(parents=True, exist_ok=True)
 
@@ -2134,9 +2125,7 @@ def test_trim_partial_filename_keeps_mp4_extension(tmp_path: Path, monkeypatch) 
     assert ".partial" in captured[0].stem
 
 
-def test_trim_endpoint_returns_existing_job_when_one_is_running(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_trim_endpoint_returns_existing_job_when_one_is_running(tmp_path: Path, monkeypatch) -> None:
     """A second submit while the first is still running adopts the existing
     job instead of spawning a parallel ffmpeg that races on the partial
     file. Symptom we're guarding against: clicking "Trim now" twice (or
@@ -2412,9 +2401,7 @@ def test_shot_detect_endpoint_ensures_trim_before_detection(tmp_path: Path, monk
     assert proj_after["stages"][0]["videos"][0]["processed"].get("trim") is True
 
 
-def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(tmp_path: Path, monkeypatch) -> None:
     """Issue #143: ``StageVideo.camera_mount`` flows through ``camera_class_from_mount``
     into ``detect_shots_ensemble``. Verifies the wiring without exercising
     the actual ensemble (which is monkeypatched).
@@ -2468,9 +2455,7 @@ def test_shot_detect_endpoint_passes_camera_class_from_primary_mount(
     assert captured.get("camera_class") == "handheld"
 
 
-def test_shot_detect_endpoint_passes_default_class_when_mount_missing(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_shot_detect_endpoint_passes_default_class_when_mount_missing(tmp_path: Path, monkeypatch) -> None:
     """``camera_mount=None`` -> default class (``headcam``) reaches the ensemble."""
     import numpy as np
     import soundfile as sf
@@ -2603,9 +2588,7 @@ def test_shot_detect_all_endpoint_submits_per_eligible_stage(tmp_path: Path, mon
         _wait_for_job(client, j["id"])
 
 
-def test_shot_detect_endpoint_writes_stage_rounds_into_audit_json(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_shot_detect_endpoint_writes_stage_rounds_into_audit_json(tmp_path: Path, monkeypatch) -> None:
     """Stage's ``stage_rounds`` (from scoreboard import) lands in the audit
     JSON and reaches the ensemble as ``expected_rounds``.
 
@@ -2679,17 +2662,26 @@ def test_camera_mount_patch_endpoint_round_trips(tmp_path: Path) -> None:
     video_id = primary.video_id
 
     # Override.
-    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": "hand"})
+    resp = client.patch(
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount",
+        json={"mount": "hand"},
+    )
     assert resp.status_code == 200, resp.text
     refreshed = MatchProject.load(project_root)
     assert refreshed.stages[0].primary().camera_mount == "hand"
 
     # Bad value rejected.
-    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": "shoulder"})
+    resp = client.patch(
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount",
+        json={"mount": "shoulder"},
+    )
     assert resp.status_code == 400, resp.text
 
     # Clear back to None.
-    resp = client.patch(f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount", json={"mount": None})
+    resp = client.patch(
+        f"/api/shooters/me/stages/1/videos/{video_id}/camera-mount",
+        json={"mount": None},
+    )
     assert resp.status_code == 200
     refreshed = MatchProject.load(project_root)
     assert refreshed.stages[0].primary().camera_mount is None
@@ -3075,9 +3067,7 @@ def test_put_stage_audit_writes_payload_and_returns_it(tmp_path: Path) -> None:
                 "source": "detected",
             }
         ],
-        "audit_events": [
-            {"ts": "2026-05-02T12:00:00Z", "kind": "marker_kept", "payload": {"id": "cand-4"}}
-        ],
+        "audit_events": [{"ts": "2026-05-02T12:00:00Z", "kind": "marker_kept", "payload": {"id": "cand-4"}}],
     }
     resp = client.put("/api/shooters/me/stages/1/audit", json=payload)
     assert resp.status_code == 200
@@ -4127,9 +4117,7 @@ def test_secondary_low_confidence_alignment_stays_soft_failed(tmp_path: Path, mo
     assert secondary["beep_alignment_confidence"] == pytest.approx(1.05)
 
 
-def test_secondary_in_stream_success_runs_cross_align_sanity_check(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_secondary_in_stream_success_runs_cross_align_sanity_check(tmp_path: Path, monkeypatch) -> None:
     """When in-stream beep_detect succeeds on a secondary, cross-correlation
     still runs as a sanity check. When the two methods agree (small delta),
     the in-stream result wins, ``beep_source`` stays ``"auto"``, but the
@@ -4182,9 +4170,7 @@ def test_secondary_in_stream_success_runs_cross_align_sanity_check(
     assert secondary["beep_alignment_delta_ms"] == pytest.approx(-15.0)
 
 
-def test_secondary_in_stream_disagreement_flagged_not_overridden(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_secondary_in_stream_disagreement_flagged_not_overridden(tmp_path: Path, monkeypatch) -> None:
     """When in-stream and cross-align disagree by hundreds of ms (typical
     of a steel-strike mistaken for the buzzer), the in-stream result is
     KEPT as ``beep_time`` -- in-stream has frequency-domain info
@@ -4253,7 +4239,10 @@ def test_secondary_soft_fail_clears_on_manual_override(tmp_path: Path, monkeypat
     )
     assert final["status"] == "succeeded"
 
-    proj = client.post(f"/api/shooters/me/stages/1/videos/{sec_id}/beep", json={"beep_time": 2.5}).json()
+    proj = client.post(
+        f"/api/shooters/me/stages/1/videos/{sec_id}/beep",
+        json={"beep_time": 2.5},
+    ).json()
     secondary = next(v for v in proj["stages"][0]["videos"] if v["role"] == "secondary")
     assert secondary["beep_time"] == pytest.approx(2.5)
     assert secondary["beep_source"] == "manual"
@@ -4708,11 +4697,17 @@ def test_beep_review_endpoint_flips_flag(tmp_path: Path, monkeypatch) -> None:
     video_id = primary["video_id"]
     assert primary["beep_reviewed"] is False
 
-    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(
+        f"/api/shooters/me/stages/1/videos/{video_id}/beep/review",
+        json={"reviewed": True},
+    )
     assert resp.status_code == 200
     assert resp.json()["stages"][0]["videos"][0]["beep_reviewed"] is True
 
-    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": False})
+    resp = client.post(
+        f"/api/shooters/me/stages/1/videos/{video_id}/beep/review",
+        json={"reviewed": False},
+    )
     assert resp.status_code == 200
     assert resp.json()["stages"][0]["videos"][0]["beep_reviewed"] is False
 
@@ -4725,7 +4720,10 @@ def test_beep_review_400_when_no_beep_yet(tmp_path: Path) -> None:
     primary = client.get("/api/shooters/me/project").json()["stages"][0]["videos"][0]
     video_id = primary["video_id"]
 
-    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(
+        f"/api/shooters/me/stages/1/videos/{video_id}/beep/review",
+        json={"reviewed": True},
+    )
     assert resp.status_code == 400
 
 
@@ -4787,9 +4785,7 @@ def test_shot_detect_gated_on_beep_review(tmp_path: Path, monkeypatch) -> None:
     # No shot_detect job queued -- the chain stops at trim until the
     # user confirms.
     jobs = client.get("/api/me/jobs").json()
-    assert not any(j["kind"] == "shot_detect" for j in jobs), [
-        (j["kind"], j["status"]) for j in jobs
-    ]
+    assert not any(j["kind"] == "shot_detect" for j in jobs), [(j["kind"], j["status"]) for j in jobs]
 
 
 def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> None:
@@ -4818,7 +4814,10 @@ def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> 
     jobs_before = client.get("/api/me/jobs").json()
     assert not any(j["kind"] == "shot_detect" for j in jobs_before)
 
-    resp = client.post(f"/api/shooters/me/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
+    resp = client.post(
+        f"/api/shooters/me/stages/1/videos/{video_id}/beep/review",
+        json={"reviewed": True},
+    )
     assert resp.status_code == 200
     jobs_after = client.get("/api/me/jobs").json()
     assert any(j["kind"] == "shot_detect" for j in jobs_after)
@@ -4947,9 +4946,7 @@ def test_bind_recent_project_404_when_path_missing(tmp_path: Path, _user_config_
     assert resp.json()["detail"]["code"] == "project_path_missing"
 
 
-def test_bind_recent_project_create_scaffolds_new_dir(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_bind_recent_project_create_scaffolds_new_dir(tmp_path: Path, _user_config_home: Path) -> None:
     """``create=true`` mkdirs the destination and scaffolds project.json so
     the picker's "Create new project" flow can target a fresh folder.
     """
@@ -4969,9 +4966,7 @@ def test_bind_recent_project_create_scaffolds_new_dir(
     assert (target / "project.json").exists()
 
 
-def test_bind_recent_project_scaffolds_empty_existing_folder(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_bind_recent_project_scaffolds_empty_existing_folder(tmp_path: Path, _user_config_home: Path) -> None:
     """An existing folder without project.json is scaffolded in place; the
     Pick page's updated copy promises this works."""
     app = create_app()
@@ -5134,9 +5129,7 @@ def test_create_match_manual_scaffolds_match_and_binds_shooter(
     assert kinds == ["match"]
 
 
-def test_create_match_manual_refuses_existing_match_folder(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_create_match_manual_refuses_existing_match_folder(tmp_path: Path, _user_config_home: Path) -> None:
     from splitsmith import match_model
 
     target = tmp_path / "occupied"
@@ -5179,9 +5172,7 @@ def test_bind_match_folder_binds_match_root(tmp_path: Path, _user_config_home: P
     assert body["project_root"] == str(target.resolve())
 
 
-def test_list_match_shooters_returns_active_and_others(
-    tmp_path: Path, _user_config_home: Path
-) -> None:
+def test_list_match_shooters_returns_active_and_others(tmp_path: Path, _user_config_home: Path) -> None:
     """The shooters endpoint surfaces every registered shooter and flags
     which is currently active. (#324)
     """
@@ -5289,9 +5280,7 @@ def test_user_config_disable_flag_makes_endpoints_safe(
     assert cleared.json() is None
 
 
-def test_load_env_files_picks_up_user_config_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_env_files_picks_up_user_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The SSI token (and any other ``SPLITSMITH_*`` var) can live in
     ``~/.splitsmith/.env`` -- it's per-user, not per-project. Project /
     cwd files still win because they're loaded earlier with
@@ -5388,9 +5377,7 @@ def _seed_match_export_project(tmp_path: Path, *, stage_count: int = 2) -> tuple
     project = MatchProject.load(project_root)
     project.stages = []
     for n in range(1, stage_count + 1):
-        project.stages.append(
-            StageEntry(stage_number=n, stage_name=f"Stage {n}", time_seconds=10.0)
-        )
+        project.stages.append(StageEntry(stage_number=n, stage_name=f"Stage {n}", time_seconds=10.0))
         src = project_root / "raw" / f"VID{n}.mp4"
         src.parent.mkdir(parents=True, exist_ok=True)
         src.write_bytes(b"\x00")
@@ -5440,9 +5427,7 @@ def _stub_match_export_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(fcpxml_mod, "probe_video", fake)
 
 
-def test_match_export_endpoint_writes_fcpxml(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_match_export_endpoint_writes_fcpxml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     client, _ = _seed_match_export_project(tmp_path)
     _stub_match_export_probe(monkeypatch)
 
@@ -5551,7 +5536,10 @@ def _seed_cleanup_project(tmp_path: Path) -> tuple[TestClient, Path]:
 
 def test_cleanup_plan_returns_per_category_totals(tmp_path: Path) -> None:
     client, _ = _seed_cleanup_project(tmp_path)
-    resp = client.get("/api/shooters/me/project/cleanup/plan", params={"categories": "audio,exports-overlays"})
+    resp = client.get(
+        "/api/shooters/me/project/cleanup/plan",
+        params={"categories": "audio,exports-overlays"},
+    )
     assert resp.status_code == 200
     body = resp.json()
     assert body["total_file_count"] == 2
@@ -5649,7 +5637,11 @@ def test_cleanup_endpoints_409_when_no_project_bound(tmp_path: Path) -> None:
     app = create_app()  # unbound
     client = TestClient(app)
     assert client.get("/api/shooters/me/project/cleanup/plan?categories=audio").status_code == 409
-    assert client.post("/api/shooters/me/project/cleanup", json={"categories": ["audio"]}).status_code == 409
+    cleanup_resp = client.post(
+        "/api/shooters/me/project/cleanup",
+        json={"categories": ["audio"]},
+    )
+    assert cleanup_resp.status_code == 409
 
 
 # --- automation settings (#216) ---------------------------------------------
@@ -5809,9 +5801,7 @@ def _build_project_with_primary(
         beep_reviewed=beep_reviewed,
         beep_auto_detect_failed=beep_auto_detect_failed,
     )
-    project.stages = [
-        StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=12.0, videos=[primary])
-    ]
+    project.stages = [StageEntry(stage_number=1, stage_name="Stage 1", time_seconds=12.0, videos=[primary])]
     project.save(root)
     return project
 
@@ -5913,9 +5903,7 @@ def test_hitl_queue_orders_by_stage_number(tmp_path: Path) -> None:
             beep_confidence=0.4,
             beep_reviewed=False,
         )
-        project.stages.append(
-            StageEntry(stage_number=n, stage_name=f"S{n}", time_seconds=12.0, videos=[v])
-        )
+        project.stages.append(StageEntry(stage_number=n, stage_name=f"S{n}", time_seconds=12.0, videos=[v]))
     project.save(root)
     app = create_app(project_root=root, project_name="ignored")
     client = TestClient(app)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -64,7 +64,7 @@ def test_health_returns_project_info(tmp_path: Path) -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert body["project_name"] == "Test Match"
-    assert body["schema_version"] == 2
+    assert body["bound"] is True
 
 
 def test_get_project_returns_full_dump(tmp_path: Path) -> None:
@@ -5145,8 +5145,11 @@ def test_create_match_manual_refuses_existing_match_folder(
     assert resp.json()["detail"]["code"] == "match_already_exists"
 
 
-def test_bind_match_folder_routes_to_first_shooter(tmp_path: Path, _user_config_home: Path) -> None:
-    """Binding a Match folder transparently switches state to the first shooter."""
+def test_bind_match_folder_binds_match_root(tmp_path: Path, _user_config_home: Path) -> None:
+    """Binding a Match folder binds the match itself, not a shooter subdir.
+
+    Shooters are addressed per-request via slug-bearing URLs (#353).
+    """
     from splitsmith import match_model
 
     target = tmp_path / "rich-match"
@@ -5161,10 +5164,9 @@ def test_bind_match_folder_routes_to_first_shooter(tmp_path: Path, _user_config_
         json={"path": str(target)},
     )
     assert resp.status_code == 200
-    # The bound root is the shooter directory, not the match root.
     body = resp.json()
     assert body["bound"] is True
-    assert body["project_root"].endswith("/shooters/ma")
+    assert body["project_root"] == str(target.resolve())
 
 
 def test_list_match_shooters_returns_active_and_others(
@@ -5208,31 +5210,6 @@ def test_list_match_shooters_returns_active_and_others(
     assert body["match_name"] == "Multi-shooter"
     slugs = [s["slug"] for s in body["shooters"]]
     assert slugs == ["ma", "jl"]
-    active = [s for s in body["shooters"] if s["is_active"]]
-    assert len(active) == 1 and active[0]["slug"] == "ma"
-
-
-def test_select_active_shooter_rebinds(tmp_path: Path, _user_config_home: Path) -> None:
-    from splitsmith import match_model
-
-    target = tmp_path / "mm"
-    match = match_model.Match.init(target, name="Test")
-    for slug, name in [("a", "A"), ("b", "B")]:
-        match.add_shooter(target, match_model.Shooter(slug=slug, name=name))
-        MatchProject.init(match_model.Match.shooter_root(target, slug), name="Test")
-
-    app = create_app()
-    client = TestClient(app)
-    client.post(
-        "/api/user/recent-projects/bind",
-        json={"path": str(target.resolve())},
-    )
-    resp = client.post("/api/match/shooters/b/select")
-    assert resp.status_code == 200
-    assert resp.json()["project_root"].endswith("/shooters/b")
-    listing = client.get("/api/match/shooters").json()
-    actives = [s["slug"] for s in listing["shooters"] if s["is_active"]]
-    assert actives == ["b"]
 
 
 def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5259,7 +5236,7 @@ def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_ho
     assert (new_root / "shooter.json").exists()
 
 
-def test_remove_match_shooter_refuses_active(tmp_path: Path, _user_config_home: Path) -> None:
+def test_remove_match_shooter_drops_dir(tmp_path: Path, _user_config_home: Path) -> None:
     from splitsmith import match_model
 
     target = tmp_path / "mm"
@@ -5275,9 +5252,6 @@ def test_remove_match_shooter_refuses_active(tmp_path: Path, _user_config_home: 
         "/api/user/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
-    resp = client.delete("/api/match/shooters/ma")
-    assert resp.status_code == 409
-    assert resp.json()["detail"]["code"] == "active_shooter"
     resp = client.delete("/api/match/shooters/jl")
     assert resp.status_code == 200
     assert not match_model.Match.shooter_root(target, "jl").exists()

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -3043,12 +3043,14 @@ def test_get_stage_audit_returns_payload_when_file_exists(tmp_path: Path) -> Non
     assert resp.json()["shots"][0]["candidate_number"] == 4
 
 
-def test_get_stage_audit_404_when_missing(tmp_path: Path) -> None:
-    """No audit JSON yet -> 404. The SPA treats this as 'start fresh'."""
+def test_get_stage_audit_returns_null_when_missing(tmp_path: Path) -> None:
+    """No audit JSON yet -> 200 null. The SPA treats this as 'start
+    fresh' and we don't want the request showing up as a failure in
+    DevTools on every audit-page mount."""
     client, _ = _seed_project_with_primary(tmp_path)
     resp = client.get("/api/shooters/me/stages/1/audit")
-    assert resp.status_code == 404
-    assert "no audit" in resp.json()["detail"]
+    assert resp.status_code == 200
+    assert resp.json() is None
 
 
 def test_get_stage_audit_404_when_stage_unknown(tmp_path: Path) -> None:
@@ -5000,8 +5002,11 @@ def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path)
     app = create_app(project_root=tmp_path / "match", project_name="x")
     client = TestClient(app)
 
-    # Empty: 404 (SPA renders the prompt rather than autopin).
-    assert client.get("/api/me/scoreboard-identity").status_code == 404
+    # Empty: 200 null. "Not pinned yet" is a normal state, not an error,
+    # so the SPA doesn't have to catch a 404 on every page load.
+    empty = client.get("/api/me/scoreboard-identity")
+    assert empty.status_code == 200
+    assert empty.json() is None
 
     payload = {
         "shooter_id": 12345,
@@ -5019,9 +5024,11 @@ def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path)
     assert got.status_code == 200
     assert got.json()["display_name"] == "Mathias Axell"
 
-    # Delete clears it.
+    # Delete clears it back to null.
     client.delete("/api/me/scoreboard-identity")
-    assert client.get("/api/me/scoreboard-identity").status_code == 404
+    cleared = client.get("/api/me/scoreboard-identity")
+    assert cleared.status_code == 200
+    assert cleared.json() is None
 
 
 def test_recent_projects_detail_enriches_metadata(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5275,9 +5282,11 @@ def test_user_config_disable_flag_makes_endpoints_safe(
     body = client.get("/api/me/recent-projects").json()
     assert body == {"projects": []}
 
-    # PUT silently drops; GET still returns 404.
+    # PUT silently drops; GET still returns 200 null.
     client.put("/api/me/scoreboard-identity", json={"shooter_id": 1})
-    assert client.get("/api/me/scoreboard-identity").status_code == 404
+    cleared = client.get("/api/me/scoreboard-identity")
+    assert cleared.status_code == 200
+    assert cleared.json() is None
 
 
 def test_load_env_files_picks_up_user_config_env(

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -46,7 +46,7 @@ def _wait_for_job(client: TestClient, job_id: str, *, timeout: float = 5.0) -> d
 
     deadline = time.time() + timeout
     while time.time() < deadline:
-        resp = client.get(f"/api/jobs/{job_id}")
+        resp = client.get(f"/api/me/jobs/{job_id}")
         assert resp.status_code == 200
         body = resp.json()
         if body["status"] in ("succeeded", "failed", "cancelled"):
@@ -2086,7 +2086,7 @@ def test_trim_invalidates_when_beep_changes(tmp_path: Path, monkeypatch) -> None
     resp = client.post("/api/stages/1/beep", json={"beep_time": 7.5})
     assert resp.status_code == 200
     # The auto-fired job is the active trim job.
-    jobs = client.get("/api/jobs").json()
+    jobs = client.get("/api/me/jobs").json()
     active = next((j for j in jobs if j["kind"] == "trim" and j["stage_number"] == 1), None)
     assert active is not None, "override_beep should auto-fire a trim job"
     final = _wait_for_job(client, active["id"])
@@ -2224,7 +2224,7 @@ def test_cancel_endpoint_aborts_running_trim(tmp_path: Path, monkeypatch) -> Non
     job = client.post("/api/stages/1/trim").json()
     assert started.wait(timeout=3.0), "worker should have started by now"
 
-    cancel_resp = client.post(f"/api/jobs/{job['id']}/cancel")
+    cancel_resp = client.post(f"/api/me/jobs/{job['id']}/cancel")
     assert cancel_resp.status_code == 200
     snapshot = cancel_resp.json()
     assert snapshot["cancel_requested"] is True
@@ -2236,7 +2236,7 @@ def test_cancel_endpoint_aborts_running_trim(tmp_path: Path, monkeypatch) -> Non
 
 def test_cancel_endpoint_returns_404_for_unknown_job(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/jobs/does-not-exist/cancel")
+    resp = client.post("/api/me/jobs/does-not-exist/cancel")
     assert resp.status_code == 404
 
 
@@ -2836,7 +2836,7 @@ def test_shot_detect_endpoint_dedupes_active_jobs(tmp_path: Path, monkeypatch) -
 
 
 def test_jobs_endpoints_list_and_get(tmp_path: Path, monkeypatch) -> None:
-    """/api/jobs lists active + recent; /api/jobs/{id} polls one. detect-beep
+    """/api/me/jobs lists active + recent; /api/me/jobs/{id} polls one. detect-beep
     and trim both surface here so the SPA has a single status surface."""
     client, _ = _seed_project_with_primary(tmp_path)
     project_root = tmp_path / "match"
@@ -2878,13 +2878,13 @@ def test_jobs_endpoints_list_and_get(tmp_path: Path, monkeypatch) -> None:
     assert final["kind"] == "detect_beep"
     assert final["stage_number"] == 1
 
-    listing = client.get("/api/jobs").json()
+    listing = client.get("/api/me/jobs").json()
     assert any(j["id"] == job_id for j in listing)
 
 
 def test_get_job_404_when_unknown(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.get("/api/jobs/does-not-exist")
+    resp = client.get("/api/me/jobs/does-not-exist")
     assert resp.status_code == 404
 
 
@@ -2928,17 +2928,17 @@ def test_acknowledge_endpoint_marks_failed_job_as_seen(tmp_path: Path, monkeypat
     assert final["status"] == "failed"
     assert final["acknowledged"] is False
 
-    ack = client.post(f"/api/jobs/{job_id}/acknowledge")
+    ack = client.post(f"/api/me/jobs/{job_id}/acknowledge")
     assert ack.status_code == 200
     assert ack.json()["acknowledged"] is True
 
-    listing = client.get("/api/jobs").json()
+    listing = client.get("/api/me/jobs").json()
     assert next(j for j in listing if j["id"] == job_id)["acknowledged"] is True
 
 
 def test_acknowledge_endpoint_404_for_unknown_job(tmp_path: Path) -> None:
     client, _ = _seed_project_with_primary(tmp_path)
-    resp = client.post("/api/jobs/does-not-exist/acknowledge")
+    resp = client.post("/api/me/jobs/does-not-exist/acknowledge")
     assert resp.status_code == 404
 
 
@@ -2972,7 +2972,7 @@ def test_acknowledge_endpoint_noop_for_succeeded_job(tmp_path: Path, monkeypatch
     submit = client.post("/api/stages/1/detect-beep")
     job_id = submit.json()["id"]
     assert _wait_for_job(client, job_id)["status"] == "succeeded"
-    resp = client.post(f"/api/jobs/{job_id}/acknowledge")
+    resp = client.post(f"/api/me/jobs/{job_id}/acknowledge")
     assert resp.status_code == 200
     assert resp.json()["acknowledged"] is False
 
@@ -2998,14 +2998,14 @@ def test_acknowledge_failures_bulk_endpoint(tmp_path: Path, monkeypatch) -> None
         ids.append(jid)
 
     # Pre-ack one so the bulk endpoint reports only the other.
-    client.post(f"/api/jobs/{ids[0]}/acknowledge")
+    client.post(f"/api/me/jobs/{ids[0]}/acknowledge")
 
-    bulk = client.post("/api/jobs/acknowledge-failures")
+    bulk = client.post("/api/me/jobs/acknowledge-failures")
     assert bulk.status_code == 200
     affected = bulk.json()
     assert {j["id"] for j in affected} == {ids[1]}
 
-    listing = client.get("/api/jobs").json()
+    listing = client.get("/api/me/jobs").json()
     by_id = {j["id"]: j for j in listing}
     assert by_id[ids[0]]["acknowledged"] is True
     assert by_id[ids[1]]["acknowledged"] is True
@@ -4339,7 +4339,7 @@ def _wait_for_jobs_to_drain(client: TestClient, *, timeout: float = 5.0) -> list
 
     deadline = time.time() + timeout
     while time.time() < deadline:
-        jobs = client.get("/api/jobs").json()
+        jobs = client.get("/api/me/jobs").json()
         active = [j for j in jobs if j["status"] in ("pending", "running")]
         if not active:
             return jobs
@@ -4499,7 +4499,7 @@ def test_auto_beep_skipped_for_unassigned_destination(tmp_path: Path, monkeypatc
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     _wait_for_jobs_to_drain(client)
-    job_count_after_assign = len(client.get("/api/jobs").json())
+    job_count_after_assign = len(client.get("/api/me/jobs").json())
 
     # Move back to tray -> no new job (idempotent on already-beeped is
     # also covered: the helper would skip even if we re-assigned).
@@ -4507,7 +4507,7 @@ def test_auto_beep_skipped_for_unassigned_destination(tmp_path: Path, monkeypatc
         "/api/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": None, "role": "secondary"},
     )
-    assert len(client.get("/api/jobs").json()) == job_count_after_assign
+    assert len(client.get("/api/me/jobs").json()) == job_count_after_assign
 
 
 def test_auto_beep_skipped_when_already_processed(tmp_path: Path, monkeypatch) -> None:
@@ -4558,14 +4558,14 @@ def test_auto_beep_skipped_when_already_processed(tmp_path: Path, monkeypatch) -
         json={"video_path": "raw/VID.mp4", "to_stage_number": 1, "role": "primary"},
     )
     _wait_for_jobs_to_drain(client)
-    jobs_before = len(client.get("/api/jobs").json())
+    jobs_before = len(client.get("/api/me/jobs").json())
 
     # Move to stage 2 -> processed.beep is already True, no new job.
     client.post(
         "/api/assignments/move",
         json={"video_path": "raw/VID.mp4", "to_stage_number": 2, "role": "primary"},
     )
-    assert len(client.get("/api/jobs").json()) == jobs_before
+    assert len(client.get("/api/me/jobs").json()) == jobs_before
 
 
 def test_auto_beep_disabled_via_env_var(tmp_path: Path, monkeypatch) -> None:
@@ -4784,7 +4784,7 @@ def test_shot_detect_gated_on_beep_review(tmp_path: Path, monkeypatch) -> None:
 
     # No shot_detect job queued -- the chain stops at trim until the
     # user confirms.
-    jobs = client.get("/api/jobs").json()
+    jobs = client.get("/api/me/jobs").json()
     assert not any(j["kind"] == "shot_detect" for j in jobs), [
         (j["kind"], j["status"]) for j in jobs
     ]
@@ -4813,12 +4813,12 @@ def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> 
     primary = client.get("/api/project").json()["stages"][0]["videos"][0]
     assert primary["processed"]["trim"] is True  # trim cached
     video_id = primary["video_id"]
-    jobs_before = client.get("/api/jobs").json()
+    jobs_before = client.get("/api/me/jobs").json()
     assert not any(j["kind"] == "shot_detect" for j in jobs_before)
 
     resp = client.post(f"/api/stages/1/videos/{video_id}/beep/review", json={"reviewed": True})
     assert resp.status_code == 200
-    jobs_after = client.get("/api/jobs").json()
+    jobs_after = client.get("/api/me/jobs").json()
     assert any(j["kind"] == "shot_detect" for j in jobs_after)
 
 
@@ -4855,7 +4855,7 @@ def test_recent_projects_endpoint(tmp_path: Path, _user_config_home: Path) -> No
     app = create_app(project_root=tmp_path / "beta", project_name="Beta")
     client = TestClient(app)
 
-    resp = client.get("/api/user/recent-projects")
+    resp = client.get("/api/me/recent-projects")
     assert resp.status_code == 200
     body = resp.json()
     names = [p["name"] for p in body["projects"]]
@@ -4869,7 +4869,7 @@ def test_forget_recent_project_endpoint(tmp_path: Path, _user_config_home: Path)
     client = TestClient(app)
 
     resp = client.post(
-        "/api/user/recent-projects/forget",
+        "/api/me/recent-projects/forget",
         json={"path": str((tmp_path / "alpha").resolve())},
     )
     assert resp.status_code == 200
@@ -4918,7 +4918,7 @@ def test_bind_recent_project_switches_in_memory(tmp_path: Path, _user_config_hom
     assert client.get("/api/health").json()["bound"] is False
 
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(alpha.resolve())},
     )
     assert resp.status_code == 200
@@ -4938,7 +4938,7 @@ def test_bind_recent_project_404_when_path_missing(tmp_path: Path, _user_config_
     app = create_app()
     client = TestClient(app)
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(tmp_path / "does-not-exist")},
     )
     assert resp.status_code == 404
@@ -4957,7 +4957,7 @@ def test_bind_recent_project_create_scaffolds_new_dir(
     assert not target.exists()
 
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target), "name": "Fresh Match", "create": True},
     )
     assert resp.status_code == 200, resp.text
@@ -4978,7 +4978,7 @@ def test_bind_recent_project_scaffolds_empty_existing_folder(
     target.mkdir()
 
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target)},
     )
     assert resp.status_code == 200
@@ -4990,7 +4990,7 @@ def test_unbind_returns_to_unbound_state(tmp_path: Path, _user_config_home: Path
     client = TestClient(app)
 
     assert client.get("/api/health").json()["bound"] is True
-    resp = client.post("/api/user/recent-projects/unbind")
+    resp = client.post("/api/me/recent-projects/unbind")
     assert resp.status_code == 200
     assert resp.json()["bound"] is False
     assert client.get("/api/project").status_code == 409
@@ -5001,7 +5001,7 @@ def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path)
     client = TestClient(app)
 
     # Empty: 404 (SPA renders the prompt rather than autopin).
-    assert client.get("/api/user/scoreboard-identity").status_code == 404
+    assert client.get("/api/me/scoreboard-identity").status_code == 404
 
     payload = {
         "shooter_id": 12345,
@@ -5010,18 +5010,18 @@ def test_scoreboard_identity_round_trip(tmp_path: Path, _user_config_home: Path)
         "club": "Bromma PK",
         "base_url": "https://shootnscoreit.com",
     }
-    resp = client.put("/api/user/scoreboard-identity", json=payload)
+    resp = client.put("/api/me/scoreboard-identity", json=payload)
     assert resp.status_code == 200
     assert resp.json()["shooter_id"] == 12345
 
     # Now readable.
-    got = client.get("/api/user/scoreboard-identity")
+    got = client.get("/api/me/scoreboard-identity")
     assert got.status_code == 200
     assert got.json()["display_name"] == "Mathias Axell"
 
     # Delete clears it.
-    client.delete("/api/user/scoreboard-identity")
-    assert client.get("/api/user/scoreboard-identity").status_code == 404
+    client.delete("/api/me/scoreboard-identity")
+    assert client.get("/api/me/scoreboard-identity").status_code == 404
 
 
 def test_recent_projects_detail_enriches_metadata(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5046,7 +5046,7 @@ def test_recent_projects_detail_enriches_metadata(tmp_path: Path, _user_config_h
     app = create_app()
     client = TestClient(app)
 
-    resp = client.get("/api/user/recent-projects?detail=true")
+    resp = client.get("/api/me/recent-projects?detail=true")
     assert resp.status_code == 200
     projects = resp.json()["projects"]
     by_kind = {p["kind"]: p for p in projects}
@@ -5070,7 +5070,7 @@ def test_recent_projects_detail_marks_missing_path(tmp_path: Path, _user_config_
 
     app = create_app()
     client = TestClient(app)
-    resp = client.get("/api/user/recent-projects?detail=true")
+    resp = client.get("/api/me/recent-projects?detail=true")
     kinds = [p["kind"] for p in resp.json()["projects"]]
     assert kinds == ["missing"]
 
@@ -5119,7 +5119,7 @@ def test_create_match_manual_scaffolds_match_and_binds_shooter(
 
     # Recent-projects gets only the match folder; the shooter subdir
     # inside it must not register as a standalone legacy project.
-    detail = client.get("/api/user/recent-projects?detail=true").json()
+    detail = client.get("/api/me/recent-projects?detail=true").json()
     kinds = sorted(p["kind"] for p in detail["projects"])
     assert kinds == ["match"]
 
@@ -5160,7 +5160,7 @@ def test_bind_match_folder_binds_match_root(tmp_path: Path, _user_config_home: P
     app = create_app()
     client = TestClient(app)
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target)},
     )
     assert resp.status_code == 200
@@ -5199,7 +5199,7 @@ def test_list_match_shooters_returns_active_and_others(
     app = create_app()
     client = TestClient(app)
     resp = client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
     assert resp.status_code == 200
@@ -5223,7 +5223,7 @@ def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_ho
     app = create_app()
     client = TestClient(app)
     client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
     resp = client.post("/api/match/shooters", json={"name": "Johan Larsson"})
@@ -5249,7 +5249,7 @@ def test_remove_match_shooter_drops_dir(tmp_path: Path, _user_config_home: Path)
     app = create_app()
     client = TestClient(app)
     client.post(
-        "/api/user/recent-projects/bind",
+        "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
     resp = client.delete("/api/match/shooters/jl")
@@ -5267,12 +5267,12 @@ def test_user_config_disable_flag_makes_endpoints_safe(
     client = TestClient(app)
 
     # Recording was a no-op.
-    body = client.get("/api/user/recent-projects").json()
+    body = client.get("/api/me/recent-projects").json()
     assert body == {"projects": []}
 
     # PUT silently drops; GET still returns 404.
-    client.put("/api/user/scoreboard-identity", json={"shooter_id": 1})
-    assert client.get("/api/user/scoreboard-identity").status_code == 404
+    client.put("/api/me/scoreboard-identity", json={"shooter_id": 1})
+    assert client.get("/api/me/scoreboard-identity").status_code == 404
 
 
 def test_load_env_files_picks_up_user_config_env(

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -54,9 +54,7 @@ def test_xdg_config_home_honoured_on_linux(monkeypatch: pytest.MonkeyPatch, tmp_
     assert user_config.user_config_dir() == xdg / "splitsmith"
 
 
-def test_directory_created_lazily_on_first_write(
-    _isolated_user_config: Path, tmp_path: Path
-) -> None:
+def test_directory_created_lazily_on_first_write(_isolated_user_config: Path, tmp_path: Path) -> None:
     project = tmp_path / "match"
     project.mkdir()
     assert not _isolated_user_config.exists()
@@ -74,9 +72,7 @@ def test_directory_created_lazily_on_first_write(
     assert (_isolated_user_config / user_config.PROJECTS_FILENAME).is_file()
 
 
-def test_record_project_open_appends_and_dedupes(
-    _isolated_user_config: Path, tmp_path: Path
-) -> None:
+def test_record_project_open_appends_and_dedupes(_isolated_user_config: Path, tmp_path: Path) -> None:
     a = tmp_path / "a"
     b = tmp_path / "b"
     a.mkdir()
@@ -106,9 +102,7 @@ def test_record_project_open_resolves_paths(_isolated_user_config: Path, tmp_pat
     # entry; otherwise users see one row per ``cd`` they tried.
     assert len(user_config.get_recent_projects()) <= 2  # parent + project both valid
     # The exact project itself is one entry, not duplicated.
-    project_entries = [
-        p for p in user_config.get_recent_projects() if Path(p.path) == project.resolve()
-    ]
+    project_entries = [p for p in user_config.get_recent_projects() if Path(p.path) == project.resolve()]
     assert len(project_entries) == 1
 
 

--- a/tests/test_video_match.py
+++ b/tests/test_video_match.py
@@ -203,12 +203,8 @@ def test_classify_video_against_stages_in_window() -> None:
     from splitsmith.video_match import classify_video_against_stages
 
     sc = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
-    stages = [
-        StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)
-    ]
-    cls, hits = classify_video_against_stages(
-        sc - timedelta(minutes=5), stages, tolerance_minutes=15
-    )
+    stages = [StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)]
+    cls, hits = classify_video_against_stages(sc - timedelta(minutes=5), stages, tolerance_minutes=15)
     assert cls == "in_window"
     assert hits == [1]
 
@@ -225,9 +221,7 @@ def test_classify_video_against_stages_contested() -> None:
         StageData(stage_number=2, stage_name="S2", time_seconds=10.0, scorecard_updated_at=sc2),
     ]
     # Timestamp inside both [sc1-15, sc1] and [sc2-15, sc2].
-    cls, hits = classify_video_against_stages(
-        sc1 - timedelta(minutes=2), stages, tolerance_minutes=15
-    )
+    cls, hits = classify_video_against_stages(sc1 - timedelta(minutes=2), stages, tolerance_minutes=15)
     assert cls == "contested"
     assert sorted(hits) == [1, 2]
 
@@ -237,9 +231,7 @@ def test_classify_video_against_stages_orphan() -> None:
     from splitsmith.video_match import classify_video_against_stages
 
     sc = datetime(2026, 5, 2, 14, 30, 0, tzinfo=UTC)
-    stages = [
-        StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)
-    ]
+    stages = [StageData(stage_number=1, stage_name="S1", time_seconds=10.0, scorecard_updated_at=sc)]
     # Way before any window.
     cls, hits = classify_video_against_stages(sc - timedelta(hours=3), stages, tolerance_minutes=15)
     assert cls == "orphan"


### PR DESCRIPTION
## Summary

Completes #353 by moving shooter identity out of in-memory server state
and into URL paths. Every shooter-scoped page now lives at
`/<route>/<slug>` (Audit / Coach / Videos / Export); the slug is opaque
random (`s_<8 hex>`) so URLs / disk paths / server logs no longer leak
competitor names. Plus the UX polish that fell out while exercising the
new shape on real match data.

## Architecture

### Path-scoped URLs (the core refactor)

- Singleton "active shooter" server state is gone -- every shooter-
  scoped endpoint takes `slug` from the URL: `/api/shooters/{slug}/...`
- Operator-scoped endpoints moved to `/api/me/...` (jobs, recent
  projects, scoreboard identity, project import)
- Match-scoped endpoints stay at `/api/match/...` (compare bundle,
  beep queue, shooter list, merge plan/execute)
- SPA URL shape: `/audit/<slug>`, `/audit/<slug>/<stage>`,
  `/coach/<slug>`, `/ingest/<slug>` (the "Videos" sidebar row),
  `/export/<slug>`. Slug-less visits redirect to `/shooters`.
- `ShooterScopedRoute` keys page mounts on slug; two tabs can hold two
  shooters' Audit views simultaneously with no cross-contamination.

### Opaque slugs

- `match_model.mint_shooter_slug()` mints random ids via
  `secrets.token_hex`
- Legacy single-shooter projects get a deterministic-but-opaque slug
  from `_legacy_view_slug(project)` (hash of project name + scoreboard
  ids)
- Migration command: `splitsmith match rename-shooter-slugs <path>`
  renames `shooters/<old>/` dirs in place and rewrites `match.json`

### Default shooter slug

- `/api/health` returns `kind` (`match` | `legacy`) + `default_shooter_slug`
  (alphabetically-first match shooter, or the legacy slug) so slug-less
  surfaces (Home, sidebar Audit/Coach/Export rows) plug into a sensible
  `/audit/<slug>` URL without forcing the user to pick first

### Auto-redirect on bind-state loss

- Shared `request()` in api.ts dispatches `splitsmith:no-project` on
  409 `no_project`; `MatchShell` listens, re-fetches health, the
  existing bound-check redirects to `/pick`. Survives dev-server
  restarts cleanly without leaving the user staring at a quietly-
  broken page.

### `200 null` sentinel for "doesn't exist yet" GETs

- `/api/me/scoreboard-identity`, `/api/shooters/{slug}/stages/{n}/audit`,
  and `.../coach` return `200 null` for the "not pinned yet" / "no
  audit yet" cases so they don't show up as failed requests in DevTools
  on every page load. 404 is reserved for genuinely-unknown resources.

## UX surfaced during real testing

### Shared shooter chip-strip on every shooter-scoped page

- `ShooterChipStrip` extracted from Audit's inline switcher (#354) and
  mounted on Audit / Videos / Coach / Export. Parameterised by
  `urlBase` + optional `stage`. Hidden in single-shooter matches.

### Persistent "Videos" nav row (renamed from Ingest)

- Sidebar row routes to `/ingest/<slug>` so video management is
  reachable from anywhere in match mode, not just immediately after
  project creation.
- "Find moved videos" button mounts the existing `RelinkDialog`
  (relink endpoints existed but were never wired up after the
  redesign).
- Per-video "Detect beep" button + beep status pill on each row -- a
  manual retry affordance for primaries where the scan-time auto-queue
  never fired (or fired and failed silently).

### Inline "Re-pick beep" on Audit

- Always-visible button next to the beep readout in the audit toolbar.
  Opens a `BeepWaveformPicker` inline; Apply queues trim + shot-detect
  via `overrideBeepForVideo` (server-side clears `shots[]`).
- Proactive "beep looks wrong" anomaly banner above the toolbar fires
  when heuristics suggest the beep is mis-placed (draw > 2.5s or
  last-shot overshoots stage time > 1s). Same CTA opens the inline
  picker.

### Compare's unfinished-shooters banner

- When a stage has playable shooters AND unfinished ones, an inline
  banner above the grid offers "Build trim cache" (audit exists,
  trim missing) or "Open in audit" (no audit yet) per shooter.
  Previously these shooters were only visible via the bottom-of-page
  empty state, and only when *every* shooter was unfinished.

### A11y sweep

- Completes the work `888933c` started: every `bg-led + text-bg`
  pairing in the SPA swept to `bg-led-fill + text-ink` (cream on
  `#DC2626` deeper red, per the existing `.btn-led-fill` recipe).
  Original commit only touched five surfaces; the new pages added
  since then reproduced the old pattern.

### Audit's "beep" filter count fix

- Was hardcoded to `count={1}` in `FilterBar`; now derived from
  `peaks.beep_time != null ? 1 : 0`. The legend pill no longer lies
  about whether the primary has a beep.

## Migration notes

- Existing match folders need a one-shot `splitsmith match rename-
  shooter-slugs <path>` to swap human-readable slugs for opaque ones.
  The user has applied this to their blacksmith + vads-easter
  matches.
- Tests use `"me"` as a sentinel slug for legacy single-shooter
  projects (any slug works -- legacy mode's `shooter_root(slug)`
  returns `_bound_root` regardless).

## Docs

- `docs/ux-redesign/01-jobs-to-be-done.md` -- 2026-05-16 addendum
  captures the six jobs that surfaced during the refactor + the
  blacksmith test sessions.
- `docs/ux-redesign/03-capability-inventory.md` -- new capabilities
  under their natural sections.
- `docs/ux-redesign/02-information-architecture.md` -- nav tree
  updated to show shipped URL shape + sidebar nav rows.
- `docs/ux-redesign/05-accessibility.md` -- drops the legacy
  vermillion-on-cream reference; describes the LED-fill pattern.
- `docs/ux-redesign/06-design-system.md` -- new primitives section
  (MatchShell / DeveloperShell / ShooterScopedRoute / ShooterChipStrip);
  section 2.6 notes the contrast sweep was finished.
- `docs/ux-redesign/07-redesign-progress.md` -- 2026-05-16 section
  lists every shipped change in this PR.
- `docs/ux-redesign/08-known-pain-and-rough-edges.md` -- new -- pain
  log for design-reviewer entry.
- `docs/ux-redesign/09-screenshot-tour.md` -- new -- per-surface
  capture checklist for visual review.

## CI / housekeeping

- F821 fix in `lab_promote_secondary` (URL slug missing from function
  signature)
- Bumped `tool.black.line-length` + `tool.ruff.line-length` from 100
  to 110 so the conservative wrapper + strict linter stop disagreeing.
  Bulk-reformatted 90 files. No semantic content changes.

## Test plan

- [x] All 1217 Python tests pass
- [x] `ruff check` + `black --check` clean
- [x] `tsc --noEmit` clean (SPA)
- [x] Manual: re-bound + opened two shooter tabs; the slug isolation
      works
- [x] Manual: blacksmith + vads-easter match folders renamed with
      `match rename-shooter-slugs`

## Deferred follow-ups (not blocking)

- **Stateless backend.** AppState still holds bound match-root in
  memory; auto-redirect to /pick is the safety net. True statelessness
  (match-root in URL or header) is noted as a SaaS-readiness follow-up.
- **End-to-end JTBD #1 on a fresh project.** Walking the full audit
  flow on a never-before-ingested match is the next canonical
  regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)