### PR TITLE
feat(ui): drop match singleton + canonical /match/:matchId URLs (#353 Phase 3 PR C)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -79,6 +79,7 @@ import sys
 import tempfile
 import threading
 import time
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -509,6 +510,17 @@ def _no_project_error() -> HTTPException:
     )
 
 
+# Per-request match root resolved by the ``/api/matches/{match_id}/...``
+# alias middleware (#353 Phase 3 PR C). When set, ``AppState.shooter_root``
+# reads from here instead of the process singleton -- which means two
+# concurrent requests carrying different match ids resolve to their own
+# match roots without fighting over ``state._bound_root``. The singleton
+# is kept as a fallback for legacy bare-path traffic + picker UX; it can
+# go away entirely once every endpoint is exercised under the new prefix.
+current_match_root: ContextVar[Path | None] = ContextVar("splitsmith_current_match_root", default=None)
+current_match_id: ContextVar[str | None] = ContextVar("splitsmith_current_match_id", default=None)
+
+
 @dataclass
 class AppState:
     """Process state. One bound project at a time (#353).
@@ -585,7 +597,30 @@ class AppState:
         and its data lives at the bound root. The slug is accepted as-is
         (the SPA derives it from ``competitor_name`` via :func:`legacy_slug`)
         so callers don't need to special-case the legacy layout.
+
+        Resolution order (#353 Phase 3 PR C):
+
+        1. ``current_match_root`` ContextVar -- set by the
+           ``/api/matches/{match_id}/...`` alias middleware. This is the
+           per-request path; multiple tabs on different matches stay
+           isolated because each request carries its own context.
+        2. ``self._bound_root`` -- the legacy singleton. Kept as a
+           fallback for legacy bare ``/api/shooters/{slug}/...`` traffic
+           (clients that haven't migrated to the new prefix yet) and for
+           the picker boot path.
         """
+        scoped_root = current_match_root.get()
+        if scoped_root is not None:
+            # Per-request scope is always a Match folder (the middleware
+            # rejects legacy projects upstream). Validate the slug and
+            # resolve under that root, ignoring the singleton.
+            match = match_model.Match.load(scoped_root)
+            if slug not in match.shooters:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"shooter {slug!r} is not registered on this match",
+                )
+            return match_model.Match.shooter_root(scoped_root, slug)
         if self._bound_root is None:
             raise _no_project_error()
         if self._bound_kind == "legacy":
@@ -1900,19 +1935,25 @@ def create_app(
     app.state.splitsmith_state = state
 
     # ----------------------------------------------------------------------
-    # /api/matches/{match_id}/... alias middleware (#353 Phase 3 PR B)
+    # /api/matches/{match_id}/... alias middleware (#353 Phase 3 PR B/C)
     # ----------------------------------------------------------------------
     #
-    # The SPA's URLs are growing a ``/match/:matchId/`` prefix so each tab
-    # can pin its own match. To accept the corresponding API prefix
-    # without rewriting 69 endpoint decorators, we register one HTTP
-    # middleware that strips ``matches/{match_id}/`` from any matching
-    # path and forwards the request to the existing route table.
+    # The SPA's URLs live under ``/match/:matchId/`` so each tab can pin
+    # its own match. The corresponding API prefix is accepted by this
+    # one middleware:
     #
-    # Validation: ``match_id`` must resolve via the registry **and** (in
-    # this PR) must equal the currently-bound match. The singleton stays
-    # in place until PR C; the mismatch check protects stale URLs from
-    # silently writing into the wrong match.
+    # 1. Validate ``match_id`` against the registry (404 ``match_not_found``
+    #    when unknown).
+    # 2. Set the ``current_match_root`` / ``current_match_id`` ContextVars
+    #    for the lifetime of the request so ``state.shooter_root`` can
+    #    resolve against the URL's match rather than the singleton.
+    # 3. Strip ``matches/{match_id}/`` and forward to the existing route
+    #    table -- 69 endpoint decorators are untouched.
+    #
+    # Two concurrent requests with different match ids stay isolated
+    # because each runs in its own contextvar scope. The singleton
+    # ``state._bound_root`` is only consulted for legacy bare-path
+    # traffic that hasn't migrated to the new prefix.
     @app.middleware("http")
     async def _match_id_alias(request, call_next):
         path = request.url.path
@@ -1932,7 +1973,7 @@ def create_app(
                 },
             )
         try:
-            state.matches.resolve(match_id)
+            match_root = state.matches.resolve(match_id)
         except KeyError:
             return JSONResponse(
                 status_code=404,
@@ -1943,24 +1984,16 @@ def create_app(
                     }
                 },
             )
-        if state.bound_match_id and state.bound_match_id != match_id:
-            return JSONResponse(
-                status_code=409,
-                content={
-                    "detail": {
-                        "code": "match_mismatch",
-                        "message": (
-                            f"URL match_id {match_id!r} does not match "
-                            f"bound match {state.bound_match_id!r}; rebind via "
-                            "POST /api/me/recent-projects/bind"
-                        ),
-                    }
-                },
-            )
         rewritten = "/api/" + rest
         request.scope["path"] = rewritten
         request.scope["raw_path"] = rewritten.encode("utf-8")
