### PR TITLE
fix(export): source-offline state + drawer z-index + selected-card contrast

### DIFF
--- a/src/splitsmith/ui_static/src/components/JobsPanel.tsx
+++ b/src/splitsmith/ui_static/src/components/JobsPanel.tsx
@@ -210,7 +210,7 @@ export function JobsPanel() {
       {open && (
         <div
           aria-hidden
-          className="fixed inset-0 z-30 bg-bg/40"
+          className="fixed inset-0 z-[55] bg-bg/40"
           onClick={() => setOpen(false)}
         />
       )}
@@ -221,7 +221,7 @@ export function JobsPanel() {
         aria-label="Background jobs"
         aria-hidden={!open}
         className={cn(
-          "fixed bottom-0 right-0 top-0 z-40 flex w-[400px] max-w-[100vw] flex-col border-l border-rule bg-bg-glow transition-transform",
+          "fixed bottom-0 right-0 top-0 z-[60] flex w-[400px] max-w-[100vw] flex-col border-l border-rule bg-bg-glow transition-transform",
           open ? "translate-x-0" : "pointer-events-none translate-x-full",
         )}
         style={{

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -186,21 +186,31 @@ function ExportInner({ slug }: { slug: string }) {
 
   // Stage eligibility
   const stages: StageExportStatus[] = overview?.stages ?? [];
+  const auditedStages = useMemo(
+    () => stages.filter((s) => !s.skipped && s.ready_to_export),
+    [stages],
+  );
   const eligibleNumbers = useMemo(
     () =>
-      stages
-        .filter(
-          (s) =>
-            !s.skipped &&
-            s.ready_to_export &&
-            s.source_reachable !== false,
-        )
+      auditedStages
+        .filter((s) => s.source_reachable !== false)
         .map((s) => s.stage_number),
-    [stages],
+    [auditedStages],
   );
   const eligibleSet = useMemo(
     () => new Set(eligibleNumbers),
     [eligibleNumbers],
+  );
+  const sourceMissingNumbers = useMemo(
+    () =>
+      auditedStages
+        .filter((s) => s.source_reachable === false)
+        .map((s) => s.stage_number),
+    [auditedStages],
+  );
+  const sourceMissingSet = useMemo(
+    () => new Set(sourceMissingNumbers),
+    [sourceMissingNumbers],
   );
 
   // Pre-select all eligible stages on first load.
@@ -391,12 +401,32 @@ function ExportInner({ slug }: { slug: string }) {
           <Section
             number={2}
             title="Stages"
-            help={
-              eligibleNumbers.length === 0
-                ? "No stage is exportable yet. Finish auditing a stage first."
-                : `${eligibleNumbers.length} of ${stages.length} stages exportable.`
-            }
+            help={stageSectionHelp(
+              eligibleNumbers.length,
+              sourceMissingNumbers.length,
+              auditedStages.length,
+              stages.length,
+            )}
           >
+            {sourceMissingNumbers.length > 0 && (
+              <div className="mb-3 flex items-start gap-2.5 rounded-md border border-live/40 bg-live/10 px-3 py-2 text-[0.8125rem] text-ink-2">
+                <span
+                  aria-hidden
+                  className="mt-1 inline-block size-2 shrink-0 rounded-full bg-live shadow-[0_0_8px_var(--color-live-glow)]"
+                />
+                <div className="min-w-0">
+                  <div className="font-display text-[0.6875rem] font-bold uppercase tracking-[0.08em] text-live">
+                    Source offline
+                  </div>
+                  <div className="mt-0.5 text-muted">
+                    {sourceMissingNumbers.length} audited{" "}
+                    {sourceMissingNumbers.length === 1 ? "stage" : "stages"} can't
+                    export -- the original video files aren't reachable. Mount
+                    the source drive (or use Relink) and reload the page.
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="flex flex-wrap gap-2">
               {stages.map((s) => (
                 <StageChip
@@ -404,6 +434,7 @@ function ExportInner({ slug }: { slug: string }) {
                   stage={s}
                   selected={selection.has(s.stage_number)}
                   eligible={eligibleSet.has(s.stage_number)}
+                  sourceMissing={sourceMissingSet.has(s.stage_number)}
                   onToggle={() => toggleStage(s.stage_number)}
                 />
               ))}
@@ -832,7 +863,7 @@ function ModeOption({
       <div className="min-w-0 flex-1">
         <div className="mb-1 inline-flex items-center gap-2 font-display text-sm font-bold uppercase tracking-[0.04em] text-ink">
           {icon}
-          <span className={selected ? "text-led" : ""}>{title}</span>
+          <span>{title}</span>
           {badge && (
             <span className="rounded border border-rule-strong bg-surface-3 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.1em] text-muted">
               {badge}
@@ -874,16 +905,16 @@ function PresetCard({
           className="absolute inset-y-0 left-0 w-[2px] bg-led shadow-[0_0_10px_var(--color-led-glow)]"
         />
       )}
-      <div
-        className={cn(
-          "font-display text-[0.8125rem] font-bold uppercase tracking-[0.04em]",
-          selected ? "text-led" : "text-ink",
-        )}
-      >
+      <div className="font-display text-[0.8125rem] font-bold uppercase tracking-[0.04em] text-ink">
         {title}
       </div>
       {body && (
-        <div className="font-mono text-[0.6875rem] tabular-nums text-muted">
+        <div
+          className={cn(
+            "font-mono text-[0.6875rem] tabular-nums",
+            selected ? "text-ink-2" : "text-muted",
+          )}
+        >
           {body}
         </div>
       )}
@@ -895,31 +926,43 @@ function StageChip({
   stage,
   selected,
   eligible,
+  sourceMissing,
   onToggle,
 }: {
   stage: StageExportStatus;
   selected: boolean;
   eligible: boolean;
+  sourceMissing: boolean;
   onToggle: () => void;
 }) {
+  let title: string;
+  if (eligible) {
+    title = `Stage ${stage.stage_number} -- ${stage.stage_name}`;
+  } else if (sourceMissing) {
+    title = "Source video offline -- reconnect the drive and reload.";
+  } else if (stage.skipped) {
+    title = "Stage skipped.";
+  } else {
+    title = "Stage not audited yet.";
+  }
   return (
     <button
       type="button"
       onClick={onToggle}
       disabled={!eligible}
       aria-pressed={selected}
-      title={
-        eligible
-          ? `Stage ${stage.stage_number} -- ${stage.stage_name}`
-          : "Not exportable yet -- finish auditing first."
-      }
+      title={title}
       className={cn(
         "inline-flex min-h-9 items-center gap-2 rounded-md border px-3 py-1.5 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.06em] transition-all",
         !eligible &&
+          !sourceMissing &&
           "cursor-not-allowed border-rule bg-surface-2 text-subtle opacity-50",
+        !eligible &&
+          sourceMissing &&
+          "cursor-not-allowed border-live/40 bg-live/10 text-live",
         eligible &&
           selected &&
-          "border-led bg-led/10 text-led shadow-[0_0_0_1px_var(--color-led-deep),0_0_10px_var(--color-led-glow)]",
+          "border-led bg-led/10 text-ink shadow-[0_0_0_1px_var(--color-led-deep),0_0_10px_var(--color-led-glow)]",
         eligible &&
           !selected &&
           "border-rule-strong bg-surface-3 text-muted hover:bg-surface-4 hover:text-ink",
@@ -929,8 +972,32 @@ function StageChip({
         {pad2(stage.stage_number)}
       </span>
       <span>{stage.stage_name}</span>
+      {sourceMissing && (
+        <span
+          aria-hidden
+          className="ml-1 inline-block size-1.5 rounded-full bg-live shadow-[0_0_6px_var(--color-live-glow)]"
+        />
+      )}
     </button>
   );
+}
+
+function stageSectionHelp(
+  eligibleCount: number,
+  sourceMissingCount: number,
+  auditedCount: number,
+  totalCount: number,
+): string {
+  if (eligibleCount > 0) {
+    return `${eligibleCount} of ${totalCount} stages exportable.`;
+  }
+  if (sourceMissingCount > 0 && auditedCount === sourceMissingCount) {
+    return "Audited, but every source video is offline. Mount the source drive and reload.";
+  }
+  if (auditedCount === 0) {
+    return "No stage is exportable yet. Finish auditing a stage first.";
+  }
+  return "No stage is exportable. Finish auditing or reconnect missing sources.";
 }
 
 function NumInput({
@@ -1053,12 +1120,7 @@ function FormatRow({
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-1.5">
-            <span
-              className={cn(
-                "font-display text-sm font-bold uppercase tracking-[0.04em]",
-                selected ? "text-led" : "text-ink",
-              )}
-            >
+            <span className="font-display text-sm font-bold uppercase tracking-[0.04em] text-ink">
               {name}
             </span>
             <span className="font-mono text-[0.625rem] tabular-nums text-muted">


### PR DESCRIPTION
## Summary
- Distinct "source offline" state on the Export screen: audited stages whose source videos can't be reached (e.g. symlinks to an unmounted drive) now show an amber banner + chip with a mount/Relink hint, instead of being silently disabled under a misleading "finish auditing first" line.
- JobsPanel drawer + overlay z-index bumped above the sticky MatchShell header (z-50 -> z-[55]/z-[60]) so the drawer stops getting clipped by the header.
- Fixed red-on-red contrast on selected PresetCard / ModeOption / FormatRow / StageChip titles in the Export form by removing the text-led override (cream-on-tint reads cleanly; selection still signaled by the LED border + glow + side bar).

## Test plan
- [ ] /export/:slug with a project whose primaries point to an unmounted drive: shows the amber "Source offline" banner, chips render in amber with a dot, help text reads "Audited, but every source video is offline...", export button stays disabled.
- [ ] Same project with the drive mounted: chips render normally, selection works, export submits.
- [ ] Open the Jobs drawer from a /:match/* route: top of the drawer (Jobs heading + worker chip) is fully visible, not clipped by the header.
- [ ] Step through each Export section selection (mode card, padding preset, transition card, title-card style, overlay tile, output FormatRow): selected card title is legible against the red-tinted background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)