### PR TITLE
feat(packaging): graceful shutdown endpoint for embedded sidecar

### DIFF
--- a/src/splitsmith/ui/embedded.py
+++ b/src/splitsmith/ui/embedded.py
@@ -189,11 +189,22 @@ def run_embedded(
         log_file=str(log_file) if log_file else None,
     )
 
+    # Expose a stop callback so the in-process /api/shutdown route (issue
+    # #369) can ask uvicorn to exit. The CLI's ``splitsmith ui`` path
+    # never reaches here, so the route stays drain-only there.
+    splitsmith_state = app.state.splitsmith_state
+    splitsmith_state.shutdown_handler = lambda: setattr(server, "should_exit", True)
+
     try:
         _wait_for_health(base_url, timeout=startup_timeout)
         _emit_banner(handle, ready_fd)
         yield handle
     finally:
+        # Drain in-flight jobs before flipping ``should_exit``. If
+        # /api/shutdown or SIGTERM already kicked the drain, this is a
+        # no-op past the first transition.
+        splitsmith_state.jobs.begin_shutdown()
+        splitsmith_state.jobs.wait_for_drain(shutdown_timeout)
         server.should_exit = True
         thread.join(timeout=shutdown_timeout)
         if thread.is_alive():

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -116,6 +116,15 @@ class JobCancelled(Exception):  # noqa: N818 -- control-flow, not error; mirrors
     """
 
 
+class ShutdownInProgressError(RuntimeError):
+    """Raised by :meth:`JobRegistry.submit` after :meth:`begin_shutdown`.
+
+    The HTTP layer maps this to a ``503 shutting_down`` so the desktop
+    shell can tell the user "wait for current work to finish, then
+    relaunch" instead of silently dropping new submissions.
+    """
+
+
 class Job(BaseModel):
     """Wire shape returned by ``/api/jobs/{id}``."""
 
@@ -261,6 +270,53 @@ class JobRegistry:
         # so we can terminate it on cancel even when the worker is blocked
         # on proc.wait().
         self._subprocs: dict[str, subprocess.Popen] = {}
+        # Set by :meth:`begin_shutdown`. Once True, ``submit`` raises
+        # :class:`ShutdownInProgressError` and ``wait_for_drain`` waits
+        # for the active set to clear before the embedded entrypoint
+        # stops uvicorn. Idempotent: a second call is a no-op.
+        self._shutting_down = False
+        self._drained = threading.Event()
+
+    @property
+    def is_shutting_down(self) -> bool:
+        return self._shutting_down
+
+    def active_count(self) -> int:
+        """Count of PENDING or RUNNING jobs at this instant."""
+        with self._lock:
+            return self._active_count_locked()
+
+    def _active_count_locked(self) -> int:
+        return sum(1 for j in self._jobs.values() if j.status in (JobStatus.PENDING, JobStatus.RUNNING))
+
+    def _signal_drain_if_complete_locked(self) -> None:
+        """Set the drain event when shutting down and the active set is empty."""
+        if self._shutting_down and self._active_count_locked() == 0:
+            self._drained.set()
+
+    def begin_shutdown(self) -> None:
+        """Reject new submissions; flip the drain event when active is 0.
+
+        Idempotent. After the call, :meth:`submit` raises
+        :class:`ShutdownInProgressError`; :meth:`wait_for_drain` returns
+        once active drops to zero (or its timeout elapses).
+        """
+        with self._lock:
+            if self._shutting_down:
+                return
+            self._shutting_down = True
+            self._signal_drain_if_complete_locked()
+
+    def wait_for_drain(self, timeout_s: float) -> bool:
+        """Block until active_count is 0 or ``timeout_s`` elapses.
+
+        Returns True if the drain completed, False on timeout. Safe to
+        call before :meth:`begin_shutdown` -- if there's no active work
+        it returns immediately.
+        """
+        if self.active_count() == 0:
+            return True
+        return self._drained.wait(timeout=timeout_s)
 
     def submit(
         self,
@@ -274,7 +330,12 @@ class JobRegistry:
 
         Returns the job snapshot (status=PENDING) immediately so the HTTP
         handler can hand the id back to the caller without blocking.
+
+        Raises :class:`ShutdownInProgressError` if :meth:`begin_shutdown`
+        has been called -- the HTTP layer maps this to a 503.
         """
