### PR TITLE
feat(slim): first-launch ffmpeg / ffprobe presence check with 24h cache

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -417,6 +417,15 @@ def ui(
             "heavy CLAP/PANN models on first use."
         ),
     ),
+    skip_system_check: bool = typer.Option(
+        False,
+        "--skip-system-check",
+        help=(
+            "Bypass the first-launch ffmpeg / ffprobe presence check. "
+            "Use only for debugging install issues -- detection will "
+            "fail with a cryptic error if either binary is missing."
+        ),
+    ),
 ) -> None:
     """Start the production UI server (issue #11/#12).
 
@@ -465,6 +474,7 @@ def ui(
             host=host,
             port=port,
             lab_enabled=lab,
+            skip_system_check=skip_system_check,
         )
     except KeyboardInterrupt:
         console.print("\n[yellow]Stopped.[/]")

--- a/src/splitsmith/system_check.py
+++ b/src/splitsmith/system_check.py
@@ -1,0 +1,162 @@
+"""First-launch system-dependency checks (issue #377 -- doc 04).
+
+The slim install ships without ffmpeg / ffprobe -- they're documented
+system deps. Before the first detection, we verify they're invocable
+and, if not, surface a copy-pasteable install hint per OS instead of
+the cryptic ``FileNotFoundError`` the engine would raise mid-trim.
+
+The positive result is cached for 24 hours in ``state.json`` under
+``runtime().user_config_dir`` so the check pays its cost once per day
+even when the user launches the UI many times.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .runtime import runtime as process_runtime
+
+logger = logging.getLogger(__name__)
+
+STATE_FILENAME = "state.json"
+CACHE_KEY = "ffmpeg_check"
+CACHE_TTL_S = 24 * 60 * 60
+_VERIFY_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class FfmpegOutcome:
+    """Result of a single ffmpeg-presence probe.
+
+    ``ok`` is the gate the caller branches on. ``hint`` is a
+    multi-line, copy-pasteable install instruction the CLI / UI prints
+    when ``ok`` is False; it's also returned on success (empty string)
+    so the dataclass shape stays uniform for templating.
+    """
+
+    ok: bool
+    binary: str
+    hint: str
+
+
+def _state_path() -> Path:
+    return process_runtime().user_config_dir / STATE_FILENAME
+
+
+def _load_state() -> dict:
+    path = _state_path()
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("ignoring unreadable state at %s", path, exc_info=True)
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def _install_hint(binary: str) -> str:
+    """OS-tailored install instructions for ffmpeg + ffprobe."""
+    head = (
+        f"Splitsmith couldn't find {binary!r} on this system.\n"
+        "Install ffmpeg (which ships ffprobe alongside) with:"
+    )
+    if sys.platform == "darwin":
+        return f"{head}\n\n    brew install ffmpeg\n\nThen re-run splitsmith."
+    if sys.platform.startswith("win"):
+        return (
+            f"{head}\n\n"
+            "    winget install --id=Gyan.FFmpeg -e\n\n"
+            "Open a new shell after install so PATH refreshes, then re-run splitsmith."
+        )
+    # Linux + everything else
+    return (
+        f"{head}\n\n"
+        "    Ubuntu / Debian: sudo apt install ffmpeg\n"
+        "    Fedora:          sudo dnf install ffmpeg\n"
+        "    Arch:            sudo pacman -S ffmpeg\n\n"
+        "Then re-run splitsmith."
+    )
+
+
+def _binary_resolves(binary: str) -> bool:
+    """``True`` iff ``binary`` is invocable in this environment.
+
+    Absolute paths must exist with the executable bit set; bare names
+    must resolve via ``shutil.which`` (PATH-aware). The slim runtime's
+    bundled-binary discovery (#370) has already turned a bare name
+    into an absolute path when one was found beside the executable, so
+    this check is straightforward.
+    """
+    candidate = Path(binary)
+    if candidate.is_absolute():
+        return candidate.is_file() and os.access(candidate, os.X_OK)
+    return shutil.which(binary) is not None
+
+
+def _binary_runs(binary: str) -> bool:
+    """``True`` iff ``binary -version`` exits 0. Bounded by timeout."""
+    try:
+        result = subprocess.run(
+            [binary, "-version"],
+            capture_output=True,
+            timeout=_VERIFY_TIMEOUT_S,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def check_ffmpeg(*, use_cache: bool = True) -> FfmpegOutcome:
+    """Verify ffmpeg + ffprobe are reachable; return a typed outcome.
+
+    Honors a 24-hour positive-result cache so repeat launches don't
+    re-spawn subprocesses. Negative results are never cached -- the
+    user is told to install the dep + re-run; on the next launch the
+    check is fresh.
+
+    ``use_cache=False`` forces the full probe even when a positive
+    result exists; useful for ``splitsmith ui --no-system-check`` debug
+    flows and the test suite.
+    """
+    runtime = process_runtime()
+    binary = runtime.ffmpeg_binary
+    ffprobe = runtime.ffprobe_binary
+
+    state = _load_state()
+    cached = state.get(CACHE_KEY) if use_cache else None
+    if (
+        isinstance(cached, dict)
+        and cached.get("ok") is True
+        and cached.get("binary") == binary
+        and cached.get("ffprobe") == ffprobe
+        and isinstance(cached.get("ts"), (int, float))
+        and (time.time() - float(cached["ts"])) < CACHE_TTL_S
+    ):
+        return FfmpegOutcome(ok=True, binary=binary, hint="")
+
+    if not _binary_resolves(binary) or not _binary_resolves(ffprobe):
+        return FfmpegOutcome(ok=False, binary=binary, hint=_install_hint("ffmpeg"))
+    if not _binary_runs(binary) or not _binary_runs(ffprobe):
+        return FfmpegOutcome(ok=False, binary=binary, hint=_install_hint("ffmpeg"))
+
+    state[CACHE_KEY] = {"ok": True, "binary": binary, "ffprobe": ffprobe, "ts": time.time()}
+    try:
+        _save_state(state)
+    except OSError:
+        logger.warning("could not persist ffmpeg check cache", exc_info=True)
+    return FfmpegOutcome(ok=True, binary=binary, hint="")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -9015,6 +9015,7 @@ def serve(
     port: int = 5174,
     reload: bool = False,
     lab_enabled: bool = False,
+    skip_system_check: bool = False,
 ) -> None:
     """Boot uvicorn synchronously. Used by the ``splitsmith ui`` CLI command.
 
@@ -9024,8 +9025,22 @@ def serve(
     like the process hanging. Uvicorn already promotes a second Ctrl-C
     to a force-exit; we just decorate the first press with the job
     inventory + a hint about pressing again.
+
+    The first thing we do is check ffmpeg / ffprobe are invocable
+    (issue #377 -- doc 04). The slim install ships them as documented
+    system deps; a missing binary surfaces a copy-pasteable install
+    hint here rather than a cryptic ``FileNotFoundError`` mid-trim.
+    ``skip_system_check=True`` bypasses the probe (used by tests).
     """
     import uvicorn
+
+    if not skip_system_check:
+        from ..system_check import check_ffmpeg
+
+        outcome = check_ffmpeg()
+        if not outcome.ok:
+            sys.stderr.write(outcome.hint + "\n")
+            sys.exit(2)
 
     _ensure_ui_built()
 

--- a/tests/test_system_check.py
+++ b/tests/test_system_check.py
@@ -1,0 +1,187 @@
+"""Tests for the first-launch ffmpeg presence check (issue #377 -- doc 04)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from splitsmith import runtime as runtime_module
+from splitsmith import system_check
+
+
+def _make_fake_ffmpeg(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+
+
+def _point_runtime_at(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ffmpeg: str,
+    ffprobe: str,
+    config_dir: Path,
+) -> None:
+    monkeypatch.setenv("SPLITSMITH_FFMPEG", ffmpeg)
+    monkeypatch.setenv("SPLITSMITH_FFPROBE", ffprobe)
+    monkeypatch.setenv("SPLITSMITH_CONFIG_DIR", str(config_dir))
+    runtime_module._clear_runtime_cache()
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime() -> None:
+    runtime_module._clear_runtime_cache()
+    yield
+    runtime_module._clear_runtime_cache()
+
+
+def test_present_binaries_yield_ok(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ff = tmp_path / "ffmpeg"
+    fp = tmp_path / "ffprobe"
+    _make_fake_ffmpeg(ff)
+    _make_fake_ffmpeg(fp)
+    _point_runtime_at(monkeypatch, ffmpeg=str(ff), ffprobe=str(fp), config_dir=tmp_path / "cfg")
+
+    outcome = system_check.check_ffmpeg()
+    assert outcome.ok is True
+    assert outcome.binary == str(ff)
+    assert outcome.hint == ""
+
+
+def test_missing_binary_returns_install_hint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    bogus_ff = tmp_path / "does-not-exist-ffmpeg"
+    bogus_fp = tmp_path / "does-not-exist-ffprobe"
+    _point_runtime_at(monkeypatch, ffmpeg=str(bogus_ff), ffprobe=str(bogus_fp), config_dir=tmp_path / "cfg")
+
+    outcome = system_check.check_ffmpeg()
+    assert outcome.ok is False
+    assert "Splitsmith couldn't find" in outcome.hint
+    # State file must not record the negative result.
+    state_path = system_check._state_path()
+    if state_path.exists():
+        assert system_check.CACHE_KEY not in json.loads(state_path.read_text())
+
+
+def test_positive_result_is_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ff = tmp_path / "ffmpeg"
+    fp = tmp_path / "ffprobe"
+    _make_fake_ffmpeg(ff)
+    _make_fake_ffmpeg(fp)
+    _point_runtime_at(monkeypatch, ffmpeg=str(ff), ffprobe=str(fp), config_dir=tmp_path / "cfg")
+
+    first = system_check.check_ffmpeg()
+    assert first.ok is True
+
+    state = json.loads(system_check._state_path().read_text())
+    assert system_check.CACHE_KEY in state
+    entry = state[system_check.CACHE_KEY]
+    assert entry["ok"] is True
+    assert entry["binary"] == str(ff)
+    assert entry["ffprobe"] == str(fp)
+
+
+def test_cached_positive_skips_subprocess(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ff = tmp_path / "ffmpeg"
+    fp = tmp_path / "ffprobe"
+    _make_fake_ffmpeg(ff)
+    _make_fake_ffmpeg(fp)
+    _point_runtime_at(monkeypatch, ffmpeg=str(ff), ffprobe=str(fp), config_dir=tmp_path / "cfg")
+    system_check.check_ffmpeg()
+
+    called = []
+
+    def _explode(*args, **kwargs):
+        called.append(args)
+        raise AssertionError("subprocess.run should not be called on cache hit")
+
+    monkeypatch.setattr(subprocess, "run", _explode)
+    outcome = system_check.check_ffmpeg()
+    assert outcome.ok is True
+    assert called == []
+
+
+def test_stale_cache_re_verifies(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ff = tmp_path / "ffmpeg"
+    fp = tmp_path / "ffprobe"
+    _make_fake_ffmpeg(ff)
+    _make_fake_ffmpeg(fp)
+    _point_runtime_at(monkeypatch, ffmpeg=str(ff), ffprobe=str(fp), config_dir=tmp_path / "cfg")
+
+    # Write a stale positive cache entry from a day + change ago.
+    state_path = system_check._state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                system_check.CACHE_KEY: {
+                    "ok": True,
+                    "binary": str(ff),
+                    "ffprobe": str(fp),
+                    "ts": time.time() - (system_check.CACHE_TTL_S + 60),
+                }
+            }
+        )
+    )
+
+    called: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _spy(args, **kwargs):
+        called.append(list(args))
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _spy)
+    outcome = system_check.check_ffmpeg()
+    assert outcome.ok is True
+    # The probe re-ran -- subprocess called at least once.
+    assert called, "stale cache must trigger a re-verify"
+
+
+def test_negative_result_is_not_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    bogus = tmp_path / "missing-ffmpeg"
+    _point_runtime_at(monkeypatch, ffmpeg=str(bogus), ffprobe=str(bogus), config_dir=tmp_path / "cfg")
+
+    system_check.check_ffmpeg()
+    state_path = system_check._state_path()
+    if state_path.exists():
+        state = json.loads(state_path.read_text())
+        assert system_check.CACHE_KEY not in state
+
+
+def test_install_hint_is_platform_aware(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    hint = system_check._install_hint("ffmpeg")
+    assert "brew install ffmpeg" in hint
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    hint = system_check._install_hint("ffmpeg")
+    assert "apt install ffmpeg" in hint
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    hint = system_check._install_hint("ffmpeg")
+    assert "winget install" in hint
+
+
+def test_use_cache_false_forces_probe(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ff = tmp_path / "ffmpeg"
+    fp = tmp_path / "ffprobe"
+    _make_fake_ffmpeg(ff)
+    _make_fake_ffmpeg(fp)
+    _point_runtime_at(monkeypatch, ffmpeg=str(ff), ffprobe=str(fp), config_dir=tmp_path / "cfg")
+    system_check.check_ffmpeg()  # primes cache
+
+    called: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _spy(args, **kwargs):
+        called.append(list(args))
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _spy)
+    outcome = system_check.check_ffmpeg(use_cache=False)
+    assert outcome.ok is True
+    assert called, "use_cache=False must run the probe"


### PR DESCRIPTION
## Summary

Third phase of #377 (local-slim v1; one of two checkboxes in the "ffmpeg + install UX" section). The slim install ships ffmpeg / ffprobe as documented system deps. Before launching \`splitsmith ui\` we verify both are invocable and, if not, print a copy-pasteable install hint per OS instead of letting the user discover the failure mid-trim.

- **\`src/splitsmith/system_check.py\`** -- new module. \`check_ffmpeg()\` returns a typed \`FfmpegOutcome\` with \`.ok\` / \`.binary\` / \`.hint\`. Probes via the resolved \`runtime()\` paths so PyInstaller-bundled or env-overridden binaries are checked too. Positive results cached for 24h in \`state.json\` under \`runtime().user_config_dir\` so repeat launches don't re-spawn ffmpeg. Negative results never cache -- the user installs the dep + tries again on a fresh probe.
- **\`src/splitsmith/ui/server.py\` \`serve()\`** runs the check before uvicorn boots. On failure, prints the hint to stderr and exits 2.
- **\`splitsmith ui --skip-system-check\`** flag for debug / test bypass.

## Test plan

- [x] \`tests/test_system_check.py\` -- 8 tests: present + ok, missing -> hint, positive result cached, cache hit skips subprocess, stale cache re-verifies, negative result not cached, hint platform-aware (darwin / linux / win32), \`use_cache=False\` forces probe
- [x] \`uv run pytest -q\` -- 1313 pass, 4 skipped (was 1305; +8)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] CLI surface: existing tests for \`splitsmith ui\` pass (skip_system_check defaults to False in serve(); the new --skip-system-check flag is opt-in)

## Refs

Tracking: #377  
Doc: [\`docs/local-slim/04-packaging-and-install.md\`](./docs/local-slim/04-packaging-and-install.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)