### PR TITLE
feat(ui): /match/:matchId URL prefix + API alias (#353 Phase 3 PR B)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1900,6 +1900,69 @@ def create_app(
     app.state.splitsmith_state = state
 
     # ----------------------------------------------------------------------
+    # /api/matches/{match_id}/... alias middleware (#353 Phase 3 PR B)
+    # ----------------------------------------------------------------------
+    #
+    # The SPA's URLs are growing a ``/match/:matchId/`` prefix so each tab
+    # can pin its own match. To accept the corresponding API prefix
+    # without rewriting 69 endpoint decorators, we register one HTTP
+    # middleware that strips ``matches/{match_id}/`` from any matching
+    # path and forwards the request to the existing route table.
+    #
+    # Validation: ``match_id`` must resolve via the registry **and** (in
+    # this PR) must equal the currently-bound match. The singleton stays
+    # in place until PR C; the mismatch check protects stale URLs from
+    # silently writing into the wrong match.
+    @app.middleware("http")
+    async def _match_id_alias(request, call_next):
+        path = request.url.path
+        prefix = "/api/matches/"
+        if not path.startswith(prefix):
+            return await call_next(request)
+        remainder = path[len(prefix) :]
+        match_id, sep, rest = remainder.partition("/")
+        if not sep or not match_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": {
+                        "code": "match_id_required",
+                        "message": "expected /api/matches/{match_id}/...",
+                    }
+                },
+            )
+        try:
+            state.matches.resolve(match_id)
+        except KeyError:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "detail": {
+                        "code": "match_not_found",
+                        "message": f"unknown match_id {match_id!r}",
+                    }
+                },
+            )
+        if state.bound_match_id and state.bound_match_id != match_id:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "detail": {
+                        "code": "match_mismatch",
+                        "message": (
+                            f"URL match_id {match_id!r} does not match "
+                            f"bound match {state.bound_match_id!r}; rebind via "
+                            "POST /api/me/recent-projects/bind"
+                        ),
+                    }
+                },
+            )
+        rewritten = "/api/" + rest
+        request.scope["path"] = rewritten
+        request.scope["raw_path"] = rewritten.encode("utf-8")
+        return await call_next(request)
+
+    # ----------------------------------------------------------------------
     # API
     # ----------------------------------------------------------------------
 

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -30,13 +30,63 @@ function RedirectLabSlug() {
   return <Navigate to={`/dev/legacy/lab/${slug ?? ""}`} replace />;
 }
 