+        if self._shutting_down:
+            raise ShutdownInProgressError("server is shutting down; no new jobs accepted")
         now = datetime.now(UTC)
         job = Job(
             id=uuid.uuid4().hex,
@@ -342,6 +403,7 @@ class JobRegistry:
                     j.updated_at = j.finished_at
                     self._trim_retained_locked()
                     break
+            self._signal_drain_if_complete_locked()
             snapshot = j.model_copy(deep=True)
         # Kill outside the lock so a slow ``terminate()`` (proc held a
         # held resource etc.) can't stall other registry callers.
@@ -492,6 +554,7 @@ class JobRegistry:
             with self._lock:
                 self._running_count = max(0, self._running_count - 1)
                 self._dispatch_locked()
+                self._signal_drain_if_complete_locked()
 
     def _dispatch_locked(self) -> None:
         """Hand the highest-priority pending job to the executor.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -79,13 +79,14 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import Body, FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi import Body, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -123,7 +124,7 @@ from ..runtime import runtime as process_runtime
 from . import audio as audio_helpers
 from . import exports as export_helpers
 from . import match_exports as match_export_helpers
-from .jobs import Job, JobCancelled, JobHandle, JobRegistry
+from .jobs import Job, JobCancelled, JobHandle, JobRegistry, ShutdownInProgressError
 from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
@@ -490,6 +491,22 @@ def _raise_scoreboard_http(exc: ScoreboardError) -> None:
     raise HTTPException(status_code=500, detail=str(exc))
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+
+
+def _is_loopback(request: Request) -> bool:
+    """Reject /api/shutdown from non-loopback callers.
+
+    ``testclient`` is included so the TestClient ASGI shim works in
+    pytest without a real socket; it's a value set by the server side
+    (the ASGI scope) so a remote caller can't spoof it.
+    """
+    client = request.client
+    if client is None:
+        return False
+    return client.host in _LOOPBACK_HOSTS
+
+
 def _no_project_error() -> HTTPException:
     """Raised by :class:`AppState` when an endpoint that needs a bound
     project is hit while the server is in unbound (picker) mode.
@@ -549,6 +566,14 @@ class AppState:
     _bound_match_id: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
     matches: MatchRegistry = field(default_factory=MatchRegistry)
+    # Stop callback registered by :func:`splitsmith.ui.embedded.run_embedded`
+    # so the /api/shutdown route can ask uvicorn to exit. None under the
+    # ``splitsmith ui`` CLI path -- Ctrl-C via _JobAwareServer.handle_exit
+    # is the stop mechanism there.
+    shutdown_handler: Callable[[], None] | None = None
+    # Idempotency latch for /api/shutdown: first call kicks the drain
+    # thread, subsequent calls return 202 without rescheduling.
+    shutdown_initiated: bool = False
 
     @property
     def is_bound(self) -> bool:
@@ -1934,6 +1959,14 @@ def create_app(
     # outside the closure.
     app.state.splitsmith_state = state
 
+    @app.exception_handler(ShutdownInProgressError)
+    async def _shutdown_in_progress_handler(request: Request, exc: ShutdownInProgressError) -> JSONResponse:
+        """Map ShutdownInProgressError to 503 across every submit() callsite."""
+        return JSONResponse(
+            status_code=503,
+            content={"detail": {"code": "shutting_down", "message": str(exc)}},
+        )
+
     # ----------------------------------------------------------------------
     # /api/matches/{match_id}/... alias middleware (#353 Phase 3 PR B/C)
     # ----------------------------------------------------------------------
@@ -2052,6 +2085,40 @@ def create_app(
         if not state.is_bound:
             return HealthResponse(bound=False)
         return _health_after_bind(state.bound_name or "")
+
+    @app.post("/api/shutdown", status_code=202)
+    def shutdown(request: Request) -> dict[str, Any]:
+        """Drain in-flight jobs and ask uvicorn to exit (issue #369).
+
+        Loopback-only -- the embedded sidecar trusts only its own host.
+        Idempotent: the first call kicks a daemon drain thread; later
+        calls return 202 without rescheduling.
+
+        Under the CLI's ``splitsmith ui`` path the registered stop
+        callback is None, so this drains jobs but does not stop the
+        server -- the operator still uses Ctrl-C there.
+        """
+        if not _is_loopback(request):
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "loopback_only", "message": "shutdown is loopback-only"},
+            )
+        if state.shutdown_initiated:
+            return {"status": "shutting_down", "already": True}
+        state.shutdown_initiated = True
+        state.jobs.begin_shutdown()
+        handler = state.shutdown_handler
+        drain_timeout = 30.0
+
+        def _drain_then_stop() -> None:
+            try:
+                state.jobs.wait_for_drain(drain_timeout)
+            finally:
+                if handler is not None:
+                    handler()
+
+        threading.Thread(target=_drain_then_stop, name="splitsmith-shutdown", daemon=True).start()
+        return {"status": "shutting_down", "already": False}
 
     @app.get("/api/shooters/{slug}/project")
     def get_project(slug: str) -> JSONResponse:

--- a/tests/test_ui_shutdown.py
+++ b/tests/test_ui_shutdown.py
@@ -1,0 +1,222 @@
+"""Tests for POST /api/shutdown and JobRegistry drain (issue #369)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from splitsmith.ui.jobs import JobRegistry, JobStatus, ShutdownInProgressError
+from splitsmith.ui.server import create_app
+
+
+def _wait_until(predicate, *, timeout=2.0, poll=0.01) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return predicate()
+
+
+# ----------------------------------------------------------------------
+# JobRegistry-level drain primitives
+# ----------------------------------------------------------------------
+
+
+def test_begin_shutdown_blocks_new_submissions() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    reg.begin_shutdown()
+    with pytest.raises(ShutdownInProgressError):
+        reg.submit(kind="test", fn=lambda _h: None)
+
+
+def test_begin_shutdown_is_idempotent() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    reg.begin_shutdown()
+    reg.begin_shutdown()  # second call is a no-op
+    assert reg.is_shutting_down
+
+
+def test_wait_for_drain_returns_immediately_when_idle() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    assert reg.wait_for_drain(timeout_s=0.1) is True
+
+
+def test_wait_for_drain_waits_for_in_flight_then_returns() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+
+    def slow(_handle):
+        proceed.wait(timeout=2.0)
+
+    job = reg.submit(kind="test", fn=slow)
+    assert _wait_until(lambda: reg.get(job.id).status == JobStatus.RUNNING)
+
+    reg.begin_shutdown()
+
+    # Drain hasn't completed yet -- the worker is still blocked.
+    assert reg.wait_for_drain(timeout_s=0.05) is False
+
+    proceed.set()
+    assert reg.wait_for_drain(timeout_s=2.0) is True
+    assert reg.active_count() == 0
+
+
+def test_wait_for_drain_returns_false_on_timeout() -> None:
+    reg = JobRegistry(max_concurrent=1)
+    proceed = threading.Event()
+
+    def slow(_handle):
+        proceed.wait(timeout=5.0)
+
+    reg.submit(kind="test", fn=slow)
+    assert _wait_until(lambda: reg.active_count() == 1)
+
+    reg.begin_shutdown()
+    assert reg.wait_for_drain(timeout_s=0.05) is False
+
+    # Cleanup: let the worker finish so the executor shuts down promptly.
+    proceed.set()
+
+
+def test_active_count_excludes_terminal_states() -> None:
+    reg = JobRegistry(max_concurrent=1)
+
+    def quick(_handle):
+        pass
+
+    job = reg.submit(kind="test", fn=quick)
+    assert _wait_until(lambda: reg.get(job.id).status == JobStatus.SUCCEEDED)
+    assert reg.active_count() == 0
+
+
+# ----------------------------------------------------------------------
+# HTTP route
+# ----------------------------------------------------------------------
+
+
+def _make_client(tmp_path: Path) -> TestClient:
+    app = create_app(project_root=tmp_path / "match", project_name="Shutdown Test")
+    return TestClient(app)
+
+
+def test_shutdown_returns_202_and_kicks_drain(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    resp = client.post("/api/shutdown")
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "shutting_down"
+    assert body["already"] is False
+
+    state = client.app.state.splitsmith_state
+    assert state.jobs.is_shutting_down
+
+
+def test_shutdown_is_idempotent(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    first = client.post("/api/shutdown")
+    second = client.post("/api/shutdown")
+    third = client.post("/api/shutdown")
+    assert first.status_code == 202
+    assert first.json()["already"] is False
+    assert second.status_code == 202
+    assert second.json()["already"] is True
+    assert third.status_code == 202
+    assert third.json()["already"] is True
+
+
+def test_shutdown_rejects_non_loopback(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="Shutdown Test")
+    client = TestClient(app, client=("192.168.1.50", 51234))
+    resp = client.post("/api/shutdown")
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "loopback_only"
+    state = client.app.state.splitsmith_state
+    assert state.jobs.is_shutting_down is False
+
+
+def test_shutdown_in_progress_error_mapped_to_503(tmp_path: Path) -> None:
+    """The global exception handler turns ShutdownInProgressError into a 503."""
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI()
+
+    # Re-register the same handler the production app uses, so this test
+    # validates the mapping shape without depending on a route that happens
+    # to call submit().
+    @app.exception_handler(ShutdownInProgressError)
+    async def _h(_request, exc: ShutdownInProgressError) -> JSONResponse:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": {"code": "shutting_down", "message": str(exc)}},
+        )
+
+    @app.get("/__probe_raise")
+    def _probe() -> dict:
+        raise ShutdownInProgressError("server is shutting down; no new jobs accepted")
+
+    client = TestClient(app)
+    resp = client.get("/__probe_raise")
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "shutting_down"
+
+
+def test_create_app_registers_shutdown_exception_handler(tmp_path: Path) -> None:
+    """create_app registers the ShutdownInProgressError handler so 503s
+    work at every submit() callsite without per-route try/except."""
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    assert ShutdownInProgressError in app.exception_handlers
+
+
+def test_submit_during_shutdown_raises_at_registry(tmp_path: Path) -> None:
+    """End-to-end: after /api/shutdown, JobRegistry.submit refuses new work."""
+    client = _make_client(tmp_path)
+    client.post("/api/shutdown")
+    state = client.app.state.splitsmith_state
+    assert state.jobs.is_shutting_down
+    with pytest.raises(ShutdownInProgressError):
+        state.jobs.submit(kind="probe", fn=lambda _h: None)
+
+
+def test_shutdown_calls_handler_after_drain(tmp_path: Path) -> None:
+    """The registered shutdown_handler is invoked once the drain completes."""
+    client = _make_client(tmp_path)
+    state = client.app.state.splitsmith_state
+
+    stopped = threading.Event()
+    state.shutdown_handler = stopped.set
+
+    resp = client.post("/api/shutdown")
+    assert resp.status_code == 202
+
+    # No active jobs -> drain completes immediately -> handler fires.
+    assert stopped.wait(timeout=2.0), "shutdown_handler not invoked after drain"
+
+
+def test_shutdown_drains_in_flight_job_before_calling_handler(tmp_path: Path) -> None:
+    client = _make_client(tmp_path)
+    state = client.app.state.splitsmith_state
+
+    proceed = threading.Event()
+    handler_fired = threading.Event()
+    state.shutdown_handler = handler_fired.set
+
+    def slow(_handle):
+        proceed.wait(timeout=5.0)
+
+    state.jobs.submit(kind="test", fn=slow)
+    assert _wait_until(lambda: state.jobs.active_count() == 1)
+
+    resp = client.post("/api/shutdown")
+    assert resp.status_code == 202
+
+    # Handler must not fire while the worker is still in-flight.
+    assert not handler_fired.wait(timeout=0.1)
+
+    proceed.set()
+    assert handler_fired.wait(timeout=2.0)


### PR DESCRIPTION
## Summary

Closes #369.

- \`POST /api/shutdown\` -- loopback-only, idempotent, 202 response. Spawns a daemon drain thread that calls the registered \`state.shutdown_handler\` when the active-job count hits zero (default 30s drain timeout).
- \`JobRegistry\` gains \`begin_shutdown()\`, \`wait_for_drain(timeout_s)\`, \`active_count()\`, and \`is_shutting_down\`. \`submit()\` raises a new \`ShutdownInProgressError\` after begin_shutdown.
- \`create_app\` registers a global FastAPI exception handler that maps \`ShutdownInProgressError\` to \`503 {detail: {code: \"shutting_down\"}}\` at every submit() callsite (20 routes) without per-route try/except.
- \`run_embedded\` registers \`shutdown_handler = setattr(server, \"should_exit\", True)\` and runs the same drain in its \`__exit__\`, so SIGTERM via the existing signal path drains identically -- not just \`/api/shutdown\`.
- CLI's \`splitsmith ui\` keeps \`shutdown_handler=None\`: Ctrl-C via \`_JobAwareServer.handle_exit\` stays the operator's stop mechanism; \`/api/shutdown\` drains but doesn't stop the server there.

## Test plan

- [x] \`tests/test_ui_shutdown.py\` -- 14 new tests: drain primitives (idempotency, timeout, in-flight wait, active_count), 202 response, repeat -> already=true, non-loopback rejection, exception-handler mapping to 503, handler invocation after drain, in-flight job blocks handler until done
- [x] \`uv run pytest -q\` -- 1298 pass, 4 skipped (was 1284; +14)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] CLI surface unchanged (\`splitsmith ui\` still uses \`_JobAwareServer\` + Ctrl-C; new endpoint is a drain-only no-op there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)