### PR TITLE
refactor(ensemble): backend selector + typed runtime callables (slim foundation)

### DIFF
--- a/src/splitsmith/ensemble/backend.py
+++ b/src/splitsmith/ensemble/backend.py
@@ -1,0 +1,81 @@
+"""Runtime backend selection for ensemble inference (issue #377).
+
+Production hides the choice of ONNX vs torch behind typed runtime
+dataclasses (``ClapRuntime`` / ``PannRuntime`` / ``VisualRuntime`` in
+sibling modules). Every voter calls into a numpy-in / numpy-out
+callable on the runtime; they never see a torch tensor or an
+``InferenceSession``. This module is the one place that decides which
+backend the loaders construct.
+
+See ``docs/local-slim/05-dev-vs-prod-parity.md`` for the parity
+contract and ``06-slim-progress.md`` for the migration status.
+
+Resolution order (matches doc 05):
+
+1. ``override`` argument to :func:`select_backend` -- callers can pin
+   per-process (CLI ``--backend``).
+2. ``SPLITSMITH_BACKEND`` env var (``onnx`` / ``torch``).
+3. ``onnxruntime`` if importable -- the default for slim wheel users.
+4. ``torch`` if importable -- the default for contributors with the
+   dev extras installed.
+5. Raise :class:`SplitsmithBackendError` with install hints for both.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from enum import StrEnum
+
+ENV_BACKEND = "SPLITSMITH_BACKEND"
+
+
+class Backend(StrEnum):
+    """Which inference engine the runtime loaders should construct."""
+
+    ONNX = "onnx"
+    TORCH = "torch"
+
+
+class SplitsmithBackendError(RuntimeError):
+    """Raised when neither backend is importable in the current process.
+
+    The message names both install paths so users can fix it without a
+    grep through this module.
+    """
+
+
+def _is_importable(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def select_backend(override: Backend | str | None = None) -> Backend:
+    """Pick the inference backend for this process.
+
+    Idempotent and side-effect-free: callers can call this in a loader
+    or a test without worrying about state. The first import of the
+    chosen backend's heavy package happens later, inside the loader.
+
+    Raises :class:`SplitsmithBackendError` when neither backend is
+    available -- e.g. a slim wheel install that lost ``onnxruntime``,
+    or a dev checkout without either group installed.
+    """
+    explicit = override if override is not None else os.environ.get(ENV_BACKEND)
+    if explicit:
+        try:
+            return Backend(str(explicit).lower())
+        except ValueError as exc:
+            raise SplitsmithBackendError(
+                f"Unknown backend {explicit!r}; expected one of " f"{[b.value for b in Backend]}"
+            ) from exc
+
+    if _is_importable("onnxruntime"):
+        return Backend.ONNX
+    if _is_importable("torch"):
+        return Backend.TORCH
+
+    raise SplitsmithBackendError(
+        "No inference backend available. Install one of:\n"
+        "  - onnxruntime (slim/prod):  uv pip install 'onnxruntime>=1.20'\n"
+        "  - torch (dev / contributor): uv sync --all-groups"
+    )

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -18,6 +18,7 @@ prompt strings were used so loading checks the bank still matches.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,7 @@ import librosa
 import numpy as np
 
 from .agc_state import compute_agc_features
+from .backend import Backend, SplitsmithBackendError, select_backend
 
 # Shot-positive prompts (used for the (shot - not-shot) differential
 # voter B keys on, and as a column subset of voter C's feature vector).
@@ -136,18 +138,40 @@ def camera_class_one_hot(camera_classes: list[str] | np.ndarray, n_rows: int) ->
 
 @dataclass
 class ClapRuntime:
-    """Pre-loaded CLAP model + pre-encoded text embeddings."""
+    """CLAP inference state, backend-agnostic.
 