-        return await call_next(request)
+        root_token = current_match_root.set(match_root)
+        id_token = current_match_id.set(match_id)
+        try:
+            return await call_next(request)
+        finally:
+            current_match_root.reset(root_token)
+            current_match_id.reset(id_token)
 
     # ----------------------------------------------------------------------
     # API

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -1,4 +1,12 @@
-import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import {
+  BrowserRouter,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 
 import { AppShell } from "@/components/AppShell";
 import { DeveloperShell } from "@/components/developer/DeveloperShell";
@@ -24,60 +32,46 @@ import { Pick } from "@/pages/Pick";
 import { Shooters } from "@/pages/Shooters";
 import { PromoteReview } from "@/pages/PromoteReview";
 import { Review } from "@/pages/Review";
+import { api } from "@/lib/api";
 
 function RedirectLabSlug() {
   const { slug } = useParams<{ slug: string }>();
   return <Navigate to={`/dev/legacy/lab/${slug ?? ""}`} replace />;
 }
 
-/* All match-scoped routes (#353 Phase 3 PR B). Rendered both under the
- * canonical /match/:matchId/ prefix and at the bare path so legacy
- * bookmarks (and incremental in-app navigations that haven't migrated to
- * the prefix yet) keep working. Once the navigation sweep is done in a
- * follow-up PR the bare paths can drop. */
-function MatchScopedRoutes() {
-  return (
-    <>
-      <Route
-        path="ingest/:slug"
-        element={<ShooterScopedRoute element={<Ingest />} />}
-      />
-      <Route path="ingest" element={<Navigate to="../shooters" replace />} />
-      <Route element={<MatchShell />}>
-        <Route index element={<Home />} />
-        <Route
-          path="audit/:slug"
-          element={<ShooterScopedRoute element={<Audit />} />}
-        />
-        <Route
-          path="audit/:slug/:stage"
-          element={<ShooterScopedRoute element={<Audit />} />}
-        />
-        <Route path="audit" element={<Navigate to="../shooters" replace />} />
-        <Route path="compare/:stage" element={<Compare />} />
-        <Route
-          path="coach/:slug"
-          element={<ShooterScopedRoute element={<Coach />} />}
-        />
-        <Route
-          path="coach/:slug/:stage"
-          element={<ShooterScopedRoute element={<Coach />} />}
-        />
-        <Route path="coach" element={<Navigate to="../shooters" replace />} />
-        <Route path="shooters" element={<Shooters />} />
-        <Route path="beep-review" element={<BeepReview />} />
-        <Route
-          path="export/:slug"
-          element={<ShooterScopedRoute element={<Export />} />}
-        />
-        <Route
-          path="export/:slug/:stage"
-          element={<ShooterScopedRoute element={<Export />} />}
-        />
-        <Route path="export" element={<Navigate to="../shooters" replace />} />
-      </Route>
-    </>
-  );
+/* Catch-all for bare match-scoped paths (``/audit/...``, ``/ingest``,
+ * ``/shooters``, etc.) hit directly via bookmark or external link. Reads
+ * the server's bound ``match_id`` via ``/api/health`` and redirects into
+ * ``/match/:matchId/<original path>``. Falls through to ``/pick`` when no
+ * match is bound. */
+function LegacyMatchRedirect() {
+  const location = useLocation();
+  const [target, setTarget] = useState<string | null>(null);
+  useEffect(() => {
+    let alive = true;
+    api
+      .getHealth()
+      .then((h) => {
+        if (!alive) return;
+        if (h.bound && h.match_id) {
+          const rest =
+            location.pathname.startsWith("/") && location.pathname !== "/"
+              ? location.pathname
+              : "";
+          setTarget(`/match/${h.match_id}${rest}${location.search}`);
+        } else {
+          setTarget("/pick");
+        }
+      })
+      .catch(() => {
+        if (alive) setTarget("/pick");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [location.pathname, location.search]);
+  if (target == null) return null;
+  return <Navigate to={target} replace />;
 }
 
 export function App() {
@@ -91,25 +85,52 @@ export function App() {
           <Route path="pick" element={<Pick />} />
           <Route path="pick/new" element={<CreateMatch />} />
           <Route path="pick/merge" element={<MergeMatches />} />
-          {/* Match-mode surfaces ride under the Shot Timer shell as
-              their redesign issues ship. Ingest stays self-shelled
-              (focused-task page, no sidebar).
-
-              Shooter-scoped routes (#353): /audit /export /ingest /coach
-              take an explicit /:slug so the URL alone identifies which
-              shooter is in focus. Slugless visits redirect to /shooters.
-              ShooterScopedRoute keys on slug so the page remounts cleanly
-              when the chip strip switches shooters.
-
-              /compare /shooters /beep-review stay slug-less: compare is
-              inherently multi-shooter, /shooters is the shooter manager
-              itself, beep-review is a cross-shooter queue.
-
-              The same subtree is mounted under /match/:matchId/* so each
-              tab can pin its own match (#353 Phase 3 PR B). The bare-path
-              copy below stays until the in-app navigation sweep is done. */}
-          <Route path="match/:matchId">{MatchScopedRoutes()}</Route>
-          {MatchScopedRoutes()}
+          {/* Canonical match-scoped surfaces (#353 Phase 3 PR C). All
+              shooter / stage / overview / picker-within-match routes
+              live under ``/match/:matchId/...``. Bare match-scoped paths
+              are caught by LegacyMatchRedirect and re-routed into the
+              prefix using ``/api/health.match_id`` so old bookmarks land
+              on the right place. */}
+          <Route path="match/:matchId">
+            <Route
+              path="ingest/:slug"
+              element={<ShooterScopedRoute element={<Ingest />} />}
+            />
+            <Route path="ingest" element={<Navigate to="../shooters" replace />} />
+            <Route element={<MatchShell />}>
+              <Route index element={<Home />} />
+              <Route
+                path="audit/:slug"
+                element={<ShooterScopedRoute element={<Audit />} />}
+              />
+              <Route
+                path="audit/:slug/:stage"
+                element={<ShooterScopedRoute element={<Audit />} />}
+              />
+              <Route path="audit" element={<Navigate to="../shooters" replace />} />
+              <Route path="compare/:stage" element={<Compare />} />
+              <Route
+                path="coach/:slug"
+                element={<ShooterScopedRoute element={<Coach />} />}
+              />
+              <Route
+                path="coach/:slug/:stage"
+                element={<ShooterScopedRoute element={<Coach />} />}
+              />
+              <Route path="coach" element={<Navigate to="../shooters" replace />} />
+              <Route path="shooters" element={<Shooters />} />
+              <Route path="beep-review" element={<BeepReview />} />
+              <Route
+                path="export/:slug"
+                element={<ShooterScopedRoute element={<Export />} />}
+              />
+              <Route
+                path="export/:slug/:stage"
+                element={<ShooterScopedRoute element={<Export />} />}
+              />
+              <Route path="export" element={<Navigate to="../shooters" replace />} />
+            </Route>
+          </Route>
           {/* Developer mode (#331). All four workflow steps + the
               retired Lab + fixture-editor surfaces sit under the
               cyan-accented DeveloperShell. */}
@@ -133,8 +154,12 @@ export function App() {
             {/* Legacy redirects so old bookmarks don't 404. */}
             <Route path="lab" element={<Navigate to="/dev/legacy/lab" replace />} />
             <Route path="lab/:slug" element={<RedirectLabSlug />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
+          {/* Bare match-scoped paths -- caught here and bounced into the
+              ``/match/:matchId/`` prefix via LegacyMatchRedirect. ``/``
+              also goes through here so a fresh-bound match lands on its
+              own overview without the picker needing to plumb the id. */}
+          <Route path="*" element={<LegacyMatchRedirect />} />
         </Routes>
       </BrowserRouter>
     </ModeProvider>

--- a/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
+++ b/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
@@ -17,8 +17,15 @@ interface Props {
 }
 
 export function ShooterScopedRoute({ element }: Props) {
-  const { slug } = useParams<{ slug: string }>();
-  if (!slug) return <Navigate to="/shooters" replace />;
+  const { slug, matchId } = useParams<{ slug: string; matchId?: string }>();
+  if (!slug) {
+    return (
+      <Navigate
+        to={matchId ? `/match/${matchId}/shooters` : "/shooters"}
+        replace
+      />
+    );
+  }
   return (
     <span key={slug} style={{ display: "contents" }}>
       {element}

--- a/src/splitsmith/ui_static/src/components/match/ShooterChipStrip.tsx
+++ b/src/splitsmith/ui_static/src/components/match/ShooterChipStrip.tsx
@@ -16,6 +16,7 @@ import { Link } from "react-router-dom";
 
 import { Avatar } from "@/components/ui";
 import type { ShooterListEntry } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -61,6 +62,7 @@ export function ShooterChipStrip({
   count = defaultCount,
   variant = "block",
 }: Props) {
+  const href = useMatchHref();
   if (shooters.length <= 1) return null;
   const isInline = variant === "inline";
   return (
@@ -85,8 +87,8 @@ export function ShooterChipStrip({
         const isActive = s.slug === activeSlug;
         const target =
           stage != null
-            ? `/${urlBase}/${s.slug}/${stage}`
-            : `/${urlBase}/${s.slug}`;
+            ? href(urlBase, s.slug, String(stage))
+            : href(urlBase, s.slug);
         const secondary = count ? count(s) : null;
         return (
           <Link

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1377,6 +1377,38 @@ class ApiError extends Error {
   }
 }
 
+/** Match id parsed from the current URL.
+ *
+ * The SPA's match-scoped routes live under ``/match/:matchId/...`` (#353
+ * Phase 3). When the operator is on one of those URLs we route API
+ * traffic through ``/api/matches/{matchId}/...`` so the request lands
+ * on the right match without depending on the server's bound singleton.
+ * Returns ``null`` for non-match URLs (picker, dev mode, root).
+ *
+ * Exported for the rare test / debug case; production code consults it
+ * via :func:`request` automatically. */
+export function currentMatchIdFromLocation(): string | null {
+  if (typeof window === "undefined") return null;
+  const m = window.location.pathname.match(/^\/match\/([^/]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** Prefixes that ride on the per-request match scope. Other ``/api/`` paths
+ *  (``/api/health``, ``/api/me/*``, ``/api/server/*``, ``/api/lab/*``,
+ *  ``/api/files/*``, ``/api/fs/*``, ``/api/dev/*``, etc.) stay on their
+ *  legacy bare paths because they are operator-global or unbound. */
+const MATCH_SCOPED_PREFIXES = ["/api/shooters/", "/api/match/"];
+
+function scopeRequestPath(path: string): string {
+  const matchId = currentMatchIdFromLocation();
+  if (!matchId) return path;
+  if (!MATCH_SCOPED_PREFIXES.some((p) => path.startsWith(p))) return path;
+  // Rewrite ``/api/shooters/foo`` -> ``/api/matches/{id}/shooters/foo``
+  // (and same for ``/api/match/...``). Preserves the query string, since
+  // we splice into the path segment only.
+  return `/api/matches/${encodeURIComponent(matchId)}${path.substring(4)}`;
+}
+
 async function request<T>(
   path: string,
   init?: RequestInit & { json?: unknown },
@@ -1389,7 +1421,7 @@ async function request<T>(
   if (json !== undefined) {
     (headers as Record<string, string>)["Content-Type"] = "application/json";
   }
-  const resp = await fetch(path, {
+  const resp = await fetch(scopeRequestPath(path), {
     ...rest,
     headers,
     body: json !== undefined ? JSON.stringify(json) : rest.body,

--- a/src/splitsmith/ui_static/src/lib/matchHref.ts
+++ b/src/splitsmith/ui_static/src/lib/matchHref.ts
@@ -1,0 +1,56 @@
+/**
+ * matchHref -- build URLs that stay inside the active match's subtree.
+ *
+ * Match-scoped SPA routes live under ``/match/:matchId/...`` (#353
+ * Phase 3). Pages that build links / fire ``navigate()`` calls need to
+ * keep that prefix on so a click doesn't fall out of the match scope.
+ *
+ * ``useMatchHref()`` returns a builder bound to the current URL's
+ * matchId (read via ``useParams``). Call it with the suffix you want
+ * to land on:
+ *
+ *     const href = useMatchHref();
+ *     navigate(href("audit", slug, String(stage)));
+ *     // -> "/match/<id>/audit/<slug>/<stage>"
+ *
+ * Missing matchId (e.g. legacy URL before the redirect kicks in) falls
+ * back to a leading slash so the result still parses as a valid path.
+ */
+
+import { useCallback } from "react";
+import { useParams } from "react-router-dom";
+
+export type MatchHrefBuilder = (...segments: string[]) => string;
+
+export function useMatchHref(): MatchHrefBuilder {
+  const { matchId } = useParams<{ matchId?: string }>();
+  return useCallback(
+    (...segments: string[]) => {
+      const tail = segments
+        .filter((s) => s != null && s !== "")
+        .map((s) => encodeURIComponent(s))
+        .join("/");
+      if (matchId) {
+        return `/match/${encodeURIComponent(matchId)}/${tail}`;
+      }
+      return `/${tail}`;
+    },
+    [matchId],
+  );
+}
+
+/** Standalone helper for places that have ``matchId`` in hand (e.g. the
+ *  match shell, the picker after bind) but aren't ready to wire a hook. */
+export function matchHref(
+  matchId: string | null | undefined,
+  ...segments: string[]
+): string {
+  const tail = segments
+    .filter((s) => s != null && s !== "")
+    .map((s) => encodeURIComponent(s))
+    .join("/");
+  if (matchId) {
+    return `/match/${encodeURIComponent(matchId)}/${tail}`;
+  }
+  return `/${tail}`;
+}

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -95,6 +95,7 @@ import {
 import { detectAnomalies, keptShotsFromMarkers } from "@/lib/anomalies";
 import { isTypingTextTarget, useBlurOnPointerClick } from "@/lib/audit-input";
 import { computeAuditNextStep } from "@/lib/audit-next-step";
+import { useMatchHref } from "@/lib/matchHref";
 import { deriveStageStatus } from "@/lib/stageStatus";
 import { cn } from "@/lib/utils";
 
@@ -111,6 +112,7 @@ export function Audit() {
     stage?: string;
   }>();
   const navigate = useNavigate();
+  const href = useMatchHref();
   const [searchParams] = useSearchParams();
   const doneParam = searchParams.get("done");
   const nextShooterParam = searchParams.get("next");
@@ -1187,14 +1189,14 @@ export function Audit() {
             activeStage: stageNumber,
           });
           if (step.kind === "stage") {
-            navigate(`/audit/${step.nextSlug}/${step.nextStage}`);
+            navigate(href("audit", step.nextSlug, String(step.nextStage)));
           } else if (step.kind === "shooter" && slugParam != null && stageNumber != null) {
             navigate(
-              `/audit/${slugParam}/${stageNumber}?done=1&next=${encodeURIComponent(step.nextSlug)}`,
+              `${href("audit", slugParam, String(stageNumber))}?done=1&next=${encodeURIComponent(step.nextSlug)}`,
               { replace: true },
             );
           } else if (slugParam != null && stageNumber != null) {
-            navigate(`/audit/${slugParam}/${stageNumber}?done=1`, { replace: true });
+            navigate(`${href("audit", slugParam, String(stageNumber))}?done=1`, { replace: true });
           }
         }
         return true;
@@ -2270,7 +2272,7 @@ export function Audit() {
                 shooters.find((s) => s.slug === slugParam)?.name ?? null
               }
               stats={summaryStats}
-              onJumpToOverview={() => navigate("/shooters")}
+              onJumpToOverview={() => navigate(href("shooters"))}
               nextShooterLabel={
                 nextShooterParam
                   ? (shooters.find((s) => s.slug === nextShooterParam)?.name ??
@@ -2279,7 +2281,7 @@ export function Audit() {
               }
               onAuditNextShooter={
                 nextShooterParam
-                  ? () => navigate(`/audit/${nextShooterParam}`)
+                  ? () => navigate(href("audit", nextShooterParam))
                   : undefined
               }
             />

--- a/src/splitsmith/ui_static/src/pages/BeepReview.tsx
+++ b/src/splitsmith/ui_static/src/pages/BeepReview.tsx
@@ -38,10 +38,12 @@ import {
   type BeepQueueItem,
   type BeepQueueResponse,
 } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 export function BeepReview() {
   const navigate = useNavigate();
+  const href = useMatchHref();
   const [data, setData] = useState<BeepQueueResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeKey, setActiveKey] = useState<string | null>(null);
@@ -217,7 +219,7 @@ export function BeepReview() {
             onConfirmAlt={(t) => void confirm(active, t)}
             onSkip={skip}
             onOpenAudit={() =>
-              navigate(`/audit/${active.slug}/${active.stage_number}`)
+              navigate(href("audit", active.slug, String(active.stage_number)))
             }
           />
         ) : (

--- a/src/splitsmith/ui_static/src/pages/Coach.tsx
+++ b/src/splitsmith/ui_static/src/pages/Coach.tsx
@@ -52,6 +52,7 @@ import {
   type CoachStageResponse,
   type MatchProject,
 } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 const INTERVAL_LABEL: Record<CoachIntervalClass, string> = {
@@ -121,14 +122,15 @@ interface PerStageAggregate {
 
 function CoachMatch({ slug }: { slug?: string }) {
   const navigate = useNavigate();
+  const href = useMatchHref();
   if (!slug) {
     // ShooterScopedRoute should keep this from rendering, but the
     // Coach() wrapper still passes slugParam through when undefined;
     // bounce back to the picker rather than 500ing on the API call.
-    return <Navigate to="/shooters" replace />;
+    return <Navigate to={href("shooters")} replace />;
   }
-  const stagePrefix = `/coach/${slug}`;
-  const auditPrefix = `/audit/${slug}`;
+  const stagePrefix = href("coach", slug);
+  const auditPrefix = href("audit", slug);
   const [project, setProject] = useState<MatchProject | null>(null);
   const [perStage, setPerStage] = useState<PerStageAggregate[]>([]);
   const [distributions, setDistributions] =
@@ -954,11 +956,12 @@ function AnnotationsCard({
 
 function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
   const navigate = useNavigate();
+  const href = useMatchHref();
   if (!slug) {
-    return <Navigate to="/shooters" replace />;
+    return <Navigate to={href("shooters")} replace />;
   }
-  const coachPrefix = `/coach/${slug}`;
-  const auditPrefix = `/audit/${slug}`;
+  const coachPrefix = href("coach", slug);
+  const auditPrefix = href("audit", slug);
   const [project, setProject] = useState<MatchProject | null>(null);
   const [coach, setCoach] = useState<CoachStageResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1174,7 +1177,7 @@ function CoachStage({ stage, slug }: { stage: number; slug?: string }) {
           </button>
           <button
             type="button"
-            onClick={() => navigate(`/compare/${stage}`)}
+            onClick={() => navigate(href("compare", String(stage)))}
             className="inline-flex min-h-9 items-center rounded-md px-3.5 font-sans text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-muted hover:text-ink-2"
           >
             Compare

--- a/src/splitsmith/ui_static/src/pages/Compare.tsx
+++ b/src/splitsmith/ui_static/src/pages/Compare.tsx
@@ -54,6 +54,7 @@ import {
   type CompareStageResponse,
   type MatchProject,
 } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 type Layout = "grid" | "row" | "stack";
@@ -64,6 +65,7 @@ const SYNC_INTERVAL_MS = 120;
 export function Compare() {
   const { stage: stageParam } = useParams();
   const navigate = useNavigate();
+  const href = useMatchHref();
   const stageNumber = stageParam ? Number(stageParam) : NaN;
 
   const [project, setProject] = useState<MatchProject | null>(null);
@@ -242,13 +244,14 @@ export function Compare() {
     if (!project) return;
     const all = project.stages.map((s) => s.stage_number).sort((a, b) => a - b);
     const idx = all.indexOf(stageNumber);
-    if (idx > 0) navigate(`/compare/${all[idx - 1]}`);
+    if (idx > 0) navigate(href("compare", String(all[idx - 1])));
   }
   function nextStage() {
     if (!project) return;
     const all = project.stages.map((s) => s.stage_number).sort((a, b) => a - b);
     const idx = all.indexOf(stageNumber);
-    if (idx >= 0 && idx < all.length - 1) navigate(`/compare/${all[idx + 1]}`);
+    if (idx >= 0 && idx < all.length - 1)
+      navigate(href("compare", String(all[idx + 1])));
   }
 
   if (!stageNumber || Number.isNaN(stageNumber)) {
@@ -319,7 +322,7 @@ export function Compare() {
               // primary shown in this view) as the target shooter so
               // the user lands on the same camera they were watching.
               const target = audioSlug ?? orderedShooters[0]?.slug;
-              if (target) navigate(`/audit/${target}/${stageNumber}`);
+              if (target) navigate(href("audit", target, String(stageNumber)));
             }}
             className="inline-flex min-h-9 items-center rounded-md px-3.5 font-sans text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-muted hover:text-ink-2"
           >
@@ -332,7 +335,7 @@ export function Compare() {
             type="button"
             onClick={() => {
               const target = audioSlug ?? orderedShooters[0]?.slug;
-              if (target) navigate(`/coach/${target}/${stageNumber}`);
+              if (target) navigate(href("coach", target, String(stageNumber)));
             }}
             className="inline-flex min-h-9 items-center rounded-md px-3.5 font-sans text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-muted hover:text-ink"
           >
@@ -398,7 +401,7 @@ export function Compare() {
         <UnfinishedShootersBanner
           unfinished={orderedShooters.filter((s) => !s.video_path)}
           onOpenInAudit={(slug) =>
-            navigate(`/audit/${slug}/${stageNumber}`)
+            navigate(href("audit", slug, String(stageNumber)))
           }
         />
       ) : null}
@@ -409,7 +412,7 @@ export function Compare() {
           <CompareEmptyState
             unfinished={orderedShooters.filter((s) => !s.video_path)}
             onOpenInAudit={(slug) => {
-              navigate(`/audit/${slug}/${stageNumber}`);
+              navigate(href("audit", slug, String(stageNumber)));
             }}
           />
         ) : (

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -113,8 +113,14 @@ const TITLE_STYLES: {
 ];
 
 export function Export() {
-  const { slug } = useParams<{ slug: string }>();
-  if (!slug) return <Navigate to="/shooters" replace />;
+  const { slug, matchId } = useParams<{ slug: string; matchId?: string }>();
+  if (!slug)
+    return (
+      <Navigate
+        to={matchId ? `/match/${matchId}/shooters` : "/shooters"}
+        replace
+      />
+    );
   return <ExportInner slug={slug} />;
 }
 

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -45,6 +45,7 @@ import {
   isNextUpCandidate,
   isTerminal,
 } from "@/lib/stageStatus";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 // Visual tone the home stage card switches on. Derived from the
@@ -65,6 +66,7 @@ interface StageView {
 
 export function Home() {
   const navigate = useNavigate();
+  const href = useMatchHref();
   const ctx = useOutletContext<MatchShellOutletContext>();
   const project = ctx?.project ?? null;
   // Slug used for slug-bearing nav links from this page. Lifted off the
@@ -211,7 +213,7 @@ export function Home() {
           <Button
             variant="outline"
             onClick={() =>
-              navigate(navSlug ? `/export/${navSlug}` : "/shooters")
+              navigate(navSlug ? href("export", navSlug) : href("shooters"))
             }
           >
             <ArrowDownToLine className="size-3.5" />
@@ -274,8 +276,9 @@ function ActiveVariant({
   navSlug: string | null;
 }) {
   const navigate = useNavigate();
+  const href = useMatchHref();
   const stageHref = (n: number) =>
-    navSlug ? `/audit/${navSlug}/${n}` : "/shooters";
+    navSlug ? href("audit", navSlug, String(n)) : href("shooters");
   return (
     <>
       {/* Resume hero */}
@@ -370,7 +373,7 @@ function ActiveVariant({
         action={
           <button
             type="button"
-            onClick={() => navigate("/shooters")}
+            onClick={() => navigate(href("shooters"))}
             className="link-led-fill inline-flex items-center gap-1.5"
           >
             Manage shooters
@@ -452,7 +455,8 @@ function EmptyVariant({
   navSlug: string | null;
 }) {
   const navigate = useNavigate();
-  const ingestHref = navSlug ? `/ingest/${navSlug}` : "/shooters";
+  const href = useMatchHref();
+  const ingestHref = navSlug ? href("ingest", navSlug) : href("shooters");
   return (
     <>
       <section
@@ -519,7 +523,7 @@ function EmptyVariant({
         action={
           <button
             type="button"
-            onClick={() => navigate("/shooters")}
+            onClick={() => navigate(href("shooters"))}
             className="link-led-fill inline-flex items-center gap-1.5"
           >
             Manage shooters

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -45,18 +45,26 @@ import {
   type StageVideo,
   type VideoRole,
 } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 type StorageMode = "symlink" | "copy";
 
 export function Ingest() {
-  const { slug } = useParams<{ slug: string }>();
-  if (!slug) return <Navigate to="/shooters" replace />;
+  const { slug, matchId } = useParams<{ slug: string; matchId?: string }>();
+  if (!slug)
+    return (
+      <Navigate
+        to={matchId ? `/match/${matchId}/shooters` : "/shooters"}
+        replace
+      />
+    );
   return <IngestInner slug={slug} />;
 }
 
 function IngestInner({ slug }: { slug: string }) {
   const navigate = useNavigate();
+  const href = useMatchHref();
   const [project, setProject] = useState<MatchProject | null>(null);
   const [health, setHealth] = useState<ServerHealth | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -269,7 +277,7 @@ function IngestInner({ slug }: { slug: string }) {
             onAddMore={() => setShowAddFootage(true)}
             onMoveAssignment={moveAssignment}
             onRemoveVideo={removeVideo}
-            onConfirm={() => navigate("/", { replace: true })}
+            onConfirm={() => navigate(href(""), { replace: true })}
             busy={busy}
             lastScannedDir={lastScannedDir}
             onError={setError}
@@ -536,6 +544,7 @@ function ReviewState({
   const ignoredCount = assignedVideos.filter(
     (v) => v.video.role === "ignored",
   ).length + unassignedVideos.filter((v) => v.role === "ignored").length;
+  const href = useMatchHref();
 
   return (
     <>
@@ -581,7 +590,7 @@ function ReviewState({
             says "almost-done work waits for you". */}
         {beepPending > 0 && (
           <Link
-            to="/beep-review"
+            to={href("beep-review")}
             className="flex items-center gap-3.5 border-b border-rule bg-gradient-to-r from-beep/10 to-transparent px-6 py-3 font-mono text-[0.75rem] uppercase tracking-[0.06em] text-ink-2 transition-colors hover:bg-beep/15"
           >
             <span className="inline-flex size-7 items-center justify-center rounded-full border border-beep/40 bg-beep-tint text-beep shadow-[0_0_10px_var(--color-beep-glow)]">

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -38,6 +38,7 @@ import {
   type ShooterListEntry,
   type ShooterListResponse,
 } from "@/lib/api";
+import { useMatchHref } from "@/lib/matchHref";
 import { cn } from "@/lib/utils";
 
 const RACING_PALETTES = ["ma", "jl", "pe", "rj", "manual"] as const;
@@ -99,6 +100,7 @@ const PALETTE_STYLE: Record<Palette, {
 
 export function Shooters() {
   const navigate = useNavigate();
+  const href = useMatchHref();
   const [data, setData] = useState<ShooterListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -213,7 +215,7 @@ export function Shooters() {
               stagesTotal={stagesTotal}
               busy={busy === shooter.slug}
               onRemove={() => void remove(shooter.slug, shooter.name)}
-              onOpenAudit={() => navigate(`/audit/${shooter.slug}`)}
+              onOpenAudit={() => navigate(href("audit", shooter.slug))}
               onRebuildTrims={() =>
                 void rebuildTrims(
                   shooter.slug,

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from splitsmith.automation import AutomationOverride
@@ -6392,25 +6393,74 @@ def test_match_id_alias_unknown_id_returns_404(tmp_path: Path, _user_config_home
     assert body["detail"]["code"] == "match_not_found"
 
 
-def test_match_id_alias_mismatched_bound_match_returns_409(tmp_path: Path, _user_config_home: Path) -> None:
-    """The middleware refuses a known-but-not-bound match id (#353 Phase 3 PR B).
+def test_match_id_alias_serves_non_bound_match(tmp_path: Path, _user_config_home: Path) -> None:
+    """A non-bound match resolves independently of the bound singleton (#353 Phase 3 PR C).
 
-    Until PR C drops the bound-match singleton, the URL must agree with
-    what the server currently has open. A second Match registered via
-    ``user_config.record_project_open`` resolves through the registry but
-    triggers a 409 because the bound match is the first one.
+    PR B briefly enforced ``match_id == state.bound_match_id``; PR C
+    drops that check because the middleware sets a per-request
+    ContextVar -- two tabs on different matches each get their own
+    scope. Both match ids must be served when both are registered.
     """
     from splitsmith import match_model, user_config
 
-    app, _, _ = _make_match_app(tmp_path)
+    app, bound_match, _ = _make_match_app(tmp_path)
     other_root = tmp_path / "other-match"
     other = match_model.Match.init(other_root, name="Other Match")
     user_config.record_project_open(other_root, other.name, kind="match")
 
     client = TestClient(app)
+    # The bound match still resolves via its own id.
+    resp = client.get(f"/api/matches/{bound_match.match_id}/health")
+    assert resp.status_code == 200
+    # The non-bound match also resolves; no more 409 ``match_mismatch``.
     resp = client.get(f"/api/matches/{other.match_id}/health")
-    assert resp.status_code == 409
-    assert resp.json()["detail"]["code"] == "match_mismatch"
+    assert resp.status_code == 200
+
+
+def test_match_id_alias_contextvar_isolates_per_request(tmp_path: Path, _user_config_home: Path) -> None:
+    """``state.shooter_root(slug)`` honours the per-request contextvar (#353 Phase 3 PR C).
+
+    Directly exercises ``current_match_root`` instead of going through
+    HTTP so the assertion can observe the resolved path without coupling
+    to a specific endpoint's storage layout.
+    """
+    from splitsmith import match_model, user_config
+    from splitsmith.ui.server import current_match_root
+
+    app, bound_match, bound_root = _make_match_app(tmp_path)
+    other_root = tmp_path / "other-match"
+    other = match_model.Match.init(other_root, name="Other Match")
+    other_shooter = match_model.Shooter(slug="alice", name="Alice")
+    other.add_shooter(other_root, other_shooter)
+    user_config.record_project_open(other_root, other.name, kind="match")
+
+    state = app.state.splitsmith_state
+    # No contextvar set -> falls back to bound singleton; ``alice`` isn't
+    # on the bound match, so 404.
+    with pytest.raises(HTTPException) as exc:
+        state.shooter_root("alice")
+    assert exc.value.status_code == 404
+
+    # Set the contextvar to point at the OTHER match (simulating what
+    # the middleware does on /api/matches/{other.match_id}/...). Now
+    # ``alice`` resolves under the other match's shooter dir.
+    token = current_match_root.set(other_root)
+    try:
+        resolved = state.shooter_root("alice")
+        assert resolved == match_model.Match.shooter_root(other_root, "alice")
+    finally:
+        current_match_root.reset(token)
+
+    # After reset the singleton fallback returns -- ``alice`` 404s on
+    # the bound match again, proving the contextvar didn't leak.
+    with pytest.raises(HTTPException) as exc:
+        state.shooter_root("alice")
+    assert exc.value.status_code == 404
+
+    # The bound match's own shooter ``mathias`` still resolves via the
+    # singleton fallback with no contextvar set.
+    resolved = state.shooter_root("mathias")
+    assert resolved == match_model.Match.shooter_root(bound_root, "mathias")
 
 
 def test_match_id_alias_missing_segment_returns_400(tmp_path: Path, _user_config_home: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the Phase 3 arc started in #365 / #366. Multi-tab on different matches now works: each request resolves against its URL's match id via a per-request ``ContextVar`` instead of the in-process singleton.

**Server**
- New ``current_match_root`` + ``current_match_id`` ContextVars. The ``/api/matches/{match_id}/...`` middleware sets them after registry validation, strips the prefix, and forwards to the existing route table. ``finally``-reset so no bleed between requests.
- ``AppState.shooter_root(slug)`` consults the ContextVar first and falls back to ``_bound_root`` only for legacy bare-path clients. PR-B's ``match_mismatch`` 409 is gone -- with per-request scope there's nothing to disagree about.

**SPA**
- ``api.ts`` ``request()`` auto-rewrites ``/api/shooters/...`` and ``/api/match/...`` paths to ``/api/matches/{matchId}/...`` when the operator is on a ``/match/:matchId/...`` URL. Zero per-call edits to api.ts surface.
- New ``useMatchHref()`` helper + sweep across pages (Audit, Compare, Coach, Home, Ingest, Export, BeepReview, Shooters), ``ShooterChipStrip``, and ``ShooterScopedRoute`` so every ``navigate``/``Link`` stays inside the match subtree.
- ``App.tsx`` -- bare match-scoped routes removed; a ``LegacyMatchRedirect`` catch-all reads ``/api/health.match_id`` and bounces stale URLs (``/audit/foo``, ``/``) into ``/match/{id}/...``. Unbound -> ``/pick``.

## Test plan

- [x] ``tests/test_ui_server.py`` updated: replaced the PR-B mismatch test with two new ones -- the non-bound match resolves cleanly, and a direct ``shooter_root`` call with ``current_match_root`` set/reset proves per-request isolation. Plus the original middleware suite (alias rewrite, unknown id 404, missing segment 400) still passes.
- [x] ``uv run ruff check src tests`` clean.
- [x] ``uv run black --check src tests`` clean.
- [x] ``uv run pytest -q`` -- 1274 passed, 4 skipped.
- [x] ``npm run build`` clean (TypeScript + Vite).
- [x] Manual: ``splitsmith-server`` smoke, the SPA fall-through still serves on ``/match/foo/audit/bar`` + bare ``/audit/bar``; the new middleware 404s an unknown match id end-to-end.

Closes #353. Singleton ``state._bound_root`` is kept as a fallback for legacy clients but no SPA code path depends on it any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)