### PR TITLE
chore(scripts): clean lint debt and gate scripts/ in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         run: uv sync --frozen
 
       - name: Lint (ruff)
-        run: uv run ruff check src tests
+        run: uv run ruff check src tests scripts
 
       - name: Format check (black)
-        run: uv run black --check src tests
+        run: uv run black --check src tests scripts
 
       - name: Run unit tests
         # Integration tests are skipped: they need ffmpeg + the full source video,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "PTH"]
 # convention. The names are part of the documented surface; renaming would
 # break callers.
 "src/splitsmith/ui/scoreboard/http.py" = ["N818"]
+# Training + evaluation scripts use ML naming conventions (X / Y / Xtr / Xte
+# for feature/label matrices) by long-standing scikit-learn convention. The
+# scripts directory is also where the team iterates on research code, so
+# accept a slightly looser rule set than ``src/`` carries.
+"scripts/*" = ["N803", "N806"]
 
 [tool.black]
 line-length = 110

--- a/scripts/analyze_negatives.py
+++ b/scripts/analyze_negatives.py
@@ -57,7 +57,8 @@ def _stage_group(fixture_slug: str, fixtures_dir: Path = FIXTURES_DIR) -> str:
     except Exception:
         base = fixture_slug
     prefix = "stage-shots-"
-    return base[len(prefix):] if base.startswith(prefix) else base
+    return base[len(prefix) :] if base.startswith(prefix) else base
+
 
 _CLAP_PROMPTS_SHOT = {
     "a single gunshot at close range",
@@ -116,23 +117,23 @@ def _build_universe(fixtures, tol_ms):
         cand_arr = np.array(cand_t, dtype=np.float64)
         confs_arr = np.array([s.confidence for s in shots], dtype=np.float64)
         peaks_arr = np.array([s.peak_amplitude for s in shots], dtype=np.float64)
-        tta_arr = compute_tta_agreement(
-            audio, sr, truth["beep_time"], truth["stage_time_seconds"], cand_arr
-        )
+        tta_arr = compute_tta_agreement(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cand_arr)
         feats_matrix = compute_hand_features(
             audio, sr, cand_arr, truth["beep_time"], confs_arr, peaks_arr, tta_arr
         )
         for i, sh in enumerate(shots):
-            universe.append({
-                "fixture": fix,
-                "t": sh.time_absolute,
-                "label": labels[i],
-                "clap_diff": float(diff[i]),
-                "hand_feats": feats_matrix[i].tolist(),
-                "clap_sims": list(sims[i]),
-                "peak": float(sh.peak_amplitude),
-                "conf_detector": float(sh.confidence),
-            })
+            universe.append(
+                {
+                    "fixture": fix,
+                    "t": sh.time_absolute,
+                    "label": labels[i],
+                    "clap_diff": float(diff[i]),
+                    "hand_feats": feats_matrix[i].tolist(),
+                    "clap_sims": list(sims[i]),
+                    "peak": float(sh.peak_amplitude),
+                    "conf_detector": float(sh.confidence),
+                }
+            )
     return universe
 
 
@@ -146,12 +147,11 @@ def _holdout_probs(X, y, sample_weight=None):
     """5-fold stratified held-out probabilities."""
     from sklearn.ensemble import GradientBoostingClassifier
     from sklearn.model_selection import StratifiedKFold
+
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     probs = np.zeros_like(y, dtype=np.float64)
     for tr, te in skf.split(X, y):
-        clf = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         sw = sample_weight[tr] if sample_weight is not None else None
         clf.fit(X[tr], y[tr], sample_weight=sw)
         probs[te] = clf.predict_proba(X[te])[:, 1]
@@ -180,9 +180,7 @@ def _lofo_probs(X, y, fixtures, groups=None):
         if tr.sum() == 0 or y[tr].sum() == 0:
             # Not enough training data after holding this group out; skip.
             continue
-        clf = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         clf.fit(X[tr], y[tr])
         probs[te] = clf.predict_proba(X[te])[:, 1]
     return probs
@@ -208,12 +206,19 @@ def main() -> None:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--tolerance-ms", type=float, default=75.0)
     p.add_argument("--target-recall", type=float, default=0.95)
-    p.add_argument("--hard-frac", type=float, default=0.20,
-                   help="Top fraction of negatives (by predicted prob) to upweight.")
-    p.add_argument("--hard-weight", type=float, default=3.0,
-                   help="Sample weight multiplier for hard negatives (1.0 = off).")
-    p.add_argument("--show", type=int, default=15,
-                   help="How many top mistakes to print per category.")
+    p.add_argument(
+        "--hard-frac",
+        type=float,
+        default=0.20,
+        help="Top fraction of negatives (by predicted prob) to upweight.",
+    )
+    p.add_argument(
+        "--hard-weight",
+        type=float,
+        default=3.0,
+        help="Sample weight multiplier for hard negatives (1.0 = off).",
+    )
+    p.add_argument("--show", type=int, default=15, help="How many top mistakes to print per category.")
     args = p.parse_args()
 
     universe = _build_universe(DEFAULT_FIXTURES, args.tolerance_ms)
@@ -240,7 +245,11 @@ def main() -> None:
     probs = _holdout_probs(X, y)
     thr, kept, pos = _eval_at_target_recall(probs, y, args.target_recall)
     print(f"Pass 1 (unweighted, target recall {args.target_recall*100:.0f} %):")
-    print(f"  threshold {thr:.4f}  kept {kept}  recall {pos}/{n_pos} = {pos/n_pos*100:.1f}%  precision {pos/kept*100:.1f}%")
+    print(
+        f"  threshold {thr:.4f}  kept {kept}  "
+        f"recall {pos}/{n_pos} = {pos/n_pos*100:.1f}%  "
+        f"precision {pos/kept*100:.1f}%"
+    )
 
     # Leave-one-stage-group-out: stress cross-fixture generalization.
     # Group key = stage-event identity (issue #126): anchor + all derived
@@ -256,7 +265,11 @@ def main() -> None:
         f"\nLOFO (leave-one-stage-group-out, {n_groups} groups, "
         f"target recall {args.target_recall*100:.0f} %):"
     )
-    print(f"  threshold {lofo_thr:.4f}  kept {lofo_kept}  recall {lofo_pos}/{n_pos} = {lofo_pos/n_pos*100:.1f}%  precision {lofo_pos/lofo_kept*100:.1f}%")
+    print(
+        f"  threshold {lofo_thr:.4f}  kept {lofo_kept}  "
+        f"recall {lofo_pos}/{n_pos} = {lofo_pos/n_pos*100:.1f}%  "
+        f"precision {lofo_pos/lofo_kept*100:.1f}%"
+    )
 
     # Per-fixture LOFO breakdown so we can see which fixtures generalize and
     # which break -- the average can hide a single fixture collapsing.
@@ -283,8 +296,10 @@ def main() -> None:
     neg_with_probs = [(probs[i], universe[i]) for i in range(len(universe)) if universe[i]["label"] == 0]
     neg_with_probs.sort(key=lambda x: -x[0])
     for prob, c in neg_with_probs[: args.show]:
-        print(f"{c['fixture']:38s} {c['t']:9.4f} {prob:6.3f} {c['conf_detector']:11.3f} "
-              f"{c['peak']:7.3f} {c['clap_diff']:10.4f}")
+        print(
+            f"{c['fixture']:38s} {c['t']:9.4f} {prob:6.3f} {c['conf_detector']:11.3f} "
+            f"{c['peak']:7.3f} {c['clap_diff']:10.4f}"
+        )
 
     # Show borderline positives -- model uncertain, you said real.
     print(f"\n=== Bottom {args.show} POSITIVES (model uncertain, audit says shot) ===")
@@ -292,8 +307,10 @@ def main() -> None:
     pos_with_probs = [(probs[i], universe[i]) for i in range(len(universe)) if universe[i]["label"] == 1]
     pos_with_probs.sort(key=lambda x: x[0])
     for prob, c in pos_with_probs[: args.show]:
-        print(f"{c['fixture']:38s} {c['t']:9.4f} {prob:6.3f} {c['conf_detector']:11.3f} "
-              f"{c['peak']:7.3f} {c['clap_diff']:10.4f}")
+        print(
+            f"{c['fixture']:38s} {c['t']:9.4f} {prob:6.3f} {c['conf_detector']:11.3f} "
+            f"{c['peak']:7.3f} {c['clap_diff']:10.4f}"
+        )
 
     # Pass 2: hard-negative mining.
     if args.hard_weight != 1.0:
@@ -309,11 +326,11 @@ def main() -> None:
             weights[hardest] = args.hard_weight
         probs2 = _holdout_probs(X, y, sample_weight=weights)
         thr2, kept2, pos2 = _eval_at_target_recall(probs2, y, args.target_recall)
+        print(f"\nPass 2 (top {args.hard_frac*100:.0f}% of negatives weighted {args.hard_weight}x):")
         print(
-            f"\nPass 2 (top {args.hard_frac*100:.0f}% of negatives weighted {args.hard_weight}x):"
-        )
-        print(
-            f"  threshold {thr2:.4f}  kept {kept2}  recall {pos2}/{n_pos} = {pos2/n_pos*100:.1f}%  precision {pos2/kept2*100:.1f}%"
+            f"  threshold {thr2:.4f}  kept {kept2}  "
+            f"recall {pos2}/{n_pos} = {pos2/n_pos*100:.1f}%  "
+            f"precision {pos2/kept2*100:.1f}%"
         )
         delta_kept = kept - kept2
         delta_prec = (pos2 / kept2 - pos / kept) * 100

--- a/scripts/build_ensemble_artifacts.py
+++ b/scripts/build_ensemble_artifacts.py
@@ -35,6 +35,7 @@ import json
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import joblib
 import numpy as np
@@ -53,12 +54,12 @@ from splitsmith.ensemble.calibration import (
     camera_class_from_mount,
     normalize_camera_model_key,
 )
-from splitsmith.ensemble.voters import within_stage_amp_anchor
 from splitsmith.ensemble.fixtures import (
     WRONG_CLIP_FIXTURES,
     fixture_stems,
 )
 from splitsmith.ensemble.tta import compute_tta_agreement
+from splitsmith.ensemble.voters import within_stage_amp_anchor
 from splitsmith.shot_detect import detect_shots
 
 # Every audited fixture; the discovery is filesystem-driven so adding a
@@ -310,7 +311,9 @@ def _split_by_camera_class(universe: list[dict]) -> dict[str, list[dict]]:
 
 
 def _x_from(universe: list[dict]) -> np.ndarray:
-    """Stack per-row Voter C features: ``[hand | clap_sims | clap_diff | gunshot_prob | camera_class_onehot]``.
+    """Stack per-row Voter C features.
+
+    Column order: ``[hand | clap_sims | clap_diff | gunshot_prob | camera_class_onehot]``.
 
     Camera-class one-hot is appended last so the column order matches
     ``voter_c_feature_matrix`` at runtime. ``gunshot_prob`` is folded in
@@ -463,10 +466,7 @@ def _load_mined_negatives(
         )
 
     if skipped:
-        log(
-            "  skipped mined fixtures (missing full cache or no positives): "
-            + ", ".join(sorted(skipped))
-        )
+        log("  skipped mined fixtures (missing full cache or no positives): " + ", ".join(sorted(skipped)))
 
     provenance = {
         "n_mined_negatives_used": len(rows),
@@ -519,17 +519,13 @@ def _train_voter_c_for_class(rows: list[dict], target_recall: float):
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     cv_probs = np.zeros_like(y, dtype=np.float64)
     for tr, te in skf.split(X, y):
-        f = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        f = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         f.fit(X[tr], y[tr])
         cv_probs[te] = f.predict_proba(X[te])[:, 1]
 
     threshold = _threshold_for_recall(cv_probs, y, target_recall)
 
-    clf = GradientBoostingClassifier(
-        n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-    )
+    clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
     clf.fit(X, y)
     return clf, threshold, cv_probs, y
 
@@ -705,9 +701,7 @@ def _train_voter_e(
         log("  Voter E: empty visual universe, skipping")
         return None, None
 
-    binary = [
-        row for row in visual_universe if row["label"] == 1 or row.get("subclass") == "cross_bay"
-    ]
+    binary = [row for row in visual_universe if row["label"] == 1 or row.get("subclass") == "cross_bay"]
     if len(binary) < 20 or sum(1 for r in binary if r["label"] == 1) < 5:
         log(
             f"  Voter E: insufficient binary corpus "
@@ -930,12 +924,8 @@ def build_artifacts(
         "n_calibration_positives": int(n_pos),
         "voter_c_feature_dim": feat.VOTER_C_FEATURE_DIM,
         "voter_e_clip_model_id": vis.CLIP_VISUAL_MODEL_ID if voter_e_probe is not None else None,
-        "voter_e_frame_offsets": (
-            list(vis.DEFAULT_FRAME_OFFSETS) if voter_e_probe is not None else None
-        ),
-        "voter_e_probe_artifact": (
-            DEFAULT_VOTER_E_PROBE_FILENAME if voter_e_probe is not None else None
-        ),
+        "voter_e_frame_offsets": (list(vis.DEFAULT_FRAME_OFFSETS) if voter_e_probe is not None else None),
+        "voter_e_probe_artifact": (DEFAULT_VOTER_E_PROBE_FILENAME if voter_e_probe is not None else None),
         "voter_e_audio_strong_min_votes_recommended": 3 if voter_e_probe is not None else None,
         "built_at": dt.datetime.now(dt.UTC).isoformat(),
         "default_camera_class": default_cls,

--- a/scripts/build_ensemble_fixture.py
+++ b/scripts/build_ensemble_fixture.py
@@ -87,23 +87,17 @@ def _label(cand_t: list[float], truth_shots: list[dict], tol_ms: float) -> list[
     return labels
 
 
-def _hand_features(
-    audio, sr, t, all_times, beep_time, confidence, peak_amp
-) -> list[float]:
+def _hand_features(audio, sr, t, all_times, beep_time, confidence, peak_amp) -> list[float]:
     idx = int(round(t * sr))
     n = audio.size
     win = int(0.050 * sr)
     pre_lo, pre_hi = max(0, idx - win), idx
     post_lo, post_hi = idx, min(n, idx + win)
     rms_pre = (
-        float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2)))
-        if pre_hi > pre_lo
-        else 0.0
+        float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2))) if pre_hi > pre_lo else 0.0
     )
     rms_post = (
-        float(np.sqrt(np.mean(audio[post_lo:post_hi].astype(np.float64) ** 2)))
-        if post_hi > post_lo
-        else 0.0
+        float(np.sqrt(np.mean(audio[post_lo:post_hi].astype(np.float64) ** 2))) if post_hi > post_lo else 0.0
     )
     pre10 = int(0.010 * sr)
     a_lo = max(0, idx - pre10)
