### PR TITLE
feat(match): stable match_id + MatchRegistry (#353 Phase 3 PR A)

### DIFF
--- a/src/splitsmith/match_model.py
+++ b/src/splitsmith/match_model.py
@@ -60,7 +60,42 @@ SHOOTER_SUBDIRS = SUBDIRS  # raw / audio / trimmed / audit / exports / scoreboar
 #: the legacy MatchProject schema (which tops out at 2) so the version space
 #: is shared and "is this a redesign-era match or a legacy project?" can be
 #: answered from a single integer.
-MATCH_SCHEMA_VERSION = 3
+#:
+#: v3 -> v4 adds ``match_id`` (issue #353 Phase 3). Pre-v4 matches get a
+#: deterministic id assigned on first load (derived from name + created_at
+#: so a re-open from the same disk always lands on the same id).
+MATCH_SCHEMA_VERSION = 4
+
+
+def _slugify(name: str) -> str:
+    """Kebab-case ``name`` for use inside a URL-safe identifier.
+
+    Strips diacritics down to ASCII via ``unicodedata.normalize``, lowers,
+    keeps ``[a-z0-9]`` runs, joins with ``-``. Bounded to 32 chars so the
+    full ``<slug>-<hash>`` id stays under typical URL-segment limits.
+    Empty result (e.g. all-symbol name) falls back to ``"match"``.
+    """
+    import re
+    import unicodedata
+
+    normalised = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    parts = re.findall(r"[a-z0-9]+", normalised.lower())
+    slug = "-".join(parts)[:32].strip("-")
+    return slug or "match"
+
+
+def generate_match_id(name: str, created_at: datetime) -> str:
+    """Deterministic, URL-safe match id from immutable identity fields.
+
+    ``<slug-of-name>-<10-char hash>``. The hash mixes name + ``created_at``
+    so two matches with the same name (different timestamps) get distinct
+    ids; once assigned the id is frozen in ``match.json`` and a later rename
+    does not invalidate links.
+    """
+    import hashlib
+
+    digest = hashlib.sha1(f"{name}\x00{created_at.isoformat()}".encode()).hexdigest()[:10]
+    return f"{_slugify(name)}-{digest}"
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +204,12 @@ class Match(BaseModel):
 
     schema_version: int = MATCH_SCHEMA_VERSION
     name: str
+    #: Stable, URL-safe match identifier (issue #353 Phase 3). Persisted in
+    #: ``match.json`` so SPA routes can carry the id without leaking the
+    #: filesystem path. Optional on the model to allow the v3 -> v4 load-time
+    #: migration; :meth:`Match.load` assigns + saves it when missing so
+    #: in-memory ``Match`` instances always have one set.
+    match_id: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     scoreboard_match_id: str | None = None
@@ -198,6 +239,7 @@ class Match(BaseModel):
         if existing.exists():
             return cls.load(root)
         match = cls(name=name)
+        match.match_id = generate_match_id(match.name, match.created_at)
         match.save(root)
         return match
 
@@ -208,6 +250,11 @@ class Match(BaseModel):
         Raises ``FileNotFoundError`` if ``root`` is neither a match folder
         nor a legacy project folder. Use :meth:`is_match_folder` or
         :meth:`from_path` to inspect a path without raising.
+
+        Side effect: pre-v4 matches (no ``match_id`` on disk) get one
+        assigned deterministically and the file is re-saved. The id is
+        derived from immutable identity fields so subsequent loads land on
+        the same value; once persisted the id is frozen.
         """
         path = root / MATCH_FILE
         if not path.exists():
@@ -215,7 +262,11 @@ class Match(BaseModel):
         import json
 
         data = json.loads(path.read_text(encoding="utf-8"))
-        return cls.model_validate(data)
+        match = cls.model_validate(data)
+        if not match.match_id:
+            match.match_id = generate_match_id(match.name, match.created_at)
+            match.save(root)
+        return match
 
     def save(self, root: Path) -> None:
         """Atomically persist the match to ``<root>/match.json``."""

--- a/src/splitsmith/match_registry.py
+++ b/src/splitsmith/match_registry.py
@@ -1,0 +1,131 @@
+"""In-process ``match_id`` -> match-root resolver (issue #353 Phase 3).
+
+The first step toward dropping the ``state._bound_root`` singleton is a
+way to address a match by something other than the bound filesystem
+path. :func:`splitsmith.match_model.generate_match_id` mints stable
+ids; this module gives the server a fast lookup from id back to disk.
+
+The registry is intentionally simple:
+
+* Backed by an in-memory dict keyed on ``match_id``.
+* Populated lazily from :mod:`splitsmith.user_config` recent projects
+  on the first :meth:`MatchRegistry.resolve` (or eagerly via
+  :meth:`MatchRegistry.refresh` -- the server boot does this).
+* Re-reads ``match.json`` on misses so a match that was just created /
+  bound shows up without a server restart.
+* Stateless beyond the cache: no on-disk index of its own. The source
+  of truth stays the per-match ``match.json`` + the recent-projects
+  list, both of which already exist.
+
+In follow-up PRs the SPA URLs grow a ``/match/:matchId/`` segment and
+shooter-scoped endpoints look up the match root via this registry
+instead of ``state.bound_root``. This PR is the foundation; nothing
+calls :meth:`resolve` for routing yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from threading import RLock
+
+from . import user_config
+from .match_model import Match
+
+logger = logging.getLogger(__name__)
+
+
+class MatchNotRegisteredError(KeyError):
+    """Raised when a ``match_id`` is not known to the registry."""
+
+
+class MatchRegistry:
+    """Resolves stable ``match_id`` strings back to filesystem paths.
+
+    Thread-safe (FastAPI happily fans requests across a thread pool;
+    cache mutations need to be serialised).
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, Path] = {}
+        self._lock = RLock()
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register(self, match_id: str, match_root: Path) -> None:
+        """Pin ``match_id`` to ``match_root``.
+
+        Idempotent: re-registering the same id with a different root
+        overwrites (the user moved the folder). Re-registering with the
+        same root is a no-op.
+        """
+        resolved = Path(match_root).resolve()
+        with self._lock:
+            self._by_id[match_id] = resolved
+
+    def forget(self, match_id: str) -> None:
+        """Drop ``match_id`` from the registry. No-op if absent."""
+        with self._lock:
+            self._by_id.pop(match_id, None)
+
+    def clear(self) -> None:
+        """Empty the cache. Test-only helper."""
+        with self._lock:
+            self._by_id.clear()
+
+    def refresh_from_recent_projects(self) -> int:
+        """Re-scan :func:`user_config.get_recent_projects` and re-pin every
+        match folder. Returns the number of entries that were registered.
+
+        Cheap on cold start (one ``match.json`` read per entry); the
+        recent-projects list is bounded so this stays under a few dozen.
+        Skips entries that no longer exist on disk and entries marked
+        ``kind="legacy"`` (legacy single-shooter projects have no
+        ``match_id``).
+        """
+        registered = 0
+        for entry in user_config.get_recent_projects():
+            if entry.kind == "legacy":
+                continue
+            root = Path(entry.path)
+            if not root.exists():
+                continue
+            try:
+                match = Match.load(root)
+            except (FileNotFoundError, ValueError) as exc:
+                logger.debug("skipping recent project %s: %s", root, exc)
+                continue
+            if match.match_id:
+                self.register(match.match_id, root)
+                registered += 1
+        return registered
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def resolve(self, match_id: str) -> Path:
+        """Return the on-disk match root for ``match_id``.
+
+        Falls back to a one-shot rescan of recent projects on a miss so
+        a freshly-created match doesn't require a server restart.
+        Raises :class:`MatchNotRegisteredError` if the id still doesn't
+        resolve afterwards.
+        """
+        with self._lock:
+            hit = self._by_id.get(match_id)
+        if hit is not None:
+            return hit
+        self.refresh_from_recent_projects()
+        with self._lock:
+            hit = self._by_id.get(match_id)
+        if hit is None:
+            raise MatchNotRegisteredError(match_id)
+        return hit
+
+    def known_ids(self) -> list[str]:
+        """Snapshot of currently-registered ids (for diagnostics)."""
+        with self._lock:
+            return sorted(self._by_id)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -117,6 +117,7 @@ from ..fixture_schema import (
     CameraPosition,
     probe_camera_metadata,
 )
+from ..match_registry import MatchRegistry
 from ..runtime import runtime as process_runtime
 from . import audio as audio_helpers
 from . import exports as export_helpers
@@ -533,7 +534,9 @@ class AppState:
     _bound_root: Path | None = None
     _bound_kind: Literal["match", "legacy"] | None = None
     _bound_name: str | None = None
+    _bound_match_id: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
+    matches: MatchRegistry = field(default_factory=MatchRegistry)
 
     @property
     def is_bound(self) -> bool:
@@ -599,20 +602,34 @@ class AppState:
         """Load the legacy ``MatchProject`` for ``slug``."""
         return MatchProject.load(self.shooter_root(slug))
 
+    @property
+    def bound_match_id(self) -> str | None:
+        """The bound match's stable id, or ``None`` when unbound / legacy."""
+        return self._bound_match_id
+
     def bind_match(self, root: Path, name: str) -> None:
         self._bound_root = root
         self._bound_kind = "match"
         self._bound_name = name
+        # Load to ensure ``match_id`` is materialised (Match.load runs the
+        # v3 -> v4 migration on the fly), then pin it into the registry so
+        # the id resolves immediately even before the next recents refresh.
+        match = match_model.Match.load(root)
+        self._bound_match_id = match.match_id
+        if match.match_id:
+            self.matches.register(match.match_id, root)
 
     def bind_legacy(self, root: Path, name: str) -> None:
         self._bound_root = root
         self._bound_kind = "legacy"
         self._bound_name = name
+        self._bound_match_id = None
 
     def unbind(self) -> None:
         self._bound_root = None
         self._bound_kind = None
         self._bound_name = None
+        self._bound_match_id = None
 
 
 def legacy_slug(project: MatchProject) -> str:
@@ -721,6 +738,10 @@ class HealthResponse(BaseModel):
     bound: bool
     project_name: str | None = None
     project_root: str | None = None
+    # Stable match identifier (issue #353 Phase 3 PR A). ``None`` when
+    # unbound or bound to a legacy single-shooter project. The SPA will
+    # start scoping URLs on this in a follow-up PR.
+    match_id: str | None = None
     # Layout discriminator + a default slug for shooter-scoped URLs (#353).
     # Match-bound: the alphabetically-first registered shooter, or ``None``
     # when the match is empty. Legacy-bound: the deterministic legacy slug.
@@ -791,6 +812,9 @@ class RecentProjectDetail(BaseModel):
     name: str
     last_opened_at: datetime
     kind: Literal["match", "legacy", "missing", "unknown"]
+    # Stable match identifier (#353 Phase 3). Populated for ``kind="match"``
+    # via the load-time migration; ``None`` on legacy / missing / unknown.
+    match_id: str | None = None
     # The five fields below only populate for resolved kinds.
     shooter_count: int = 0
     stage_count: int = 0
@@ -1758,6 +1782,7 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
             match = match_model.Match.load(path)
             detail.kind = "match"
             detail.name = match.name or rp.name
+            detail.match_id = match.match_id
             detail.shooter_count = len(match.shooters)
             detail.stage_count = len(match.stages)
             detail.match_date = match.match_date.isoformat() if match.match_date else None
@@ -1843,6 +1868,12 @@ def create_app(
     nav entry). Hidden by default; opt in via ``splitsmith ui --lab``.
     """
     state = AppState()
+    # Populate the match-id registry from recent projects so id -> path
+    # lookups resolve without waiting for a picker bind. Cheap (one
+    # match.json read per recent entry; legacy projects are skipped).
+    # Pre-v4 match.json files get the id assigned + persisted here on
+    # the fly via Match.load's load-time migration.
+    state.matches.refresh_from_recent_projects()
     # Load .env / .env.local before binding so SPLITSMITH_SSI_TOKEN (and
     # friends) are available on the unbound boot path too -- the
     # create-match-from-scoreboard flow needs the token before any
@@ -1917,6 +1948,7 @@ def create_app(
             project_root=str(state.bound_root),
             kind=kind,
             default_shooter_slug=default_slug,
+            match_id=state.bound_match_id,
         )
 
     @app.get("/api/health", response_model=HealthResponse)

--- a/tests/test_match_model.py
+++ b/tests/test_match_model.py
@@ -11,6 +11,7 @@ import pytest
 from splitsmith.config import StageRounds
 from splitsmith.match_model import (
     MATCH_FILE,
+    MATCH_SCHEMA_VERSION,
     SHOOTER_FILE,
     SHOOTERS_DIR,
     Match,
@@ -20,6 +21,7 @@ from splitsmith.match_model import (
     ShooterStageData,
     execute_merge,
     from_path,
+    generate_match_id,
     is_legacy_project_folder,
     is_match_folder,
     legacy_to_match_view,
@@ -463,3 +465,98 @@ def test_execute_merge_shooter_json_has_no_match_fields(tmp_path: Path):
             assert shooter_json["name"] == "Anton"
             continue
         assert forbidden not in shooter_json, forbidden
+
+
+# ---------------------------------------------------------------------------
+# match_id (issue #353 Phase 3 PR A)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_match_id_is_deterministic_for_same_inputs():
+    from datetime import UTC, datetime
+
+    ts = datetime(2026, 4, 3, 12, 0, 0, tzinfo=UTC)
+    a = generate_match_id("VADS Easter Shoot 2026", ts)
+    b = generate_match_id("VADS Easter Shoot 2026", ts)
+    assert a == b
+    assert a.startswith("vads-easter-shoot-2026-")
+    # ``<slug>-<10-char hex>``
+    assert len(a.rsplit("-", 1)[1]) == 10
+
+
+def test_generate_match_id_differs_for_distinct_timestamps():
+    from datetime import UTC, datetime
+
+    a = generate_match_id("VADS", datetime(2026, 1, 1, tzinfo=UTC))
+    b = generate_match_id("VADS", datetime(2026, 1, 2, tzinfo=UTC))
+    assert a != b
+    # Same slug prefix, different hash tail.
+    assert a.split("-")[0] == b.split("-")[0] == "vads"
+
+
+def test_generate_match_id_handles_unicode_and_punctuation():
+    from datetime import UTC, datetime
+
+    mid = generate_match_id("Brömma Klassikern 2026!", datetime(2026, 1, 1, tzinfo=UTC))
+    assert mid.startswith("bromma-klassikern-2026-")
+
+
+def test_generate_match_id_empty_name_falls_back():
+    from datetime import UTC, datetime
+
+    mid = generate_match_id("!!!", datetime(2026, 1, 1, tzinfo=UTC))
+    assert mid.startswith("match-")
+
+
+def test_match_init_assigns_match_id(tmp_path: Path):
+    match = Match.init(tmp_path / "match", name="VADS Easter Shoot 2026")
+    assert match.match_id is not None
+    assert match.match_id.startswith("vads-easter-shoot-2026-")
+
+
+def test_match_id_persists_across_reload(tmp_path: Path):
+    match = Match.init(tmp_path / "match", name="Persisted")
+    minted = match.match_id
+    reloaded = Match.load(tmp_path / "match")
+    assert reloaded.match_id == minted
+    # Frozen on disk too.
+    on_disk = json.loads((tmp_path / "match" / MATCH_FILE).read_text())
+    assert on_disk["match_id"] == minted
+    assert on_disk["schema_version"] == MATCH_SCHEMA_VERSION
+
+
+def test_load_migrates_pre_v4_match_in_place(tmp_path: Path):
+    """A match.json written before #353 (no match_id) gets one on first load."""
+    root = tmp_path / "legacy-match"
+    root.mkdir()
+    # Hand-write a v3-shaped match.json (no match_id; older schema_version).
+    legacy_payload = {
+        "schema_version": 3,
+        "name": "Legacy",
+        "match_id": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "shooters": [],
+        "stages": [],
+    }
+    (root / MATCH_FILE).write_text(json.dumps(legacy_payload))
+
+    loaded = Match.load(root)
+    assert loaded.match_id is not None
+    # Persisted: a second read sees the same id without another migration.
+    second = Match.load(root)
+    assert second.match_id == loaded.match_id
+    # The on-disk file now has it too.
+    on_disk = json.loads((root / MATCH_FILE).read_text())
+    assert on_disk["match_id"] == loaded.match_id
+
+
+def test_rename_does_not_change_match_id(tmp_path: Path):
+    """Once minted, match_id is frozen; renaming the match is purely cosmetic."""
+    match = Match.init(tmp_path / "match", name="Original Name")
+    original_id = match.match_id
+    match.name = "Renamed Match"
+    match.save(tmp_path / "match")
+    reloaded = Match.load(tmp_path / "match")
+    assert reloaded.match_id == original_id
+    assert reloaded.name == "Renamed Match"

--- a/tests/test_match_registry.py
+++ b/tests/test_match_registry.py
@@ -1,0 +1,127 @@
+"""Tests for ``splitsmith.match_registry`` (issue #353 Phase 3 PR A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith import user_config
+from splitsmith.match_model import Match
+from splitsmith.match_registry import MatchNotRegisteredError, MatchRegistry
+
+
+@pytest.fixture
+def isolated_user_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``~/.splitsmith`` at a per-test tmp dir.
+
+    The autouse fixture in conftest already isolates ``SPLITSMITH_HOME``,
+    but several of these tests call ``user_config.record_project_open``
+    directly, so we re-establish a fresh dir here to keep the state
+    deterministic and avoid bleed from other tests in the file.
+    """
+    home = tmp_path / "user-config-home"
+    monkeypatch.setenv("SPLITSMITH_HOME", str(home))
+    return home
+
+
+def _make_match(root: Path, *, name: str) -> Match:
+    return Match.init(root, name=name)
+
+
+def test_register_and_resolve_roundtrip(tmp_path: Path) -> None:
+    reg = MatchRegistry()
+    root = tmp_path / "m"
+    match = _make_match(root, name="Test Match")
+    reg.register(match.match_id, root)
+    assert reg.resolve(match.match_id) == root.resolve()
+
+
+def test_resolve_unknown_id_raises(tmp_path: Path, isolated_user_config: Path) -> None:
+    reg = MatchRegistry()
+    with pytest.raises(MatchNotRegisteredError):
+        reg.resolve("never-seen-id-0000000000")
+
+
+def test_refresh_picks_up_recent_match(tmp_path: Path, isolated_user_config: Path) -> None:
+    reg = MatchRegistry()
+    match_root = tmp_path / "recent"
+    match = _make_match(match_root, name="Recent Match")
+    user_config.record_project_open(match_root, match.name, kind="match")
+
+    registered = reg.refresh_from_recent_projects()
+    assert registered == 1
+    assert reg.resolve(match.match_id) == match_root.resolve()
+
+
+def test_refresh_skips_legacy_and_missing_entries(tmp_path: Path, isolated_user_config: Path) -> None:
+    reg = MatchRegistry()
+    # A real match.
+    real_root = tmp_path / "real"
+    real = _make_match(real_root, name="Real")
+    user_config.record_project_open(real_root, real.name, kind="match")
+    # Legacy single-shooter project (no match.json).
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    user_config.record_project_open(legacy_root, "Legacy", kind="legacy")
+    # Path that disappeared from disk after being recorded.
+    ghost = tmp_path / "ghost"
+    ghost.mkdir()
+    user_config.record_project_open(ghost, "Ghost", kind="match")
+    import shutil
+
+    shutil.rmtree(ghost)
+
+    n = reg.refresh_from_recent_projects()
+    assert n == 1
+    assert reg.known_ids() == [real.match_id]
+
+
+def test_resolve_falls_back_to_refresh_on_miss(tmp_path: Path, isolated_user_config: Path) -> None:
+    """Freshly-recorded match becomes resolvable without an explicit refresh."""
+    reg = MatchRegistry()
+    match_root = tmp_path / "fresh"
+    match = _make_match(match_root, name="Fresh Match")
+    # Recording the match *after* the registry was built; resolve() must
+    # rescan recent projects on miss to find it.
+    user_config.record_project_open(match_root, match.name, kind="match")
+    assert reg.resolve(match.match_id) == match_root.resolve()
+
+
+def test_register_overwrites_when_path_changes(tmp_path: Path) -> None:
+    reg = MatchRegistry()
+    match_root = tmp_path / "original"
+    match = _make_match(match_root, name="Movable")
+
+    moved_root = tmp_path / "moved"
+    match_root.rename(moved_root)
+
+    reg.register(match.match_id, match_root)
+    reg.register(match.match_id, moved_root)
+    assert reg.resolve(match.match_id) == moved_root.resolve()
+
+
+def test_forget_removes_id(tmp_path: Path) -> None:
+    reg = MatchRegistry()
+    match = _make_match(tmp_path / "m", name="Bye")
+    reg.register(match.match_id, tmp_path / "m")
+    reg.forget(match.match_id)
+    assert match.match_id not in reg.known_ids()
+
+
+def test_two_matches_same_name_get_distinct_ids(tmp_path: Path, isolated_user_config: Path) -> None:
+    """Two matches with identical names but different created_at register separately."""
+    import time
+
+    a = _make_match(tmp_path / "a", name="Dup Name")
+    # ``created_at`` is generated via ``datetime.now(UTC)``; sleep enough
+    # microseconds to guarantee a different timestamp on the second match.
+    time.sleep(0.005)
+    b = _make_match(tmp_path / "b", name="Dup Name")
+    assert a.match_id != b.match_id
+
+    reg = MatchRegistry()
+    reg.register(a.match_id, tmp_path / "a")
+    reg.register(b.match_id, tmp_path / "b")
+    assert reg.resolve(a.match_id) == (tmp_path / "a").resolve()
+    assert reg.resolve(b.match_id) == (tmp_path / "b").resolve()


### PR DESCRIPTION
## Summary

First of three PRs toward Phase 3 of #353. Foundation only -- no URL or routing changes yet.

- ``Match`` gains a ``match_id`` field: ``<slug-of-name>-<10-char sha1 prefix of name+created_at>``. Minted on ``Match.init``, assigned + persisted on first ``Match.load`` for pre-v4 matches (schema bump 3 -> 4). Frozen once written, so renames don't invalidate URLs in follow-up PRs.
- New ``splitsmith.match_registry`` with ``MatchRegistry`` -- thread-safe in-process id -> path cache. Populated from ``user_config.recent_projects`` on boot (one ``match.json`` read per entry); rescans on miss so a freshly-created match resolves without a server restart.
- ``AppState`` carries the registry and a ``bound_match_id`` shortcut. ``bind_match`` registers the id on every picker bind.
- ``HealthResponse`` and ``RecentProjectDetail`` surface ``match_id`` so the SPA can start reading it ahead of any URL changes.

Phase 1 of #353 was already done in earlier work (slugged routes, ``ShooterScopedRoute`` with ``key={slug}`` remount, no ``window.location.reload`` calls, slugless redirects to ``/shooters``). Phase 2's per-request slug is structurally done via the ``/api/shooters/{slug}/...`` path-param convention. What's left after this PR:

- **PR B (next session):** Add ``/match/:matchId/`` SPA route prefix + ``/api/matches/:matchId/shooters/:slug/`` API prefix. ``state.bound_root`` becomes fallback only.
- **PR C (later):** Drop ``state._bound_root`` entirely; every shooter-bound endpoint requires explicit match-id.

## Test plan

- [x] ``tests/test_match_model.py`` -- 8 new cases: id determinism for same inputs, distinct timestamps -> distinct ids, unicode/punctuation slugging, empty-name fallback, ``Match.init`` assignment, persistence across reload, pre-v4 in-place migration on ``load``, rename keeps id frozen.
- [x] ``tests/test_match_registry.py`` -- 8 cases: register/resolve roundtrip, unknown-id raises, refresh picks up recent matches, refresh skips legacy + missing entries, resolve falls back to refresh on miss, register overwrites on move, forget removes id, two same-name matches get distinct ids.
- [x] ``uv run ruff check src tests`` clean.
- [x] ``uv run black --check src tests`` clean.
- [x] ``uv run pytest -q`` -- 1268 passed, 4 skipped.

Toward #353. Foundation for follow-up PRs B + C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)