### PR TITLE
feat(ui): embeddable FastAPI entrypoint with structured handshake (#131)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 
 [project.scripts]
 splitsmith = "splitsmith.cli:app"
+splitsmith-server = "splitsmith.ui.embedded:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/splitsmith/ui/embedded.py
+++ b/src/splitsmith/ui/embedded.py
@@ -1,0 +1,265 @@
+"""Embeddable FastAPI entrypoint for the desktop shell (issue #131).
+
+Spawn the splitsmith UI server as a sidecar process or context manager,
+discover the bound port via a structured handshake, and shut it down
+cleanly. The existing ``splitsmith ui`` CLI keeps its Ctrl-C summary
+UX -- this is a parallel surface that adds no flag noise to the CLI.
+
+Tauri-style env-var launch (the desktop shell from #129 spawns this as
+a child process and parses the banner line to learn the bound port and
+resolved runtime paths)::
+
+    SPLITSMITH_PROJECT_ROOT=/Users/me/match \\
+    SPLITSMITH_FFMPEG=/path/to/bundled/ffmpeg \\
+    SPLITSMITH_ARTIFACTS_DIR=/path/to/bundled/artifacts \\
+    SPLITSMITH_PORT=0 \\
+    python -m splitsmith.ui.embedded
+    # -> stderr: SPLITSMITH_READY {"host": "127.0.0.1", "port": 53241, ...}
+
+In-process callers (tests, future Python embedders) use the context
+manager::
+
+    from splitsmith.ui.embedded import run_embedded
+
+    with run_embedded(port=0) as handle:
+        # handle.base_url, handle.port, handle.artifacts_dir, ...
+        requests.get(f"{handle.base_url}/api/health")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..runtime import runtime as process_runtime
+from .server import create_app
+
+logger = logging.getLogger(__name__)
+
+READY_PREFIX = "SPLITSMITH_READY"
+DEFAULT_STARTUP_TIMEOUT_S = 10.0
+DEFAULT_SHUTDOWN_TIMEOUT_S = 30.0
+
+ENV_PROJECT_ROOT = "SPLITSMITH_PROJECT_ROOT"
+ENV_PROJECT_NAME = "SPLITSMITH_PROJECT_NAME"
+ENV_HOST = "SPLITSMITH_HOST"
+ENV_PORT = "SPLITSMITH_PORT"
+ENV_READY_FD = "SPLITSMITH_READY_FD"
+ENV_LAB_ENABLED = "SPLITSMITH_LAB_ENABLED"
+
+
+@dataclass(frozen=True)
+class ServerHandle:
+    """Structured info about a running embedded server.
+
+    ``base_url`` is the convenience HTTP root the caller should hit;
+    ``artifacts_dir`` and ``ffmpeg_binary`` reflect the resolved
+    :mod:`splitsmith.runtime`, so the desktop shell can verify its env
+    overrides made it through end-to-end (acceptance criterion in #131).
+    """
+
+    host: str
+    port: int
+    pid: int
+    base_url: str
+    artifacts_dir: str
+    ffmpeg_binary: str
+
+    def as_banner(self) -> str:
+        """Render the one-line ``SPLITSMITH_READY {json}`` handshake."""
+        return f"{READY_PREFIX} {json.dumps(asdict(self), sort_keys=True)}"
+
+
+def _pick_free_port(host: str) -> int:
+    """Bind, read back, release -- gives uvicorn a known port without holding it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_health(base_url: str, *, timeout: float) -> None:
+    """Poll ``/api/health`` until 200 or ``timeout`` elapses.
+
+    Uses ``httpx`` (already a dep via FastAPI's TestClient and the
+    scoreboard client) so we don't pull in ``requests`` just for this.
+    """
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with httpx.Client(timeout=1.0) as client:
+                resp = client.get(f"{base_url}/api/health")
+            if resp.status_code == 200:
+                return
+            last_exc = RuntimeError(f"/api/health returned {resp.status_code}")
+        except httpx.HTTPError as exc:
+            last_exc = exc
+        time.sleep(0.05)
+    raise TimeoutError(
+        f"embedded server did not become healthy within {timeout:.1f}s " f"(last error: {last_exc!r})"
+    )
+
+
+def _emit_banner(handle: ServerHandle, ready_fd: int | None) -> None:
+    """Write the handshake line to ``ready_fd`` (if set) or stderr."""
+    line = handle.as_banner() + "\n"
+    if ready_fd is not None:
+        os.write(ready_fd, line.encode("utf-8"))
+        return
+    sys.stderr.write(line)
+    sys.stderr.flush()
+
+
+@contextmanager
+def run_embedded(
+    *,
+    project_root: Path | None = None,
+    project_name: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    lab_enabled: bool = False,
+    ready_fd: int | None = None,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT_S,
+    shutdown_timeout: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
+) -> Iterator[ServerHandle]:
+    """Boot uvicorn on a daemon thread for the duration of the context.
+
+    The server uses the same :func:`create_app` factory as the CLI's
+    ``serve`` -- this surface is purely additive (per #131's "do not
+    modify ``serve()`` / ``_JobAwareServer``" constraint).
+
+    ``port=0`` picks a free port up-front so the handle can carry the
+    real value before the server thread starts. The banner is emitted
+    after ``/api/health`` returns 200 and *before* the context yields,
+    so subprocess parents can synchronously parse it on stderr / fd.
+    """
+    import uvicorn
+
+    if port == 0:
+        port = _pick_free_port(host)
+
+    app = create_app(
+        project_root=project_root,
+        project_name=project_name,
+        lab_enabled=lab_enabled,
+    )
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="info",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    # Uvicorn installs SIGINT/SIGTERM handlers in ``server.run()`` by
+    # default. From a non-main thread those calls raise ``ValueError``;
+    # disable them so the embedded thread starts cleanly and the
+    # context manager (or main()) owns signal delivery.
+    server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
+    thread = threading.Thread(target=server.run, name="splitsmith-embedded", daemon=True)
+    thread.start()
+
+    base_url = f"http://{host}:{port}"
+    rt = process_runtime()
+    handle = ServerHandle(
+        host=host,
+        port=port,
+        pid=os.getpid(),
+        base_url=base_url,
+        artifacts_dir=str(rt.artifacts_dir),
+        ffmpeg_binary=rt.ffmpeg_binary,
+    )
+
+    try:
+        _wait_for_health(base_url, timeout=startup_timeout)
+        _emit_banner(handle, ready_fd)
+        yield handle
+    finally:
+        server.should_exit = True
+        thread.join(timeout=shutdown_timeout)
+        if thread.is_alive():
+            logger.warning(
+                "embedded server thread did not stop within %.1fs; " "escalating to force_exit",
+                shutdown_timeout,
+            )
+            server.force_exit = True
+            thread.join(timeout=5.0)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return int(raw)
+
+
+def _env_bool(name: str) -> bool:
+    raw = os.environ.get(name, "")
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> None:
+    """``python -m splitsmith.ui.embedded`` -- sidecar entrypoint.
+
+    Reads launch parameters from the environment (so the desktop shell
+    can spawn this without a wrapper script):
+
+    * ``SPLITSMITH_PROJECT_ROOT`` -- optional pre-bound match dir.
+    * ``SPLITSMITH_PROJECT_NAME`` -- display name override.
+    * ``SPLITSMITH_HOST`` / ``SPLITSMITH_PORT`` -- bind address; port=0
+      picks free.
+    * ``SPLITSMITH_READY_FD`` -- file descriptor to write the banner
+      to instead of stderr (the shell typically uses fd 3).
+    * ``SPLITSMITH_LAB_ENABLED`` -- truthy values enable the ``/api/lab/*``
+      routes.
+    * runtime overrides from :mod:`splitsmith.runtime` apply unchanged.
+
+    SIGTERM and SIGINT trigger a graceful shutdown and exit status 0.
+    """
+    project_root_raw = os.environ.get(ENV_PROJECT_ROOT)
+    project_root = Path(project_root_raw) if project_root_raw else None
+    project_name = os.environ.get(ENV_PROJECT_NAME)
+    host = os.environ.get(ENV_HOST, "127.0.0.1")
+    port = _env_int(ENV_PORT, 0)
+    ready_fd_val = os.environ.get(ENV_READY_FD)
+    ready_fd = int(ready_fd_val) if ready_fd_val else None
+    lab_enabled = _env_bool(ENV_LAB_ENABLED)
+
+    stop = threading.Event()
+
+    def _handle_signal(signum: int, _frame: Any) -> None:
+        logger.info("embedded server received signal %d; shutting down", signum)
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    with run_embedded(
+        project_root=project_root,
+        project_name=project_name,
+        host=host,
+        port=port,
+        lab_enabled=lab_enabled,
+        ready_fd=ready_fd,
+    ):
+        # Block until the signal handler flips the event. The context
+        # manager's ``__exit__`` takes care of orderly shutdown.
+        stop.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -90,6 +90,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
+from .. import __version__ as splitsmith_version
 from .. import automation as automation_settings
 from .. import backup as backup_mod
 from .. import beep_detect, cross_align, match_model, report, user_config, video_probe
@@ -716,6 +717,7 @@ def _get_ensemble_runtime() -> ensemble_module.EnsembleRuntime:
 
 class HealthResponse(BaseModel):
     status: str = "ok"
+    version: str = splitsmith_version
     bound: bool
     project_name: str | None = None
     project_root: str | None = None

--- a/tests/test_ui_embedded.py
+++ b/tests/test_ui_embedded.py
@@ -1,0 +1,146 @@
+"""Tests for the embedded UI server entrypoint (issue #131)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from splitsmith.ui.embedded import (
+    READY_PREFIX,
+    run_embedded,
+)
+
+
+def test_context_manager_binds_serves_health_and_shuts_down() -> None:
+    with run_embedded(port=0) as handle:
+        assert handle.port != 0
+        resp = httpx.get(f"{handle.base_url}/api/health", timeout=5.0)
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["status"] == "ok"
+        assert "version" in payload
+
+    # After __exit__, the port must be released. Re-binding it from
+    # another socket should succeed (i.e. the server is actually gone).
+    with pytest.raises(httpx.HTTPError):
+        httpx.get(f"http://127.0.0.1:{handle.port}/api/health", timeout=0.5)
+
+
+def test_port_zero_yields_nonzero_in_handle() -> None:
+    with run_embedded(port=0) as handle:
+        assert handle.port > 0
+        assert handle.host == "127.0.0.1"
+        assert handle.base_url == f"http://127.0.0.1:{handle.port}"
+
+
+def test_handle_reflects_resolved_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Acceptance: env override visible end-to-end on the handle."""
+    from splitsmith import runtime as runtime_module
+
+    fake_ffmpeg = tmp_path / "fake-ffmpeg"
+    fake_ffmpeg.write_text("#!/bin/sh\nexit 0\n")
+    fake_ffmpeg.chmod(0o755)
+
+    monkeypatch.setenv("SPLITSMITH_FFMPEG", str(fake_ffmpeg))
+    runtime_module._clear_runtime_cache()
+    try:
+        with run_embedded(port=0) as handle:
+            assert handle.ffmpeg_binary == str(fake_ffmpeg)
+    finally:
+        runtime_module._clear_runtime_cache()
+
+
+def test_banner_is_well_formed_json() -> None:
+    with run_embedded(port=0) as handle:
+        banner = handle.as_banner()
+    prefix, _, payload = banner.partition(" ")
+    assert prefix == READY_PREFIX
+    parsed = json.loads(payload)
+    assert set(parsed) == {
+        "host",
+        "port",
+        "pid",
+        "base_url",
+        "artifacts_dir",
+        "ffmpeg_binary",
+    }
+    assert parsed["host"] == handle.host
+    assert parsed["port"] == handle.port
+
+
+def test_ready_fd_receives_banner_before_yield() -> None:
+    """The shell-style handshake: a pipe parent reads the banner synchronously."""
+    read_fd, write_fd = os.pipe()
+    try:
+        with run_embedded(port=0, ready_fd=write_fd) as handle:
+            # By the time the context yields, the banner has been written.
+            # Read non-blockingly with a tight deadline -- if the fd is
+            # empty we have a regression.
+            os.set_blocking(read_fd, False)
+            time.sleep(0.05)
+            data = os.read(read_fd, 4096).decode("utf-8")
+    finally:
+        os.close(read_fd)
+        try:
+            os.close(write_fd)
+        except OSError:
+            pass
+
+    assert data.startswith(READY_PREFIX + " ")
+    payload = json.loads(data[len(READY_PREFIX) + 1 :].rstrip("\n"))
+    assert payload["port"] == handle.port
+
+
+def test_sigterm_to_main_exits_clean(tmp_path: Path) -> None:
+    """The subprocess entrypoint exits 0 on SIGTERM and emits a banner."""
+    env = os.environ.copy()
+    env["SPLITSMITH_PORT"] = "0"
+    env["SPLITSMITH_HOST"] = "127.0.0.1"
+    # Keep the test isolated from the developer's real ~/.splitsmith.
+    env["SPLITSMITH_HOME"] = str(tmp_path / "home")
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "splitsmith.ui.embedded"],
+        env=env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        banner_line = _read_banner(proc, deadline_s=15.0)
+        proc.terminate()
+        # SIGTERM must produce exit 0 within a short grace window.
+        rc = proc.wait(timeout=10.0)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    assert rc == 0, f"non-zero exit {rc}; banner={banner_line!r}"
+    assert banner_line.startswith(READY_PREFIX + " ")
+    payload = json.loads(banner_line[len(READY_PREFIX) + 1 :])
+    assert payload["port"] > 0
+    assert payload["pid"] == proc.pid
+
+
+def _read_banner(proc: subprocess.Popen[str], *, deadline_s: float) -> str:
+    """Read stderr line-by-line until ``SPLITSMITH_READY`` shows up."""
+    assert proc.stderr is not None
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        line = proc.stderr.readline()
+        if not line:
+            if proc.poll() is not None:
+                raise RuntimeError(f"server exited early (rc={proc.returncode}) before banner")
+            time.sleep(0.05)
+            continue
+        if line.startswith(READY_PREFIX + " "):
+            return line.rstrip("\n")
+    raise TimeoutError("never saw SPLITSMITH_READY banner")


### PR DESCRIPTION
## Summary

- ``splitsmith.ui.embedded`` -- ``ServerHandle`` dataclass, ``run_embedded()`` context manager (port=0 picks free, polls ``/api/health`` then emits ``SPLITSMITH_READY {json}`` to ``ready_fd`` / stderr before yielding), and ``main()`` sidecar entrypoint. SIGTERM / SIGINT shut down cleanly with exit status 0.
- ``splitsmith-server = splitsmith.ui.embedded:main`` console script wired for PyInstaller.
- ``HealthResponse.version`` field added; ``/api/health`` still doesn't require a bound project.
- ``serve()`` / ``_JobAwareServer`` untouched -- this is purely additive.
- Banner JSON keys (host, port, pid, base_url, artifacts_dir, ffmpeg_binary) reflect ``splitsmith.runtime`` so the desktop shell's env overrides (from #130) are visible end-to-end.

## Test plan

- [x] ``tests/test_ui_embedded.py`` -- 6 cases: context-manager start/serve/stop, port=0 returns nonzero, runtime override visible on handle, banner is well-formed JSON, ``ready_fd`` receives banner before yield, ``python -m splitsmith.ui.embedded`` exits 0 on SIGTERM after emitting the banner.
- [x] ``uv run ruff check src tests`` clean.
- [x] ``uv run black --check src tests`` clean.
- [x] ``uv run pytest -q`` -- 1252 passed, 4 skipped.
- [x] Manual: ``SPLITSMITH_PORT=0 splitsmith-server`` starts, prints a parseable banner, serves ``/api/health``, exits clean on SIGTERM.

Closes #131. With #130 this finishes the #129 desktop-embedding prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)