@@ -208,9 +202,7 @@ def _compute_universe(fixtures: list[str], tolerance_ms: float, voter_a_floor: f
 
         clap = np.load(CACHE_DIR / f"{fix}_clap.npz", allow_pickle=True)
         if clap["audio_emb"].shape[0] != len(all_shots):
-            raise SystemExit(
-                f"{fix}: CLAP cache stale; re-run extract_clap_features.py --force"
-            )
+            raise SystemExit(f"{fix}: CLAP cache stale; re-run extract_clap_features.py --force")
         prompts = [str(p) for p in clap["prompts"].tolist()]
         sims = clap["text_sims"]
         shot_idx = [i for i, p in enumerate(prompts) if p in _CLAP_PROMPTS_SHOT]
@@ -221,14 +213,10 @@ def _compute_universe(fixtures: list[str], tolerance_ms: float, voter_a_floor: f
 
         pann_path = CACHE_DIR / f"{fix}_pann.npz"
         if not pann_path.exists():
-            raise SystemExit(
-                f"{fix}: PANN cache missing; run scripts/extract_audio_embeddings.py first."
-            )
+            raise SystemExit(f"{fix}: PANN cache missing; run scripts/extract_audio_embeddings.py first.")
         pann = np.load(pann_path)
         if pann["gunshot_prob"].shape[0] != len(all_shots):
-            raise SystemExit(
-                f"{fix}: PANN cache stale; re-run extract_audio_embeddings.py --force"
-            )
+            raise SystemExit(f"{fix}: PANN cache stale; re-run extract_audio_embeddings.py --force")
         gunshot_prob = pann["gunshot_prob"]
 
         per_fixture[fix] = {
@@ -239,23 +227,30 @@ def _compute_universe(fixtures: list[str], tolerance_ms: float, voter_a_floor: f
 
         for i, shot in enumerate(all_shots):
             feats = _hand_features(
-                audio, sr, shot.time_absolute, cand_t, truth["beep_time"],
-                shot.confidence, shot.peak_amplitude,
+                audio,
+                sr,
+                shot.time_absolute,
+                cand_t,
+                truth["beep_time"],
+                shot.confidence,
+                shot.peak_amplitude,
             )
             per_fixture[fix]["indices_in_universe"].append(len(universe))
-            universe.append({
-                "fixture": fix,
-                "t": shot.time_absolute,
-                "label": labels[i],
-                "vote_a": int(round(shot.time_absolute, 6) in safe_times),
-                "clap_diff": float(diff[i]),
-                "gunshot_prob": float(gunshot_prob[i]),
-                "hand_feats": feats,
-                "clap_sims": list(sims[i]),
-                "peak_amplitude": float(shot.peak_amplitude),
-                "confidence": float(shot.confidence),
-                "time_from_beep": float(shot.time_from_beep),
-            })
+            universe.append(
+                {
+                    "fixture": fix,
+                    "t": shot.time_absolute,
+                    "label": labels[i],
+                    "vote_a": int(round(shot.time_absolute, 6) in safe_times),
+                    "clap_diff": float(diff[i]),
+                    "gunshot_prob": float(gunshot_prob[i]),
+                    "hand_feats": feats,
+                    "clap_sims": list(sims[i]),
+                    "peak_amplitude": float(shot.peak_amplitude),
+                    "confidence": float(shot.confidence),
+                    "time_from_beep": float(shot.time_from_beep),
+                }
+            )
     return universe, per_fixture
 
 
@@ -266,10 +261,7 @@ def _vote_b_threshold(calib_universe) -> float:
 
 def _x_from(cands) -> np.ndarray:
     return np.array(
-        [
-            c["hand_feats"] + c["clap_sims"] + [c["clap_diff"], c["gunshot_prob"]]
-            for c in cands
-        ],
+        [c["hand_feats"] + c["clap_sims"] + [c["clap_diff"], c["gunshot_prob"]] for c in cands],
         dtype=np.float64,
     )
 
@@ -283,9 +275,7 @@ def _train_voter_c(calib_universe, target_recall: float):
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     cv_probs = np.zeros_like(y, dtype=np.float64)
     for tr, te in skf.split(X, y):
-        f = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        f = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         f.fit(X[tr], y[tr])
         cv_probs[te] = f.predict_proba(X[te])[:, 1]
 
@@ -301,9 +291,7 @@ def _train_voter_c(calib_universe, target_recall: float):
 
     # Final model trained on ALL calibration data (no held-out -- this is what
     # we apply to the new fixtures).
-    clf = GradientBoostingClassifier(
-        n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-    )
+    clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
     clf.fit(X, y)
     return clf, threshold
 
@@ -341,17 +329,26 @@ def _materialize(json_path: Path, wav_src: Path, fixture_dict: dict) -> None:
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("--fixture", action="append", help="Calibration fixture stem (repeatable). Default: all four audited.")
+    p.add_argument(
+        "--fixture",
+        action="append",
+        help="Calibration fixture stem (repeatable). Default: all four audited.",
+    )
     p.add_argument(
         "--include-fixture",
         action="append",
         default=[],
         help="Apply the trained ensemble to this fixture too (no labels needed). Repeatable.",
     )
-    p.add_argument("--consensus", type=int, default=2, choices=[1, 2, 3],
-                   help="Consensus threshold for the *-ensemble-{N}of3.json variant. "
-                   "Default 2 (= 2-of-3 strict majority, preserves 100 %% recall). "
-                   "Keep if (vote_total + apriori_boost) >= consensus.")
+    p.add_argument(
+        "--consensus",
+        type=int,
+        default=2,
+        choices=[1, 2, 3],
+        help="Consensus threshold for the *-ensemble-{N}of3.json variant. "
+        "Default 2 (= 2-of-3 strict majority, preserves 100 %% recall). "
+        "Keep if (vote_total + apriori_boost) >= consensus.",
+    )
     p.add_argument(
         "--gbdt-target-recall",
         type=float,
@@ -470,25 +467,29 @@ def main() -> None:
         # are 1-based and stable within a fixture.
         all_candidates = []
         for n, shot in enumerate(all_shots, start=1):
-            all_candidates.append({
-                "candidate_number": n,
-                "time": round(shot.time_absolute, 4),
-                "ms_after_beep": round(shot.time_from_beep * 1000, 0),
-                "peak_amplitude": round(shot.peak_amplitude, 4),
-                "confidence": round(shot.confidence, 3),
-            })
+            all_candidates.append(
+                {
+                    "candidate_number": n,
+                    "time": round(shot.time_absolute, 4),
+                    "ms_after_beep": round(shot.time_from_beep * 1000, 0),
+                    "peak_amplitude": round(shot.peak_amplitude, 4),
+                    "confidence": round(shot.confidence, 3),
+                }
+            )
 
         # Baseline shots[]: candidates voted by A (cwt + min_confidence=0.03).
         baseline_shots = []
         for n, ui in enumerate(idxs, start=1):
             if universe[ui]["vote_a"] == 1:
-                baseline_shots.append({
-                    "shot_number": len(baseline_shots) + 1,
-                    "candidate_number": n,
-                    "time": round(universe[ui]["t"], 4),
-                    "ms_after_beep": round(universe[ui]["time_from_beep"] * 1000, 0),
-                    "source": "detected",
-                })
+                baseline_shots.append(
+                    {
+                        "shot_number": len(baseline_shots) + 1,
+                        "candidate_number": n,
+                        "time": round(universe[ui]["t"], 4),
+                        "ms_after_beep": round(universe[ui]["time_from_beep"] * 1000, 0),
+                        "source": "detected",
+                    }
+                )
 
         # Ensemble shots[]: keep if (vote_total + apriori_boost) >= consensus.
         # Each entry surfaces its votes / boost / score so the JSON documents
@@ -497,29 +498,41 @@ def main() -> None:
         for n, ui in enumerate(idxs, start=1):
             u = universe[ui]
             if u["score"] >= args.consensus:
-                ensemble_shots.append({
-                    "shot_number": len(ensemble_shots) + 1,
-                    "candidate_number": n,
-                    "time": round(u["t"], 4),
-                    "ms_after_beep": round(u["time_from_beep"] * 1000, 0),
-                    "source": "detected",
-                    "ensemble_votes": u["vote_total"],
-                    "apriori_boost": u["apriori_boost"],
-                    "ensemble_score": round(u["score"], 2),
-                })
+                ensemble_shots.append(
+                    {
+                        "shot_number": len(ensemble_shots) + 1,
+                        "candidate_number": n,
+                        "time": round(u["t"], 4),
+                        "ms_after_beep": round(u["time_from_beep"] * 1000, 0),
+                        "source": "detected",
+                        "ensemble_votes": u["vote_total"],
+                        "apriori_boost": u["apriori_boost"],
+                        "ensemble_score": round(u["score"], 2),
+                    }
+                )
 
         # Materialize both.
         wav_src = FIXTURES_DIR / f"{fix}.wav"
         baseline_json = OUTPUT_DIR / f"{fix}-baseline.json"
         ensemble_json = OUTPUT_DIR / f"{fix}-ensemble-{args.consensus}of3.json"
 
-        _materialize(baseline_json, wav_src, _build_fixture_json(
-            truth, baseline_shots, all_candidates, label="baseline (cwt + min_confidence=0.03)"
-        ))
-        _materialize(ensemble_json, wav_src, _build_fixture_json(
-            truth, ensemble_shots, all_candidates,
-            label=f"ensemble {args.consensus}-of-3 consensus (A=baseline+0.03, B=CLAP, C=GBDT+PANN)",
-        ))
+        _materialize(
+            baseline_json,
+            wav_src,
+            _build_fixture_json(
+                truth, baseline_shots, all_candidates, label="baseline (cwt + min_confidence=0.03)"
+            ),
+        )
+        _materialize(
+            ensemble_json,
+            wav_src,
+            _build_fixture_json(
+                truth,
+                ensemble_shots,
+                all_candidates,
+                label=f"ensemble {args.consensus}-of-3 consensus (A=baseline+0.03, B=CLAP, C=GBDT+PANN)",
+            ),
+        )
 
         n_total = len(all_candidates)
         n_base = len(baseline_shots)
@@ -528,9 +541,7 @@ def main() -> None:
         n_manual = sum(1 for s in truth.get("shots", []) if s.get("source") == "manual")
         boost_tag = ""
         if fix in boost_set and args.expected_rounds is not None:
-            n_boosted = sum(
-                1 for ui in idxs if universe[ui]["apriori_boost"] > 0
-            )
+            n_boosted = sum(1 for ui in idxs if universe[ui]["apriori_boost"] > 0)
             n_lift = sum(
                 1
                 for ui in idxs
@@ -548,7 +559,7 @@ def main() -> None:
             f"audited {n_audited} (+{n_manual} manual){boost_tag}"
         )
 
-    print(f"\nOpen in the review UI -- one fixture per browser tab/window:")
+    print("\nOpen in the review UI -- one fixture per browser tab/window:")
     for fix in apply_fixtures:
         b = OUTPUT_DIR / f"{fix}-baseline.json"
         e = OUTPUT_DIR / f"{fix}-ensemble-{args.consensus}of3.json"

--- a/scripts/build_sweep_signals.py
+++ b/scripts/build_sweep_signals.py
@@ -51,6 +51,15 @@ import pyarrow.parquet as pq
 # directory is not a package).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# Import the same canonical fixture list calibration uses so the sweep
+# universe stays in lockstep with the shipped artifacts. Underscore-
+# prefixed in build_ensemble_artifacts; pulling it directly keeps a
+# single source of truth.
+from build_ensemble_artifacts import (  # type: ignore[import-not-found]
+    DEFAULT_FIXTURES,
+    WRONG_CLIP_FIXTURES,
+)
+
 from splitsmith.beep_detect import load_audio
 from splitsmith.config import ShotDetectConfig
 from splitsmith.ensemble import features as feat
@@ -64,15 +73,6 @@ from splitsmith.ensemble.calibration import (
 )
 from splitsmith.ensemble.tta import compute_tta_agreement
 from splitsmith.shot_detect import detect_shots
-
-# Import the same canonical fixture list calibration uses so the sweep
-# universe stays in lockstep with the shipped artifacts. Underscore-
-# prefixed in build_ensemble_artifacts; pulling it directly keeps a
-# single source of truth.
-from build_ensemble_artifacts import (  # type: ignore[import-not-found]
-    DEFAULT_FIXTURES,
-    WRONG_CLIP_FIXTURES,
-)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
@@ -191,9 +191,7 @@ def build_signals(
         times = np.array([s.time_absolute for s in shots], dtype=np.float64)
         confidences = np.array([s.confidence for s in shots], dtype=np.float64)
         peak_amps = np.array([s.peak_amplitude for s in shots], dtype=np.float64)
-        ms_after_beep = np.array(
-            [round(s.time_from_beep * 1000) for s in shots], dtype=np.int64
-        )
+        ms_after_beep = np.array([round(s.time_from_beep * 1000) for s in shots], dtype=np.int64)
         labels = _label(times.tolist(), truth.get("shots", []), tolerance_ms)
         audit_count = int(sum(labels))
         rounds = truth.get("stage_rounds") or {}
@@ -225,9 +223,7 @@ def build_signals(
         hand = feat.compute_hand_features(
             audio, sr, times, truth["beep_time"], confidences, peak_amps, tta_agreement
         )
-        x = feat.voter_c_feature_matrix(
-            hand, clap_sims, clap_diff, gunshot_prob, camera_classes=cam_class
-        )
+        x = feat.voter_c_feature_matrix(hand, clap_sims, clap_diff, gunshot_prob, camera_classes=cam_class)
         cls_key = cam_class if cam_class in voter_c_model else cal.default_camera_class
         score_c = voter_c_model[cls_key].predict_proba(x)[:, 1].astype(np.float64)
 
@@ -251,9 +247,7 @@ def build_signals(
                 features = vis.compute_visual_features(
                     video_path, source_times, visual_runtime, frame_offsets=offsets
                 )
-                voter_e_signal = vis.score_visual_candidates(
-                    features, visual_runtime
-                ).astype(np.float64)
+                voter_e_signal = vis.score_visual_candidates(features, visual_runtime).astype(np.float64)
                 voter_e_ok = True
                 fixtures_with_voter_e.append(fix)
 
@@ -279,12 +273,12 @@ def build_signals(
             }
             for j, name in enumerate(HAND_FEATURE_NAMES):
                 row[f"hand_{name}"] = float(hand[i, j])
-            for j, prompt in enumerate(feat.CLAP_PROMPTS):
+            for j, _prompt in enumerate(feat.CLAP_PROMPTS):
                 row[f"clap_sim_{j:02d}"] = float(clap_sims[i, j])
             rows.append(row)
         fixtures_seen.append(fix)
 
-    now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    now = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
     sha = _git_short_sha()
     signals_build_id = f"{now}_{sha}"
 
@@ -297,7 +291,7 @@ def build_signals(
     table = pa.Table.from_pylist(rows)
     sidecar = {
         "signals_build_id": signals_build_id,
-        "built_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "built_at": dt.datetime.now(dt.UTC).isoformat(),
         "git_short_sha": sha,
         "tolerance_ms": tolerance_ms,
         "default_camera_class": DEFAULT_CAMERA_CLASS,
@@ -337,9 +331,7 @@ def main() -> None:
     fixtures = args.fixture or list(DEFAULT_FIXTURES)
     args.out.parent.mkdir(parents=True, exist_ok=True)
 
-    table, sidecar = build_signals(
-        fixtures, args.tolerance_ms, skip_voter_e=args.skip_voter_e
-    )
+    table, sidecar = build_signals(fixtures, args.tolerance_ms, skip_voter_e=args.skip_voter_e)
     pq.write_table(table, args.out)
     sidecar_path = args.out.with_suffix(".meta.json")
     sidecar_path.write_text(json.dumps(sidecar, indent=2))

--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -38,10 +38,9 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from contextlib import closing, contextmanager
 from pathlib import Path
-from typing import Iterator
-
 
 SCREENSHOTS = [
     # (route_template, filename, description, optional)
@@ -72,9 +71,7 @@ def wait_for_health(base_url: str, timeout_s: float = 30.0) -> dict[str, object]
         except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
             last_err = e
         time.sleep(0.3)
-    raise TimeoutError(
-        f"splitsmith ui never reported bound=true at {base_url} (last error: {last_err})"
-    )
+    raise TimeoutError(f"splitsmith ui never reported bound=true at {base_url} (last error: {last_err})")
 
 
 @contextmanager

--- a/scripts/eval_beep_detector.py
+++ b/scripts/eval_beep_detector.py
@@ -147,9 +147,7 @@ def evaluate_entry(
 
 def format_row(r: FixtureEvalResult) -> str:
     if r.detected_time_s is None:
-        return (
-            f"  [{r.track:4}] {r.stem:55} MISS ({r.error_kind})  " f"truth={r.ground_truth_s:.3f}s"
-        )
+        return f"  [{r.track:4}] {r.stem:55} MISS ({r.error_kind})  " f"truth={r.ground_truth_s:.3f}s"
     err_ms = (r.error_s or 0.0) * 1000.0
     flag = "OK" if r.correct_top1 else ("topN" if r.correct_in_topn else "FAIL")
     conf = f"  conf={r.detected_confidence:.2f}" if r.detected_confidence is not None else ""
@@ -176,9 +174,7 @@ def format_confidence_bins(results: list[FixtureEvalResult]) -> list[str]:
     rows = ["", "Per confidence bin (top-1 precision):"]
     for lo, hi, name in bands:
         bucket = [
-            r
-            for r in results
-            if r.detected_confidence is not None and lo <= r.detected_confidence < hi
+            r for r in results if r.detected_confidence is not None and lo <= r.detected_confidence < hi
         ]
         n = len(bucket)
         correct = sum(1 for r in bucket if r.correct_top1)
@@ -198,31 +194,22 @@ def format_bucket(name: str, summary: EvalSummary) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    parser.add_argument(
-        "--manifest", type=Path, default=MANIFEST_PATH, help="Manifest YAML to evaluate."
-    )
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH, help="Manifest YAML to evaluate.")
     parser.add_argument(
         "--track",
         action="append",
         choices=["clip", "full"],
         help="Run only the given tracks (default: both).",
     )
-    parser.add_argument(
-        "--tag", action="append", help="Restrict to fixtures with this tag (repeatable)."
-    )
-    parser.add_argument(
-        "--stem", action="append", help="Restrict to fixtures with this stem (repeatable)."
-    )
-    parser.add_argument(
-        "--json", type=Path, help="Write the per-fixture results to this JSON file."
-    )
+    parser.add_argument("--tag", action="append", help="Restrict to fixtures with this tag (repeatable).")
+    parser.add_argument("--stem", action="append", help="Restrict to fixtures with this stem (repeatable).")
+    parser.add_argument("--json", type=Path, help="Write the per-fixture results to this JSON file.")
     args = parser.parse_args()
 
     manifest = load_manifest(args.manifest)
     if not manifest.fixtures:
         raise SystemExit(
-            f"manifest empty or missing at {args.manifest}; "
-            "run scripts/build_beep_calibration.py first."
+            f"manifest empty or missing at {args.manifest}; " "run scripts/build_beep_calibration.py first."
         )
 
     selected: list[BeepFixtureEntry] = []
@@ -240,9 +227,7 @@ def main() -> None:
 
     results: list[FixtureEvalResult] = []
     for entry in selected:
-        results.extend(
-            evaluate_entry(entry, fixtures_dir=FIXTURES_DIR, config=config, tracks=tracks)
-        )
+        results.extend(evaluate_entry(entry, fixtures_dir=FIXTURES_DIR, config=config, tracks=tracks))
 
     print(f"Evaluated {len(selected)} fixtures across {len(results)} (fixture, track) rows.\n")
     print("Per-fixture results:")

--- a/scripts/eval_cwt_twopass.py
+++ b/scripts/eval_cwt_twopass.py
@@ -97,8 +97,7 @@ def two_pass_detect(
     env = cwt_envelope(audio, sr)
     pad = int(0.005 * sr)
     p1_strengths = [
-        float(env[max(0, int(t * sr) - pad) : min(env.size, int(t * sr) + pad)].max())
-        for t in pass1_t
+        float(env[max(0, int(t * sr) - pad) : min(env.size, int(t * sr) + pad)].max()) for t in pass1_t
     ]
     threshold = float(np.quantile(p1_strengths, shot_strength_quantile))
     splits = [pass1_t[i + 1] - pass1_t[i] for i in range(len(pass1_t) - 1)]
@@ -145,9 +144,7 @@ def evaluate(name: str, **kw) -> dict:
     pre_path = FIX / f"{name}.json.before-rise-foot"
     gt_src = json.loads(pre_path.read_text()) if pre_path.exists() else truth
     gt = sorted(s["time"] for s in gt_src.get("shots", []))
-    pass1, extras = two_pass_detect(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], **kw
-    )
+    pass1, extras = two_pass_detect(audio, sr, truth["beep_time"], truth["stage_time_seconds"], **kw)
     all_t = sorted(pass1 + extras)
     used: set[int] = set()
     drags: list[float] = []
@@ -180,9 +177,7 @@ def main() -> None:
         print(f"\n[shot_strength_quantile={q}, gap_factor=3.0, gap_min_ms=250]")
         tot_p1 = tot_ex = tot_match = tot_gt = 0
         for name in NAMES:
-            r = evaluate(
-                name, gap_factor=3.0, gap_min_ms=250, shot_strength_quantile=q
-            )
+            r = evaluate(name, gap_factor=3.0, gap_min_ms=250, shot_strength_quantile=q)
             miss_s = ", ".join(f"{t:.4f}" for t in r["misses"]) or "-"
             rec = r["matched"] / r["gt"] if r["gt"] else 0
             print(

--- a/scripts/eval_detector.py
+++ b/scripts/eval_detector.py
@@ -37,15 +37,11 @@ DEFAULT_FIXTURES = fixture_stems(mount="head", shooter_id="s97dcec94")
 FIXTURES_DIR = Path("tests/fixtures")
 
 
-def evaluate_one(
-    name: str, *, tolerance_ms: float, config: ShotDetectConfig | None = None
-) -> dict:
+def evaluate_one(name: str, *, tolerance_ms: float, config: ShotDetectConfig | None = None) -> dict:
     truth = json.loads((FIXTURES_DIR / f"{name}.json").read_text())
     audio, sr = load_audio(FIXTURES_DIR / f"{name}.wav")
     config = config or ShotDetectConfig()
-    shots = detect_shots(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], config
-    )
+    shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], config)
     cand_t = sorted(s.time_absolute for s in shots)
     gt_t = sorted(s["time"] for s in truth.get("shots", []))
 

--- a/scripts/eval_ensemble.py
+++ b/scripts/eval_ensemble.py
@@ -60,9 +60,7 @@ _CLAP_PROMPTS_SHOT = {
 }
 
 
-def _label(
-    cand_t: list[float], truth_shots: list[dict], tol_ms: float
-) -> tuple[list[int], list[dict]]:
+def _label(cand_t: list[float], truth_shots: list[dict], tol_ms: float) -> tuple[list[int], list[dict]]:
     """Map candidates to GT shots. Returns (labels, generator_misses).
 
     Strategy per audit shot:
@@ -100,19 +98,23 @@ def _label(
             continue
         cn = s.get("candidate_number")
         if cn is not None and 1 <= cn <= len(cand_t):
-            misses.append({
-                "audit_time": t,
-                "candidate_number": cn,
-                "candidate_time": cand_t[cn - 1],
-                "drift_ms": abs(cand_t[cn - 1] - t) * 1000.0,
-            })
+            misses.append(
+                {
+                    "audit_time": t,
+                    "candidate_number": cn,
+                    "candidate_time": cand_t[cn - 1],
+                    "drift_ms": abs(cand_t[cn - 1] - t) * 1000.0,
+                }
+            )
         else:
-            misses.append({
-                "audit_time": t,
-                "candidate_number": None,
-                "candidate_time": None,
-                "drift_ms": None,
-            })
+            misses.append(
+                {
+                    "audit_time": t,
+                    "candidate_number": None,
+                    "candidate_time": None,
+                    "drift_ms": None,
+                }
+            )
     return labels, misses
 
 
@@ -165,9 +167,7 @@ def main() -> None:
         truth = json.loads((FIXTURES_DIR / f"{fix}.json").read_text())
         audio, sr = load_audio(FIXTURES_DIR / f"{fix}.wav")
         cfg_recall = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
-        all_shots = detect_shots(
-            audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_recall
-        )
+        all_shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_recall)
         cand_t = [s.time_absolute for s in all_shots]
         labels, _ = _label(cand_t, truth.get("shots", []), args.tolerance_ms)
         for sh, lbl in zip(all_shots, labels, strict=True):
@@ -184,12 +184,8 @@ def main() -> None:
         audio, sr = load_audio(FIXTURES_DIR / f"{fix}.wav")
         cfg_recall = ShotDetectConfig(recall_fallback="cwt", min_confidence=0.0)
         cfg_safe = ShotDetectConfig(recall_fallback="cwt", min_confidence=voter_a_floor)
-        all_shots = detect_shots(
-            audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_recall
-        )
-        safe_shots = detect_shots(
-            audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_safe
-        )
+        all_shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_recall)
+        safe_shots = detect_shots(audio, sr, truth["beep_time"], truth["stage_time_seconds"], cfg_safe)
         safe_times = {round(s.time_absolute, 6) for s in safe_shots}
 
         cand_t = [s.time_absolute for s in all_shots]
@@ -198,9 +194,7 @@ def main() -> None:
 
         clap_path = CACHE_DIR / f"{fix}_clap.npz"
         if not clap_path.exists():
-            raise SystemExit(
-                f"Missing CLAP cache for {fix}. Run scripts/extract_clap_features.py first."
-            )
+            raise SystemExit(f"Missing CLAP cache for {fix}. Run scripts/extract_clap_features.py first.")
         clap = np.load(clap_path, allow_pickle=True)
         if clap["audio_emb"].shape[0] != len(all_shots):
             raise SystemExit(
@@ -217,9 +211,7 @@ def main() -> None:
 
         pann_path = CACHE_DIR / f"{fix}_pann.npz"
         if not pann_path.exists():
-            raise SystemExit(
-                f"Missing PANN cache for {fix}. Run scripts/extract_audio_embeddings.py first."
-            )
+            raise SystemExit(f"Missing PANN cache for {fix}. Run scripts/extract_audio_embeddings.py first.")
         pann = np.load(pann_path)
         if pann["gunshot_prob"].shape[0] != len(all_shots):
             raise SystemExit(
@@ -283,9 +275,7 @@ def main() -> None:
     pos_pann = [c["gunshot_prob"] for c in universe if c["label"] == 1]
     pann_threshold = min(pos_pann) if pos_pann else 0.0
     d_kept = sum(1 for c in universe if c["gunshot_prob"] >= pann_threshold)
-    d_pos = sum(
-        1 for c in universe if c["gunshot_prob"] >= pann_threshold and c["label"] == 1
-    )
+    d_pos = sum(1 for c in universe if c["gunshot_prob"] >= pann_threshold and c["label"] == 1)
     print(
         f"Voter D (PANN gunshot_prob >= {pann_threshold:.4f}): kept {d_kept}, recall "
         f"{d_pos}/{n_pos} = {d_pos/n_pos*100:.1f}%, precision "
@@ -296,16 +286,12 @@ def main() -> None:
     from sklearn.ensemble import GradientBoostingClassifier
     from sklearn.model_selection import StratifiedKFold
 
-    X = np.array(
-        [c["hand_feats"] + c["clap_sims"] + [c["clap_diff"]] for c in universe], dtype=np.float64
-    )
+    X = np.array([c["hand_feats"] + c["clap_sims"] + [c["clap_diff"]] for c in universe], dtype=np.float64)
     y = np.array([c["label"] for c in universe], dtype=np.int64)
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     probs = np.zeros_like(y, dtype=np.float64)
     for tr, te in skf.split(X, y):
-        clf = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         clf.fit(X[tr], y[tr])
         probs[te] = clf.predict_proba(X[te])[:, 1]
 
@@ -337,9 +323,7 @@ def main() -> None:
         for fix in fixtures:
             truth = json.loads((FIXTURES_DIR / f"{fix}.json").read_text())
             rounds = truth.get("stage_rounds", {})
-            expected_by_fixture[fix] = (
-                rounds.get("expected") if isinstance(rounds, dict) else None
-            )
+            expected_by_fixture[fix] = rounds.get("expected") if isinstance(rounds, dict) else None
         per_fixture_indices: dict[str, list[int]] = {}
         for i, c in enumerate(universe):
             per_fixture_indices.setdefault(c["fixture"], []).append(i)
@@ -357,15 +341,12 @@ def main() -> None:
             target = K + slack
             fix_probs = np.array([probs[i] for i in idxs])
             order = np.argsort(-fix_probs)
-            keep_local = set(order[:min(target, len(order))].tolist())
+            keep_local = set(order[: min(target, len(order))].tolist())
             for li, gi in enumerate(idxs):
                 if li in keep_local:
                     voter_c_adaptive[gi] = True
             ad_kept += len(keep_local)
-            ad_pos += sum(
-                1 for li, gi in enumerate(idxs)
-                if li in keep_local and universe[gi]["label"] == 1
-            )
+            ad_pos += sum(1 for li, gi in enumerate(idxs) if li in keep_local and universe[gi]["label"] == 1)
         print(
             f"Voter C ADAPTIVE (per-stage top-K+max(3,10%) by GBDT prob, "
             f"{n_real_prior}/{len(per_fixture_indices)} fixtures use real "
@@ -376,9 +357,7 @@ def main() -> None:
 
     for i, c in enumerate(universe):
         c["vote_b"] = int(c["clap_diff"] >= clap_threshold)
-        c["vote_c"] = (
-            int(voter_c_adaptive[i]) if args.adaptive_voter_c else int(probs[i] >= threshold_c)
-        )
+        c["vote_c"] = int(voter_c_adaptive[i]) if args.adaptive_voter_c else int(probs[i] >= threshold_c)
         c["vote_d"] = int(c["gunshot_prob"] >= pann_threshold)
         c["vote_total"] = c["vote_a"] + c["vote_b"] + c["vote_c"] + c["vote_d"]
 
@@ -476,19 +455,11 @@ def main() -> None:
             cn_s = str(cn) if cn is not None else "-"
             ct_s = f"{ct:9.4f}" if ct is not None else "        -"
             dr_s = f"{dr:+.1f} ms" if dr is not None else "-"
-            print(
-                f"{m['fixture']:38s} {m['audit_time']:9.4f} {cn_s:>5s} {ct_s} {dr_s:>10s}"
-            )
+            print(f"{m['fixture']:38s} {m['audit_time']:9.4f} {cn_s:>5s} {ct_s} {dr_s:>10s}")
 
     print("\n=== Solo-correct shots (would be lost without that voter) ===")
     for voter in ("a", "b", "c", "d"):
-        solo = [
-            c
-            for c in universe
-            if c["label"] == 1
-            and c[f"vote_{voter}"] == 1
-            and c["vote_total"] == 1
-        ]
+        solo = [c for c in universe if c["label"] == 1 and c[f"vote_{voter}"] == 1 and c["vote_total"] == 1]
         print(f"  voter {voter.upper()}: {len(solo)} real shots saved only by this voter")
 
 

--- a/scripts/eval_refinement.py
+++ b/scripts/eval_refinement.py
@@ -41,12 +41,16 @@ def main() -> None:
         min_confidence=args.min_confidence,
     )
 
-    print(f"method={args.method}  search=+/-{args.search_half_window_ms:.0f}ms  "
-          f"min_conf={args.min_confidence}\n")
+    print(
+        f"method={args.method}  search=+/-{args.search_half_window_ms:.0f}ms  "
+        f"min_conf={args.min_confidence}\n"
+    )
     all_orig: list[float] = []
     all_refined: list[float] = []
-    print(f"{'fixture':38s} {'n_pos':>5s} {'orig_med':>9s} {'orig_p90':>9s} "
-          f"{'ref_med':>8s} {'ref_p90':>8s} {'big_fix':>7s} {'rejected':>8s}")
+    print(
+        f"{'fixture':38s} {'n_pos':>5s} {'orig_med':>9s} {'orig_p90':>9s} "
+        f"{'ref_med':>8s} {'ref_p90':>8s} {'big_fix':>7s} {'rejected':>8s}"
+    )
     for fix in DEFAULT_FIXTURES:
         truth_path = FIXTURES_DIR / f"{fix}.json"
         if not truth_path.exists():
@@ -88,16 +92,20 @@ def main() -> None:
         all_refined.extend(refined_drifts)
         o = np.array(orig_drifts)
         r_arr = np.array(refined_drifts)
-        print(f"{fix:38s} {len(orig_drifts):5d} "
-              f"{np.median(o):8.1f}  {np.quantile(o, 0.9):8.1f}  "
-              f"{np.median(r_arr):7.1f}  {np.quantile(r_arr, 0.9):7.1f}  "
-              f"{big_fixes:7d}  {rejected:8d}")
+        print(
+            f"{fix:38s} {len(orig_drifts):5d} "
+            f"{np.median(o):8.1f}  {np.quantile(o, 0.9):8.1f}  "
+            f"{np.median(r_arr):7.1f}  {np.quantile(r_arr, 0.9):7.1f}  "
+            f"{big_fixes:7d}  {rejected:8d}"
+        )
 
     o = np.array(all_orig)
     r = np.array(all_refined)
-    print(f"\n{'TOTAL':38s} {len(all_orig):5d} "
-          f"{np.median(o):8.1f}  {np.quantile(o, 0.9):8.1f}  "
-          f"{np.median(r):7.1f}  {np.quantile(r, 0.9):7.1f}")
+    print(
+        f"\n{'TOTAL':38s} {len(all_orig):5d} "
+        f"{np.median(o):8.1f}  {np.quantile(o, 0.9):8.1f}  "
+        f"{np.median(r):7.1f}  {np.quantile(r, 0.9):7.1f}"
+    )
     delta_med = np.median(o) - np.median(r)
     delta_p90 = np.quantile(o, 0.9) - np.quantile(r, 0.9)
     print(f"  median improvement: {delta_med:+.1f} ms")

--- a/scripts/eval_visual_voter.py
+++ b/scripts/eval_visual_voter.py
@@ -23,8 +23,8 @@ PROBE_DIR = REPO_ROOT / "build" / "visual-probe"
 
 
 def roc_auc(scores: list[float], labels: list[bool]) -> float | None:
-    pos = [s for s, y in zip(scores, labels) if y]
-    neg = [s for s, y in zip(scores, labels) if not y]
+    pos = [s for s, y in zip(scores, labels, strict=True) if y]
+    neg = [s for s, y in zip(scores, labels, strict=True) if not y]
     if not pos or not neg:
         return None
     wins = ties = 0
@@ -40,7 +40,7 @@ def roc_auc(scores: list[float], labels: list[bool]) -> float | None:
 def precision_at_recall(
     scores: list[float], labels: list[bool], target_recalls: list[float]
 ) -> dict[float, dict]:
-    paired = sorted(zip(scores, labels), key=lambda x: -x[0])
+    paired = sorted(zip(scores, labels, strict=True), key=lambda x: -x[0])
     total_pos = sum(1 for _, y in paired if y)
     if total_pos == 0:
         return {r: {"precision": None, "k": 0, "threshold": None} for r in target_recalls}
@@ -85,12 +85,12 @@ def _signals(rows: list[dict]) -> dict[str, list[float]]:
     out = {
         "audio": audio,
         "visual_zeroshot": visual,
-        "combined_zeroshot": [v + a for v, a in zip(zscore(visual), zscore(audio))],
+        "combined_zeroshot": [v + a for v, a in zip(zscore(visual), zscore(audio), strict=True)],
     }
     if all("clip_probe_score" in r and r["clip_probe_score"] is not None for r in rows):
         probe = [float(r["clip_probe_score"]) for r in rows]
         out["visual_probe"] = probe
-        out["combined_probe"] = [v + a for v, a in zip(zscore(probe), zscore(audio))]
+        out["combined_probe"] = [v + a for v, a in zip(zscore(probe), zscore(audio), strict=True)]
     return out
 
 
@@ -107,9 +107,7 @@ def evaluate_one(probe: dict) -> dict:
         "n_candidates": len(rows),
         "n_shots": sum(labels),
         "auc": {name: roc_auc(s, labels) for name, s in signals.items()},
-        "p_at_r": {
-            name: precision_at_recall(s, labels, targets) for name, s in signals.items()
-        },
+        "p_at_r": {name: precision_at_recall(s, labels, targets) for name, s in signals.items()},
         "subclass_breakdown": _subclass_stats(rows),
     }
 
@@ -141,9 +139,7 @@ def aggregate(probes: list[dict]) -> dict:
         "n_candidates": len(rows),
         "n_shots": sum(labels),
         "auc": {name: roc_auc(s, labels) for name, s in signals.items()},
-        "p_at_r": {
-            name: precision_at_recall(s, labels, targets) for name, s in signals.items()
-        },
+        "p_at_r": {name: precision_at_recall(s, labels, targets) for name, s in signals.items()},
         "subclass_breakdown": _subclass_stats(rows),
     }
 
@@ -180,10 +176,7 @@ def render_report(per_fixture: list[dict], aggregate_stats: dict) -> str:
     lines.append("| subclass | n | mean | median | stdev |")
     lines.append("|----------|---|------|--------|-------|")
     for sub, s in sorted(a["subclass_breakdown"].items()):
-        lines.append(
-            f"| {sub} | {s['n']} | {fmt(s['mean'])} | "
-            f"{fmt(s['median'])} | {fmt(s['stdev'])} |"
-        )
+        lines.append(f"| {sub} | {s['n']} | {fmt(s['mean'])} | " f"{fmt(s['median'])} | {fmt(s['stdev'])} |")
     lines.append("")
     lines.append("## Per-fixture (P@R=1.0)")
     lines.append("")
@@ -194,15 +187,8 @@ def render_report(per_fixture: list[dict], aggregate_stats: dict) -> str:
     for f in per_fixture:
         if not f.get("auc"):
             continue
-        cells = [
-            fmt(f["p_at_r"][sig][1.0]["precision"]) if sig in f["p_at_r"] else "n/a"
-            for sig in signals
-        ]
-        lines.append(
-            f"| {f['fixture']} | {f['n_candidates']} | {f['n_shots']} | "
-            + " | ".join(cells)
-            + " |"
-        )
+        cells = [fmt(f["p_at_r"][sig][1.0]["precision"]) if sig in f["p_at_r"] else "n/a" for sig in signals]
+        lines.append(f"| {f['fixture']} | {f['n_candidates']} | {f['n_shots']} | " + " | ".join(cells) + " |")
     lines.append("")
     lines.append("## Per-fixture (ROC AUC)")
     lines.append("")
@@ -212,11 +198,7 @@ def render_report(per_fixture: list[dict], aggregate_stats: dict) -> str:
         if not f.get("auc"):
             continue
         cells = [fmt(f["auc"].get(sig)) for sig in signals]
-        lines.append(
-            f"| {f['fixture']} | {f['n_candidates']} | {f['n_shots']} | "
-            + " | ".join(cells)
-            + " |"
-        )
+        lines.append(f"| {f['fixture']} | {f['n_candidates']} | {f['n_shots']} | " + " | ".join(cells) + " |")
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/extract_audio_embeddings.py
+++ b/scripts/extract_audio_embeddings.py
@@ -110,9 +110,7 @@ def extract_for_fixture(name: str, *, force: bool, audio_tagger, full: bool = Fa
         audio_pann = librosa.resample(audio.astype(np.float32), orig_sr=sr, target_sr=PANN_SR)
     else:
         audio_pann = audio.astype(np.float32)
-    batch = np.stack(
-        [_slice_window(audio_pann, PANN_SR, float(t), WINDOW_S) for t in times], axis=0
-    )
+    batch = np.stack([_slice_window(audio_pann, PANN_SR, float(t), WINDOW_S) for t in times], axis=0)
 
     # PANNs.inference returns (clipwise_output, embedding) for batch input.
     clipwise, embedding = audio_tagger.inference(batch)

--- a/scripts/extract_clap_features.py
+++ b/scripts/extract_clap_features.py
@@ -165,10 +165,7 @@ def extract_for_fixture(name: str, *, force: bool, model, processor, full: bool 
         text_sims=text_sims.astype(np.float32),
         prompts=np.array(PROMPTS, dtype=object),
     )
-    print(
-        f"  {name}: {len(times)} cands  audio_emb {audio_emb.shape}  "
-        f"text_sims {text_sims.shape}"
-    )
+    print(f"  {name}: {len(times)} cands  audio_emb {audio_emb.shape}  " f"text_sims {text_sims.shape}")
 
 
 def main() -> None:
@@ -198,12 +195,10 @@ def main() -> None:
     fixtures = args.fixture or DEFAULT_FIXTURES
     print("\nExtracting CLAP features:")
     for f in fixtures:
-        extract_for_fixture(
-            f, force=args.force, model=model, processor=processor, full=args.full
-        )
+        extract_for_fixture(f, force=args.force, model=model, processor=processor, full=args.full)
     suffix = "_clap_full" if args.full else "_clap"
     print(f"\nDone. Cached to tests/fixtures/.cache/*{suffix}.npz")
-    print(f"\nPrompts (in column order):")
+    print("\nPrompts (in column order):")
     for i, prompt in enumerate(PROMPTS):
         flag = "[shot]" if prompt in PROMPTS_SHOT else "[not] "
         print(f"  {i:2d} {flag} {prompt}")

--- a/scripts/extract_full_fixture_audio.py
+++ b/scripts/extract_full_fixture_audio.py
@@ -74,14 +74,10 @@ def resolve_video(stem: str, sources: dict) -> Path:
     else:
         basename = (sources.get("fixtures") or {}).get(stem)
         if not basename:
-            raise ExtractError(
-                f"{stem}: no entry in _sources.yaml. Add a 'fixtures' or 'overrides' line."
-            )
+            raise ExtractError(f"{stem}: no entry in _sources.yaml. Add a 'fixtures' or 'overrides' line.")
         video_dir = sources.get("video_dir")
         if not video_dir:
-            raise ExtractError(
-                f"{stem}: 'video_dir' unset in _sources.yaml and no override given."
-            )
+            raise ExtractError(f"{stem}: 'video_dir' unset in _sources.yaml and no override given.")
         candidate = Path(video_dir) / basename
     if not candidate.exists():
         raise ExtractError(
@@ -152,9 +148,7 @@ def run_ffmpeg_extract(
     except FileNotFoundError as exc:
         raise ExtractError(f"ffmpeg binary not found: {ffmpeg_binary}") from exc
     except subprocess.CalledProcessError as exc:
-        raise ExtractError(
-            f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
-        ) from exc
+        raise ExtractError(f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}") from exc
 
 
 def extract_one(
@@ -204,9 +198,7 @@ def extract_one(
     )
     duration = end - start
     if duration <= 0.0:
-        raise ExtractError(
-            f"{stem}: computed extraction window [{start}, {end}] is non-positive"
-        )
+        raise ExtractError(f"{stem}: computed extraction window [{start}, {end}] is non-positive")
 
     FULL_DIR.mkdir(parents=True, exist_ok=True)
     run_ffmpeg_extract(

--- a/scripts/fetch_dtds.py
+++ b/scripts/fetch_dtds.py
@@ -64,8 +64,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.fcp_app.exists():
         print(
-            f"Final Cut Pro not found at {args.fcp_app}; "
-            "pass --fcp-app to point at your install.",
+            f"Final Cut Pro not found at {args.fcp_app}; " "pass --fcp-app to point at your install.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/lofo_mining_experiment.py
+++ b/scripts/lofo_mining_experiment.py
@@ -22,7 +22,6 @@ Run:
 from __future__ import annotations
 
 import json
-from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -94,12 +93,8 @@ def build_in_stage_rows(fix: str) -> list[dict]:
     peak_amps = np.array([s.peak_amplitude for s in shots], dtype=np.float64)
     from splitsmith.ensemble.tta import compute_tta_agreement
 
-    tta_arr = compute_tta_agreement(
-        audio, sr, truth["beep_time"], truth["stage_time_seconds"], times
-    )
-    hand = feat.compute_hand_features(
-        audio, sr, times, truth["beep_time"], confidences, peak_amps, tta_arr
-    )
+    tta_arr = compute_tta_agreement(audio, sr, truth["beep_time"], truth["stage_time_seconds"], times)
+    hand = feat.compute_hand_features(audio, sr, times, truth["beep_time"], confidences, peak_amps, tta_arr)
 
     rows: list[dict] = []
     for i, shot in enumerate(shots):
@@ -157,9 +152,7 @@ def build_mined_rows_for_fixture(fix: str, mined_npz: np.lib.npyio.NpzFile) -> l
     # Mined negatives sit outside any stage window; TTA agreement isn't
     # meaningful here, so use the 1.0 floor (matches build_ensemble_artifacts).
     tta_arr = np.ones(len(cand_t), dtype=np.float64)
-    hand = feat.compute_hand_features(
-        audio, sr, cand_t, beep_in_full, cand_conf, cand_peak, tta_arr
-    )
+    hand = feat.compute_hand_features(audio, sr, cand_t, beep_in_full, cand_conf, cand_peak, tta_arr)
 
     rows: list[dict] = []
     for k, mi in enumerate(indices):
@@ -220,9 +213,7 @@ def train_with_threshold(rows: list[dict]) -> tuple[GradientBoostingClassifier, 
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     cv_probs = np.zeros_like(y, dtype=np.float64)
     for tr, te in skf.split(X, y):
-        f = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        f = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         f.fit(X[tr], y[tr])
         cv_probs[te] = f.predict_proba(X[te])[:, 1]
     pairs = sorted(zip(cv_probs, y, strict=True), key=lambda x: -x[0])
@@ -233,9 +224,7 @@ def train_with_threshold(rows: list[dict]) -> tuple[GradientBoostingClassifier, 
         if cum / n_pos >= TARGET_RECALL:
             threshold = float(prob)
             break
-    final = GradientBoostingClassifier(
-        n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-    )
+    final = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
     final.fit(X, y)
     return final, threshold
 
@@ -299,9 +288,7 @@ def run() -> None:
     else:
         raise SystemExit("missing _mined_negatives.npz; run scripts/mine_negatives.py first")
 
-    n_pos_by_fixture = {
-        fix: sum(r["label"] for r in rows) for fix, rows in in_stage_by_fixture.items()
-    }
+    n_pos_by_fixture = {fix: sum(r["label"] for r in rows) for fix, rows in in_stage_by_fixture.items()}
 
     print(
         f"In-stage universe: {sum(len(v) for v in in_stage_by_fixture.values())} candidates, "
@@ -344,9 +331,7 @@ def run() -> None:
             train_in_stage.extend(in_stage_by_fixture[f])
             train_mined_raw.extend(mined_by_fixture[f])
 
-        train_pos_by_fix = {
-            f: sum(r["label"] for r in in_stage_by_fixture[f]) for f in fixtures if f != held
-        }
+        train_pos_by_fix = {f: sum(r["label"] for r in in_stage_by_fixture[f]) for f in fixtures if f != held}
         train_mined = cap_mined(train_mined_raw, train_pos_by_fix)
 
         clf_no, thr_no = train_with_threshold(train_in_stage)
@@ -413,23 +398,15 @@ def run() -> None:
         agg_recall_y.append(in_pos_y / n_pos)
 
         # Full 4-voter ensemble (production: consensus=3, no apriori).
-        ens_kept_no_in, _ = evaluate_ensemble(
-            held_in, clf_no, a_floor, b_thr, thr_no, d_thr
-        )
-        ens_kept_y_in, _ = evaluate_ensemble(
-            held_in, clf_y, a_floor, b_thr, thr_y, d_thr
-        )
+        ens_kept_no_in, _ = evaluate_ensemble(held_in, clf_no, a_floor, b_thr, thr_no, d_thr)
+        ens_kept_y_in, _ = evaluate_ensemble(held_in, clf_y, a_floor, b_thr, thr_y, d_thr)
         ens_in_pos_no = int((ens_kept_no_in & (y_in == 1)).sum())
         ens_in_pos_y = int((ens_kept_y_in & (y_in == 1)).sum())
         ens_in_kept_no = int(ens_kept_no_in.sum())
         ens_in_kept_y = int(ens_kept_y_in.sum())
         if held_mined:
-            ens_kept_no_m, _ = evaluate_ensemble(
-                held_mined, clf_no, a_floor, b_thr, thr_no, d_thr
-            )
-            ens_kept_y_m, _ = evaluate_ensemble(
-                held_mined, clf_y, a_floor, b_thr, thr_y, d_thr
-            )
+            ens_kept_no_m, _ = evaluate_ensemble(held_mined, clf_no, a_floor, b_thr, thr_no, d_thr)
+            ens_kept_y_m, _ = evaluate_ensemble(held_mined, clf_y, a_floor, b_thr, thr_y, d_thr)
             ens_mined_no = int(ens_kept_no_m.sum())
             ens_mined_y = int(ens_kept_y_m.sum())
         else:
@@ -523,16 +500,8 @@ def run() -> None:
     p_y = ens_y["in_pos"] / ens_y["in_kept"] * 100.0 if ens_y["in_kept"] else 0.0
     r_no = ens_no["in_pos"] / n_pos_total * 100.0
     r_y = ens_y["in_pos"] / n_pos_total * 100.0
-    fp_rate_no = (
-        ens_no["mined_fired"] / ens_no["mined_total"] * 100.0
-        if ens_no["mined_total"]
-        else 0.0
-    )
-    fp_rate_y = (
-        ens_y["mined_fired"] / ens_y["mined_total"] * 100.0
-        if ens_y["mined_total"]
-        else 0.0
-    )
+    fp_rate_no = ens_no["mined_fired"] / ens_no["mined_total"] * 100.0 if ens_no["mined_total"] else 0.0
+    fp_rate_y = ens_y["mined_fired"] / ens_y["mined_total"] * 100.0 if ens_y["mined_total"] else 0.0
     print(
         f"  NO_MINING   in-stage precision={p_no:5.1f}%  recall={r_no:5.1f}%  "
         f"mined-FP rate={fp_rate_no:5.2f}% ({ens_no['mined_fired']}/{ens_no['mined_total']})"
@@ -551,15 +520,9 @@ def run() -> None:
     cp_no = ens_no["in_pos"] / combined_kept_no * 100.0 if combined_kept_no else 0.0
     cp_y = ens_y["in_pos"] / combined_kept_y * 100.0 if combined_kept_y else 0.0
     print()
-    print(
-        "Combined production-realistic precision (in-stage kept + mined-FP as denominator):"
-    )
-    print(
-        f"  NO_MINING   {ens_no['in_pos']}/{combined_kept_no} = {cp_no:5.2f}%"
-    )
-    print(
-        f"  WITH_MINING {ens_y['in_pos']}/{combined_kept_y} = {cp_y:5.2f}%"
-    )
+    print("Combined production-realistic precision (in-stage kept + mined-FP as denominator):")
+    print(f"  NO_MINING   {ens_no['in_pos']}/{combined_kept_no} = {cp_no:5.2f}%")
+    print(f"  WITH_MINING {ens_y['in_pos']}/{combined_kept_y} = {cp_y:5.2f}%")
 
     print()
     print(

--- a/scripts/migrate_fixtures_event_id.py
+++ b/scripts/migrate_fixtures_event_id.py
@@ -141,9 +141,7 @@ def main() -> None:
         wants_shooter_override = fnmatch.fnmatch(slug, args.scope) and (
             args.shooter_id != DEFAULT_SHOOTER_KEY or args.shooter_name is not None
         )
-        if not isinstance(existing_shooter, dict) or not isinstance(
-            existing_shooter.get("id"), str
-        ):
+        if not isinstance(existing_shooter, dict) or not isinstance(existing_shooter.get("id"), str):
             shooter_block: dict[str, object] = {"id": DEFAULT_SHOOTER_KEY}
         else:
             shooter_block = dict(existing_shooter)
@@ -173,12 +171,8 @@ def main() -> None:
             )
             event_id = build_event_id(match_slug, n, shooter_key)
 
-        existing_event_str = (
-            existing_event if isinstance(existing_event, str) and existing_event else None
-        )
-        existing_shooter_id = (
-            existing_shooter.get("id") if isinstance(existing_shooter, dict) else None
-        )
+        existing_event_str = existing_event if isinstance(existing_event, str) and existing_event else None
+        existing_shooter_id = existing_shooter.get("id") if isinstance(existing_shooter, dict) else None
         new_shooter_id = shooter_block.get("id")
         if existing_event_str == event_id and existing_shooter_id == new_shooter_id:
             by_event.setdefault(event_id, []).append(slug)

--- a/scripts/migrate_self_fixtures_to_token.py
+++ b/scripts/migrate_self_fixtures_to_token.py
@@ -203,8 +203,10 @@ def migrate_main_fixtures() -> None:
         if name.endswith("-promotion-report.json"):
             rewrite_and_rename(path, rewrite_promotion_report)
             continue
-        if name.endswith(".json") and ".peaks-" not in name and not name.endswith(
-            (".bak", ".before-promote", ".before-rise-foot")
+        if (
+            name.endswith(".json")
+            and ".peaks-" not in name
+            and not name.endswith((".bak", ".before-promote", ".before-rise-foot"))
         ):
             # Could be a primary or derived fixture (whose payload we want
             # to fully rewrite). The .json.bak / .before-* and .peaks-*
@@ -232,6 +234,7 @@ def migrate_full_dir() -> None:
     sources_yaml = FULL_ROOT / "_sources.yaml"
     if sources_yaml.exists():
         text = sources_yaml.read_text(encoding="utf-8")
+
         # Preserve the file's leading comments by doing a regex sub on
         # only the keys we care about. yaml.safe_load + safe_dump would
         # strip the doc comment block.
@@ -248,9 +251,7 @@ def migrate_full_dir() -> None:
         payload = json.loads(mining_report.read_text(encoding="utf-8"))
         per = payload.get("per_fixture")
         if isinstance(per, dict):
-            payload["per_fixture"] = {
-                (map_stem(k) or k): v for k, v in per.items()
-            }
+            payload["per_fixture"] = {(map_stem(k) or k): v for k, v in per.items()}
         write_json(mining_report, payload)
 
 

--- a/scripts/mine_negatives.py
+++ b/scripts/mine_negatives.py
@@ -74,9 +74,7 @@ def _stage_window_in_full(audit: dict, sidecar: dict) -> tuple[float, float]:
     beep_in_full = (fws_start + float(audit["beep_time"])) - full_start
     stage_t = float(audit["stage_time_seconds"])
     shots = audit.get("shots") or []
-    last_shot_from_beep = (
-        max(float(s["time"]) for s in shots) - float(audit["beep_time"]) if shots else 0.0
-    )
+    last_shot_from_beep = max(float(s["time"]) for s in shots) - float(audit["beep_time"]) if shots else 0.0
     stage_end_in_full = beep_in_full + max(stage_t, last_shot_from_beep)
     return beep_in_full, stage_end_in_full
 
@@ -172,14 +170,10 @@ def write_outputs(all_rows: list[dict], log: Callable[[str], None]) -> None:
                 "n_pre_beep": sum(1 for r in rows if r["region_tag"] == "pre_beep"),
                 "n_post_stage": sum(1 for r in rows if r["region_tag"] == "post_stage"),
                 "sample_times_pre_beep": [
-                    round(r["time_in_full"], 3)
-                    for r in rows
-                    if r["region_tag"] == "pre_beep"
+                    round(r["time_in_full"], 3) for r in rows if r["region_tag"] == "pre_beep"
                 ][:10],
                 "sample_times_post_stage": [
-                    round(r["time_in_full"], 3)
-                    for r in rows
-                    if r["region_tag"] == "post_stage"
+                    round(r["time_in_full"], 3) for r in rows if r["region_tag"] == "post_stage"
                 ][:10],
             }
             for stem, rows in sorted(by_fixture.items())
@@ -199,10 +193,7 @@ def mine_all(
     if fixtures is None:
         fixtures = sorted(p.stem.removesuffix("_full") for p in FULL_DIR.glob("*_full.wav"))
     if not fixtures:
-        log(
-            f"No *_full.wav files in {FULL_DIR}. Run "
-            "scripts/extract_full_fixture_audio.py first."
-        )
+        log(f"No *_full.wav files in {FULL_DIR}. Run " "scripts/extract_full_fixture_audio.py first.")
         return []
     log(f"Mining negatives across {len(fixtures)} fixture(s)...")
     rows: list[dict] = []

--- a/scripts/plot_sweep.py
+++ b/scripts/plot_sweep.py
@@ -80,8 +80,10 @@ def _load_runs(path: Path, run_id: str | None) -> tuple[list[dict], str]:
         run_id = sorted({r["run_id"] for r in rows})[-1]
     rows = [r for r in rows if r["run_id"] == run_id]
     if not rows:
-        raise SystemExit(f"No rows for run_id={run_id!r}. Available: "
-                         f"{sorted({r['run_id'] for r in table.to_pylist()})}")
+        raise SystemExit(
+            f"No rows for run_id={run_id!r}. Available: "
+            f"{sorted({r['run_id'] for r in table.to_pylist()})}"
+        )
     return rows, run_id
 
 
@@ -107,11 +109,7 @@ def _agg_rows(rows: list[dict], fixture: str = "__all__") -> list[dict]:
 
 
 def _fixture_rows(rows: list[dict]) -> list[dict]:
-    return [
-        r
-        for r in rows
-        if r["fixture"] != "__all__" and not r["fixture"].startswith("__class_")
-    ]
+    return [r for r in rows if r["fixture"] != "__all__" and not r["fixture"].startswith("__class_")]
 
 
 def _unique_sorted(values: list[Any]) -> list[Any]:
@@ -129,14 +127,11 @@ def _unique_sorted(values: list[Any]) -> list[Any]:
     return sorted(set(values), key=_key)
 
 
-def _plot_1d(
-    rows: list[dict], key: str, out_dir: Path
-) -> list[tuple[str, Path]]:
+def _plot_1d(rows: list[dict], key: str, out_dir: Path) -> list[tuple[str, Path]]:
     """Three line plots (P/R/F1) over the swept key + per-fixture facet."""
     agg = _agg_rows(rows, "__all__")
     xs = [r[f"param_{key}"] for r in agg]
-    order = np.argsort([float(v) if isinstance(v, (int, float, bool)) and v is not None else 0
-                        for v in xs])
+    order = np.argsort([float(v) if isinstance(v, (int, float, bool)) and v is not None else 0 for v in xs])
     xs_sorted = [xs[i] for i in order]
     series = {
         "precision": [agg[i]["precision"] for i in order],
@@ -146,9 +141,13 @@ def _plot_1d(
     artifacts: list[tuple[str, Path]] = []
     for metric, ys in series.items():
         fig, ax = plt.subplots(figsize=(6.5, 4))
-        ax.plot(xs_sorted, ys, marker="o", linewidth=1.5, color={
-            "precision": "tab:blue", "recall": "tab:orange", "f1": "tab:green"
-        }[metric])
+        ax.plot(
+            xs_sorted,
+            ys,
+            marker="o",
+            linewidth=1.5,
+            color={"precision": "tab:blue", "recall": "tab:orange", "f1": "tab:green"}[metric],
+        )
         ax.set_xlabel(key)
         ax.set_ylabel(metric)
         ax.set_title(f"{metric} vs {key} (overall)")
@@ -168,10 +167,8 @@ def _plot_1d(
         these = [r for r in fix_rows if r["fixture"] == fix]
         x = [r[f"param_{key}"] for r in these]
         y = [r["f1"] for r in these]
-        idx = np.argsort([float(v) if isinstance(v, (int, float, bool)) and v is not None else 0
-                          for v in x])
-        ax.plot([x[i] for i in idx], [y[i] for i in idx], marker=".", alpha=0.7,
-                label=_short_fixture(fix))
+        idx = np.argsort([float(v) if isinstance(v, (int, float, bool)) and v is not None else 0 for v in x])
+        ax.plot([x[i] for i in idx], [y[i] for i in idx], marker=".", alpha=0.7, label=_short_fixture(fix))
     ax.set_xlabel(key)
     ax.set_ylabel("F1")
     ax.set_title(f"per-fixture F1 vs {key}")
@@ -186,9 +183,7 @@ def _plot_1d(
     return artifacts
 
 
-def _plot_2d(
-    rows: list[dict], keys: list[str], out_dir: Path
-) -> list[tuple[str, Path]]:
+def _plot_2d(rows: list[dict], keys: list[str], out_dir: Path) -> list[tuple[str, Path]]:
     agg = _agg_rows(rows, "__all__")
     k1, k2 = keys
     v1 = _unique_sorted([r[f"param_{k1}"] for r in agg])
@@ -214,8 +209,15 @@ def _plot_2d(
         for i in range(grid.shape[0]):
             for j in range(grid.shape[1]):
                 if not np.isnan(grid[i, j]):
-                    ax.text(j, i, f"{grid[i,j]:.2f}", ha="center", va="center", fontsize=8,
-                            color="black" if grid[i,j] < 0.55 else "white")
+                    ax.text(
+                        j,
+                        i,
+                        f"{grid[i,j]:.2f}",
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                        color="black" if grid[i, j] < 0.55 else "white",
+                    )
         fig.colorbar(im, ax=ax)
         path = out_dir / f"{metric}_heatmap.png"
         fig.tight_layout()
@@ -230,9 +232,7 @@ def _plot_per_fixture_bars(rows: list[dict], out_dir: Path) -> Path:
     agg = _agg_rows(rows, "__all__")
     best = max(agg, key=lambda r: r["f1"]) if agg else None
     combo_idx = best["combo_idx"] if best else None
-    fix_rows = [
-        r for r in _fixture_rows(rows) if combo_idx is None or r["combo_idx"] == combo_idx
-    ]
+    fix_rows = [r for r in _fixture_rows(rows) if combo_idx is None or r["combo_idx"] == combo_idx]
     fixtures = sorted({r["fixture"] for r in fix_rows})
     metrics = ("precision", "recall", "f1")
     width = 0.27
@@ -269,7 +269,7 @@ def _compose_overview(
 ) -> None:
     """Stitch a 2x2 (or 1x2) collage of the most useful plots into one PNG."""
     panels: list[Path] = []
-    by_name = {n: p for n, p in artifacts}
+    by_name = dict(artifacts)
     for n in ("f1", "precision", "recall"):
         if n in by_name:
             panels.append(by_name[n])
@@ -287,9 +287,7 @@ def _compose_overview(
     for ax, p in zip(axes, panels, strict=False):
         img = plt.imread(p)
         ax.imshow(img)
-    title = "Splitsmith ensemble sweep -- " + (
-        "x".join(swept) if swept else "defaults snapshot"
-    )
+    title = "Splitsmith ensemble sweep -- " + ("x".join(swept) if swept else "defaults snapshot")
     fig.suptitle(title, fontsize=13)
     fig.tight_layout()
     fig.savefig(out, dpi=130)
@@ -331,11 +329,15 @@ def _write_report(
         lines.append("")
         lines.append("### Best aggregate F1")
         lines.append("")
-        lines.append(f"- F1 = **{best['f1']:.4f}**, "
-                     f"precision = {best['precision']:.4f}, recall = {best['recall']:.4f}")
-        lines.append(f"- True positives: {best['true_pos']} / {best['n_positives']}; "
-                     f"false positives: {best['false_pos']}; "
-                     f"false negatives: {best['false_neg']}")
+        lines.append(
+            f"- F1 = **{best['f1']:.4f}**, "
+            f"precision = {best['precision']:.4f}, recall = {best['recall']:.4f}"
+        )
+        lines.append(
+            f"- True positives: {best['true_pos']} / {best['n_positives']}; "
+            f"false positives: {best['false_pos']}; "
+            f"false negatives: {best['false_neg']}"
+        )
         lines.append("")
         lines.append("Parameters at the best point:")
         lines.append("")
@@ -371,8 +373,7 @@ def _write_report(
     lines.append(f"![per-fixture]({per_fixture.name})")
     lines.append("")
 
-    fix_rows = [r for r in _fixture_rows(rows)
-                if best is None or r["combo_idx"] == best["combo_idx"]]
+    fix_rows = [r for r in _fixture_rows(rows) if best is None or r["combo_idx"] == best["combo_idx"]]
     if fix_rows:
         lines.append("## Per-fixture table (at best aggregate F1)")
         lines.append("")
@@ -419,9 +420,7 @@ def main() -> None:
     shutil.copyfile(overview, latest_png)
     # Rewrite image paths inside the copied report so the "latest" pointer resolves
     # against the run-id directory rather than the cwd.
-    rewritten = report.read_text().replace("(", f"({run_id}/").replace(
-        f"({run_id}/http", "(http"
-    )
+    rewritten = report.read_text().replace("(", f"({run_id}/").replace(f"({run_id}/http", "(http")
     latest_md.write_text(rewritten)
 
     # Also drop a tracked copy under docs/ so the README image works for
@@ -438,9 +437,7 @@ def main() -> None:
     # (latest_overview.png) since we deliberately don't copy the
     # composite as ``overview.png`` -- it would shadow the run-specific
     # naming on subsequent rebuilds.
-    docs_report = report.read_text().replace(
-        "![overview](overview.png)", "![overview](latest_overview.png)"
-    )
+    docs_report = report.read_text().replace("![overview](overview.png)", "![overview](latest_overview.png)")
     (docs_dir / "latest_report.md").write_text(docs_report)
 
     print(f"run_id: {run_id}")

--- a/scripts/probe_visual_voter.py
+++ b/scripts/probe_visual_voter.py
@@ -20,8 +20,8 @@ import json
 import subprocess
 import sys
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import torch
 from PIL import Image
@@ -101,8 +101,7 @@ def extract_frame(video: Path, source_time: float, dest: Path) -> bool:
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0 or not dest.exists():
         print(
-            f"    ffmpeg failed at t={source_time:.3f} for {video.name}: "
-            f"{result.stderr.strip()[:200]}",
+            f"    ffmpeg failed at t={source_time:.3f} for {video.name}: " f"{result.stderr.strip()[:200]}",
             file=sys.stderr,
         )
         return False
@@ -147,7 +146,7 @@ def score_frames(
         pos_mean = pos_sims.mean(dim=-1).cpu().tolist()
         pos_max = pos_sims.max(dim=-1).values.cpu().tolist()
         neg_mean = neg_sims.mean(dim=-1).cpu().tolist()
-        for pm, pmax, nm in zip(pos_mean, pos_max, neg_mean):
+        for pm, pmax, nm in zip(pos_mean, pos_max, neg_mean, strict=True):
             out.append(
                 {
                     "clip_pos_mean": pm,
@@ -173,9 +172,7 @@ def probe_fixture(
     src_offset = float(window[0])
     video = Path(data["source_video"])
     shots_by_cand = {s.get("candidate_number"): s for s in (data.get("shots") or [])}
-    labels_by_time = (
-        (data.get("_candidates_pending_audit") or {}).get("labels_by_time")
-    ) or {}
+    labels_by_time = ((data.get("_candidates_pending_audit") or {}).get("labels_by_time")) or {}
 
     print(f"\n{fixture_path.stem}: {len(candidates)} candidates", file=sys.stderr)
 
@@ -193,13 +190,11 @@ def probe_fixture(
             extracted.append((cand, frame_path))
         if (idx + 1) % 25 == 0:
             print(
-                f"  extracted {idx+1}/{len(candidates)} "
-                f"(elapsed {time.time()-extract_t0:.1f}s)",
+                f"  extracted {idx+1}/{len(candidates)} " f"(elapsed {time.time()-extract_t0:.1f}s)",
                 file=sys.stderr,
             )
     print(
-        f"  frame extraction: {len(extracted)}/{len(candidates)} ok "
-        f"in {time.time()-extract_t0:.1f}s",
+        f"  frame extraction: {len(extracted)}/{len(candidates)} ok " f"in {time.time()-extract_t0:.1f}s",
         file=sys.stderr,
     )
 
@@ -209,7 +204,7 @@ def probe_fixture(
     print(f"  CLIP scoring: {len(scores)} frames in {time.time()-score_t0:.1f}s", file=sys.stderr)
 
     rows: list[dict] = []
-    for (cand, frame_path), score in zip(extracted, scores):
+    for (cand, frame_path), score in zip(extracted, scores, strict=True):
         cn = cand["candidate_number"]
         is_shot = cn in shots_by_cand
         time_key = f"{float(cand['time']):.3f}"
@@ -286,9 +281,7 @@ def main() -> int:
             finally:
                 tmp.unlink(missing_ok=True)
         else:
-            report = probe_fixture(
-                fixture_path, model, processor, pos_feats, neg_feats, args.device
-            )
+            report = probe_fixture(fixture_path, model, processor, pos_feats, neg_feats, args.device)
         out_path = OUT_DIR / f"{fixture_path.stem}.json"
         out_path.write_text(json.dumps(report, indent=2))
         print(f"  wrote {out_path.relative_to(REPO_ROOT)}", file=sys.stderr)

--- a/scripts/promote_ensemble_audit.py
+++ b/scripts/promote_ensemble_audit.py
@@ -90,10 +90,7 @@ def main() -> None:
     n_shots = len(canon_data["shots"])
     n_cands = len(canon_data.get("_candidates_pending_audit", {}).get("candidates", []))
     n_manual = sum(1 for s in canon_data["shots"] if s.get("source") == "manual")
-    print(
-        f"wrote {canonical}: {n_shots} shots ({n_manual} manual), "
-        f"{n_cands} candidates pending"
-    )
+    print(f"wrote {canonical}: {n_shots} shots ({n_manual} manual), " f"{n_cands} candidates pending")
     print()
     print("Next steps:")
     print(f"  git add {canonical}")

--- a/scripts/regression_voter_e.py
+++ b/scripts/regression_voter_e.py
@@ -114,9 +114,7 @@ def main() -> int:
     print(f"Evaluating {len(fixtures)} head-mounted Go 3S fixtures with reachable video")
     print(f"Variants: {[v[0] for v in VARIANTS]}\n")
 
-    aggregates: dict[str, dict[str, int]] = {
-        name: {"tp": 0, "fp": 0, "fn": 0} for name, _, _ in VARIANTS
-    }
+    aggregates: dict[str, dict[str, int]] = {name: {"tp": 0, "fp": 0, "fn": 0} for name, _, _ in VARIANTS}
 
     rows: list[dict] = []
     for fixture_path in fixtures:

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -97,7 +97,7 @@ DEFAULTS: dict[str, Any] = {
     "enable_voter_e": False,
     "e_audio_strong_min_votes": 3,
     "apriori_boost": 1.0,
-    "voter_a_floor": None,             # use calibration
+    "voter_a_floor": None,  # use calibration
     "voter_b_threshold": None,
     "voter_c_threshold": None,
     "voter_e_threshold": None,
@@ -131,9 +131,7 @@ def _load_grid(path: str) -> dict[str, list[Any]]:
     grid: dict[str, list[Any]] = {}
     for k, v in raw.items():
         if k not in PARAM_KEYS:
-            raise SystemExit(
-                f"Unknown grid key: {k!r}. Valid keys: {sorted(PARAM_KEYS)}"
-            )
+            raise SystemExit(f"Unknown grid key: {k!r}. Valid keys: {sorted(PARAM_KEYS)}")
         grid[k] = list(v) if isinstance(v, (list, tuple)) else [v]
     return grid
 
@@ -190,8 +188,10 @@ def _evaluate_combo(
 
         va = voters.vote_a(conf, thresholds["a_floor"] or 0.0)
         vb = voters.vote_b(clap_diff, thresholds["b_threshold"] or -np.inf)
-        if combo["voter_c_mode"] == "adaptive" and combo["use_expected_rounds"] and (
-            expected is not None and expected > 0
+        if (
+            combo["voter_c_mode"] == "adaptive"
+            and combo["use_expected_rounds"]
+            and (expected is not None and expected > 0)
         ):
             vc = voters.vote_c_adaptive(
                 score_c,
@@ -225,9 +225,7 @@ def _evaluate_combo(
             ve = np.zeros_like(va)
 
         vote_total = va + vb + vc
-        eff_expected = (
-            int(expected) if (combo["use_expected_rounds"] and expected is not None) else None
-        )
+        eff_expected = int(expected) if (combo["use_expected_rounds"] and expected is not None) else None
         boost = voters.apriori_boost(conf, eff_expected, float(combo["apriori_boost"]))
         keep_mask = voters.consensus_keep(
             vote_total,
@@ -254,32 +252,32 @@ def _evaluate_combo(
 
         solo = {}
         for name, vec in (("a", va), ("b", vb), ("c", vc), ("e", ve)):
-            solo[f"solo_{name}"] = int(
-                ((label == 1) & (vec == 1) & (vote_total + ve == 1)).sum()
-            )
+            solo[f"solo_{name}"] = int(((label == 1) & (vec == 1) & (vote_total + ve == 1)).sum())
         disagree1 = int((vote_total + ve == 1).sum())
         disagree1_pos = int(((vote_total + ve == 1) & (label == 1)).sum())
 
-        rows_out.append({
-            "fixture": fixture,
-            "camera_class": cam_class,
-            "n_candidates": int(idx.size),
-            "n_positives": n_pos,
-            "n_kept": n_kept,
-            "true_pos": tp,
-            "false_pos": fp,
-            "false_neg": fn,
-            "precision": precision,
-            "recall": recall,
-            "f1": f1,
-            "disagreement_1_count": disagree1,
-            "disagreement_1_pos": disagree1_pos,
-            **solo,
-            "voter_a_floor_eff": thresholds["a_floor"],
-            "voter_b_threshold_eff": thresholds["b_threshold"],
-            "voter_c_threshold_eff": thresholds["c_threshold"],
-            "voter_e_threshold_eff": thresholds["e_threshold"],
-        })
+        rows_out.append(
+            {
+                "fixture": fixture,
+                "camera_class": cam_class,
+                "n_candidates": int(idx.size),
+                "n_positives": n_pos,
+                "n_kept": n_kept,
+                "true_pos": tp,
+                "false_pos": fp,
+                "false_neg": fn,
+                "precision": precision,
+                "recall": recall,
+                "f1": f1,
+                "disagreement_1_count": disagree1,
+                "disagreement_1_pos": disagree1_pos,
+                **solo,
+                "voter_a_floor_eff": thresholds["a_floor"],
+                "voter_b_threshold_eff": thresholds["b_threshold"],
+                "voter_c_threshold_eff": thresholds["c_threshold"],
+                "voter_e_threshold_eff": thresholds["e_threshold"],
+            }
+        )
 
         all_kept[idx] = keep_mask
         all_mask[idx] = True
@@ -353,13 +351,9 @@ def main() -> None:
     args = p.parse_args()
 
     if not args.signals.exists():
-        raise SystemExit(
-            f"{args.signals} does not exist -- run scripts/build_sweep_signals.py first."
-        )
+        raise SystemExit(f"{args.signals} does not exist -- run scripts/build_sweep_signals.py first.")
     table = pq.read_table(args.signals)
-    signals_build_id = (
-        table.column("signals_build_id")[0].as_py() if table.num_rows else "unknown"
-    )
+    signals_build_id = table.column("signals_build_id")[0].as_py() if table.num_rows else "unknown"
 
     # Materialise as numpy column-major dict for fast slicing.
     raw_cols = {name: np.array(table.column(name).to_pylist()) for name in table.schema.names}
@@ -390,15 +384,14 @@ def main() -> None:
 
     if value_lists:
         combos = [
-            {**DEFAULTS, **dict(zip(keys, vals))}
-            for vals in itertools.product(*value_lists)
+            {**DEFAULTS, **dict(zip(keys, vals, strict=True))} for vals in itertools.product(*value_lists)
         ]
     else:
         combos = [dict(DEFAULTS)]
 
     cal = load_calibration()
 
-    now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    now = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
     sha = _git_short_sha()
     slug = args.run_name
     if slug is None:

--- a/scripts/smoke_runtime.py
+++ b/scripts/smoke_runtime.py
@@ -147,7 +147,10 @@ def main() -> None:
     cfg = EnsembleConfig()
     print(f"Calibration built at: {runtime.calibration.built_at}")
     print(f"Default class: {runtime.calibration.default_camera_class}  consensus: {cfg.consensus}")
-    print(f"{'fixture':62s} {'kept':>5s} {'TP':>4s} {'FP':>4s} {'FN':>4s} {'gt':>4s} {'prec':>7s} {'rec':>7s}")
+    print(
+        f"{'fixture':62s} {'kept':>5s} {'TP':>4s} {'FP':>4s} "
+        f"{'FN':>4s} {'gt':>4s} {'prec':>7s} {'rec':>7s}"
+    )
     print("-" * 110)
 
     rows: list[dict[str, object]] = []

--- a/scripts/sweep_multiframe_voter_e.py
+++ b/scripts/sweep_multiframe_voter_e.py
@@ -177,10 +177,7 @@ def _train_and_score_lofo(
                 continue
             sub = subclasses_by_fixture[f]
             mask = np.array(
-                [
-                    (labels_by_fixture[f][i] == 1) or (sub[i] == "cross_bay")
-                    for i in range(len(sub))
-                ],
+                [(labels_by_fixture[f][i] == 1) or (sub[i] == "cross_bay") for i in range(len(sub))],
                 dtype=bool,
             )
             train_emb_chunks.append(embeddings_by_fixture[f][mask])
@@ -196,9 +193,7 @@ def _train_and_score_lofo(
     return held_out_scores
 
 
-def _precision_at_recall(
-    scores: np.ndarray, labels: np.ndarray, target: float
-) -> tuple[float, int]:
+def _precision_at_recall(scores: np.ndarray, labels: np.ndarray, target: float) -> tuple[float, int]:
     """Return ``(precision, k)`` -- smallest top-k that captures the target recall."""
     n_pos = int(labels.sum())
     if n_pos == 0:
@@ -292,14 +287,11 @@ def main() -> int:
         a = per_config[cfg_name]["aggregate"]
         e = per_config[cfg_name]["elapsed_extract_s"]
         print(
-            f"{cfg_name:10s}  {a['auc']:6.3f}  {a['p_at_r_1.0']:8.3f}  "
-            f"{a['p_at_r_0.95']:8.3f}  {e:6.1f}"
+            f"{cfg_name:10s}  {a['auc']:6.3f}  {a['p_at_r_1.0']:8.3f}  " f"{a['p_at_r_0.95']:8.3f}  {e:6.1f}"
         )
 
     print("\n=== per-fixture AUC (single -> multi) ===")
-    fixtures = sorted(
-        set(per_config["single"]["per_fixture"]) & set(per_config["multi"]["per_fixture"])
-    )
+    fixtures = sorted(set(per_config["single"]["per_fixture"]) & set(per_config["multi"]["per_fixture"]))
     deltas: list[float] = []
     print(f"{'fixture':48s}  {'single':>8s}  {'multi':>8s}  {'delta':>8s}")
     for f in fixtures:

--- a/scripts/sweep_negative_pool_voter_e.py
+++ b/scripts/sweep_negative_pool_voter_e.py
@@ -79,9 +79,7 @@ def _load_cache(fixture: str) -> dict | None:
     }
 
 
-def _train_mask_for_variant(
-    variant: str, labels: np.ndarray, subclasses: list[str | None]
-) -> np.ndarray:
+def _train_mask_for_variant(variant: str, labels: np.ndarray, subclasses: list[str | None]) -> np.ndarray:
     """Boolean mask over a fixture's rows selecting which join the training pool.
 
     ``labels`` is the binary shot/non-shot vector; ``subclasses`` carry

--- a/scripts/train_classifier.py
+++ b/scripts/train_classifier.py
@@ -106,8 +106,12 @@ def _featurize(
     win = int(0.050 * sr)
     pre_lo, pre_hi = max(0, idx - win), idx
     post_lo, post_hi = idx, min(n, idx + win)
-    rms_pre = float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2))) if pre_hi > pre_lo else 0.0
-    rms_post = float(np.sqrt(np.mean(audio[post_lo:post_hi].astype(np.float64) ** 2))) if post_hi > post_lo else 0.0
+    rms_pre = (
+        float(np.sqrt(np.mean(audio[pre_lo:pre_hi].astype(np.float64) ** 2))) if pre_hi > pre_lo else 0.0
+    )
+    rms_post = (
+        float(np.sqrt(np.mean(audio[post_lo:post_hi].astype(np.float64) ** 2))) if post_hi > post_lo else 0.0
+    )
     rms_ratio = rms_post / (rms_pre + 1e-6)
 
     # CWT envelope max in ±5 ms window.
@@ -169,9 +173,7 @@ def _featurize(
     }
 
 
-def _label_candidates(
-    cand_times: list[float], gt_times: list[float], tolerance_ms: float
-) -> list[int]:
+def _label_candidates(cand_times: list[float], gt_times: list[float], tolerance_ms: float) -> list[int]:
     """Greedy match: each ground-truth claims its closest unused candidate
     within tolerance. Unmatched candidates -> 0; matched -> 1."""
     used: set[int] = set()
@@ -223,8 +225,7 @@ def collect_candidates(
     pann_cache = _load_pann_cache(fixture) if use_pann else None
     if use_pann and pann_cache is None:
         raise SystemExit(
-            f"--use-pann set but no cache for {fixture}; "
-            f"run scripts/extract_audio_embeddings.py first"
+            f"--use-pann set but no cache for {fixture}; " f"run scripts/extract_audio_embeddings.py first"
         )
     if pann_cache is not None:
         if pann_cache["embedding"].shape[0] != len(shots):
@@ -237,8 +238,7 @@ def collect_candidates(
     clap_cache = _load_clap_cache(fixture) if use_clap else None
     if use_clap and clap_cache is None:
         raise SystemExit(
-            f"--use-clap set but no cache for {fixture}; "
-            f"run scripts/extract_clap_features.py first"
+            f"--use-clap set but no cache for {fixture}; " f"run scripts/extract_clap_features.py first"
         )
     if clap_cache is not None:
         if clap_cache["audio_emb"].shape[0] != len(shots):
@@ -264,9 +264,7 @@ def collect_candidates(
         gprob = float(pann_cache["gunshot_prob"][i]) if pann_cache is not None else None
         clap_aemb = clap_cache["audio_emb"][i] if clap_cache is not None else None
         clap_sims = clap_cache["text_sims"][i] if clap_cache is not None else None
-        clap_prompts = (
-            [str(p) for p in clap_cache["prompts"].tolist()] if clap_cache is not None else None
-        )
+        clap_prompts = [str(p) for p in clap_cache["prompts"].tolist()] if clap_cache is not None else None
         out.append(
             Candidate(
                 fixture=fixture,
@@ -284,8 +282,7 @@ def collect_candidates(
     n_gt = len(gt_t)
     matched_recall = n_pos / n_gt if n_gt else 0.0
     print(
-        f"  {fixture}: {len(out)} cands, {n_pos} positives, {n_gt} gt, "
-        f"recall={matched_recall*100:.1f}%"
+        f"  {fixture}: {len(out)} cands, {n_pos} positives, {n_gt} gt, " f"recall={matched_recall*100:.1f}%"
     )
     return out
 
@@ -444,10 +441,7 @@ def main() -> None:
         else:
             ap = float("nan")
             f1_str = "n/a"
-        print(
-            f"{held:38s} {rec*100:6.1f}% {prec*100:6.1f}% {kept:5d} {miss:5d} "
-            f"{ap:5.2f} {f1_str:>14s}"
-        )
+        print(f"{held:38s} {rec*100:6.1f}% {prec*100:6.1f}% {kept:5d} {miss:5d} " f"{ap:5.2f} {f1_str:>14s}")
         held_results.append((rec, prec, kept, miss))
 
     if held_results:
@@ -474,9 +468,7 @@ def main() -> None:
     skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
     fold_probs = np.zeros_like(y, dtype=np.float64)
     for tr_idx, te_idx in skf.split(X, y):
-        clf = GradientBoostingClassifier(
-            n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-        )
+        clf = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
         clf.fit(X[tr_idx], y[tr_idx])
         fold_probs[te_idx] = clf.predict_proba(X[te_idx])[:, 1]
     print(f"{'threshold':>10s} {'recall':>8s} {'prec':>8s} {'kept':>6s} {'miss':>6s}")
@@ -502,9 +494,7 @@ def main() -> None:
             )
 
     # === Feature importance on full fit ===
-    clf_full = GradientBoostingClassifier(
-        n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42
-    )
+    clf_full = GradientBoostingClassifier(n_estimators=200, max_depth=3, learning_rate=0.05, random_state=42)
     clf_full.fit(X, y)
     print("\n=== Feature importance (full-dataset fit, top 20) ===")
     importances = clf_full.feature_importances_

--- a/scripts/train_visual_probe.py
+++ b/scripts/train_visual_probe.py
@@ -70,9 +70,7 @@ def main() -> int:
         choices=("cpu", "mps", "cuda"),
     )
     parser.add_argument("--probe-dir", default=str(PROBE_DIR))
-    parser.add_argument(
-        "--C", type=float, default=1.0, help="logistic regression inverse regularization"
-    )
+    parser.add_argument("--C", type=float, default=1.0, help="logistic regression inverse regularization")
     args = parser.parse_args()
 
     probe_dir = Path(args.probe_dir)
@@ -87,7 +85,7 @@ def main() -> int:
 
     rows: list[tuple[int, str, int, Path, bool, str | None]] = []
     fixture_index: dict[str, int] = {}
-    for path, probe in sidecars:
+    for _path, probe in sidecars:
         fname = probe["fixture"]
         if fname not in fixture_index:
             fixture_index[fname] = len(fixture_index)
@@ -111,9 +109,7 @@ def main() -> int:
 
     model, processor = load_clip(args.device)
     t0 = time.time()
-    embeds = embed_frames(
-        model, processor, [r[3] for r in rows], args.device, batch=64
-    )
+    embeds = embed_frames(model, processor, [r[3] for r in rows], args.device, batch=64)
     print(f"Embedded {len(rows)} frames in {time.time()-t0:.1f}s", file=sys.stderr)
 
     is_shot = np.array([r[4] for r in rows], dtype=bool)
@@ -147,9 +143,7 @@ def main() -> int:
             print(f"  fold {held_name}: skipping (degenerate labels)")
             continue
 
-        clf = LogisticRegression(
-            C=args.C, max_iter=1000, class_weight="balanced", solver="lbfgs"
-        )
+        clf = LogisticRegression(C=args.C, max_iter=1000, class_weight="balanced", solver="lbfgs")
         clf.fit(Xtr, ytr)
 
         Xte = embeds[test_idx]
@@ -178,7 +172,7 @@ def main() -> int:
         print(f"Mean leave-one-out AUC (shot vs cross_bay only): {mean_auc:.3f}")
 
     by_fixture: dict[str, dict[int, float]] = {}
-    for (_, fname, cn, _, _, _), score in zip(rows, held_out_scores):
+    for (_, fname, cn, _, _, _), score in zip(rows, held_out_scores, strict=True):
         if not np.isnan(score):
             by_fixture.setdefault(fname, {})[cn] = float(score)
 


### PR DESCRIPTION
## Summary

Self-introduced lint debt across \`scripts/\` (56 ruff errors, ~28 black diffs) that the CI gate let through because it only checked \`src + tests\`. Cleaned it up and extended CI so it can't recur.

- ruff: fix 9x B905 (\`zip(..., strict=True)\`), 8x E501, 3x F821 (missing \`typing.Any\` import), 2x B007 (unused loop vars), 1x C416, ~13 auto-fixable
- ruff config: \`scripts/* = [\"N803\", \"N806\"]\` per-file-ignore -- scikit-learn-style \`X\`/\`Y\`/\`Xtr\`/\`Xte\` are deliberate in training/eval scripts
- black: reformat across \`scripts/\`
- \`.github/workflows/ci.yml\`: lint + format-check \`scripts/\` alongside \`src\` and \`tests\`

## Test plan

- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] \`uv run pytest -q\` -- 1284 pass, 4 skipped (no regressions)
- [x] No semantic changes intended; all \`zip(..., strict=True)\` calls operate on equal-length sequences already (asserts on \`scores/labels\`, \`pos_mean/pos_max/neg_mean\`, \`keys/vals\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)