-    model: Any
-    processor: Any
+    ``encode_audio`` takes an ``(N, T_samples)`` float32 batch at
+    ``CLAP_SR`` and returns ``(N, D)`` L2-normalised embeddings in
+    numpy. ``text_embeddings`` is ``(P, D)``, pre-encoded once at load
+    time so per-detection runs only pay the audio cost.
+
+    The torch and ONNX implementations both wrap their backend-specific
+    objects (``transformers.ClapModel``, ``onnxruntime.InferenceSession``)
+    inside the callable so voter code stays backend-agnostic. ``model``
+    and ``processor`` are retained as opaque ``Any`` slots so the torch
+    branch can keep references alive for the lifetime of the runtime;
+    consumers should not read them directly.
+    """
+
+    encode_audio: Callable[[np.ndarray], np.ndarray]
     text_embeddings: np.ndarray  # (P, D), L2-normalised
+    backend: Backend
+    model: Any = None
+    processor: Any = None
 
 
 @dataclass
 class PannRuntime:
-    """Pre-loaded PANN audio tagger."""
+    """PANN gunshot-class inference state, backend-agnostic.
 
-    tagger: Any
+    ``predict_gunshot_prob`` takes an ``(N, T_samples)`` float32 batch
+    at ``PANN_SR`` and returns an ``(N,)`` numpy vector of the AudioSet
+    ``Gunshot, gunfire`` class probability per row.
+    """
+
+    predict_gunshot_prob: Callable[[np.ndarray], np.ndarray]
+    backend: Backend
+    tagger: Any = None
 
 
 def _slice_window(audio: np.ndarray, sr: int, t: float, win_s: float) -> np.ndarray:
@@ -304,12 +328,8 @@ def compute_hand_features(
     return out
 
 
-def load_clap_runtime() -> ClapRuntime:
-    """Load the CLAP model + pre-encode the prompt bank.
-
-    First call downloads ~600 MB to the HF cache. Reuse the returned
-    runtime across detections.
-    """
+def _build_clap_runtime_torch() -> ClapRuntime:
+    """Construct a torch-backed :class:`ClapRuntime`. Dev / contributor path."""
     import torch
     from transformers import ClapModel, ClapProcessor
 
@@ -319,11 +339,46 @@ def load_clap_runtime() -> ClapRuntime:
 
     text_inputs = processor(text=list(CLAP_PROMPTS), return_tensors="pt", padding=True)
     with torch.no_grad():
-        out = model.get_text_features(**dict(text_inputs))
-    text_emb_t = out.pooler_output if hasattr(out, "pooler_output") else out
+        text_out = model.get_text_features(**dict(text_inputs))
+    text_emb_t = text_out.pooler_output if hasattr(text_out, "pooler_output") else text_out
     text_emb = text_emb_t.cpu().numpy().astype(np.float32)
     text_emb = text_emb / (np.linalg.norm(text_emb, axis=1, keepdims=True) + 1e-9)
-    return ClapRuntime(model=model, processor=processor, text_embeddings=text_emb)
+
+    def encode_audio(batch: np.ndarray) -> np.ndarray:
+        """``(N, T)`` float32 audio -> ``(N, D)`` L2-normalised embeddings."""
+        inputs = processor(
+            audio=list(batch),
+            sampling_rate=CLAP_SR,
+            return_tensors="pt",
+        )
+        with torch.no_grad():
+            audio_out = model.get_audio_features(**dict(inputs))
+        emb = audio_out.pooler_output if hasattr(audio_out, "pooler_output") else audio_out
+        emb_np = emb.cpu().numpy().astype(np.float32)
+        return emb_np / (np.linalg.norm(emb_np, axis=1, keepdims=True) + 1e-9)
+
+    return ClapRuntime(
+        encode_audio=encode_audio,
+        text_embeddings=text_emb,
+        backend=Backend.TORCH,
+        model=model,
+        processor=processor,
+    )
+
+
+def load_clap_runtime() -> ClapRuntime:
+    """Load CLAP through the selected backend.
+
+    First call on the torch path downloads ~600 MB to the HF cache;
+    ONNX path will fetch the slim artifacts from R2 once doc 02 ships.
+    Reuse the returned runtime across detections.
+    """
+    backend = select_backend()
+    if backend is Backend.TORCH:
+        return _build_clap_runtime_torch()
+    if backend is Backend.ONNX:
+        raise NotImplementedError("ONNX CLAP runtime not implemented yet (issue #377 phase 'ONNX exports')")
+    raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 
 
 def compute_clap_similarities(
@@ -334,11 +389,11 @@ def compute_clap_similarities(
 ) -> np.ndarray:
     """Per-candidate cosine similarity to every prompt, shape ``(N, P)``.
 
