### PR TITLE
copy(site): drop headcam framing — any camera with audio works

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Splitsmith — Splits from your stage video</title>
-<meta name="description" content="Extract per-shot split times from your stage video. Any camera with audio works. Open source. Built for athletes, not lawyers.">
+<meta name="description" content="Extract per-shot split times from your stage video — any camera with audio works. Open source IPSC tooling.">
 
 <meta property="og:title" content="Splitsmith">
 <meta property="og:description" content="Splits from your stage video. Open source IPSC tooling.">
@@ -1238,9 +1238,7 @@ uv sync
     <h2 id="waitlist-title">Coming soon</h2>
     <p class="waitlist-body" id="waitlist-body">
       Share projects with a coach or a squadmate for review, without anyone
-      needing a local environment. Sync your stages between devices, keep
-      every split in one place, and invite others to annotate the runs that
-      matter.
+      needing a local environment.
     </p>
     <ul class="waitlist-points">
       <li>Hosted projects — no local install required</li>

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Splitsmith — Splits from your stage video</title>
-<meta name="description" content="Extract per-shot split times from head-mounted camera footage of IPSC matches. Open source. Built for athletes, not lawyers.">
+<meta name="description" content="Extract per-shot split times from your stage video. Any camera with audio works. Open source. Built for athletes, not lawyers.">
 
 <meta property="og:title" content="Splitsmith">
 <meta property="og:description" content="Splits from your stage video. Open source IPSC tooling.">
@@ -1000,8 +1000,8 @@ footer.colophon {
       </span>
       <h1 class="title">Coach your splits. <span class="accent">Or cut your tape.</span></h1>
       <p class="lede">
-        Your head-mounted cam already captures audio of every shot. <span class="term">Splitsmith</span> turns it into
-        per-shot splits you can review and coach inside the app — shot-by-shot playback, multi-shooter compare,
+        Any camera with audio already captured every shot you took on stage. <span class="term">Splitsmith</span> turns that audio
+        into per-shot splits you can review and coach inside the app — shot-by-shot playback, multi-shooter compare,
         per-shot notes — or export an FCPXML timeline with frame-aligned markers you can pop open in
         Final Cut Pro and step through on <span class="num">M</span> / <span class="num">Shift+M</span>.
         The RO's timer only records your total stage time — the splits live in your video, and this is how you get them out.
@@ -1057,7 +1057,7 @@ footer.colophon {
       <div class="step">
         <div class="step-num"><span class="dot"></span>Step 01</div>
         <h3>Ingest</h3>
-        <p>Drop a folder of head-cam clips. The engine auto-matches them to stages by file timestamp.</p>
+        <p>Drop a folder of stage clips from any camera. The engine auto-matches them to stages by file timestamp.</p>
       </div>
       <div class="step">
         <div class="step-num"><span class="dot"></span>Step 02</div>
@@ -1133,9 +1133,9 @@ footer.colophon {
     <div class="io-grid">
       <div class="io-card">
         <div class="io-label">Inputs</div>
-        <h3>Just drop in video</h3>
+        <h3>Any camera with audio</h3>
         <ul class="io-list">
-          <li><code>VIDEO</code><span class="desc">Footage from head, chest, gimbal, or handheld cameras — MP4, MOV, MKV, .360, and more</span></li>
+          <li><code>VIDEO</code><span class="desc">Head, chest, gimbal, handheld — if it recorded the beep and the shots, it works. MP4, MOV, MKV, .360, and more</span></li>
         </ul>
       </div>
       <div class="io-card">


### PR DESCRIPTION
## Summary

The marketing site framed Splitsmith as a headcam tool in three spots, even though the IO list and Corpus block already correctly say it works across head, chest, gimbal, and handheld setups. This pass aligns the rest of the copy with that broader framing — the only real requirement is a camera that captured audio.

## Changes (`site/index.html`)

- **Meta description** — "head-mounted camera footage of IPSC matches" → "your stage video. Any camera with audio works."
- **Hero lede** — "Your head-mounted cam already captures audio of every shot" → "Any camera with audio already captured every shot you took on stage."
- **Pipeline · Ingest** — "a folder of head-cam clips" → "a folder of stage clips from any camera."
- **IO input card** — title "Just drop in video" → "Any camera with audio"; description now leads with "Head, chest, gimbal, handheld — if it recorded the beep and the shots, it works."

Corpus enumeration ("head, chest, gimbal, and handheld setups") left intact — it documents training-data coverage, which is evidentiary rather than positioning.

## Test plan

- [ ] `pnpm pages:dev` from repo root and visually confirm the hero, Pipeline 01, and IO card read correctly on desktop + narrow viewport
- [ ] Inspect `<meta name="description">` in page source
- [ ] Cloudflare Pages preview deploy renders without layout shifts (no structural HTML changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZfnDVu9KhLpGb88gsyF5X)_