### PR TITLE
feat(packaging): rotating file logging for embedded sidecar

### DIFF
--- a/src/splitsmith/ui/embedded.py
+++ b/src/splitsmith/ui/embedded.py
@@ -28,6 +28,7 @@ manager::
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
@@ -45,6 +46,7 @@ from typing import Any
 import httpx
 
 from ..runtime import runtime as process_runtime
+from .logging_setup import configure_file_logging
 from .server import create_app
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,7 @@ class ServerHandle:
     base_url: str
     artifacts_dir: str
     ffmpeg_binary: str
+    log_file: str | None = None
 
     def as_banner(self) -> str:
         """Render the one-line ``SPLITSMITH_READY {json}`` handshake."""
@@ -132,6 +135,7 @@ def run_embedded(
     port: int = 0,
     lab_enabled: bool = False,
     ready_fd: int | None = None,
+    log_file: Path | None = None,
     startup_timeout: float = DEFAULT_STARTUP_TIMEOUT_S,
     shutdown_timeout: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
 ) -> Iterator[ServerHandle]:
@@ -182,6 +186,7 @@ def run_embedded(
         base_url=base_url,
         artifacts_dir=str(rt.artifacts_dir),
         ffmpeg_binary=rt.ffmpeg_binary,
+        log_file=str(log_file) if log_file else None,
     )
 
     try:
@@ -212,8 +217,31 @@ def _env_bool(name: str) -> bool:
     return raw.lower() in {"1", "true", "yes", "on"}
 
 
-def main() -> None:
-    """``python -m splitsmith.ui.embedded`` -- sidecar entrypoint.
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="splitsmith-server",
+        description=(
+            "Embeddable splitsmith UI server. Flags override env vars; " "env vars override defaults."
+        ),
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=None,
+        help=(
+            "Directory for the rotated log file. "
+            f"Default: <user_config_dir>/logs (env: {'SPLITSMITH_LOG_DIR'})."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        help=("Logging level for the file handler. " f"Default: INFO (env: {'SPLITSMITH_LOG_LEVEL'})."),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """``splitsmith-server`` / ``python -m splitsmith.ui.embedded``.
 
     Reads launch parameters from the environment (so the desktop shell
     can spawn this without a wrapper script):