-    Audio is resampled to ``CLAP_SR`` once; per-candidate windows are then
-    sliced from the resampled stream so the model sees its native rate.
+    Audio is resampled to ``CLAP_SR`` once; per-candidate windows are
+    then sliced from the resampled stream so the model sees its native
+    rate. Inference goes through ``runtime.encode_audio`` so this
+    function is backend-agnostic and free of ``import torch``.
     """
-    import torch
-
     if not len(candidate_times):
         return np.zeros((0, len(CLAP_PROMPTS)), dtype=np.float32)
     if sample_rate != CLAP_SR:
@@ -346,19 +401,16 @@ def compute_clap_similarities(
     else:
         clap_audio = audio.astype(np.float32)
 
-    windows = [_slice_window(clap_audio, CLAP_SR, float(t), CLAP_WINDOW_S) for t in candidate_times]
+    windows = np.stack(
+        [_slice_window(clap_audio, CLAP_SR, float(t), CLAP_WINDOW_S) for t in candidate_times],
+        axis=0,
+    )
 
     audio_embeddings: list[np.ndarray] = []
     batch_size = 16
-    for i in range(0, len(windows), batch_size):
-        batch = windows[i : i + batch_size]
-        inputs = runtime.processor(audio=batch, sampling_rate=CLAP_SR, return_tensors="pt")
-        with torch.no_grad():
-            out = runtime.model.get_audio_features(**dict(inputs))
-        emb = out.pooler_output if hasattr(out, "pooler_output") else out
-        audio_embeddings.append(emb.cpu().numpy())
+    for i in range(0, windows.shape[0], batch_size):
+        audio_embeddings.append(runtime.encode_audio(windows[i : i + batch_size]))
     audio_emb = np.concatenate(audio_embeddings, axis=0).astype(np.float32)
-    audio_emb = audio_emb / (np.linalg.norm(audio_emb, axis=1, keepdims=True) + 1e-9)
     return (audio_emb @ runtime.text_embeddings.T).astype(np.float32)
 
 
@@ -372,15 +424,36 @@ def clap_diff_from_similarities(sims: np.ndarray) -> np.ndarray:
     return (shot_mean - not_mean).astype(np.float32)
 
 
-def load_pann_runtime() -> PannRuntime:
-    """Load the PANN CNN14 audio tagger.
-
-    First call downloads ~80 MB to ``~/panns_data/``. Reuse across
-    detections.
-    """
+def _build_pann_runtime_torch() -> PannRuntime:
+    """Construct a torch-backed :class:`PannRuntime`. Dev / contributor path."""
     from panns_inference import AudioTagging
 
-    return PannRuntime(tagger=AudioTagging(checkpoint_path=None, device="cpu"))
+    tagger = AudioTagging(checkpoint_path=None, device="cpu")
+
+    def predict_gunshot_prob(batch: np.ndarray) -> np.ndarray:
+        clipwise, _embedding = tagger.inference(batch)
+        return np.asarray(clipwise, dtype=np.float32)[:, PANN_GUNSHOT_CLASS_INDEX].astype(np.float32)
+
+    return PannRuntime(
+        predict_gunshot_prob=predict_gunshot_prob,
+        backend=Backend.TORCH,
+        tagger=tagger,
+    )
+
+
+def load_pann_runtime() -> PannRuntime:
+    """Load PANN through the selected backend.
+
+    First call on the torch path downloads ~80 MB to ``~/panns_data/``;
+    ONNX path will fetch the slim artifact from R2 once doc 02 ships.
+    Reuse the returned runtime across detections.
+    """
+    backend = select_backend()
+    if backend is Backend.TORCH:
+        return _build_pann_runtime_torch()
+    if backend is Backend.ONNX:
+        raise NotImplementedError("ONNX PANN runtime not implemented yet (issue #377 phase 'ONNX exports')")
+    raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 
 
 def compute_pann_gunshot_probs(
@@ -389,7 +462,11 @@ def compute_pann_gunshot_probs(
     candidate_times: np.ndarray,
     runtime: PannRuntime,
 ) -> np.ndarray:
-    """Per-candidate ``Gunshot, gunfire`` class probability, shape ``(N,)``."""
+    """Per-candidate ``Gunshot, gunfire`` class probability, shape ``(N,)``.
+
+    Inference goes through ``runtime.predict_gunshot_prob`` so this
+    function is backend-agnostic and free of ``import torch``.
+    """
     if not len(candidate_times):
         return np.zeros(0, dtype=np.float32)
     if sample_rate != PANN_SR:
@@ -400,9 +477,7 @@ def compute_pann_gunshot_probs(
         [_slice_window(pann_audio, PANN_SR, float(t), PANN_WINDOW_S) for t in candidate_times],
         axis=0,
     )
-    clipwise, _embedding = runtime.tagger.inference(batch)
-    clipwise = np.asarray(clipwise, dtype=np.float32)
-    return clipwise[:, PANN_GUNSHOT_CLASS_INDEX].astype(np.float32)
+    return runtime.predict_gunshot_prob(batch)
 
 
 def voter_c_feature_matrix(

--- a/src/splitsmith/ensemble/visual.py
+++ b/src/splitsmith/ensemble/visual.py
@@ -21,12 +21,17 @@ import hashlib
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+from .backend import Backend, SplitsmithBackendError, select_backend
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PilImage
 
 from ..runtime import runtime as process_runtime
 
@@ -38,35 +43,39 @@ DEFAULT_FRAME_CACHE_DIR = Path.home() / ".cache" / "splitsmith" / "voter_e_frame
 
 @dataclass
 class VisualRuntime:
-    """Loaded heavy state for Voter E.
+    """Loaded heavy state for Voter E, backend-agnostic.
 
-    ``probe`` is the trained sklearn classifier (``LogisticRegression``)
-    that maps a CLIP image embedding to a per-candidate shot probability.
-    Cleared / replaced when the calibration is rebuilt.
+    ``encode_images`` takes a list of PIL ``Image`` objects (RGB) and
+    returns ``(N, CLIP_VISUAL_EMBED_DIM)`` L2-normalised CLIP image
+    embeddings in numpy. The torch and ONNX implementations both wrap
+    their backend-specific objects inside this callable so voter code
+    is backend-agnostic.
+
+    ``probe`` is the trained sklearn classifier
+    (``LogisticRegression``) that maps a CLIP image embedding to a
+    per-candidate shot probability. ``model`` / ``processor`` slots
+    remain as opaque ``Any`` references so the torch branch can hold
+    its objects alive; consumers should not read them directly.
     """
 
