### PR TITLE
feat(packaging): bundled-binary discovery for ffmpeg/ffprobe

### DIFF
--- a/src/splitsmith/runtime.py
+++ b/src/splitsmith/runtime.py
@@ -11,12 +11,26 @@ The same hooks let OSS users A/B-test custom model artifacts:
 
     SPLITSMITH_ARTIFACTS_DIR=/path/to/experimental splitsmith ui
 
-Resolution priority for every field:
+Resolution priority for paths:
 
 1. Explicit kwargs to :func:`resolve_runtime`.
 2. Environment variables (see ``ENV_*`` constants below).
-3. Built-in defaults: package data dir for artifacts, ``shutil.which``
-   for binaries, platform-appropriate cache/config dirs.
+3. Built-in defaults: package data dir for artifacts,
+   platform-appropriate cache/config dirs.
+
+Binary resolution adds two more steps before falling back to PATH so
+PyInstaller-bundled sidecars find their ffmpeg/ffprobe without env
+vars (issue #370):
+
+1. Explicit kwarg.
+2. Environment variable.
+3. ``sys._MEIPASS`` -- PyInstaller onefile temp dir, set on extracted
+   bundle launch only.
+4. Directory of ``sys.executable`` -- PyInstaller onedir layout, also
+   covers the dev case where ffmpeg is dropped into the venv's ``bin``.
+5. ``shutil.which`` on PATH.
+
+Each candidate must be executable; non-executable entries fall through.
 
 The first call has a side effect: it ``setdefault``-s ``HF_HOME`` and
 ``TORCH_HOME`` into the resolved cache dir so CLAP / PANN downloads
@@ -97,12 +111,53 @@ def _platform_user_config_dir() -> Path:
     return Path.home() / ".splitsmith"
 
 
+def _bundle_search_dirs() -> list[Path]:
+    """Directories adjacent to the running executable to probe for bundled binaries.
+
+    Returned in priority order:
+
+    * ``sys._MEIPASS`` -- PyInstaller onefile mode extracts datas + binaries
+      to a temp dir and points this attr at it.
+    * ``Path(sys.executable).parent`` -- PyInstaller onedir layout, plus the
+      dev case where ffmpeg/ffprobe live in the venv's ``bin`` next to
+      the Python interpreter.
+    """
+    dirs: list[Path] = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        dirs.append(Path(meipass))
+    exe_dir = Path(sys.executable).parent
+    if exe_dir not in dirs:
+        dirs.append(exe_dir)
+    return dirs
+
+
+def _executable_in_dir(directory: Path, name: str) -> Path | None:
+    """Return ``directory/name`` (with ``.exe`` on Windows) if it's executable."""
+    candidates = [directory / name]
+    if sys.platform.startswith("win") and not name.lower().endswith(".exe"):
+        candidates.append(directory / f"{name}.exe")
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _resolve_binary(explicit: str | None, env_name: str, default: str) -> str:
+    """Pick the most specific binary the caller has provided or shipped.
+
+    Order: explicit kwarg > env var > bundled (``_MEIPASS`` / executable
+    dir) > the bare name (resolved by the OS via PATH at exec time).
+    """
     if explicit:
         return explicit
     env_val = os.environ.get(env_name)
     if env_val:
         return env_val
+    for directory in _bundle_search_dirs():
+        bundled = _executable_in_dir(directory, default)
+        if bundled is not None:
+            return str(bundled)
     return default
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -164,3 +164,100 @@ def test_calibration_loader_uses_runtime_artifacts_dir(
     with pytest.raises(FileNotFoundError) as exc:
         load_calibration()
     assert "ensemble_calibration.json" in str(exc.value)
+
+
+# ----------------------------------------------------------------------
+# Bundled-binary discovery (issue #370)
+# ----------------------------------------------------------------------
+
+
+def _make_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+
+
+def test_meipass_dir_wins_over_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A bundled binary under ``sys._MEIPASS`` beats whatever's on PATH."""
+    bundle = tmp_path / "meipass"
+    bundle.mkdir()
+    _make_executable(bundle / "ffmpeg")
+    _make_executable(bundle / "ffprobe")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == str(bundle / "ffmpeg")
+    assert rt.ffprobe_binary == str(bundle / "ffprobe")
+
+
+def test_executable_dir_used_when_no_meipass(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without _MEIPASS, ffmpeg next to ``sys.executable`` is picked up."""
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    bin_dir = tmp_path / "venv-bin"
+    bin_dir.mkdir()
+    fake_exe = bin_dir / "python-fake"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+    _make_executable(bin_dir / "ffmpeg")
+    _make_executable(bin_dir / "ffprobe")
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == str(bin_dir / "ffmpeg")
+    assert rt.ffprobe_binary == str(bin_dir / "ffprobe")
+
+
+def test_env_var_beats_bundled_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``SPLITSMITH_FFMPEG`` overrides the bundled lookup."""
+    bundle = tmp_path / "meipass"
+    bundle.mkdir()
+    _make_executable(bundle / "ffmpeg")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+
+    override = tmp_path / "override-ffmpeg"
+    _make_executable(override)
+    monkeypatch.setenv(ENV_FFMPEG, str(override))
+
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == str(override)
+
+
+def test_explicit_kwarg_beats_bundled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    bundle = tmp_path / "meipass"
+    bundle.mkdir()
+    _make_executable(bundle / "ffmpeg")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+
+    rt = resolve_runtime(ffmpeg_binary="/explicit/ffmpeg")
+    assert rt.ffmpeg_binary == "/explicit/ffmpeg"
+
+
+def test_falls_back_to_bare_name_when_no_bundle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No env / no _MEIPASS / nothing next to executable -> bare name for PATH lookup."""
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    empty_dir = tmp_path / "no-binaries"
+    empty_dir.mkdir()
+    fake_exe = empty_dir / "python-fake"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == "ffmpeg"
+    assert rt.ffprobe_binary == "ffprobe"
+
+
+def test_non_executable_candidate_is_skipped(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A file named 'ffmpeg' without +x doesn't get picked up."""
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    bin_dir = tmp_path / "venv-bin"
+    bin_dir.mkdir()
+    fake_exe = bin_dir / "python-fake"
+    fake_exe.write_text("")
+    fake_exe.chmod(0o755)
+    not_executable = bin_dir / "ffmpeg"
+    not_executable.write_text("")
+    not_executable.chmod(0o644)
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+
+    rt = resolve_runtime()
+    assert rt.ffmpeg_binary == "ffmpeg"  # fell through to PATH lookup


### PR DESCRIPTION
## Summary

Closes #370.

Teach \`runtime.resolve_runtime()\` to find ffmpeg/ffprobe sitting next to the running executable so a PyInstaller-bundled sidecar works without the shell having to wrap every launch in env vars.

New lookup order for binaries:
1. Explicit kwarg
2. \`SPLITSMITH_FFMPEG\` / \`SPLITSMITH_FFPROBE\`
3. **NEW**: \`sys._MEIPASS\` (PyInstaller onefile temp dir)
4. **NEW**: \`Path(sys.executable).parent\` (PyInstaller onedir + venv-local dev case)
5. \`shutil.which\` on PATH (via bare name)

Each candidate must be a file with the executable bit set; non-executable entries fall through. Windows lookups also try \`.exe\`.

## Test plan

- [x] \`tests/test_runtime.py\` -- 6 new tests: _MEIPASS wins over PATH, executable dir used when no _MEIPASS, env var still beats bundled, explicit kwarg still beats bundled, bare-name fallback when nothing found, non-executable candidate skipped
- [x] \`uv run pytest -q\` -- 1304 pass (was 1298; +6), 4 skipped
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] Existing env-var / explicit-kwarg tests still pass (resolution priority preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)