### PR TITLE
feat(packaging): PyInstaller spec + release workflow for splitsmith-server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Manual dispatch lets us validate the workflow without cutting a tag.
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.os }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+            artifact_suffix: macos-arm64
+          - os: macos-13
+            arch: x86_64
+            artifact_suffix: macos-x86_64
+          - os: ubuntu-22.04
+            arch: x86_64
+            artifact_suffix: linux-x86_64
+          - os: windows-2022
+            arch: x86_64
+            artifact_suffix: windows-x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.11
+        run: uv python install 3.11
+
+      - name: Sync Python dependencies
+        run: uv sync --frozen
+
+      - name: Install Node (for SPA build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Build SPA
+        working-directory: src/splitsmith/ui_static
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Run PyInstaller
+        run: uv run pyinstaller packaging/splitsmith-server.spec --noconfirm
+
+      - name: Smoke-test the bundled binary (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          ./dist/splitsmith-server/splitsmith-server --help
+
+      - name: Smoke-test the bundled binary (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          ./dist/splitsmith-server/splitsmith-server.exe --help
+
+      - name: Package as archive (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          cd dist
+          tar -czf splitsmith-server-${{ matrix.artifact_suffix }}.tar.gz splitsmith-server
+
+      - name: Package as archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path dist/splitsmith-server -DestinationPath dist/splitsmith-server-${{ matrix.artifact_suffix }}.zip
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: splitsmith-server-${{ matrix.artifact_suffix }}
+          path: |
+            dist/splitsmith-server-${{ matrix.artifact_suffix }}.tar.gz
+            dist/splitsmith-server-${{ matrix.artifact_suffix }}.zip
+          if-no-files-found: error
+
+  release:
+    name: Attach to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only attach on actual tag pushes; workflow_dispatch invocations
+    # build + smoke-test only, no release upload.
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create / update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ uv run pytest -q                # unit tests
 uv run pytest -q -m integration # ffmpeg/ffprobe-backed tests
 ```
 
+## Prebuilt sidecar binaries
+
+For embedding the engine into a desktop shell (issue #129), tagged releases on the [GitHub releases page](https://github.com/mandakan/splitsmith/releases) ship a standalone `splitsmith-server` per platform (macOS arm64/x86_64, Linux x86_64, Windows x86_64). The binary boots a local HTTP server, prints a `SPLITSMITH_READY {json}` handshake on stderr, and serves the same FastAPI surface the source checkout does. ffmpeg/ffprobe are **not** bundled -- drop them next to the binary or rely on `PATH`; the runtime resolver looks at both.
+
 ## Subcommands
 
 All commands run as `uv run splitsmith <subcommand>`. Pass `--help` for the full option list. See [`docs/COMMANDS.md`](docs/COMMANDS.md) for usage examples per command.

--- a/packaging/splitsmith-server.spec
+++ b/packaging/splitsmith-server.spec
@@ -1,0 +1,147 @@
+# PyInstaller spec for splitsmith-server (issue #371).
+#
+# Produces a standalone sidecar binary that the closed-source desktop
+# shell from issue #129 spawns as a child process. The OSS bundle does
+# NOT include ffmpeg / ffprobe (license complexity + size); the shell
+# repo layers them on top, or users install via package manager. The
+# binary discovers ffmpeg next to itself at runtime via the lookup
+# added in issue #370.
+#
+# Local invocation (slow -- 15-30 min, ~1-2 GB output):
+#     uv run pyinstaller packaging/splitsmith-server.spec
+#
+# Per-platform release artifacts come out of .github/workflows/release.yml
+# on every ``v*`` tag push.
+
+# ruff: noqa
+# PyInstaller injects the analysis builtins at parse time; static analyzers
+# treat this file as a plain Python module and flag the implicit names.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+REPO_ROOT = Path(SPECPATH).resolve().parent
+ENTRY = REPO_ROOT / "src" / "splitsmith" / "ui" / "embedded.py"
+DATA_DIR = REPO_ROOT / "src" / "splitsmith" / "data"
+SPA_DIST = REPO_ROOT / "src" / "splitsmith" / "ui_static" / "dist"
+TEMPLATES_DIR = REPO_ROOT / "src" / "splitsmith" / "templates"
+
+if not SPA_DIST.exists():
+    raise SystemExit(
+        f"SPA dist not found at {SPA_DIST}. "
+        "Run `npm --prefix src/splitsmith/ui_static run build` first."
+    )
+
+# Bundle the shipped ensemble artifacts, fonts, overlay templates, and
+# the built SPA assets at their package-relative paths. PyInstaller
+# preserves the second element of each tuple as the path inside the
+# bundle, matching how splitsmith.runtime + importlib.resources read
+# them at runtime.
+datas: list[tuple[str, str]] = [
+    (str(DATA_DIR), "splitsmith/data"),
+    (str(SPA_DIST), "splitsmith/ui_static/dist"),
+]
+if TEMPLATES_DIR.exists():
+    datas.append((str(TEMPLATES_DIR), "splitsmith/templates"))
+
+# Scientific Python rarely auto-detects cleanly: pull every submodule
+# we touch so the analyzer doesn't drop one we lazy-import. Heavy but
+# avoids the "works in dev, fails on packaged" trap.
+hiddenimports: list[str] = []
+for package in (
+    "sklearn",
+    "transformers",
+    "panns_inference",
+    "librosa",
+    "soundfile",
+    "mcp",
+    "uvicorn",
+    "fastapi",
+    "pydantic",
+    "pydantic_settings",
+):
+    hiddenimports.extend(collect_submodules(package))
+
+# Some packages ship data files (model configs, vocabularies) that need
+# to land beside the import. collect_data_files surfaces those.
+for package in ("transformers", "sklearn", "librosa", "panns_inference"):
+    datas.extend(collect_data_files(package))
+
+# torch ships its own libs + datas; let PyInstaller's torch hook do the
+# heavy lifting (avoids over-collecting which inflates the bundle).
+# Adding submodules selectively rather than the whole tree.
+hiddenimports.extend(
+    [
+        "torch",
+        "torch.nn",
+        "torch.nn.functional",
+        "torch._C",
+    ]
+)
+
+# Excludes: dev-only deps (the wheel resolves them; the bundled sidecar
+# never imports them) and the bundler itself.
+excludes: list[str] = [
+    "matplotlib",
+    "pyarrow",
+    "PyInstaller",
+    "tests",
+    "pytest",
+    "respx",
+    "mypy",
+    "ruff",
+    "black",
+]
+
+
+a = Analysis(
+    [str(ENTRY)],
+    pathex=[str(REPO_ROOT / "src")],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=excludes,
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="splitsmith-server",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+# onedir layout: gives the closed-source shell a directory it can ship
+# alongside its own assets (ffmpeg, app icon, etc.) and pin via the
+# bundled-binary discovery added in issue #370. onefile mode is slower
+# to start (extracts to a temp dir on every launch) and produces worse
+# error messages when a hidden import is missing -- not worth the
+# single-file convenience here.
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="splitsmith-server",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ dev = [
     # Dev-only: the production API does not read these files.
     "pyarrow>=17.0.0",
     "matplotlib>=3.9.0",
+    # Packaging the splitsmith-server sidecar into a standalone binary
+    # for the (closed-source) desktop shell (issue #371). Invoked via
+    # the .github/workflows/release.yml matrix; dev-only because the
+    # OSS workflow is "splitsmith ui" via the source checkout.
+    "pyinstaller>=6.10.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1214,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1811,6 +1832,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2129,6 +2159,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/60/d03d52e6690d4e9caf333dcd14550cde634ce6c118b3bc8fa3112c3186fd/pyinstaller-6.20.0.tar.gz", hash = "sha256:95c5c7e03d5d61e9dfb8ef259c699cf492bb1041beb6dbe83696608cec07347a", size = 4048728, upload-time = "2026-04-22T20:59:36.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/e4/e228d6d1bbb7fd62dc660a8fb202a583b023d3a3624ca95d1a9290ee4d6a/pyinstaller-6.20.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:bf3be4e1284ee78ddccba5e29f99443a12a7b4673168288ffc4c9d38c6f7b90e", size = 1047642, upload-time = "2026-04-22T20:58:32.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/afb631bcb3f9040efebd4f6d067f0828b51710818f69fb41a2d4b7787f52/pyinstaller-6.20.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:72ae9c1fdea134afa791f58bdc9a1934d5c7609753c111e0026bfc272b32b712", size = 742494, upload-time = "2026-04-22T20:58:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/76/08/0729a5bac14754150e5d83b39d87d842eb42b0bffcaa03dbad6252e23a39/pyinstaller-6.20.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1031bcc307f3fbeffd4e162723e64d46dbf591c82dd0997413afb2a07328b941", size = 754191, upload-time = "2026-04-22T20:58:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/82/bc0ee4c7b97db1958eb651e0da9fb1e672e5ae53ca8867fd97701de52906/pyinstaller-6.20.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8df3b3f347659fa2562d8d193a98ad4600133b8b8d07c268df89e4154376750e", size = 751902, upload-time = "2026-04-22T20:58:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/770002d6aaa54173881cb2c49bb195ba67b97bf39bac1cdf320f28401629/pyinstaller-6.20.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:b0d3cc9dd8120d448459bd3880a12e2f9774c51443af49047801446377999a59", size = 748634, upload-time = "2026-04-22T20:58:48.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/db/68ba1fccb71278b2124fb90b37b7c8c0bc4c1173fba45b94466df3d9cb7f/pyinstaller-6.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:03696bb6350177c6bc23bcaf78e71a33c4a89b6754dd90d1be2f318e978c918b", size = 748490, upload-time = "2026-04-22T20:58:52.749Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0f/ac77ffa996a56be3d5c8f85734a007f8347240691657f9704e7de2527fa3/pyinstaller-6.20.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:6357f1699f6af84f37e7367f031d4f68abdba65543b83990c9e8f5a4cebed0b7", size = 747650, upload-time = "2026-04-22T20:58:57.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/1ee91c3a2bc10ca1f36da10a6fd55ff7efc4dec367171eb25992a827874f/pyinstaller-6.20.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0ab39c690abad26ba148e8f664f0478acc82a733997f4f22e757774832802da9", size = 747413, upload-time = "2026-04-22T20:59:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/55/ae264339996953c4cdf9d89d916a0a8fa26a83cf917a742fff8b9d5f3fe8/pyinstaller-6.20.0-py3-none-win32.whl", hash = "sha256:9a7637e8e44b4387b13667fdcaac86ab6b29c446c16d34d8401539b81838759c", size = 1331584, upload-time = "2026-04-22T20:59:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/300f57578882cce259bfb5ae56fda3b69caa3fe9df40a176c719920ea6e2/pyinstaller-6.20.0-py3-none-win_amd64.whl", hash = "sha256:d588844e890ee80c4365867f98146636e1849bbca8e4284bbf0c809aff0f161a", size = 1391851, upload-time = "2026-04-22T20:59:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/b2f8e1642aecda78c0b75c7321f708e49e10bb3c00dd4f148c40761a1527/pyinstaller-6.20.0-py3-none-win_arm64.whl", hash = "sha256:bd53282c0a73e5c95573e1ddc8e5d564d4932bec91efbaed4dc5fdff9c2ae7f2", size = 1332259, upload-time = "2026-04-22T20:59:20.509Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/67/f4452d68793fb15beba4f19ef39a38a8822f0da7452b503c400d5a21f5c1/pyinstaller_hooks_contrib-2026.5.tar.gz", hash = "sha256:f066dfca8f7c45ff6336c9cf9fe25b4e48bfeb322a1aa24faaedfb8a8d1b0b08", size = 173689, upload-time = "2026-05-04T22:36:55.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/5c/fd465d11da4d12b50d7eb5d2ee2ceb780d8d049dbb489f3828d131e387af/pyinstaller_hooks_contrib-2026.5-py3-none-any.whl", hash = "sha256:ea1535783fbdac4626351709e83f3ea80b681d3a4745763ebb407b5e27342eb9", size = 457314, upload-time = "2026-05-04T22:36:53.598Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2262,6 +2333,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2857,6 +2937,7 @@ dev = [
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "pyarrow" },
+    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "respx" },
@@ -2892,6 +2973,7 @@ dev = [
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
+    { name = "pyinstaller", specifier = ">=6.10.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "respx", specifier = ">=0.21.1" },


### PR DESCRIPTION
## Summary

Closes #371. Final piece of the desktop-packaging arc -- tagged \`v*\` releases now ship a standalone \`splitsmith-server\` sidecar per platform so the closed-source desktop shell from #129 can embed the engine without re-bundling on every shell build.

- **\`packaging/splitsmith-server.spec\`** -- PyInstaller onedir build. Entry: \`src/splitsmith/ui/embedded.py:main\`. Bundles ensemble artifacts (\`src/splitsmith/data\`), built SPA assets (\`src/splitsmith/ui_static/dist\`), templates. Collects sklearn / torch / transformers / panns_inference / librosa / soundfile / mcp / uvicorn / fastapi / pydantic submodules. Excludes matplotlib / pyarrow / pytest. ffmpeg + ffprobe explicitly NOT bundled (license + size); the runtime resolver from #370 finds them via \`_MEIPASS\` / executable dir / PATH.

- **\`.github/workflows/release.yml\`** -- matrix over macos-14 (arm64), macos-13 (x86_64), ubuntu-22.04, windows-2022. Per-platform steps: uv sync, pnpm SPA build, PyInstaller, \`--help\` smoke test, archive (tar.gz on UNIX, zip on Windows), upload-artifact. Second \`release\` job attaches archives to the GitHub release on \`v*\` tag push (workflow_dispatch validates the build without uploading).

- **\`pyinstaller>=6.10\`** added to dev deps; uv.lock regenerated.

- **README** -- short note pointing shell-repo consumers at the releases page.

## Validation strategy

A real PyInstaller bundle of this app (torch + transformers + librosa + panns) lands around 1-2 GB and takes 15-30 min per platform. Running it locally in the PR session isn't realistic; the workflow itself is the validation surface. \`workflow_dispatch\` is enabled so you can fire a no-tag build to validate the spec end-to-end without cutting a release.

## Test plan

- [x] \`uv run pyinstaller --version\` -- 6.20.0 installed
- [x] Spec parses as valid Python (\`ast.parse\`)
- [x] \`uv run pytest -q\` -- 1304 pass, 4 skipped (no regressions)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [ ] **Validate by triggering the workflow** (workflow_dispatch on main after merge) before cutting any \`v0.1.0\` tag
- [ ] First tagged release smoke-tests: download each platform archive, run \`splitsmith-server --help\` on the matching host, confirm the SPLITSMITH_READY banner appears when the binary launches

## Followups (not in this PR)

- Code signing + notarization land in the closed-source shell repo (#129 carved them out)
- ffmpeg/ffprobe bundling is a per-shell decision
- The desktop shell's launcher consumes the archive via its own build script

🤖 Generated with [Claude Code](https://claude.com/claude-code)