@@ -226,10 +254,14 @@ def main() -> None:
       to instead of stderr (the shell typically uses fd 3).
     * ``SPLITSMITH_LAB_ENABLED`` -- truthy values enable the ``/api/lab/*``
       routes.
+    * ``SPLITSMITH_LOG_DIR`` / ``SPLITSMITH_LOG_LEVEL`` -- file logging
+      destination + level (or pass ``--log-dir`` / ``--log-level``).
     * runtime overrides from :mod:`splitsmith.runtime` apply unchanged.
 
     SIGTERM and SIGINT trigger a graceful shutdown and exit status 0.
     """
+    args = _build_arg_parser().parse_args(argv)
+
     project_root_raw = os.environ.get(ENV_PROJECT_ROOT)
     project_root = Path(project_root_raw) if project_root_raw else None
     project_name = os.environ.get(ENV_PROJECT_NAME)
@@ -238,6 +270,9 @@ def main() -> None:
     ready_fd_val = os.environ.get(ENV_READY_FD)
     ready_fd = int(ready_fd_val) if ready_fd_val else None
     lab_enabled = _env_bool(ENV_LAB_ENABLED)
+
+    log_file = configure_file_logging(log_dir=args.log_dir, level=args.log_level)
+    logger.info("file logging enabled at %s", log_file)
 
     stop = threading.Event()
 
@@ -255,6 +290,7 @@ def main() -> None:
         port=port,
         lab_enabled=lab_enabled,
         ready_fd=ready_fd,
+        log_file=log_file,
     ):
         # Block until the signal handler flips the event. The context
         # manager's ``__exit__`` takes care of orderly shutdown.

--- a/src/splitsmith/ui/logging_setup.py
+++ b/src/splitsmith/ui/logging_setup.py
@@ -1,0 +1,108 @@
+"""File logging setup for the embedded sidecar (issue #368).
+
+The CLI keeps its existing stdout-only behavior; this module is used
+exclusively by :mod:`splitsmith.ui.embedded` so a desktop shell with no
+terminal can read support diagnostics from a known on-disk location.
+
+Default log path is ``runtime().user_config_dir / "logs" /
+"splitsmith-server.log"`` so it follows ``SPLITSMITH_CONFIG_DIR``
+overrides. Override the dir explicitly via ``SPLITSMITH_LOG_DIR`` or
+the ``--log-dir`` CLI flag; override the level via
+``SPLITSMITH_LOG_LEVEL`` or ``--log-level``.
+
+Rotation: 5 MiB per file, 5 backups -- enough to keep a few weeks of
+typical use without growing unbounded.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import os
+from pathlib import Path
+
+from ..runtime import runtime as process_runtime
+
+ENV_LOG_DIR = "SPLITSMITH_LOG_DIR"
+ENV_LOG_LEVEL = "SPLITSMITH_LOG_LEVEL"
+
+LOG_FILE_NAME = "splitsmith-server.log"
+MAX_BYTES = 5 * 1024 * 1024
+BACKUP_COUNT = 5
+
+_LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+_UVICORN_LOGGERS = ("uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+def resolve_log_dir(explicit: Path | str | None) -> Path:
+    """Pick the log directory using flag > env > runtime default."""
+    if explicit is not None:
+        return Path(explicit)
+    env_val = os.environ.get(ENV_LOG_DIR)
+    if env_val:
+        return Path(env_val)
+    return process_runtime().user_config_dir / "logs"
+
+
+def resolve_log_level(explicit: str | None) -> int:
+    """Pick the log level using flag > env > INFO."""
+    raw = explicit or os.environ.get(ENV_LOG_LEVEL) or "INFO"
+    level = logging.getLevelName(raw.upper())
+    if not isinstance(level, int):
+        return logging.INFO
+    return level
+
+
+def configure_file_logging(
+    *,
+    log_dir: Path | str | None = None,
+    level: str | None = None,
+) -> Path:
+    """Attach a RotatingFileHandler to the root + uvicorn loggers.
+
+    Idempotent: a second call replaces the previously attached splitsmith
+    handler instead of doubling up. Returns the resolved log file path
+    so callers can advertise it (e.g. in the ready banner).
+    """
+    resolved_dir = resolve_log_dir(log_dir)
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+    log_file = resolved_dir / LOG_FILE_NAME
+    resolved_level = resolve_log_level(level)
+
+    handler = logging.handlers.RotatingFileHandler(
+        log_file,
+        maxBytes=MAX_BYTES,
+        backupCount=BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT))
+    handler.setLevel(resolved_level)
+    handler.set_name("splitsmith-file")
+
+    root = logging.getLogger()
+    _replace_named_handler(root, handler)
+    if root.level == logging.NOTSET or root.level > resolved_level:
+        root.setLevel(resolved_level)
+
+    for name in _UVICORN_LOGGERS:
+        uv_logger = logging.getLogger(name)
+        _replace_named_handler(uv_logger, handler)
+        uv_logger.setLevel(resolved_level)
+        # Let uvicorn keep its default stderr handler too; the file
+        # mirror is additive. propagate=False stays uvicorn's default.
+
+    return log_file
+
+
+def _replace_named_handler(logger: logging.Logger, handler: logging.Handler) -> None:
+    """Detach any handler with the same name, then attach ``handler``."""
+    for existing in list(logger.handlers):
+        if existing.get_name() == handler.get_name():
+            logger.removeHandler(existing)
+            try:
+                existing.close()
+            except Exception:
+                pass
+    logger.addHandler(handler)

--- a/tests/test_ui_embedded.py
+++ b/tests/test_ui_embedded.py
@@ -70,6 +70,7 @@ def test_banner_is_well_formed_json() -> None:
         "base_url",
         "artifacts_dir",
         "ffmpeg_binary",
+        "log_file",
     }
     assert parsed["host"] == handle.host
     assert parsed["port"] == handle.port
@@ -105,6 +106,8 @@ def test_sigterm_to_main_exits_clean(tmp_path: Path) -> None:
     env["SPLITSMITH_HOST"] = "127.0.0.1"
     # Keep the test isolated from the developer's real ~/.splitsmith.
     env["SPLITSMITH_HOME"] = str(tmp_path / "home")
+    env["SPLITSMITH_CONFIG_DIR"] = str(tmp_path / "config")
+    env["SPLITSMITH_LOG_DIR"] = str(tmp_path / "logs")
 
     proc = subprocess.Popen(
         [sys.executable, "-m", "splitsmith.ui.embedded"],
@@ -128,6 +131,11 @@ def test_sigterm_to_main_exits_clean(tmp_path: Path) -> None:
     payload = json.loads(banner_line[len(READY_PREFIX) + 1 :])
     assert payload["port"] > 0
     assert payload["pid"] == proc.pid
+    # The banner advertises a log file inside the directory we set up.
+    assert payload["log_file"] is not None
+    log_file = Path(payload["log_file"])
+    assert log_file.parent == tmp_path / "logs"
+    assert log_file.exists() and log_file.stat().st_size > 0
 
 
 def _read_banner(proc: subprocess.Popen[str], *, deadline_s: float) -> str:

--- a/tests/test_ui_logging_setup.py
+++ b/tests/test_ui_logging_setup.py
@@ -1,0 +1,102 @@
+"""Tests for the embedded sidecar's rotating file logger (issue #368)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from splitsmith.ui import logging_setup
+
+
+@pytest.fixture(autouse=True)
+def _reset_handlers() -> None:
+    """Strip the splitsmith file handler between tests to avoid cross-talk."""
+    yield
+    for name in ("", *logging_setup._UVICORN_LOGGERS):
+        logger = logging.getLogger(name)
+        for handler in list(logger.handlers):
+            if handler.get_name() == "splitsmith-file":
+                logger.removeHandler(handler)
+                handler.close()
+
+
+def test_creates_dir_and_writes_log_file(tmp_path: Path) -> None:
+    log_file = logging_setup.configure_file_logging(log_dir=tmp_path / "logs")
+    logging.getLogger("splitsmith.test").info("hello world")
+
+    assert log_file == tmp_path / "logs" / logging_setup.LOG_FILE_NAME
+    assert log_file.exists()
+    contents = log_file.read_text(encoding="utf-8")
+    assert "hello world" in contents
+    assert "splitsmith.test" in contents
+
+
+def test_log_dir_priority_explicit_over_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(logging_setup.ENV_LOG_DIR, str(tmp_path / "from-env"))
+    resolved = logging_setup.resolve_log_dir(tmp_path / "explicit")
+    assert resolved == tmp_path / "explicit"
+
+
+def test_log_dir_priority_env_over_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(logging_setup.ENV_LOG_DIR, str(tmp_path / "from-env"))
+    assert logging_setup.resolve_log_dir(None) == tmp_path / "from-env"
+
+
+def test_log_dir_default_follows_runtime_config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from splitsmith import runtime as runtime_module
+
+    monkeypatch.delenv(logging_setup.ENV_LOG_DIR, raising=False)
+    monkeypatch.setenv("SPLITSMITH_CONFIG_DIR", str(tmp_path / "cfg"))
+    runtime_module._clear_runtime_cache()
+    try:
+        assert logging_setup.resolve_log_dir(None) == tmp_path / "cfg" / "logs"
+    finally:
+        runtime_module._clear_runtime_cache()
+
+
+def test_log_level_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(logging_setup.ENV_LOG_LEVEL, "WARNING")
+    assert logging_setup.resolve_log_level("debug") == logging.DEBUG
+    assert logging_setup.resolve_log_level(None) == logging.WARNING
+
+
+def test_log_level_falls_back_to_info_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(logging_setup.ENV_LOG_LEVEL, raising=False)
+    assert logging_setup.resolve_log_level("nonsense-level") == logging.INFO
+
+
+def test_idempotent_does_not_double_attach(tmp_path: Path) -> None:
+    logging_setup.configure_file_logging(log_dir=tmp_path / "logs")
+    logging_setup.configure_file_logging(log_dir=tmp_path / "logs")
+    matching = [h for h in logging.getLogger().handlers if h.get_name() == "splitsmith-file"]
+    assert len(matching) == 1
+
+
+def test_rotation_triggers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop MAX_BYTES tiny enough that two writes force a rollover."""
+    monkeypatch.setattr(logging_setup, "MAX_BYTES", 256)
+    log_file = logging_setup.configure_file_logging(log_dir=tmp_path / "logs")
+
+    test_logger = logging.getLogger("splitsmith.rotation")
+    payload = "x" * 200
+    for _ in range(8):
+        test_logger.info(payload)
+
+    rotated = list((tmp_path / "logs").glob(f"{logging_setup.LOG_FILE_NAME}.*"))
+    assert log_file.exists()
+    assert len(rotated) >= 1, "expected at least one rotated backup file"
+
+
+def test_uvicorn_loggers_get_file_handler(tmp_path: Path) -> None:
+    logging_setup.configure_file_logging(log_dir=tmp_path / "logs")
+    for name in logging_setup._UVICORN_LOGGERS:
+        handlers = [h for h in logging.getLogger(name).handlers if h.get_name() == "splitsmith-file"]
+        assert handlers, f"{name} missing splitsmith file handler"
+
+
+def test_cli_keeps_stdout_only_by_default() -> None:
+    """Sanity: importing the module must not attach a file handler on its own."""
+    root = logging.getLogger()
+    assert not any(h.get_name() == "splitsmith-file" for h in root.handlers)


### PR DESCRIPTION
## Summary

Closes #368.

- New `splitsmith.ui.logging_setup.configure_file_logging` attaches a `RotatingFileHandler` (5 MiB x 5 backups) to the root + uvicorn loggers
- Wired from `splitsmith.ui.embedded.main` only -- the CLI keeps its stdout-only behavior
- Default path: `runtime().user_config_dir/logs/splitsmith-server.log` (follows `SPLITSMITH_CONFIG_DIR` overrides)
- Override via `SPLITSMITH_LOG_DIR` / `SPLITSMITH_LOG_LEVEL` or the new `--log-dir` / `--log-level` CLI flags (precedence: flag > env > default)
- Ready-banner JSON now includes `log_file` so the shell can find it without guessing

## Test plan

- [x] `uv run pytest tests/test_ui_logging_setup.py tests/test_ui_embedded.py` -- 16 pass
- [x] `uv run pytest -q` -- 1284 pass, 4 skipped (no regressions)
- [x] `uv run ruff check src tests` -- clean
- [x] `uv run black --check src tests` -- clean
- [x] `uv run splitsmith-server --help` -- new flags visible
- [x] `uv run splitsmith --help` -- CLI surface unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)