### PR TITLE
feat(runtime): process-wide config for artifacts + binaries (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ production UI's ``/api/stages/{n}/shot-detect`` endpoint. Calibration
 artifacts ship under ``src/splitsmith/data/`` (built once by
 ``scripts/build_ensemble_artifacts.py``); the FastAPI server lazy-loads
 the CLAP / PANN / GBDT models on the first detection. Re-run the build
-script after adding new audited fixtures.
+script after adding new audited fixtures. Set
+``SPLITSMITH_ARTIFACTS_DIR=/path/to/experimental`` to point the engine
+at a different artifact set for A/B comparisons without rebuilding the
+shipped one (see ``splitsmith.runtime`` for the full env-var list).
 
 The review-time variant generator ``scripts/build_ensemble_fixture.py``
 still exists for offline comparison under ``build/ensemble-review/``.

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -39,6 +39,7 @@ from . import (
 from . import (
     cleanup as cleanup_mod,
 )
+from .runtime import runtime
 from .config import (
     CompetitorStages,
     Config,
@@ -527,15 +528,16 @@ def audit_prep(
     config = Config.load(config_path)
     if not video.exists():
         raise typer.BadParameter(f"video not found: {video}")
-    if not shutil.which("ffmpeg"):
-        raise typer.BadParameter("ffmpeg is required to extract audio")
+    ffmpeg_bin = runtime().ffmpeg_binary
+    if not shutil.which(ffmpeg_bin):
+        raise typer.BadParameter(f"ffmpeg binary not found: {ffmpeg_bin}")
     output_dir.mkdir(parents=True, exist_ok=True)
 
     full_wav = output_dir / f"{stem}-FULL.wav"
     console.print(f"  extracting full audio -> {full_wav}")
     _subprocess.run(
         [
-            "ffmpeg",
+            ffmpeg_bin,
             "-hide_banner",
             "-loglevel",
             "error",
@@ -812,7 +814,7 @@ def fcpxml(
         )
         for r in rows
     ]
-    meta = fcpxml_gen.probe_video(video)
+    meta = fcpxml_gen.probe_video(video, ffprobe_binary=runtime().ffprobe_binary)
     fcpxml_gen.generate_fcpxml(
         video_path=video,
         video=meta,
@@ -887,6 +889,7 @@ def overlay(
         max_fps=max_fps,
         font_name=font_name,
         theme=theme,  # type: ignore[arg-type]
+        ffmpeg_binary=runtime().ffmpeg_binary,
     )
     console.print(f"[green]Wrote[/] {output}")
 
@@ -1009,6 +1012,7 @@ def _process_one(
             crf=config.output.trim_audit_crf,
             preset=config.output.trim_audit_preset,
             overwrite=True,
+            ffmpeg_binary=runtime().ffmpeg_binary,
         )
         console.print(f"  [green]trimmed video[/]: {files.video}")
 
@@ -1023,7 +1027,7 @@ def _process_one(
 
     if write_fcpxml and files.video and files.video.exists():
         files.fcpxml = output_dir / f"{base}.fcpxml"
-        meta = fcpxml_gen.probe_video(files.video)
+        meta = fcpxml_gen.probe_video(files.video, ffprobe_binary=runtime().ffprobe_binary)
         fcpxml_gen.generate_fcpxml(
             video_path=files.video,
             video=meta,
@@ -1099,13 +1103,16 @@ def _extract_or_load_audio(video: Path, audio_path: Path):
     which trades disk for repeat-run speed.
     """
     if not audio_path.exists() or audio_path.stat().st_mtime < video.stat().st_mtime:
-        if not shutil.which("ffmpeg"):
-            raise typer.BadParameter("ffmpeg is required to extract audio from video files")
+        ffmpeg_bin = runtime().ffmpeg_binary
+        if not shutil.which(ffmpeg_bin):
+            raise typer.BadParameter(
+                f"ffmpeg binary not found: {ffmpeg_bin} (required to extract audio)"
+            )
         import subprocess
 
         subprocess.run(
             [
-                "ffmpeg",
+                ffmpeg_bin,
                 "-hide_banner",
                 "-loglevel",
                 "error",

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -39,7 +39,6 @@ from . import (
 from . import (
     cleanup as cleanup_mod,
 )
-from .runtime import runtime
 from .config import (
     CompetitorStages,
     Config,
@@ -48,6 +47,7 @@ from .config import (
     StageAnalysis,
     StageData,
 )
+from .runtime import runtime
 from .ui.project import MatchProject
 
 app = typer.Typer(
@@ -1105,9 +1105,7 @@ def _extract_or_load_audio(video: Path, audio_path: Path):
     if not audio_path.exists() or audio_path.stat().st_mtime < video.stat().st_mtime:
         ffmpeg_bin = runtime().ffmpeg_binary
         if not shutil.which(ffmpeg_bin):
-            raise typer.BadParameter(
-                f"ffmpeg binary not found: {ffmpeg_bin} (required to extract audio)"
-            )
+            raise typer.BadParameter(f"ffmpeg binary not found: {ffmpeg_bin} (required to extract audio)")
         import subprocess
 
         subprocess.run(

--- a/src/splitsmith/compare/emitter.py
+++ b/src/splitsmith/compare/emitter.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 from ..config import OutputConfig
+from ..runtime import runtime
 from ..fcpxml_gen import (
     VideoMetadata,
     _asset_grid_str,
@@ -234,6 +235,7 @@ def emit_compare_fcpxml(
             duration_seconds=duration_seconds,
             output_dir=filler_dir,
             runner=runner,
+            ffmpeg_binary=runtime().ffmpeg_binary,
         )
         format_id = _format_id_for(seq_meta)  # shares the sequence format
         asset_id = _next_id()

--- a/src/splitsmith/compare/emitter.py
+++ b/src/splitsmith/compare/emitter.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 from ..config import OutputConfig
-from ..runtime import runtime
 from ..fcpxml_gen import (
     VideoMetadata,
     _asset_grid_str,
@@ -28,6 +27,7 @@ from ..fcpxml_gen import (
     _frame_aligned_str,
     _tag_source_application,
 )
+from ..runtime import runtime
 from .filler import Runner as FillerRunner
 from .filler import ensure_filler
 from .layout import GridSlot, compute_layout

--- a/src/splitsmith/ensemble/calibration.py
+++ b/src/splitsmith/ensemble/calibration.py
@@ -17,10 +17,11 @@ installed (wheel) or run from the source tree.
 from __future__ import annotations
 
 import json
-from importlib.resources import as_file, files
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+from ..runtime import runtime
 
 # Coarse camera classes the ensemble stratifies thresholds on. Keeping the
 # vocabulary small on purpose: we only stratify per-voter thresholds today,
@@ -327,16 +328,13 @@ class EnsembleCalibration(BaseModel):
         return next(iter(per_class.values()))
 
 
-_DATA_PACKAGE = "splitsmith.data"
-_CALIBRATION_FILENAME = "ensemble_calibration.json"
-_VOTER_C_MODEL_FILENAME = "voter_c_gbdt.joblib"
 DEFAULT_VOTER_E_PROBE_FILENAME = "voter_e_visual_probe.joblib"
 
 
 def load_calibration() -> EnsembleCalibration:
-    """Read ``ensemble_calibration.json`` from the installed package."""
-    resource = files(_DATA_PACKAGE).joinpath(_CALIBRATION_FILENAME)
-    with resource.open("r", encoding="utf-8") as fh:
+    """Read ``ensemble_calibration.json`` from the resolved artifacts dir."""
+    path = runtime().artifact("ensemble_calibration.json")
+    with path.open("r", encoding="utf-8") as fh:
         return EnsembleCalibration.model_validate(json.load(fh))
 
 
@@ -349,11 +347,7 @@ def load_voter_c_model() -> dict[str, Any]:
     """
     import joblib
 
-    resource = files(_DATA_PACKAGE).joinpath(_VOTER_C_MODEL_FILENAME)
-    # joblib needs a real filesystem path, so materialise via as_file (which
-    # is a no-op when the package is laid out on disk).
-    with as_file(resource) as path:
-        return joblib.load(path)
+    return joblib.load(runtime().artifact("voter_c_gbdt.joblib"))
 
 
 def load_voter_e_probe(filename: str | None = None) -> Any | None:
@@ -367,8 +361,7 @@ def load_voter_e_probe(filename: str | None = None) -> Any | None:
     import joblib
 
     name = filename or DEFAULT_VOTER_E_PROBE_FILENAME
-    resource = files(_DATA_PACKAGE).joinpath(name)
-    if not resource.is_file():
+    path = runtime().artifacts_dir / name
+    if not path.is_file():
         return None
-    with as_file(resource) as path:
-        return joblib.load(path)
+    return joblib.load(path)

--- a/src/splitsmith/ensemble/visual.py
+++ b/src/splitsmith/ensemble/visual.py
@@ -28,6 +28,8 @@ from typing import Any
 
 import numpy as np
 
+from ..runtime import runtime as process_runtime
+
 CLIP_VISUAL_MODEL_ID = "openai/clip-vit-base-patch32"
 CLIP_VISUAL_EMBED_DIM = 512
 DEFAULT_FRAME_OFFSETS: tuple[float, ...] = (0.0,)
@@ -172,8 +174,9 @@ def compute_visual_features(
         return np.zeros((0, n_offsets * CLIP_VISUAL_EMBED_DIM), dtype=np.float32)
     if not video_path.exists():
         raise FileNotFoundError(f"Voter E source video not found: {video_path}")
-    if not shutil.which("ffmpeg"):
-        raise RuntimeError("Voter E requires ffmpeg on $PATH")
+    ffmpeg_bin = process_runtime().ffmpeg_binary
+    if not shutil.which(ffmpeg_bin):
+        raise RuntimeError(f"Voter E requires ffmpeg: {ffmpeg_bin} not found")
 
     fingerprint = _video_fingerprint(video_path)
     times = np.asarray(source_times, dtype=np.float64)
@@ -188,7 +191,7 @@ def compute_visual_features(
                 missing.append((p, float(t) + float(off)))
 
     for dest, t_seek in missing:
-        if not _extract_frame(video_path, t_seek, dest):
+        if not _extract_frame(video_path, t_seek, dest, ffmpeg=ffmpeg_bin):
             raise RuntimeError(
                 f"Voter E: ffmpeg frame extraction failed for {video_path} at "
                 f"t={t_seek:.3f}s (target {dest.name})"

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -24,6 +24,7 @@ from . import beep_detect
 from . import lab as lab_module
 from .cross_align import CrossAlignError, align_secondary_to_primary
 from .ensemble.api import detect_shots_ensemble, load_ensemble_runtime
+from .runtime import runtime as process_runtime
 from .fixture_schema import (
     AgcState,
     AudioSource,
@@ -275,10 +276,11 @@ def load_config(
 
 def _extract_video_audio(video: Path, dest: Path, *, sample_rate: int) -> None:
     """Drop a mono float32 WAV at ``dest`` from ``video`` via ffmpeg."""
-    if not shutil.which("ffmpeg"):
-        raise typer.BadParameter("ffmpeg binary not found on PATH")
+    ffmpeg_bin = process_runtime().ffmpeg_binary
+    if not shutil.which(ffmpeg_bin):
+        raise typer.BadParameter(f"ffmpeg binary not found: {ffmpeg_bin}")
     cmd = [
-        "ffmpeg",
+        ffmpeg_bin,
         "-hide_banner",
         "-loglevel",
         "error",

--- a/src/splitsmith/lab_cli.py
+++ b/src/splitsmith/lab_cli.py
@@ -24,7 +24,6 @@ from . import beep_detect
 from . import lab as lab_module
 from .cross_align import CrossAlignError, align_secondary_to_primary
 from .ensemble.api import detect_shots_ensemble, load_ensemble_runtime
-from .runtime import runtime as process_runtime
 from .fixture_schema import (
     AgcState,
     AudioSource,
@@ -34,6 +33,7 @@ from .fixture_schema import (
     probe_camera_metadata,
 )
 from .lab.snap_window import snap_anchor_shots
+from .runtime import runtime as process_runtime
 
 app = typer.Typer(help="Algorithm lab: fixtures, eval, tuning.", no_args_is_help=True)
 

--- a/src/splitsmith/runtime.py
+++ b/src/splitsmith/runtime.py
@@ -1,0 +1,197 @@
+"""Process-wide runtime config for artifacts and binaries (issue #130).
+
+One resolver decides where ensemble artifacts live and which
+``ffmpeg`` / ``ffprobe`` to invoke. Read everywhere via :func:`runtime`
+so no module hardcodes ``"ffmpeg"`` at the orchestrator layer again.
+
+The motivating use case is the (closed-source) desktop shell from
+issue #129: a Tauri app bundles its own ffmpeg and ensemble artifacts
+and points the embedded engine at them via env vars, without forking.
+The same hooks let OSS users A/B-test custom model artifacts:
+
+    SPLITSMITH_ARTIFACTS_DIR=/path/to/experimental splitsmith ui
+
+Resolution priority for every field:
+
+1. Explicit kwargs to :func:`resolve_runtime`.
+2. Environment variables (see ``ENV_*`` constants below).
+3. Built-in defaults: package data dir for artifacts, ``shutil.which``
+   for binaries, platform-appropriate cache/config dirs.
+
+The first call has a side effect: it ``setdefault``-s ``HF_HOME`` and
+``TORCH_HOME`` into the resolved cache dir so CLAP / PANN downloads
+land somewhere a packaged app can clean up, instead of the user's
+home dir.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ENV_ARTIFACTS_DIR = "SPLITSMITH_ARTIFACTS_DIR"
+ENV_FFMPEG = "SPLITSMITH_FFMPEG"
+ENV_FFPROBE = "SPLITSMITH_FFPROBE"
+ENV_CACHE_DIR = "SPLITSMITH_CACHE_DIR"
+ENV_CONFIG_DIR = "SPLITSMITH_CONFIG_DIR"
+
+_PACKAGE_DATA_DIR = Path(__file__).parent / "data"
+
+
+@dataclass(frozen=True)
+class Runtime:
+    """Resolved locations of all process-wide engine resources.
+
+    Read fields directly, or call :meth:`artifact` for files inside
+    :attr:`artifacts_dir` (raises ``FileNotFoundError`` with an
+    actionable message when the artifact is missing -- typically means
+    a stale ``SPLITSMITH_ARTIFACTS_DIR`` override).
+    """
+
+    artifacts_dir: Path
+    ffmpeg_binary: str
+    ffprobe_binary: str
+    cache_dir: Path
+    user_config_dir: Path
+
+    def artifact(self, name: str) -> Path:
+        path = self.artifacts_dir / name
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"splitsmith artifact {name!r} not found under "
+                f"{self.artifacts_dir} -- check ${ENV_ARTIFACTS_DIR} or "
+                "rebuild via scripts/build_ensemble_artifacts.py"
+            )
+        return path
+
+
+def _platform_cache_dir() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "splitsmith"
+    if sys.platform.startswith("win"):
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "splitsmith"
+        return Path.home() / "AppData" / "Local" / "splitsmith"
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / "splitsmith"
+    return Path.home() / ".cache" / "splitsmith"
+
+
+def _platform_user_config_dir() -> Path:
+    # Mirror the convention from ``user_config.py`` so both modules
+    # agree on where per-user state lives.
+    if sys.platform.startswith("linux"):
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        if xdg:
+            return Path(xdg) / "splitsmith"
+        return Path.home() / ".config" / "splitsmith"
+    return Path.home() / ".splitsmith"
+
+
+def _resolve_binary(
+    explicit: str | None, env_name: str, default: str
+) -> str:
+    if explicit:
+        return explicit
+    env_val = os.environ.get(env_name)
+    if env_val:
+        return env_val
+    return default
+
+
+def _validate_binary(value: str, label: str) -> None:
+    """Log (do not raise) when ``value`` doesn't look invocable."""
+    # Absolute path: must exist on disk.
+    candidate = Path(value)
+    if candidate.is_absolute():
+        if not candidate.exists():
+            logger.warning(
+                "%s binary %s does not exist on disk; subprocess calls will fail",
+                label,
+                value,
+            )
+        return
+    if shutil.which(value) is None:
+        logger.warning(
+            "%s binary %r not found on PATH; subprocess calls will fail",
+            label,
+            value,
+        )
+
+
+@lru_cache(maxsize=1)
+def resolve_runtime(
+    *,
+    artifacts_dir: Path | str | None = None,
+    ffmpeg_binary: str | None = None,
+    ffprobe_binary: str | None = None,
+    cache_dir: Path | str | None = None,
+    user_config_dir: Path | str | None = None,
+) -> Runtime:
+    """Build and cache the process-wide :class:`Runtime`.
+
+    Each parameter follows the same priority: explicit kwarg > env var
+    > built-in default. Pass kwargs to pin an override programmatically
+    (tests, embedded host); leave them ``None`` for normal use.
+
+    The result is cached for the lifetime of the process. Tests can
+    reset the cache via :func:`_clear_runtime_cache`.
+    """
+    art_env = os.environ.get(ENV_ARTIFACTS_DIR)
+    art = (
+        Path(artifacts_dir)
+        if artifacts_dir is not None
+        else Path(art_env) if art_env else _PACKAGE_DATA_DIR
+    )
+
+    cache_env = os.environ.get(ENV_CACHE_DIR)
+    cache = (
+        Path(cache_dir)
+        if cache_dir is not None
+        else Path(cache_env) if cache_env else _platform_cache_dir()
+    )
+
+    cfg_env = os.environ.get(ENV_CONFIG_DIR)
+    cfg = (
+        Path(user_config_dir)
+        if user_config_dir is not None
+        else Path(cfg_env) if cfg_env else _platform_user_config_dir()
+    )
+
+    ffm = _resolve_binary(ffmpeg_binary, ENV_FFMPEG, "ffmpeg")
+    ffp = _resolve_binary(ffprobe_binary, ENV_FFPROBE, "ffprobe")
+    _validate_binary(ffm, "ffmpeg")
+    _validate_binary(ffp, "ffprobe")
+
+    # Point HuggingFace / Torch caches into our cleanable cache dir so
+    # CLAP/PANN downloads don't pollute ``~``. ``setdefault`` so users
+    # who already point these elsewhere stay in control.
+    os.environ.setdefault("HF_HOME", str(cache / "hf"))
+    os.environ.setdefault("TORCH_HOME", str(cache / "torch"))
+
+    return Runtime(
+        artifacts_dir=art,
+        ffmpeg_binary=ffm,
+        ffprobe_binary=ffp,
+        cache_dir=cache,
+        user_config_dir=cfg,
+    )
+
+
+def runtime() -> Runtime:
+    """Return the cached process-wide :class:`Runtime` (resolving on first call)."""
+    return resolve_runtime()
+
+
+def _clear_runtime_cache() -> None:
+    """Reset the ``lru_cache`` on :func:`resolve_runtime`. Test-only helper."""
+    resolve_runtime.cache_clear()

--- a/src/splitsmith/runtime.py
+++ b/src/splitsmith/runtime.py
@@ -97,9 +97,7 @@ def _platform_user_config_dir() -> Path:
     return Path.home() / ".splitsmith"
 
 
-def _resolve_binary(
-    explicit: str | None, env_name: str, default: str
-) -> str:
+def _resolve_binary(explicit: str | None, env_name: str, default: str) -> str:
     if explicit:
         return explicit
     env_val = os.environ.get(env_name)
@@ -148,16 +146,12 @@ def resolve_runtime(
     """
     art_env = os.environ.get(ENV_ARTIFACTS_DIR)
     art = (
-        Path(artifacts_dir)
-        if artifacts_dir is not None
-        else Path(art_env) if art_env else _PACKAGE_DATA_DIR
+        Path(artifacts_dir) if artifacts_dir is not None else Path(art_env) if art_env else _PACKAGE_DATA_DIR
     )
 
     cache_env = os.environ.get(ENV_CACHE_DIR)
     cache = (
-        Path(cache_dir)
-        if cache_dir is not None
-        else Path(cache_env) if cache_env else _platform_cache_dir()
+        Path(cache_dir) if cache_dir is not None else Path(cache_env) if cache_env else _platform_cache_dir()
     )
 
     cfg_env = os.environ.get(ENV_CONFIG_DIR)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -100,6 +100,7 @@ from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
+from ..runtime import runtime as process_runtime
 from ..config import (
     BeepDetectConfig,
     CoachAutoClassifyConfig,
@@ -660,11 +661,12 @@ def _trim_wav_to_clip(src_wav: Path, dst_wav: Path, start_s: float, end_s: float
     Re-encodes (PCM s16 / mono / 48 kHz) so the output is a stable WAV
     regardless of the source codec.
     """
-    if not shutil.which("ffmpeg"):
-        raise RuntimeError("ffmpeg binary not found on PATH")
+    ffmpeg_bin = process_runtime().ffmpeg_binary
+    if not shutil.which(ffmpeg_bin):
+        raise RuntimeError(f"ffmpeg binary not found: {ffmpeg_bin}")
     duration = max(0.0, end_s - start_s)
     cmd = [
-        "ffmpeg",
+        ffmpeg_bin,
         "-hide_banner",
         "-loglevel",
         "error",
@@ -3028,6 +3030,7 @@ def create_app(
                 video,
                 source,
                 project=proj,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
         except beep_detect.BeepNotFoundError as exc:
             # Primary failure is fatal -- the entire downstream pipeline
@@ -3150,6 +3153,7 @@ def create_app(
                     stg.time_seconds,
                     project=proj,
                     runner=_cancellable_runner(handle),
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
                 )
                 video.processed["trim"] = True
                 trimmed_ok = True
@@ -3443,6 +3447,7 @@ def create_app(
             stg.time_seconds,
             project=proj,
             runner=_cancellable_runner(handle),
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
         )
         handle.update(progress=0.85, message="Saving project...")
         # Read-modify-write to avoid stomping concurrent edits made
@@ -3513,6 +3518,7 @@ def create_app(
             stg.time_seconds,
             project=proj,
             runner=_cancellable_runner(handle),
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
         )
         handle.update(progress=0.85, message="Saving project...")
         fresh = MatchProject.load(shooter_root)
@@ -3592,6 +3598,7 @@ def create_app(
                 stg.time_seconds,
                 project=proj,
                 runner=_cancellable_runner(handle),
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
             trim_fresh = state.shooter_project(slug)
             try:
@@ -3618,6 +3625,7 @@ def create_app(
             source,
             prim.beep_time,
             project=proj,
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
         )
         beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else prim.beep_time
 
@@ -4145,7 +4153,12 @@ def create_app(
             raise HTTPException(status_code=400, detail="window_s must be > 0")
 
         audio_path = audio_helpers.ensure_video_audio(
-            state.shooter_root(slug), stage_number, video, source, project=project
+            state.shooter_root(slug),
+            stage_number,
+            video,
+            source,
+            project=project,
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
         )
         audio, sr = beep_detect.load_audio(audio_path)
         duration_s = audio.size / sr if sr > 0 else 0.0
@@ -4407,6 +4420,7 @@ def create_app(
                 project.resolve_video_path(state.shooter_root(slug), primary.path),
                 primary.beep_time,
                 project=project,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -4436,6 +4450,7 @@ def create_app(
                 video,
                 source,
                 project=project,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -4477,6 +4492,7 @@ def create_app(
                 center_time=float(center),
                 duration_s=1.0,
                 width=480,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
         except thumbnail_helpers.ThumbnailError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -7839,7 +7855,12 @@ def create_app(
 
             try:
                 secondary_wav_path = audio_helpers.ensure_video_audio(
-                    state.shooter_root(slug), stage_number, video, source, project=project
+                    state.shooter_root(slug),
+                    stage_number,
+                    video,
+                    source,
+                    project=project,
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
                 )
             except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -8054,7 +8075,12 @@ def create_app(
 
             try:
                 secondary_wav_path = audio_helpers.ensure_video_audio(
-                    state.shooter_root(slug), stage_number, video, source, project=project
+                    state.shooter_root(slug),
+                    stage_number,
+                    video,
+                    source,
+                    project=project,
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
                 )
             except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -8737,7 +8763,11 @@ def _video_metadata_for(
         duration = cached_probe.duration
     elif allow_new:
         try:
-            result = video_probe.probe(source, cache_dir=probes_dir)
+            result = video_probe.probe(
+                source,
+                cache_dir=probes_dir,
+                ffprobe_binary=process_runtime().ffprobe_binary,
+            )
             duration = result.duration
         except video_probe.ProbeError as exc:
             logger.debug("probe failed for %s: %s", source, exc)
@@ -8753,6 +8783,7 @@ def _video_metadata_for(
                 source,
                 cache_dir=thumbs_dir,
                 duration=t_dur,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
             )
             thumbnail_url = f"/api/shooters/{slug}/thumbnails/{extracted.stem}.jpg"
         except thumbnail_helpers.ThumbnailError as exc:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -100,7 +100,6 @@ from .. import ensemble as ensemble_module
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
-from ..runtime import runtime as process_runtime
 from ..config import (
     BeepDetectConfig,
     CoachAutoClassifyConfig,
@@ -117,6 +116,7 @@ from ..fixture_schema import (
     CameraPosition,
     probe_camera_metadata,
 )
+from ..runtime import runtime as process_runtime
 from . import audio as audio_helpers
 from . import exports as export_helpers
 from . import match_exports as match_export_helpers

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,178 @@
+"""Tests for ``splitsmith.runtime`` (issue #130)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from splitsmith import runtime as runtime_module
+from splitsmith.runtime import (
+    ENV_ARTIFACTS_DIR,
+    ENV_CACHE_DIR,
+    ENV_CONFIG_DIR,
+    ENV_FFMPEG,
+    ENV_FFPROBE,
+    _clear_runtime_cache,
+    resolve_runtime,
+    runtime,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear the resolver cache + scrub runtime env vars per test.
+
+    Without this, tests leak Runtime objects across each other and the
+    autouse ``_isolate_user_config`` fixture's ``SPLITSMITH_HOME`` --
+    plus any developer-shell exports -- bleed into the priority test.
+    """
+    for key in (
+        ENV_ARTIFACTS_DIR,
+        ENV_FFMPEG,
+        ENV_FFPROBE,
+        ENV_CACHE_DIR,
+        ENV_CONFIG_DIR,
+        "HF_HOME",
+        "TORCH_HOME",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    _clear_runtime_cache()
+    yield
+    _clear_runtime_cache()
+
+
+def test_default_artifacts_dir_points_at_package_data() -> None:
+    rt = resolve_runtime()
+    assert rt.artifacts_dir.name == "data"
+    # The shipped calibration should resolve via ``artifact()``.
+    assert rt.artifact("ensemble_calibration.json").is_file()
+
+
+def test_artifact_missing_raises_actionable_error(tmp_path: Path) -> None:
+    rt = resolve_runtime(artifacts_dir=tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        rt.artifact("ensemble_calibration.json")
+    msg = str(exc.value)
+    assert "ensemble_calibration.json" in msg
+    assert str(tmp_path) in msg
+    assert ENV_ARTIFACTS_DIR in msg
+
+
+def test_explicit_kwarg_beats_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_dir = tmp_path / "env-dir"
+    kwarg_dir = tmp_path / "kwarg-dir"
+    env_dir.mkdir()
+    kwarg_dir.mkdir()
+    monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(env_dir))
+    monkeypatch.setenv(ENV_FFMPEG, "/env/bin/ffmpeg")
+
+    rt = resolve_runtime(
+        artifacts_dir=kwarg_dir, ffmpeg_binary="/kwarg/bin/ffmpeg"
+    )
+    assert rt.artifacts_dir == kwarg_dir
+    assert rt.ffmpeg_binary == "/kwarg/bin/ffmpeg"
+
+
+def test_env_beats_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(tmp_path))
+    monkeypatch.setenv(ENV_FFMPEG, "/env/ffmpeg")
+    monkeypatch.setenv(ENV_FFPROBE, "/env/ffprobe")
+    monkeypatch.setenv(ENV_CACHE_DIR, str(tmp_path / "cache"))
+    monkeypatch.setenv(ENV_CONFIG_DIR, str(tmp_path / "cfg"))
+
+    rt = resolve_runtime()
+    assert rt.artifacts_dir == tmp_path
+    assert rt.ffmpeg_binary == "/env/ffmpeg"
+    assert rt.ffprobe_binary == "/env/ffprobe"
+    assert rt.cache_dir == tmp_path / "cache"
+    assert rt.user_config_dir == tmp_path / "cfg"
+
+
+def test_default_binary_is_ffmpeg() -> None:
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == "ffmpeg"
+    assert rt.ffprobe_binary == "ffprobe"
+
+
+def test_default_cache_dir_is_platform_specific() -> None:
+    rt = resolve_runtime()
+    if sys.platform == "darwin":
+        assert rt.cache_dir == Path.home() / "Library" / "Caches" / "splitsmith"
+    elif sys.platform.startswith("win"):
+        # The cache dir lands under ``%LOCALAPPDATA%\splitsmith`` or
+        # ``~/AppData/Local/splitsmith``. Either is acceptable.
+        assert rt.cache_dir.name == "splitsmith"
+    else:
+        # Linux: XDG_CACHE_HOME-aware -- with the env var scrubbed by
+        # the fixture, falls back to ``~/.cache/splitsmith``.
+        assert rt.cache_dir == Path.home() / ".cache" / "splitsmith"
+
+
+def test_hf_and_torch_home_setdefault(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cache = tmp_path / "cache"
+    monkeypatch.setenv(ENV_CACHE_DIR, str(cache))
+    resolve_runtime()
+    assert os.environ["HF_HOME"] == str(cache / "hf")
+    assert os.environ["TORCH_HOME"] == str(cache / "torch")
+
+
+def test_hf_and_torch_home_respect_existing_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HF_HOME", "/already/set/hf")
+    monkeypatch.setenv("TORCH_HOME", "/already/set/torch")
+    monkeypatch.setenv(ENV_CACHE_DIR, str(tmp_path))
+    resolve_runtime()
+    assert os.environ["HF_HOME"] == "/already/set/hf"
+    assert os.environ["TORCH_HOME"] == "/already/set/torch"
+
+
+def test_resolve_runtime_is_cached() -> None:
+    first = resolve_runtime()
+    second = resolve_runtime()
+    assert first is second
+    assert runtime() is first
+
+
+def test_clear_runtime_cache_resets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    first = resolve_runtime()
+    monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(tmp_path))
+    # Without clearing, the cached value wins.
+    assert resolve_runtime() is first
+    _clear_runtime_cache()
+    second = resolve_runtime()
+    assert second is not first
+    assert second.artifacts_dir == tmp_path
+
+
+def test_missing_binary_logs_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv(ENV_FFMPEG, "definitely-not-a-real-binary-xyz")
+    with caplog.at_level("WARNING", logger=runtime_module.__name__):
+        rt = resolve_runtime()
+    assert rt.ffmpeg_binary == "definitely-not-a-real-binary-xyz"
+    assert any("ffmpeg" in r.message for r in caplog.records)
+
+
+def test_calibration_loader_uses_runtime_artifacts_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The actionable error from ``runtime().artifact()`` reaches callers."""
+    from splitsmith.ensemble.calibration import load_calibration
+
+    monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(tmp_path))
+    with pytest.raises(FileNotFoundError) as exc:
+        load_calibration()
+    assert "ensemble_calibration.json" in str(exc.value)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -61,9 +61,7 @@ def test_artifact_missing_raises_actionable_error(tmp_path: Path) -> None:
     assert ENV_ARTIFACTS_DIR in msg
 
 
-def test_explicit_kwarg_beats_env(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_explicit_kwarg_beats_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     env_dir = tmp_path / "env-dir"
     kwarg_dir = tmp_path / "kwarg-dir"
     env_dir.mkdir()
@@ -71,16 +69,12 @@ def test_explicit_kwarg_beats_env(
     monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(env_dir))
     monkeypatch.setenv(ENV_FFMPEG, "/env/bin/ffmpeg")
 
-    rt = resolve_runtime(
-        artifacts_dir=kwarg_dir, ffmpeg_binary="/kwarg/bin/ffmpeg"
-    )
+    rt = resolve_runtime(artifacts_dir=kwarg_dir, ffmpeg_binary="/kwarg/bin/ffmpeg")
     assert rt.artifacts_dir == kwarg_dir
     assert rt.ffmpeg_binary == "/kwarg/bin/ffmpeg"
 
 
-def test_env_beats_default(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_env_beats_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(tmp_path))
     monkeypatch.setenv(ENV_FFMPEG, "/env/ffmpeg")
     monkeypatch.setenv(ENV_FFPROBE, "/env/ffprobe")
@@ -115,9 +109,7 @@ def test_default_cache_dir_is_platform_specific() -> None:
         assert rt.cache_dir == Path.home() / ".cache" / "splitsmith"
 
 
-def test_hf_and_torch_home_setdefault(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_hf_and_torch_home_setdefault(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cache = tmp_path / "cache"
     monkeypatch.setenv(ENV_CACHE_DIR, str(cache))
     resolve_runtime()
@@ -125,9 +117,7 @@ def test_hf_and_torch_home_setdefault(
     assert os.environ["TORCH_HOME"] == str(cache / "torch")
 
 
-def test_hf_and_torch_home_respect_existing_value(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_hf_and_torch_home_respect_existing_value(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HF_HOME", "/already/set/hf")
     monkeypatch.setenv("TORCH_HOME", "/already/set/torch")
     monkeypatch.setenv(ENV_CACHE_DIR, str(tmp_path))
@@ -143,9 +133,7 @@ def test_resolve_runtime_is_cached() -> None:
     assert runtime() is first
 
 
-def test_clear_runtime_cache_resets(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_clear_runtime_cache_resets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     first = resolve_runtime()
     monkeypatch.setenv(ENV_ARTIFACTS_DIR, str(tmp_path))
     # Without clearing, the cached value wins.


### PR DESCRIPTION
## Summary

- New ``splitsmith.runtime`` module with ``Runtime`` + cached ``resolve_runtime()``: kwargs > env (`SPLITSMITH_ARTIFACTS_DIR`, `SPLITSMITH_FFMPEG`, `SPLITSMITH_FFPROBE`, `SPLITSMITH_CACHE_DIR`, `SPLITSMITH_CONFIG_DIR`) > platform defaults. ``runtime().artifact("...")`` raises actionable ``FileNotFoundError`` on missing files. First resolve ``setdefault``-s ``HF_HOME`` / ``TORCH_HOME`` into the cache dir so CLAP/PANN downloads don't pollute ``~``.
- ``ensemble/calibration.py`` -- ``load_calibration`` / ``load_voter_c_model`` / ``load_voter_e_probe`` go through ``runtime().artifact()``; old ``_DATA_PACKAGE`` constants dropped.
- Orchestrator sweep: cli.py, ui/server.py, lab_cli.py, ensemble/visual.py, compare/emitter.py now pass ``runtime().ffmpeg_binary`` / ``runtime().ffprobe_binary`` explicitly. Pure-function defaults untouched. ``grep '"ffmpeg"' src/splitsmith`` returns only kwarg defaults.
- ui/server.py had a local ``runtime = _get_ensemble_runtime()`` shadowing the import, so the module imports as ``process_runtime`` (caught by existing UI tests).

## Test plan

- [x] ``uv run pytest tests/`` -- 1246 passed, 4 skipped
- [x] ``uv run pytest tests/test_runtime.py`` -- new 12-case suite covers env vs kwarg priority, missing-binary warning, lru_cache reset, HF/TORCH ``setdefault``, calibration loader actionable error
- [x] ``SPLITSMITH_ARTIFACTS_DIR=/tmp/empty-nope python -c 'from splitsmith.ensemble.calibration import load_calibration; load_calibration()'`` exits with the actionable artifact error, not a stack trace from missing package data

Closes #130. Unblocks #131 (embedded server entrypoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)