+/* All match-scoped routes (#353 Phase 3 PR B). Rendered both under the
+ * canonical /match/:matchId/ prefix and at the bare path so legacy
+ * bookmarks (and incremental in-app navigations that haven't migrated to
+ * the prefix yet) keep working. Once the navigation sweep is done in a
+ * follow-up PR the bare paths can drop. */
+function MatchScopedRoutes() {
+  return (
+    <>
+      <Route
+        path="ingest/:slug"
+        element={<ShooterScopedRoute element={<Ingest />} />}
+      />
+      <Route path="ingest" element={<Navigate to="../shooters" replace />} />
+      <Route element={<MatchShell />}>
+        <Route index element={<Home />} />
+        <Route
+          path="audit/:slug"
+          element={<ShooterScopedRoute element={<Audit />} />}
+        />
+        <Route
+          path="audit/:slug/:stage"
+          element={<ShooterScopedRoute element={<Audit />} />}
+        />
+        <Route path="audit" element={<Navigate to="../shooters" replace />} />
+        <Route path="compare/:stage" element={<Compare />} />
+        <Route
+          path="coach/:slug"
+          element={<ShooterScopedRoute element={<Coach />} />}
+        />
+        <Route
+          path="coach/:slug/:stage"
+          element={<ShooterScopedRoute element={<Coach />} />}
+        />
+        <Route path="coach" element={<Navigate to="../shooters" replace />} />
+        <Route path="shooters" element={<Shooters />} />
+        <Route path="beep-review" element={<BeepReview />} />
+        <Route
+          path="export/:slug"
+          element={<ShooterScopedRoute element={<Export />} />}
+        />
+        <Route
+          path="export/:slug/:stage"
+          element={<ShooterScopedRoute element={<Export />} />}
+        />
+        <Route path="export" element={<Navigate to="../shooters" replace />} />
+      </Route>
+    </>
+  );
+}
+
 export function App() {
   return (
     <ModeProvider>
       <BrowserRouter>
         <Routes>
-          {/* Picker lives outside AppShell -- it has its own header and
-              runs whether or not a project is bound. AppShell redirects
+          {/* Picker lives outside any shell -- it has its own header and
+              runs whether or not a project is bound. MatchShell redirects
               here when it sees /api/health.bound === false. */}
           <Route path="pick" element={<Pick />} />
           <Route path="pick/new" element={<CreateMatch />} />
@@ -53,48 +103,13 @@ export function App() {
 
               /compare /shooters /beep-review stay slug-less: compare is
               inherently multi-shooter, /shooters is the shooter manager
-              itself, beep-review is a cross-shooter queue. */}
-          <Route
-            path="ingest/:slug"
-            element={<ShooterScopedRoute element={<Ingest />} />}
-          />
-          <Route
-            path="ingest"
-            element={<Navigate to="/shooters" replace />}
-          />
-          <Route element={<MatchShell />}>
-            <Route index element={<Home />} />
-            <Route
-              path="audit/:slug"
-              element={<ShooterScopedRoute element={<Audit />} />}
-            />
-            <Route
-              path="audit/:slug/:stage"
-              element={<ShooterScopedRoute element={<Audit />} />}
-            />
-            <Route path="audit" element={<Navigate to="/shooters" replace />} />
-            <Route path="compare/:stage" element={<Compare />} />
-            <Route
-              path="coach/:slug"
-              element={<ShooterScopedRoute element={<Coach />} />}
-            />
-            <Route
-              path="coach/:slug/:stage"
-              element={<ShooterScopedRoute element={<Coach />} />}
-            />
-            <Route path="coach" element={<Navigate to="/shooters" replace />} />
-            <Route path="shooters" element={<Shooters />} />
-            <Route path="beep-review" element={<BeepReview />} />
-            <Route
-              path="export/:slug"
-              element={<ShooterScopedRoute element={<Export />} />}
-            />
-            <Route
-              path="export/:slug/:stage"
-              element={<ShooterScopedRoute element={<Export />} />}
-            />
-            <Route path="export" element={<Navigate to="/shooters" replace />} />
-          </Route>
+              itself, beep-review is a cross-shooter queue.
+
+              The same subtree is mounted under /match/:matchId/* so each
+              tab can pin its own match (#353 Phase 3 PR B). The bare-path
+              copy below stays until the in-app navigation sweep is done. */}
+          <Route path="match/:matchId">{MatchScopedRoutes()}</Route>
+          {MatchScopedRoutes()}
           {/* Developer mode (#331). All four workflow steps + the
               retired Lab + fixture-editor surfaces sit under the
               cyan-accented DeveloperShell. */}

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -54,7 +54,10 @@ export function MatchShell() {
   // /compare/:stage). When a slug is in the URL we load that shooter's
   // project so the sidebar reflects their progress; otherwise the sidebar
   // shows match-level info without per-stage status.
-  const { slug } = useParams<{ slug?: string }>();
+  const { slug, matchId: urlMatchId } = useParams<{
+    slug?: string;
+    matchId?: string;
+  }>();
   const { pathname } = useLocation();
   const { mode, setMode } = useMode();
   // Trailing breadcrumb segment ("AUDIT" / "COACH" / ...) derived from the
@@ -371,9 +374,12 @@ export function MatchShell() {
           }
           onStageClick={(n) => {
             const target = slug ?? health?.default_shooter_slug;
-            navigate(target ? `/audit/${target}/${n}` : "/shooters");
+            const mid = urlMatchId ?? health?.match_id ?? null;
+            const base = mid ? `/match/${mid}` : "";
+            navigate(target ? `${base}/audit/${target}/${n}` : `${base}/shooters`);
           }}
           shooterSlug={slug ?? health?.default_shooter_slug ?? undefined}
+          matchId={urlMatchId ?? health?.match_id ?? undefined}
           collapsed={sidebarCollapsed}
           onCollapseToggle={toggleSidebar}
         />

--- a/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
@@ -79,6 +79,12 @@ interface MatchSidebarProps {
    *  focus (e.g. /shooters, /); in that case the per-shooter nav rows
    *  point at /shooters so the user picks one. */
   shooterSlug?: string;
+  /** Match identifier for the canonical ``/match/:matchId/`` URL prefix
+   *  (#353 Phase 3 PR B). When set the sidebar's nav rows include it so
+   *  every click stays inside the match-scoped subtree. ``undefined`` on
+   *  legacy bind contexts (no match id) -- in that case the bare paths
+   *  are used and React Router's legacy routes pick them up. */
+  matchId?: string;
   /** Collapsed state -- when true the sidebar renders at COLLAPSED_WIDTH
    *  with icon-only nav and the match card / stages list hidden. */
   collapsed?: boolean;
@@ -99,10 +105,16 @@ export function MatchSidebar({
   awaiting = false,
   onStageClick,
   shooterSlug,
+  matchId,
   collapsed = false,
   onCollapseToggle,
   className,
 }: MatchSidebarProps) {
+  // Prefix every nav row with /match/:matchId when one is in scope, so
+  // clicks keep the user inside the match-scoped subtree (#353 Phase 3).
+  // Without a match id we fall back to the bare paths -- legacy routes
+  // in App.tsx still resolve them, so this stays backwards compatible.
+  const base = matchId ? `/match/${matchId}` : "";
   // Sidebar header shows audited / total. Skipped stages count as
   // closed out (operator made a decision) but read as audited in the
   // tally; this matches the Home progress bar.
@@ -169,7 +181,7 @@ export function MatchSidebar({
         )}
       >
         <SidebarLink
-          to="/"
+          to={`${base}/`}
           icon={<LayoutGrid className="size-[15px]" />}
           end
           collapsed={collapsed}
@@ -177,21 +189,21 @@ export function MatchSidebar({
           Overview
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `/audit/${shooterSlug}` : "/shooters"}
+          to={shooterSlug ? `${base}/audit/${shooterSlug}` : `${base}/shooters`}
           icon={<Crosshair className="size-[15px]" />}
           collapsed={collapsed}
         >
           Audit
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `/coach/${shooterSlug}` : "/shooters"}
+          to={shooterSlug ? `${base}/coach/${shooterSlug}` : `${base}/shooters`}
           icon={<ClipboardCheck className="size-[15px]" />}
           collapsed={collapsed}
         >
           Coach
         </SidebarLink>
         <SidebarLink
-          to="/shooters"
+          to={`${base}/shooters`}
           icon={<Users className="size-[15px]" />}
           count={shooterCount}
           badgeKind="count"
@@ -200,14 +212,14 @@ export function MatchSidebar({
           Shooters
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `/ingest/${shooterSlug}` : "/shooters"}
+          to={shooterSlug ? `${base}/ingest/${shooterSlug}` : `${base}/shooters`}
           icon={<Film className="size-[15px]" />}
           collapsed={collapsed}
         >
           Videos
         </SidebarLink>
         <SidebarLink
-          to="/beep-review"
+          to={`${base}/beep-review`}
           icon={<Volume2 className="size-[15px]" />}
           count={beepReviewPendingCount}
           badgeKind="pending"
@@ -216,7 +228,7 @@ export function MatchSidebar({
           Beep review
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `/export/${shooterSlug}` : "/shooters"}
+          to={shooterSlug ? `${base}/export/${shooterSlug}` : `${base}/shooters`}
           icon={<ArrowDownToLine className="size-[15px]" />}
           collapsed={collapsed}
         >

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1101,9 +1101,16 @@ export function isNoProjectError(err: unknown): boolean {
  *  the SPA renders the picker until the user selects one. */
 export interface ServerHealth {
   status: string;
+  /** Engine version (issue #131). */
+  version?: string;
   bound: boolean;
   project_name: string | null;
   project_root: string | null;
+  /** Stable match identifier (#353 Phase 3). Populated for ``kind="match"``;
+   *  ``null`` for legacy single-shooter projects and the unbound state.
+   *  SPA URLs are migrating to a ``/match/:matchId/`` prefix; this field
+   *  is the source of truth for what to write into the URL. */
+  match_id?: string | null;
   /** Discriminates the on-disk layout. ``"match"`` for the Match -> Shooter
    *  folder layout; ``"legacy"`` for single-shooter projects that predate
    *  the split; ``null`` when the server is unbound. */

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -39,10 +39,21 @@ import {
   api,
   type RecentProjectDetail,
   type ScoreboardIdentity,
+  type ServerHealth,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 type StatusFilter = "all" | "in_progress" | "exported" | "archived";
+
+/** Build the URL the picker should navigate to after a successful bind.
+ *
+ * Prefers the match-id-prefixed home (#353 Phase 3 PR B) so each tab
+ * carries its match in the URL. Falls back to ``/`` when the server
+ * doesn't surface an id (legacy single-shooter projects, or a future
+ * unbound state). */
+function matchHome(health: ServerHealth): string {
+  return health.match_id ? `/match/${health.match_id}/` : "/";
+}
 
 export function Pick() {
   const navigate = useNavigate();
@@ -148,8 +159,8 @@ export function Pick() {
     setOpening(target.path);
     setError(null);
     try {
-      await api.bindProject(target.path, target.name);
-      navigate("/", { replace: true });
+      const health = await api.bindProject(target.path, target.name);
+      navigate(matchHome(health), { replace: true });
     } catch (e: unknown) {
       setOpening(null);
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -175,8 +186,8 @@ export function Pick() {
     setOpening(trimmed);
     setError(null);
     try {
-      await api.bindProject(trimmed);
-      navigate("/", { replace: true });
+      const health = await api.bindProject(trimmed);
+      navigate(matchHome(health), { replace: true });
     } catch (e: unknown) {
       setOpening(null);
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -192,7 +203,10 @@ export function Pick() {
         overwrite: importOverwrite,
         bind: true,
       });
-      navigate("/", { replace: true });
+      // Import returns a manifest, not a HealthResponse -- read /api/health
+      // to pick up the just-bound match's id for the URL prefix.
+      const health = await api.getHealth();
+      navigate(matchHome(health), { replace: true });
     } catch (e: unknown) {
       setImporting(false);
       setError(e instanceof ApiError ? e.detail : String(e));

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -6334,3 +6334,91 @@ def test_merge_execute_refuses_destination_with_existing_match(tmp_path: Path) -
         json={"inputs": [str(a), str(b)], "output": str(out), "name": "Match X"},
     )
     assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# /api/matches/{match_id}/ alias middleware (#353 Phase 3 PR B)
+# ---------------------------------------------------------------------------
+
+
+def _make_match_app(tmp_path: Path):
+    """Build a TestClient bound to a real Match folder with one shooter."""
+    from splitsmith import match_model
+
+    match_root = tmp_path / "scoped-match"
+    match = match_model.Match.init(match_root, name="Scoped Match")
+    shooter = match_model.Shooter(slug="mathias", name="Mathias")
+    match.add_shooter(match_root, shooter)
+    app = create_app(project_root=match_root, project_name=match.name)
+    return app, match, match_root
+
+
+def test_match_id_alias_rewrites_to_existing_route(tmp_path: Path, _user_config_home: Path) -> None:
+    """``/api/matches/{match_id}/health`` resolves to the same health route."""
+    app, match, _ = _make_match_app(tmp_path)
+    client = TestClient(app)
+
+    direct = client.get("/api/health")
+    aliased = client.get(f"/api/matches/{match.match_id}/health")
+
+    assert direct.status_code == 200
+    assert aliased.status_code == 200
+    # Same payload on either prefix: the middleware strips the
+    # match-id segment and hands off to the existing handler.
+    assert direct.json() == aliased.json()
+    assert aliased.json()["match_id"] == match.match_id
+
+
+def test_match_id_alias_resolves_match_level_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
+    """A real match-level endpoint works through both prefixes."""
+    app, match, _ = _make_match_app(tmp_path)
+    client = TestClient(app)
+
+    direct = client.get("/api/match/shooters")
+    aliased = client.get(f"/api/matches/{match.match_id}/match/shooters")
+
+    assert direct.status_code == 200
+    assert aliased.status_code == 200
+    assert direct.json() == aliased.json()
+
+
+def test_match_id_alias_unknown_id_returns_404(tmp_path: Path, _user_config_home: Path) -> None:
+    app, _, _ = _make_match_app(tmp_path)
+    client = TestClient(app)
+
+    resp = client.get("/api/matches/nope-deadbeef/health")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["detail"]["code"] == "match_not_found"
+
+
+def test_match_id_alias_mismatched_bound_match_returns_409(tmp_path: Path, _user_config_home: Path) -> None:
+    """The middleware refuses a known-but-not-bound match id (#353 Phase 3 PR B).
+
+    Until PR C drops the bound-match singleton, the URL must agree with
+    what the server currently has open. A second Match registered via
+    ``user_config.record_project_open`` resolves through the registry but
+    triggers a 409 because the bound match is the first one.
+    """
+    from splitsmith import match_model, user_config
+
+    app, _, _ = _make_match_app(tmp_path)
+    other_root = tmp_path / "other-match"
+    other = match_model.Match.init(other_root, name="Other Match")
+    user_config.record_project_open(other_root, other.name, kind="match")
+
+    client = TestClient(app)
+    resp = client.get(f"/api/matches/{other.match_id}/health")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "match_mismatch"
+
+
+def test_match_id_alias_missing_segment_returns_400(tmp_path: Path, _user_config_home: Path) -> None:
+    app, _, _ = _make_match_app(tmp_path)
+    client = TestClient(app)
+
+    # No trailing segment after /api/matches/{id} -- the middleware can't
+    # rewrite to a real route without one.
+    resp = client.get("/api/matches/")
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "match_id_required"


### PR DESCRIPTION
## Summary

Second step of the URL-scoped Phase 3 arc (PR A landed ``match_id`` + the registry).

**Server**
- New HTTP middleware: ``/api/matches/{match_id}/{rest}`` is validated against the registry then rewritten to ``/api/{rest}``. Unknown id -> 404 ``match_not_found``; known but not the currently-bound match -> 409 ``match_mismatch`` (the singleton stays until PR C).
- One integration point in ``create_app`` -- no endpoint decorators touched, zero per-route churn.
- ``HealthResponse`` (Pydantic) + the SPA's ``ServerHealth`` TS type both carry ``match_id``.

**SPA**
- ``App.tsx`` mounts every match-scoped route under a new ``<Route path=\"match/:matchId\">`` parent. The bare copy is kept alongside so bookmarks + un-migrated in-app navigations still resolve; the bare paths retire in PR C after the navigation sweep is done.
- ``Pick.tsx`` -- all three bind paths (open existing, open by path, import + bind) navigate to ``/match/{matchId}/`` after bind so each tab carries the match in its URL.
- ``MatchShell`` reads ``matchId`` from ``useParams`` and threads it to the sidebar. ``MatchSidebar`` prefixes every nav row with ``/match/{matchId}`` when in scope; falls back to bare paths when ``matchId`` is absent (legacy bind without ``match_id``).

After this PR, the standard happy path (picker -> match) keeps the user inside the prefixed subtree end-to-end. Direct entry to a legacy bare URL still works.

## Test plan

- [x] ``tests/test_ui_server.py`` -- 5 new middleware tests: alias rewrites to ``/api/health``, alias resolves a match-level endpoint, unknown match id -> 404, mismatched bound match -> 409, missing match-id segment -> 400.
- [x] ``uv run ruff check src tests`` clean.
- [x] ``uv run black --check src tests`` clean.
- [x] ``uv run pytest -q`` -- 1273 passed, 4 skipped.
- [x] ``npm run build`` clean.
- [x] Manual: ``splitsmith-server``, opened a match, picker redirected to ``/match/<id>/``; sidebar links land under the prefix.

Toward #353. Follow-up PR C drops the legacy bare routes, migrates the remaining ``navigate``/``Link`` callers, switches the API client to the new prefix, and finally removes ``state._bound_root``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)