### PR TITLE
feat(slim): PANN ONNX export + onnxruntime backend branch (first voter migrated)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,15 @@ dev = [
     # Dev-only: the production API does not read these files.
     "pyarrow>=17.0.0",
     "matplotlib>=3.9.0",
+    # ONNX export tooling (docs/local-slim/02). Needed when running
+    # scripts/export_*_onnx.py and tests/test_onnx_parity.py. The
+    # slim runtime path imports only ``onnxruntime``; ``onnxruntime``
+    # stays in [dev] until all three voters have ONNX branches and the
+    # full slim path replaces torch in [project] dependencies (see doc
+    # 06 "pyproject.toml changes" phase).
+    "onnx>=1.16.0",
+    "onnxruntime>=1.20.0",
+    "onnxscript>=0.1.0",
 ]
 
 [tool.ruff]

--- a/scripts/export_pann_onnx.py
+++ b/scripts/export_pann_onnx.py
@@ -1,0 +1,165 @@
+"""Export the PANN Cnn14 audio tagger to a self-contained ONNX file.
+
+Lands the slim-runtime ONNX path for Voter D (PANN gunshot probability)
+per docs/local-slim/02. The original spike (PR #84) tested only the
+shape and dtype of the export; this version consolidates external
+weight data into a single ``.onnx`` file so the slim model registry
+can fetch one artifact rather than a graph + sidecar pair.
+
+What it writes
+--------------
+``--out-dir`` defaults to ``build/onnx-spike/`` and ends up with:
+
+* ``pann_cnn14.onnx`` -- self-contained graph + weights (~312 MB FP32).
+  Input ``audio`` shape ``(batch, samples)`` at 32 kHz; output
+  ``clipwise_output`` shape ``(batch, 527)``. Mel-spec layer baked in.
+* ``pann_sample_audio.npy`` / ``pann_torch_reference.npy`` -- fixed-seed
+  parity inputs used by ``verify_onnx_parity.py`` and
+  ``tests/test_onnx_parity.py``.
+
+After export the script prints a copy-pasteable ``model_artifacts``
+JSON snippet (slug = ``pann_cnn14``) you paste into
+``src/splitsmith/data/ensemble_calibration.json`` once the artifact is
+uploaded to R2 (placeholder URL until then).
+
+Run:
+    uv run python scripts/export_pann_onnx.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+
+from splitsmith.ensemble.features import PANN_SR
+
+OUT_DIR = Path("build/onnx-spike")
+ONNX_OPSET = 17
+SAMPLE_LEN_S = 1.0
+ARTIFACT_SLUG = "pann_cnn14"
+PLACEHOLDER_URL_BASE = "https://models.splitsmith.app/artifacts"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _consolidate_external(onnx_path: Path) -> None:
+    """Merge external ``.data`` weights back into the ``.onnx`` file in place.
+
+    PyTorch's dynamo-based ``torch.onnx.export`` writes a small graph
+    file with weights in a sidecar ``<name>.data``. Slim users get one
+    artifact per slug, so we re-save with ``save_as_external_data=False``
+    and delete the sidecar.
+    """
+    import onnx
+    from onnx import TensorProto
+
+    model = onnx.load(str(onnx_path), load_external_data=True)
+    for init in model.graph.initializer:
+        if init.data_location == TensorProto.EXTERNAL:
+            init.data_location = TensorProto.DEFAULT
+            del init.external_data[:]
+    onnx.save(model, str(onnx_path), save_as_external_data=False)
+
+    sidecar = onnx_path.with_suffix(onnx_path.suffix + ".data")
+    if sidecar.exists():
+        sidecar.unlink()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--opset", type=int, default=ONNX_OPSET)
+    args = p.parse_args()
+
+    import torch
+    import torch.nn as nn
+    from panns_inference import AudioTagging
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Loading PANN Cnn14 (downloads ~80 MB on first run)")
+    tagger = AudioTagging(checkpoint_path=None, device="cpu")
+    inner = tagger.model
+    inner.eval()
+
+    class Cnn14Trunk(nn.Module):
+        """Returns just ``clipwise_output`` so ONNX sees a tensor, not a dict."""
+
+        def __init__(self, model: nn.Module) -> None:
+            super().__init__()
+            self.model = model
+
+        def forward(self, audio: torch.Tensor) -> torch.Tensor:
+            out = self.model(audio, None)
+            return out["clipwise_output"]
+
+    trunk = Cnn14Trunk(inner).eval()
+
+    rng = np.random.default_rng(0)
+    sample_audio = rng.standard_normal(int(PANN_SR * SAMPLE_LEN_S)).astype(np.float32) * 0.05
+    sample_path = args.out_dir / "pann_sample_audio.npy"
+    np.save(sample_path, sample_audio)
+    print(f"  wrote {sample_path}  shape={sample_audio.shape}")
+
+    dummy = torch.from_numpy(sample_audio[None, :])
+    with torch.no_grad():
+        torch_out = trunk(dummy).cpu().numpy()
+    print(f"  torch reference output shape={torch_out.shape}  dtype={torch_out.dtype}")
+
+    onnx_path = args.out_dir / "pann_cnn14.onnx"
+    print(f"Exporting ONNX -> {onnx_path}  (opset={args.opset})")
+    torch.onnx.export(
+        trunk,
+        (dummy,),
+        str(onnx_path),
+        input_names=["audio"],
+        output_names=["clipwise_output"],
+        dynamic_axes={
+            "audio": {0: "batch", 1: "samples"},
+            "clipwise_output": {0: "batch"},
+        },
+        opset_version=args.opset,
+        do_constant_folding=True,
+    )
+
+    print("  consolidating external weight data into a single .onnx file")
+    _consolidate_external(onnx_path)
+
+    ref_path = args.out_dir / "pann_torch_reference.npy"
+    np.save(ref_path, torch_out)
+    print(f"  wrote {ref_path} for parity check")
+
+    sha256 = _sha256_file(onnx_path)
+    size_bytes = onnx_path.stat().st_size
+    print(f"\n  final artifact: {onnx_path}")
+    print(f"    sha256: {sha256}")
+    print(f"    size:   {size_bytes/1024/1024:.1f} MiB ({size_bytes} bytes)")
+
+    snippet = {
+        ARTIFACT_SLUG: {
+            "filename": onnx_path.name,
+            "sha256": sha256,
+            "size_bytes": size_bytes,
+            "url": f"{PLACEHOLDER_URL_BASE}/{sha256}/{onnx_path.name}",
+        }
+    }
+    print("\n  model_artifacts snippet -- paste into ensemble_calibration.json:")
+    print(json.dumps(snippet, indent=2))
+    print(
+        "\nDone. Run scripts/verify_onnx_parity.py to compare ONNX vs torch, "
+        "or pytest tests/test_onnx_parity.py with SPLITSMITH_ONNX_PANN set."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_onnx_parity.py
+++ b/scripts/verify_onnx_parity.py
@@ -1,0 +1,90 @@
+"""Compare CLAP / PANN ONNX outputs against their torch references.
+
+Reads the artifacts written by ``export_clap_onnx.py`` and
+``export_pann_onnx.py`` from ``build/onnx-spike/`` and checks that
+``onnxruntime`` produces outputs matching the torch reference within
+tolerance. Tolerance defaults are deliberately tight (1e-4 absolute,
+1e-3 relative); loosen with ``--atol`` / ``--rtol`` if the platform
+introduces rounding drift.
+
+Exit code is non-zero if any check fails so this can run in CI once the
+full slim path lands.
+
+Run:
+    uv pip install onnxruntime
+    uv run python scripts/verify_onnx_parity.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+OUT_DIR = Path("build/onnx-spike")
+
+
+def _check(name: str, ref: np.ndarray, got: np.ndarray, atol: float, rtol: float) -> bool:
+    if ref.shape != got.shape:
+        print(f"  FAIL {name}: shape mismatch  ref={ref.shape}  got={got.shape}")
+        return False
+    diff = np.abs(ref - got)
+    max_abs = float(diff.max())
+    max_rel = float((diff / (np.abs(ref) + 1e-9)).max())
+    ok = np.allclose(ref, got, atol=atol, rtol=rtol)
+    flag = "PASS" if ok else "FAIL"
+    print(f"  {flag} {name}: max_abs={max_abs:.3e}  max_rel={max_rel:.3e}")
+    return ok
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--atol", type=float, default=1e-4)
+    p.add_argument("--rtol", type=float, default=1e-3)
+    args = p.parse_args()
+
+    import onnxruntime as ort
+
+    all_ok = True
+
+    clap_onnx = args.out_dir / "clap_audio.onnx"
+    if clap_onnx.exists():
+        print(f"CLAP: {clap_onnx}")
+        sample = np.load(args.out_dir / "clap_sample_input_features.npy")
+        ref = np.load(args.out_dir / "clap_torch_reference.npy")
+        sess = ort.InferenceSession(str(clap_onnx), providers=["CPUExecutionProvider"])
+        (got,) = sess.run(None, {"input_features": sample})
+        all_ok &= _check("clap_audio", ref, got, args.atol, args.rtol)
+    else:
+        print(f"CLAP: skip (missing {clap_onnx}; run export_clap_onnx.py first)")
+
+    pann_onnx = args.out_dir / "pann_cnn14.onnx"
+    if pann_onnx.exists():
+        print(f"\nPANN: {pann_onnx}")
+        sample = np.load(args.out_dir / "pann_sample_audio.npy")[None, :]
+        ref = np.load(args.out_dir / "pann_torch_reference.npy")
+        sess = ort.InferenceSession(str(pann_onnx), providers=["CPUExecutionProvider"])
+        (got,) = sess.run(None, {"audio": sample})
+        all_ok &= _check("pann_clipwise", ref, got, args.atol, args.rtol)
+
+        gunshot_idx = 427
+        ref_g = ref[:, gunshot_idx]
+        got_g = got[:, gunshot_idx]
+        all_ok &= _check("pann_gunshot_class", ref_g, got_g, args.atol, args.rtol)
+    else:
+        print(f"\nPANN: skip (missing {pann_onnx}; run export_pann_onnx.py first)")
+
+    print()
+    if all_ok:
+        print("All parity checks passed.")
+        sys.exit(0)
+    else:
+        print("Parity check FAILED. See diffs above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/splitsmith/ensemble/backend.py
+++ b/src/splitsmith/ensemble/backend.py
@@ -10,14 +10,18 @@ backend the loaders construct.
 See ``docs/local-slim/05-dev-vs-prod-parity.md`` for the parity
 contract and ``06-slim-progress.md`` for the migration status.
 
-Resolution order (matches doc 05):
+Resolution order:
 
 1. ``override`` argument to :func:`select_backend` -- callers can pin
    per-process (CLI ``--backend``).
 2. ``SPLITSMITH_BACKEND`` env var (``onnx`` / ``torch``).
-3. ``onnxruntime`` if importable -- the default for slim wheel users.
-4. ``torch`` if importable -- the default for contributors with the
-   dev extras installed.
+3. ``torch`` if importable -- preferred while only PANN has an ONNX
+   branch. CLAP and the visual probe still need torch, and the doc
+   05 invariant "one backend per process" means we can't mix mid-run.
+   When the remaining ONNX branches land, this preference flips to
+   "onnxruntime first" so slim wheel users (no torch installed) keep
+   working unchanged.
+4. ``onnxruntime`` if importable -- the slim wheel's only backend.
 5. Raise :class:`SplitsmithBackendError` with install hints for both.
 """
 
@@ -69,10 +73,14 @@ def select_backend(override: Backend | str | None = None) -> Backend:
                 f"Unknown backend {explicit!r}; expected one of " f"{[b.value for b in Backend]}"
             ) from exc
 
-    if _is_importable("onnxruntime"):
-        return Backend.ONNX
+    # During slim migration: torch wins when both are installed because
+    # only PANN has an ONNX branch (issue #377). When CLAP + visual ONNX
+    # land, swap these two checks so onnxruntime wins -- the slim wheel
+    # path (no torch installed) keeps working unchanged either way.
     if _is_importable("torch"):
         return Backend.TORCH
+    if _is_importable("onnxruntime"):
+        return Backend.ONNX
 
     raise SplitsmithBackendError(
         "No inference backend available. Install one of:\n"

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -18,8 +18,10 @@ prompt strings were used so loading checks the bank still matches.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import librosa
@@ -441,18 +443,81 @@ def _build_pann_runtime_torch() -> PannRuntime:
     )
 
 
+PANN_ARTIFACT_SLUG = "pann_cnn14"
+ENV_ONNX_PANN_OVERRIDE = "SPLITSMITH_ONNX_PANN"
+
+
+def _resolve_onnx_pann_path() -> Path:
+    """Locate the PANN ONNX artifact.
+
+    Order:
+    1. ``SPLITSMITH_ONNX_PANN`` env var -- dev / test override pointing
+       at a freshly exported file under ``build/onnx-spike/``.
+    2. The slim model registry -- ``ensemble_calibration.json`` must have
+       a ``model_artifacts.pann_cnn14`` block; the registry downloads
+       from R2 and SHA256-verifies. Raises clear errors if the block
+       isn't there yet (still in slim v1 rollout).
+    """
+    override = os.environ.get(ENV_ONNX_PANN_OVERRIDE)
+    if override:
+        path = Path(override)
+        if not path.is_file():
+            raise FileNotFoundError(f"{ENV_ONNX_PANN_OVERRIDE} points at {path}, which does not exist")
+        return path
+
+    from ..models import get_default_registry
+
+    registry = get_default_registry()
+    if registry is None:
+        raise RuntimeError(
+            "ONNX PANN backend selected but ensemble_calibration.json has no "
+            "model_artifacts block. Run `uv run python "
+            "scripts/export_pann_onnx.py` and paste the printed snippet into "
+            "src/splitsmith/data/ensemble_calibration.json, or point "
+            f"{ENV_ONNX_PANN_OVERRIDE} at a local export."
+        )
+    return registry.resolve(PANN_ARTIFACT_SLUG)
+
+
+def _build_pann_runtime_onnx() -> PannRuntime:
+    """Construct an onnxruntime-backed :class:`PannRuntime`.
+
+    Loads the consolidated single-file artifact produced by
+    ``scripts/export_pann_onnx.py``. Inference contract matches the
+    torch branch: ``(N, T)`` float32 audio at ``PANN_SR`` -> ``(N,)``
+    gunshot probability in numpy.
+    """
+    import onnxruntime as ort
+
+    onnx_path = _resolve_onnx_pann_path()
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+
+    def predict_gunshot_prob(batch: np.ndarray) -> np.ndarray:
+        audio = np.ascontiguousarray(batch.astype(np.float32, copy=False))
+        clipwise = session.run(None, {input_name: audio})[0]
+        return clipwise[:, PANN_GUNSHOT_CLASS_INDEX].astype(np.float32)
+
+    return PannRuntime(
+        predict_gunshot_prob=predict_gunshot_prob,
+        backend=Backend.ONNX,
+        tagger=None,
+    )
+
+
 def load_pann_runtime() -> PannRuntime:
     """Load PANN through the selected backend.
 
-    First call on the torch path downloads ~80 MB to ``~/panns_data/``;
-    ONNX path will fetch the slim artifact from R2 once doc 02 ships.
-    Reuse the returned runtime across detections.
+    First call on the torch path downloads ~80 MB to ``~/panns_data/``.
+    On the ONNX path, the consolidated ``pann_cnn14.onnx`` is resolved
+    via :func:`_resolve_onnx_pann_path` (env override or slim model
+    registry). Reuse the returned runtime across detections.
     """
     backend = select_backend()
     if backend is Backend.TORCH:
         return _build_pann_runtime_torch()
     if backend is Backend.ONNX:
-        raise NotImplementedError("ONNX PANN runtime not implemented yet (issue #377 phase 'ONNX exports')")
+        return _build_pann_runtime_onnx()
     raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 
 

--- a/tests/test_onnx_parity.py
+++ b/tests/test_onnx_parity.py
@@ -1,0 +1,115 @@
+"""ONNX vs torch parity for the slim runtime (issue #377 -- doc 05).
+
+Currently covers PANN only -- the first voter ported to ONNX. CLAP and
+the visual probe land in follow-up PRs against the same harness.
+
+The parity files are big enough that we don't commit them to git. The
+test discovers them via env vars (set by the build script or a
+contributor) and ``pytest.skip``s otherwise. Once the R2 hosting +
+slim registry path lands end-to-end, this test will pull the
+artifacts from the cache instead.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ENV_PANN_ONNX = "SPLITSMITH_ONNX_PANN"
+ENV_PANN_SAMPLE = "SPLITSMITH_ONNX_PANN_SAMPLE"
+ENV_PANN_REF = "SPLITSMITH_ONNX_PANN_REF"
+
+# Same per-voter tolerance as doc 05's parity table.
+PANN_L_INF_TOLERANCE = 1e-4
+
+
+def _require(env: str) -> Path:
+    value = os.environ.get(env)
+    if not value:
+        pytest.skip(
+            f"{env} not set -- export with scripts/export_pann_onnx.py and set "
+            f"{ENV_PANN_ONNX} / {ENV_PANN_SAMPLE} / {ENV_PANN_REF} to enable parity"
+        )
+    path = Path(value)
+    if not path.is_file():
+        pytest.skip(f"{env}={value!r} does not exist")
+    return path
+
+
+def test_pann_onnx_matches_torch_reference() -> None:
+    """The exported PANN ONNX produces clipwise outputs matching the saved torch reference."""
+    onnxruntime = pytest.importorskip("onnxruntime")
+
+    onnx_path = _require(ENV_PANN_ONNX)
+    sample_path = _require(ENV_PANN_SAMPLE)
+    ref_path = _require(ENV_PANN_REF)
+
+    sample = np.load(sample_path)
+    ref = np.load(ref_path)
+    if sample.ndim == 1:
+        sample = sample[None, :]
+
+    session = onnxruntime.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    out = session.run(None, {input_name: sample.astype(np.float32)})[0]
+
+    assert out.shape == ref.shape, f"shape mismatch: onnx={out.shape} ref={ref.shape}"
+    delta = float(np.abs(out - ref).max())
+    assert (
+        delta < PANN_L_INF_TOLERANCE
+    ), f"PANN ONNX vs torch parity exceeded {PANN_L_INF_TOLERANCE:.1e}: L_inf={delta:.3e}"
+
+
+def test_pann_onnx_runtime_branch_loads_and_predicts() -> None:
+    """End-to-end: load_pann_runtime() under ONNX backend produces gunshot probs."""
+    pytest.importorskip("onnxruntime")
+    onnx_path = _require(ENV_PANN_ONNX)
+    sample_path = _require(ENV_PANN_SAMPLE)
+
+    from splitsmith import runtime as runtime_module
+    from splitsmith.ensemble import features as feat
+
+    # Force the ONNX backend even if torch is also installed.
+    prior = os.environ.get("SPLITSMITH_BACKEND")
+    os.environ["SPLITSMITH_BACKEND"] = "onnx"
+    os.environ[ENV_PANN_ONNX] = str(onnx_path)
+    runtime_module._clear_runtime_cache()
+    try:
+        pann = feat.load_pann_runtime()
+        assert pann.backend.value == "onnx"
+        sample = np.load(sample_path)
+        if sample.ndim == 1:
+            sample = sample[None, :]
+        probs = pann.predict_gunshot_prob(sample.astype(np.float32))
+        assert probs.shape == (sample.shape[0],)
+        # Sanity: probability between 0 and 1.
+        assert (probs >= 0).all() and (probs <= 1.0).all()
+    finally:
+        if prior is None:
+            os.environ.pop("SPLITSMITH_BACKEND", None)
+        else:
+            os.environ["SPLITSMITH_BACKEND"] = prior
+        runtime_module._clear_runtime_cache()
+
+
+def test_pann_onnx_runtime_branch_raises_clear_error_without_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no artifact is reachable, the ONNX branch tells the user what to do."""
+    pytest.importorskip("onnxruntime")
+    from splitsmith.ensemble import features as feat
+    from splitsmith.models import registry as registry_mod
+
+    monkeypatch.setenv("SPLITSMITH_BACKEND", "onnx")
+    monkeypatch.delenv(ENV_PANN_ONNX, raising=False)
+    monkeypatch.setattr(registry_mod, "_default_registry", None)
+    monkeypatch.setattr(registry_mod, "load_spec_from_calibration", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc:
+        feat.load_pann_runtime()
+    msg = str(exc.value)
+    assert "scripts/export_pann_onnx.py" in msg
+    assert "ensemble_calibration.json" in msg

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,14 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.13' and python_full_version < '3.15'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.15' and platform_machine != 's390x'",
+    "python_full_version >= '3.15' and platform_machine == 's390x'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and platform_machine != 's390x'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and platform_machine == 's390x'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x'",
+    "python_full_version < '3.12' and platform_machine != 's390x'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x'",
+    "python_full_version < '3.12' and platform_machine == 's390x'",
 ]
 
 [[package]]
@@ -702,6 +707,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1389,6 +1402,47 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1779,6 +1833,112 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/93/942d2a0f6a70538eea042ce0445c8aefd46559ad153469986f29a743c01c/onnx-1.21.0.tar.gz", hash = "sha256:4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764", size = 12074608, upload-time = "2026-03-27T21:33:36.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/48/32e383aa6bc40b72a9fd419937aaa647078190c9bfccdc97b316d2dee687/onnx-1.21.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2aca19949260875c14866fc77ea0bc37e4e809b24976108762843d328c92d3ce", size = 17968053, upload-time = "2026-03-27T21:32:29.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/26/5726e8df7d36e96bb3c679912d1a86af42f393d77aa17d6b98a97d4289ce/onnx-1.21.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82aa6ab51144df07c58c4850cb78d4f1ae969d8c0bf657b28041796d49ba6974", size = 17534821, upload-time = "2026-03-27T21:32:32.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2b/021dcd2dd50c3c71b7959d7368526da384a295c162fb4863f36057973f78/onnx-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c3185a232089335581fabb98fba4e86d3e8246b8140f2e406082438100ebda", size = 17616664, upload-time = "2026-03-27T21:32:34.921Z" },
+    { url = "https://files.pythonhosted.org/packages/12/00/afa32a46fa122a7ed42df1cfe8796922156a3725ba8fc581c4779c96e2fc/onnx-1.21.0-cp311-cp311-win32.whl", hash = "sha256:f53b3c15a3b539c16b99655c43c365622046d68c49b680c48eba4da2a4fb6f27", size = 16289035, upload-time = "2026-03-27T21:32:37.783Z" },
+    { url = "https://files.pythonhosted.org/packages/73/8d/483cc980a24d4c0131d0af06d0ff6a37fb08ae90a7848ece8cef645194f1/onnx-1.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:5f78c411743db317a76e5d009f84f7e3d5380411a1567a868e82461a1e5c775d", size = 16443748, upload-time = "2026-03-27T21:32:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/38/78/9d06fd5aaaed1ec9cb8a3b70fbbf00c1bdc18db610771e96379f0ed58112/onnx-1.21.0-cp311-cp311-win_arm64.whl", hash = "sha256:ab6a488dabbb172eebc9f3b3e7ac68763f32b0c571626d4a5004608f866cc83d", size = 16406123, upload-time = "2026-03-27T21:32:45.159Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ae/cb644ec84c25e63575d9d8790fdcc5d1a11d67d3f62f872edb35fa38d158/onnx-1.21.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:fc2635400fe39ff37ebc4e75342cc54450eadadf39c540ff132c319bf4960095", size = 17965930, upload-time = "2026-03-27T21:32:48.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/eeb5903586645ef8a49b4b7892580438741acc3df91d7a5bd0f3a59ea9cb/onnx-1.21.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9003d5206c01fa2ff4b46311566865d8e493e1a6998d4009ec6de39843f1b59b", size = 17531344, upload-time = "2026-03-27T21:32:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9261bd580fb8548c9c37b3c6750387eb8f21ea43c63880d37b2c622e1684285", size = 17613697, upload-time = "2026-03-27T21:32:54.222Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1d/391f3c567ae068c8ac4f1d1316bae97c9eb45e702f05975fe0e17ad441f0/onnx-1.21.0-cp312-abi3-win32.whl", hash = "sha256:9ea4e824964082811938a9250451d89c4ec474fe42dd36c038bfa5df31993d1e", size = 16287200, upload-time = "2026-03-27T21:32:57.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a6/5eefbe5b40ea96de95a766bd2e0e751f35bdea2d4b951991ec9afaa69531/onnx-1.21.0-cp312-abi3-win_amd64.whl", hash = "sha256:458d91948ad9a7729a347550553b49ab6939f9af2cddf334e2116e45467dc61f", size = 16441045, upload-time = "2026-03-27T21:33:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c4/0ed8dc037a39113d2a4d66e0005e07751c299c46b993f1ad5c2c35664c20/onnx-1.21.0-cp312-abi3-win_arm64.whl", hash = "sha256:ca14bc4842fccc3187eb538f07eabeb25a779b39388b006db4356c07403a7bbb", size = 16403134, upload-time = "2026-03-27T21:33:03.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/89/0e1a9beb536401e2f45ac88735e123f2735e12fc7b56ff6c11727e097526/onnx-1.21.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:257d1d1deb6a652913698f1e3f33ef1ca0aa69174892fe38946d4572d89dd94f", size = 17975430, upload-time = "2026-03-27T21:33:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e6dc71a7b3b317265591b20a5f71d0ff5c0d26c24e52283139dc90c66038/onnx-1.21.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7cd7cb8f6459311bdb557cbf6c0ccc6d8ace11c304d1bba0a30b4a4688e245f8", size = 17537435, upload-time = "2026-03-27T21:33:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/27affcac63eaf2ef183a44fd1a1354b11da64a6c72fe6f3fdcf5571bcee5/onnx-1.21.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b58a4cfec8d9311b73dc083e4c1fa362069267881144c05139b3eba5dc3a840", size = 17617687, upload-time = "2026-03-27T21:33:12.619Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5c/ac8ed15e941593a3672ce424280b764979026317811f2e8508432bfc3429/onnx-1.21.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1a9baf882562c4cebf79589bebb7cd71a20e30b51158cac3e3bbaf27da6163bd", size = 16449402, upload-time = "2026-03-27T21:33:15.555Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/aa/d2231e0dcaad838217afc64c306c8152a080134d2034e247cc973d577674/onnx-1.21.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bba12181566acf49b35875838eba49536a327b2944664b17125577d230c637ad", size = 16408273, upload-time = "2026-03-27T21:33:18.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0a/8905b14694def6ad23edf1011fdd581500384062f8c4c567e114be7aa272/onnx-1.21.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:7ee9d8fd6a4874a5fa8b44bbcabea104ce752b20469b88bc50c7dcf9030779ad", size = 17975331, upload-time = "2026-03-27T21:33:21.69Z" },
+    { url = "https://files.pythonhosted.org/packages/61/28/f4e401e5199d1b9c8b76c7e7ae1169e050515258e877b58fa8bb49d3bdcc/onnx-1.21.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5489f25fe461e7f32128218251a466cabbeeaf1eaa791c79daebf1a80d5a2cc9", size = 17537430, upload-time = "2026-03-27T21:33:24.547Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/5d13320eb3660d5af360ea3b43aa9c63a70c92a9b4d1ea0d34501a32fcb8/onnx-1.21.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db17fc0fec46180b6acbd1d5d8650a04e5527c02b09381da0b5b888d02a204c8", size = 17617662, upload-time = "2026-03-27T21:33:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/50/3eaa1878338247be021e6423696813d61e77e534dccbd15a703a144e703d/onnx-1.21.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19d9971a3e52a12968ae6c70fd0f86c349536de0b0c33922ecdbe52d1972fe60", size = 16463688, upload-time = "2026-03-27T21:33:30.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/38d46b43bbb525e0b6a4c2c4204cc6795d67e45687a2f7403e06d8e7053d/onnx-1.21.0-cp314-cp314t-win_arm64.whl", hash = "sha256:efba467efb316baf2a9452d892c2f982b9b758c778d23e38c7f44fa211b30bb9", size = 16423387, upload-time = "2026-03-27T21:33:33.446Z" },
+]
+
+[[package]]
+name = "onnx-ir"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/e6/672fefb2f108d077f58181a7babf4c0f8d1182a30353ffc9c79c63afc5ee/onnx_ir-0.2.1.tar.gz", hash = "sha256:8b8b10a93f43e65962104de6070c43c5dacb0e3cdfefc7c8059dd83c9db64f35", size = 144279, upload-time = "2026-04-20T20:21:47.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/aa/f7a53321c60b9ad9ee184b6018292ed6b5389947592a2c8c09c736bb7f9e/onnx_ir-0.2.1-py3-none-any.whl", hash = "sha256:c7285da889312f91882de2092e298a9eeeefbfc1d1951c49d983992967eb09a7", size = 166792, upload-time = "2026-04-20T20:21:46.357Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/81/29a9eb470994a75eb7b3ccf32be314d7c66675a00ac7b50294816cc2db27/onnxruntime-1.26.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ee1109ef4ef27cad90e823399e61e03b3c6c7bfe0fb820b4baf3678c15be8b3c", size = 18005108, upload-time = "2026-05-08T19:08:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c7/73efa6c8a4000c38fcc14947d84f234a17e5d66f203b37b7f1ad4a7b46eb/onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35c7c7b0ac2e02001d28fab6c9fc24e9abc5e6faa35e6e19c63cecf1406ba89f", size = 16043752, upload-time = "2026-05-08T19:07:10.707Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/8de630f595daf6ce884d4dd95afd2a60e70ec6572e52bfee3aa2229befab/onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11a8df4dcfe9ad5ff0bd71a7571dbed019fabc7594676c89fe8b86ea029c246f", size = 18176043, upload-time = "2026-05-08T19:07:33.735Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/9f041de20787cd85498bd48e0ec4d098bf2a6c486e25b24b8dae1bf492b2/onnxruntime-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:e6456718125fd777c673f3b78d4a9ab58d6adea641e9afae85ee6444f0e0e9a9", size = 13023165, upload-time = "2026-05-08T19:08:00.633Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/82/3b9fe0ead2557cc3adf74c74c141bd1c7c4c6a9548c610af37df199f4512/onnxruntime-1.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:cd920e45b730e4a87833e2910d8ca375aaca9da6ccc09e24bce463b3356d637f", size = 12789514, upload-time = "2026-05-08T19:07:49.433Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/1dcf88e45e4c69db5f7b106f2dacc3801ba98994e082ca03e1dfdf7bfe57/onnxruntime-1.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:54a8053410fd31fd66469bd754fcfe8a4df9f7eb44756b4b5479bf50c842d948", size = 12796647, upload-time = "2026-05-08T19:07:52.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/64/0492c0b1db04e29b2630c87cfa36f9d6872b1ca8614b90c5cad58fac7d76/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdbed8cf3b672b66acb032f33a253bc27f42bce6ece48ae3fab4fa483a5e96e0", size = 16052634, upload-time = "2026-05-08T19:07:16.885Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/26/4d09ddc755a84fc8d5e192991626b0e0680e8f6c5d58f4f1d05c42bc48cf/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07af6fc6d5557835f2b6ee7a96d8b3235d0c57a8e230efdedaee106a8a3cbc6", size = 18185632, upload-time = "2026-05-08T19:07:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/3e52249aa08fa301e217ecba07b5246a8338fa2b401e109326e3fc5be0f9/onnxruntime-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:61bec80655efa460591c2bc655392d57d2650ce85533a6b9b3b7a790d7ea7916", size = 13026751, upload-time = "2026-05-08T19:08:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/c1c8782b14af6797c303de132d6eef26a9fb80dfacd3750ce57911d11c6b/onnxruntime-1.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a6677545ff451e3539a02746d2f207d8c5baa4a0a818886bb9d6a6eb9511ee89", size = 12796807, upload-time = "2026-05-08T19:07:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f5/47b0676408abec652c14b84d7173e389837832d850c24f87184277313e8d/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e016edc15d3c19f36807e1c6b10be5b27807688c32720f91b5ae480a95215d0", size = 16057265, upload-time = "2026-05-08T19:07:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/45/33ab6deeef010ca844c877dd618cebc079590bbe52d2a3678e7223b1b908/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5fc48a91a046a6a5c9b147f83fb41d65d24d24923373b222cdd248f0f4f4aac", size = 18197590, upload-time = "2026-05-08T19:07:41.422Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993", size = 18019724, upload-time = "2026-05-08T19:07:30.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/24/89457a35f6af29538a76647f2c18c3a28277e6c19234c847e7b4b7c19860/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e90c00732c4553618103149d93f688e8c3063017938f8983e21a71d9f3b6d22e", size = 16054821, upload-time = "2026-05-08T19:07:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f9/15b2e1815cf570d238e0135529f80d2dce64e8e8818a1489cae83823c5c6/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01498e80ba8988428d08c2d51b1338f89e3de2a93e6ffe555f79c68f26a5c06b", size = 18185815, upload-time = "2026-05-08T19:07:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/65/2e11055faf015e4b07f45b513fa49b391baf2e19d92d77d73ebee13c1004/onnxruntime-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:7ead61450d8405167c87dd3a31d8da1d576b490a57dab1aa8b82a7da6825f5aa", size = 13349887, upload-time = "2026-05-08T19:08:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
+name = "onnxscript"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "onnx-ir" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/99/fd948eba63ba65b52265a4cd09a14f96bb9f5b730fcef58876c4358bf406/onnxscript-0.7.0.tar.gz", hash = "sha256:c95ed7b339b02cface56ee27689565c46612e1fc542c562298dddfdad5268dc5", size = 612032, upload-time = "2026-04-20T17:09:19.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl", hash = "sha256:5b356907d4501e9919f8599c91d8da967406a37b1fac2b40caa55a49acf242ea", size = 714842, upload-time = "2026-04-20T17:09:22.089Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1927,6 +2087,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
 ]
 
 [[package]]
@@ -2856,6 +3031,9 @@ dev = [
     { name = "black" },
     { name = "matplotlib" },
     { name = "mypy" },
+    { name = "onnx" },
+    { name = "onnxruntime" },
+    { name = "onnxscript" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2891,6 +3069,9 @@ dev = [
     { name = "black", specifier = ">=24.0.0" },
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "mypy", specifier = ">=1.10.0" },
+    { name = "onnx", specifier = ">=1.16.0" },
+    { name = "onnxruntime", specifier = ">=1.20.0" },
+    { name = "onnxscript", specifier = ">=0.1.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Summary

Fourth phase of #377 (local-slim v1). First voter migrated to ONNX. Validates the full pipeline -- export script -> consolidated single-file artifact -> runtime branch via onnxruntime -> parity test -- on the smallest model before tackling CLAP's processor / mel-spec parity work in a follow-up PR.

Builds on the [spike in #84](https://github.com/mandakan/splitsmith/pull/84) (PANN export script). #84 was authored under a sandboxed env that blocked HF / Zenodo so the spike was untested; this PR ran the export locally and **confirmed parity at L_inf ~5e-7** (doc 05 tolerance is 1e-4).

- **\`scripts/export_pann_onnx.py\`** -- spike script + (1) consolidates external weights into a single \`.onnx\` file (~312 MiB FP32) and (2) emits a \`model_artifacts\` JSON snippet ready to paste into \`ensemble_calibration.json\` once R2 hosting lands
- **\`scripts/verify_onnx_parity.py\`** -- kept from the spike as a manual diagnostic
- **\`features.py::_build_pann_runtime_onnx\`** loads the artifact via \`onnxruntime.InferenceSession\`. Honors \`SPLITSMITH_ONNX_PANN\` env override; otherwise resolves through the slim model registry. Raises clear errors when neither path can produce the file. \`load_pann_runtime()\` routes to ONNX when the selected backend is ONNX.
- **\`backend.py::select_backend()\`** -- during the migration window (CLAP + visual ONNX still TODO), prefer torch when both backends are importable. The slim wheel path (no torch installed) still gets ONNX by elimination. Doc comment notes when the preference flips back to the doc 05 end-state.
- **\`tests/test_onnx_parity.py\`** -- 3 tests. Two require local exports (env vars) and skip otherwise; the third asserts the "no artifact" error path tells users to run the export script
- **pyproject** -- \`onnxruntime\` + \`onnx\` + \`onnxscript\` added to \`[dev]\` for the export scripts + parity tests. Moves to \`[project]\` dependencies in the later slim pyproject phase per doc 06

## Test plan

- [x] \`uv run python scripts/export_pann_onnx.py --out-dir ~/.claude-tmp/onnx-spike\` -- exports a 312 MiB \`.onnx\`
- [x] \`SPLITSMITH_ONNX_PANN=... SPLITSMITH_ONNX_PANN_SAMPLE=... SPLITSMITH_ONNX_PANN_REF=... uv run pytest tests/test_onnx_parity.py -v\` -- 3 pass with the local artifact present
- [x] \`uv run pytest tests/test_onnx_parity.py -v\` (no env) -- 2 skip cleanly, 1 passes (the "no artifact -> error" path)
- [x] \`uv run pytest -q\` -- 1337 pass, 6 skipped (was 1313 + 1 onnx-error-path + 2 skipped-parity-tests)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean

## Refs

Tracking: #377  
Supersedes the spike: #84 (close after this merges; export script lives here now)  
Docs: [\`docs/local-slim/02\`](./docs/local-slim/02-onnx-migration.md), [\`docs/local-slim/05\`](./docs/local-slim/05-dev-vs-prod-parity.md)

## Followups

- CLAP ONNX export + NumPy mel-spectrogram (next slim PR)
- CLIP visual encoder ONNX export
- R2 provisioning + actually uploading \`pann_cnn14.onnx\` + filling \`model_artifacts\` in calibration
- Once all three voters have ONNX branches: flip \`select_backend()\` preference back to ONNX-first per doc 05's end state, and move \`onnxruntime\` to \`[project]\` deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)