-    model: Any
-    processor: Any
+    encode_images: Callable[[list[PilImage]], np.ndarray]
     probe: Any
+    backend: Backend
+    model: Any = None
+    processor: Any = None
     model_id: str = CLIP_VISUAL_MODEL_ID
     device: str = "cpu"
     frame_cache_dir: Path = field(default_factory=lambda: DEFAULT_FRAME_CACHE_DIR)
 
 
-def load_visual_runtime(
+def _build_visual_runtime_torch(
     probe: Any,
     *,
-    model_id: str = CLIP_VISUAL_MODEL_ID,
-    device: str | None = None,
-    frame_cache_dir: Path | None = None,
+    model_id: str,
+    device: str | None,
+    frame_cache_dir: Path | None,
 ) -> VisualRuntime:
-    """Materialise the CLIP model + processor; bind the supplied probe head.
-
-    First call downloads ~600 MB to the HF cache. Reuse the returned
-    runtime across detections. ``probe`` is loaded by the caller (typically
-    via ``calibration.load_voter_e_probe``) so this function stays a pure
-    model-init helper.
-    """
+    """Torch-backed :class:`VisualRuntime`. Dev / contributor path."""
     import torch
     from transformers import CLIPModel, CLIPProcessor
 
@@ -80,14 +89,52 @@ def load_visual_runtime(
 
     model = CLIPModel.from_pretrained(model_id).to(device).eval()
     processor = CLIPProcessor.from_pretrained(model_id)
+
+    def encode_images(images: list[PilImage]) -> np.ndarray:  # noqa: F821 -- TYPE_CHECKING import
+        """Per-image CLIP embedding, L2-normalised on the embedding axis."""
+        inputs = processor(images=images, return_tensors="pt").to(device)
+        with torch.no_grad():
+            feats = model.get_image_features(**inputs).pooler_output
+            feats = feats / feats.norm(dim=-1, keepdim=True)
+        return feats.cpu().numpy().astype(np.float32)
+
     return VisualRuntime(
+        encode_images=encode_images,
+        probe=probe,
+        backend=Backend.TORCH,
         model=model,
         processor=processor,
-        probe=probe,
         model_id=model_id,
         device=device,
         frame_cache_dir=frame_cache_dir or DEFAULT_FRAME_CACHE_DIR,
     )
+
+
+def load_visual_runtime(
+    probe: Any,
+    *,
+    model_id: str = CLIP_VISUAL_MODEL_ID,
+    device: str | None = None,
+    frame_cache_dir: Path | None = None,
+) -> VisualRuntime:
+    """Load the visual probe runtime through the selected backend.
+
+    First call on the torch path downloads ~600 MB to the HF cache;
+    ONNX path will fetch the slim artifact from R2 once doc 02 ships.
+    Reuse the returned runtime across detections. ``probe`` is loaded
+    by the caller (typically via ``calibration.load_voter_e_probe``)
+    so this function stays a pure model-init helper.
+    """
+    backend = select_backend()
+    if backend is Backend.TORCH:
+        return _build_visual_runtime_torch(
+            probe, model_id=model_id, device=device, frame_cache_dir=frame_cache_dir
+        )
+    if backend is Backend.ONNX:
+        raise NotImplementedError(
+            "ONNX visual probe runtime not implemented yet " "(issue #377 phase 'ONNX exports')"
+        )
+    raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 
 
 def _video_fingerprint(video_path: Path) -> str:
@@ -165,7 +212,6 @@ def compute_visual_features(
     ``runtime.frame_cache_dir/<video_fingerprint>/`` keyed on
     ``(time_ms, offset_ms)``.
     """
-    import torch
     from PIL import Image
 
     n = int(np.asarray(source_times).shape[0])
@@ -201,11 +247,7 @@ def compute_visual_features(
     for i in range(0, len(frame_paths), batch_size):
         chunk_paths = frame_paths[i : i + batch_size]
         images = [Image.open(p).convert("RGB") for p in chunk_paths]
-        inputs = runtime.processor(images=images, return_tensors="pt").to(runtime.device)
-        with torch.no_grad():
-            feats = runtime.model.get_image_features(**inputs).pooler_output
-            feats = feats / feats.norm(dim=-1, keepdim=True)
-        embeds.append(feats.cpu().numpy().astype(np.float32))
+        embeds.append(runtime.encode_images(images))
     flat = np.vstack(embeds)
     return flat.reshape(n, n_offsets * CLIP_VISUAL_EMBED_DIM)
 

--- a/tests/test_no_torch_in_prod_path.py
+++ b/tests/test_no_torch_in_prod_path.py
@@ -1,0 +1,72 @@
+"""Sentinel: production-path modules must not ``import torch`` at module level.
+
+See ``docs/local-slim/05-dev-vs-prod-parity.md``. The slim wheel ships
+without torch; if anyone adds a top-level ``import torch`` to
+``splitsmith.ensemble.*``, the slim install crashes at startup before
+the user has a chance to swap backends.
+
+How the test works
+------------------
+The subprocess starts with a clean ``sys.modules`` -- no test fixture
+or sibling module has had a chance to pull in torch yet. After
+importing every prod module, the test asserts ``"torch"`` is still
+absent from ``sys.modules``. Lazy imports inside
+``_build_*_runtime_torch`` helpers don't fire here because the module
+import doesn't call those helpers.
+
+This observe-don't-block design avoids scipy's array-api compatibility
+probe, which does ``getattr(sys.modules['torch'], 'Tensor')`` and
+breaks when the slot is poisoned with ``None``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+# Modules that must stay torch-free at import time. The list is
+# deliberately narrow: it covers the prod hot path (features, visual,
+# api, voters, calibration) and avoids the build / training scripts
+# under ``scripts/`` -- those keep torch on purpose.
+_PROD_MODULES = (
+    "splitsmith.ensemble",
+    "splitsmith.ensemble.api",
+    "splitsmith.ensemble.backend",
+    "splitsmith.ensemble.calibration",
+    "splitsmith.ensemble.features",
+    "splitsmith.ensemble.visual",
+    "splitsmith.ensemble.voters",
+    "splitsmith.ensemble.tta",
+)
+
+
+def test_prod_modules_import_without_torch() -> None:
+    """No prod module pulls in torch as a transitive side-effect of import."""
+    snippet = textwrap.dedent(f"""
+        import sys
+
+        modules = {list(_PROD_MODULES)!r}
+        for name in modules:
+            __import__(name)
+
+        torch_modules = sorted(
+            m for m in sys.modules
+            if m == "torch" or m.startswith("torch.")
+        )
+        if torch_modules:
+            raise SystemExit(
+                "splitsmith.ensemble.* pulled in torch at import time: "
+                + ", ".join(torch_modules)
+            )
+        """)
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        "splitsmith.ensemble.* must not import torch at module top level.\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )


### PR DESCRIPTION
## Summary

First phase of #377 (local-slim v1). Pure refactor; the torch inference path becomes the torch branch of a backend selector so the ONNX branch can land later without re-plumbing every voter. No behavioural change on the torch path.

- **\`src/splitsmith/ensemble/backend.py\`** -- new module. \`Backend\` enum + \`select_backend(override)\` honouring \`SPLITSMITH_BACKEND\` env var, \`SplitsmithBackendError\` with install hints. Order: override > env > onnxruntime importable > torch importable > raise.
- **\`ClapRuntime\` / \`PannRuntime\` / \`VisualRuntime\`** now expose numpy-in / numpy-out callables (\`encode_audio\`, \`predict_gunshot_prob\`, \`encode_images\`) so voter code is backend-agnostic. Existing \`model\` / \`processor\` / \`tagger\` / \`probe\` slots stay as opaque \`Any\` references for the torch branch and for tests' \`Stub*Runtime\` shapes.
- **\`load_clap_runtime\` / \`load_pann_runtime\` / \`load_visual_runtime\`** route through \`select_backend()\`. The ONNX branch raises \`NotImplementedError\` pointing at the next phase. The torch branch lives in \`_build_*_runtime_torch\` helpers that own the remaining \`import torch\` lines.
- **\`compute_clap_similarities\` / \`compute_pann_gunshot_probs\` / \`compute_visual_features\`** no longer import torch. They call the typed runtime callable instead.
- **\`tests/test_no_torch_in_prod_path.py\`** -- subprocess sentinel that asserts no prod ensemble module pulls in torch at import time. Observes \`sys.modules\` after import rather than poisoning the torch slot (which breaks scipy's array-api compat probe).

## Test plan

- [x] New sentinel test passes (catches future regressions)
- [x] \`uv run pytest -q\` -- 1305 pass, 4 skipped (was 1304 + 1 sentinel)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] CLI surface unchanged (\`splitsmith ui\`, \`splitsmith detect\` still call the same loaders)
- [x] No behavioural change on the torch path (same model objects, same processor calls, same outputs)

## Refs

Tracking: #377  
Doc set: [\`docs/local-slim/\`](./docs/local-slim/), in particular \`05-dev-vs-prod-parity.md\` for the typed-runtime contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)