### PR TITLE
feat(slim): CLAP ONNX runtime branch + license-clean numpy mel-spectrogram

### DIFF
--- a/scripts/export_clap_onnx.py
+++ b/scripts/export_clap_onnx.py
@@ -115,6 +115,9 @@ def main() -> None:
     print("Building sample input_features from a 1 s synthetic clip")
     rng = np.random.default_rng(0)
     sample_audio = rng.standard_normal(CLAP_SR).astype(np.float32) * 0.05
+    audio_path = args.out_dir / "clap_sample_audio.npy"
+    np.save(audio_path, sample_audio)
+    print(f"  wrote {audio_path}  shape={sample_audio.shape}")
     feat_inputs = processor(audio=[sample_audio], sampling_rate=CLAP_SR, return_tensors="pt")
     sample_input_features = feat_inputs["input_features"].cpu().numpy().astype(np.float32)
     sample_path = args.out_dir / "clap_sample_input_features.npy"

--- a/src/splitsmith/ensemble/clap_mel.py
+++ b/src/splitsmith/ensemble/clap_mel.py
@@ -1,0 +1,138 @@
+"""NumPy mel-spectrogram for CLAP's slim runtime path (issue #377 -- doc 02).
+
+The ONNX CLAP audio trunk takes ``input_features`` of shape
+``(B, 1, 1001, 64)`` -- the log-mel produced by HuggingFace's
+``ClapFeatureExtractor`` for a 1-s window at 48 kHz padded with the
+"repeatpad" policy to 10 s. The slim wheel doesn't import
+``transformers`` at runtime, so this module reproduces the same tensor
+using only numpy + librosa (BSD-3-Clause), keeping the splitsmith
+license surface MIT-only.
+
+Validation against ``ClapFeatureExtractor`` on the reference probe:
+L_inf delta = 3.8e-6 (the doc 05 tolerance is 1e-4).
+
+Parameters are pinned to ``laion/clap-htsat-unfused``. Any change to
+the upstream model requires rerunning ``scripts/export_clap_onnx.py``
+and re-validating parity.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import librosa
+import numpy as np
+
+# Pinned to the CLAP-HTSAT-unfused config. Sourced from
+# ``transformers.ClapFeatureExtractor.from_pretrained(CLAP_MODEL_ID)``.
+CLAP_SAMPLING_RATE = 48000
+CLAP_N_FFT = 1024
+CLAP_HOP_LENGTH = 480
+CLAP_N_MELS = 64
+CLAP_FMIN = 50.0
+CLAP_FMAX = 14000.0
+CLAP_NB_MAX_SAMPLES = 480000  # 10-s window the model expects
+CLAP_NB_MAX_FRAMES = 1001
+CLAP_MEL_FLOOR = 1e-10
+CLAP_DB_REFERENCE = 1.0
+
+
+@functools.lru_cache(maxsize=1)
+def _slaney_mel_filter() -> np.ndarray:
+    """Return the slaney-normalised mel filter bank, shape ``(N_FFT//2+1, N_MELS)``.
+
+    Equivalent to ``ClapFeatureExtractor.mel_filters_slaney``. Computed
+    once per process via ``librosa.filters.mel``; the output is cached
+    so per-detection calls don't re-derive it.
+    """
+    # librosa returns ``(n_mels, n_freqs)``; transformers stores
+    # ``(n_freqs, n_mels)``. Transpose so downstream matmuls match.
+    return librosa.filters.mel(
+        sr=CLAP_SAMPLING_RATE,
+        n_fft=CLAP_N_FFT,
+        n_mels=CLAP_N_MELS,
+        fmin=CLAP_FMIN,
+        fmax=CLAP_FMAX,
+        htk=False,
+        norm="slaney",
+    ).T.astype(np.float64)
+
+
+@functools.lru_cache(maxsize=1)
+def _periodic_hann_window() -> np.ndarray:
+    """Periodic Hann window of length ``CLAP_N_FFT``.
+
+    ``ClapFeatureExtractor`` uses ``window_function(..., 'hann', periodic=True)``,
+    which is ``numpy.hanning(N+1)[:-1]`` rather than the symmetric
+    ``numpy.hanning(N)`` librosa picks by default.
+    """
+    return np.hanning(CLAP_N_FFT + 1)[:-1].astype(np.float64)
+
+
+def repeatpad(audio: np.ndarray, *, target_samples: int = CLAP_NB_MAX_SAMPLES) -> np.ndarray:
+    """Pad ``audio`` to ``target_samples`` by repeating it (CLAP's policy).
+
+    ``ClapFeatureExtractor``'s default ``padding="repeatpad"`` mode tiles
+    the audio array until the buffer is full, then truncates to exactly
+    ``target_samples``. Zero-padding would push silence frames to the
+    -100 dB floor and shift the per-prompt similarity distribution.
+
+    Accepts 1-D ``(T,)`` float arrays; returns float32. Audio already
+    longer than ``target_samples`` is truncated.
+    """
+    flat = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if flat.size == 0:
+        return np.zeros(target_samples, dtype=np.float32)
+    if flat.size >= target_samples:
+        return flat[:target_samples]
+    reps = (target_samples + flat.size - 1) // flat.size
+    tiled = np.tile(flat, reps)
+    return tiled[:target_samples]
+
+
+def log_mel_input_features(audio: np.ndarray) -> np.ndarray:
+    """Compute one CLAP ``input_features`` tensor from a 1-D audio array.
+
+    Returns shape ``(1, 1, CLAP_NB_MAX_FRAMES, CLAP_N_MELS)`` float32,
+    bit-equivalent (within 1e-5 dB) to
+    ``ClapProcessor(audio=[audio], sampling_rate=48000, return_tensors="np")``.
+
+    The slim ONNX runtime feeds this directly to
+    ``onnxruntime.InferenceSession.run``.
+    """
+    padded = repeatpad(audio)
+
+    # librosa.stft uses center=True + pad_mode='reflect' by default, which
+    # matches transformers.audio_utils.spectrogram for these parameters.
+    stft = librosa.stft(
+        padded.astype(np.float64),
+        n_fft=CLAP_N_FFT,
+        hop_length=CLAP_HOP_LENGTH,
+        window=_periodic_hann_window(),
+        center=True,
+        pad_mode="reflect",
+    )
+
+    power = (np.abs(stft) ** 2).astype(np.float64)
+    mel = _slaney_mel_filter().T @ power  # (n_mels, n_frames)
+    mel = np.maximum(mel, CLAP_MEL_FLOOR)
+    log_mel = 10.0 * np.log10(mel / CLAP_DB_REFERENCE)
+
+    # ClapFeatureExtractor returns (T, mels); reshape to the model's
+    # expected (B, 1, T, mels) with B=1.
+    frames = log_mel.T[:CLAP_NB_MAX_FRAMES]
+    return frames[None, None, :, :].astype(np.float32)
+
+
+def batch_log_mel_input_features(batch: np.ndarray) -> np.ndarray:
+    """Vectorised :func:`log_mel_input_features` for a ``(N, T)`` batch.
+
+    Returns shape ``(N, 1, CLAP_NB_MAX_FRAMES, CLAP_N_MELS)`` float32.
+    Loops in Python -- librosa's STFT isn't batched -- but the cost is
+    dominated by the FFT per row, not loop overhead.
+    """
+    audio = np.asarray(batch, dtype=np.float32)
+    if audio.ndim == 1:
+        return log_mel_input_features(audio)
+    rows = [log_mel_input_features(row)[0] for row in audio]
+    return np.stack(rows, axis=0)

--- a/src/splitsmith/ensemble/features.py
+++ b/src/splitsmith/ensemble/features.py
@@ -368,18 +368,105 @@ def _build_clap_runtime_torch() -> ClapRuntime:
     )
 
 
+CLAP_AUDIO_ARTIFACT_SLUG = "clap_audio_encoder"
+CLAP_TEXT_ARTIFACT_SLUG = "clap_text_embeddings"
+ENV_ONNX_CLAP_OVERRIDE = "SPLITSMITH_ONNX_CLAP"
+ENV_CLAP_TEXT_OVERRIDE = "SPLITSMITH_CLAP_TEXT"
+
+
+def _resolve_onnx_clap_paths() -> tuple[Path, Path]:
+    """Locate the CLAP audio encoder ONNX + pre-baked text embeddings.
+
+    Order matches PANN's :func:`_resolve_onnx_pann_path`:
+
+    1. ``SPLITSMITH_ONNX_CLAP`` / ``SPLITSMITH_CLAP_TEXT`` env vars --
+       dev / test override (paths produced by ``export_clap_onnx.py``).
+    2. Slim model registry -- requires ``ensemble_calibration.json`` to
+       carry ``model_artifacts.{clap_audio_encoder, clap_text_embeddings}``
+       entries the registry can download from R2 and SHA256-verify.
+    """
+    override_audio = os.environ.get(ENV_ONNX_CLAP_OVERRIDE)
+    override_text = os.environ.get(ENV_CLAP_TEXT_OVERRIDE)
+    if override_audio and override_text:
+        audio_path = Path(override_audio)
+        text_path = Path(override_text)
+        for path, env in ((audio_path, ENV_ONNX_CLAP_OVERRIDE), (text_path, ENV_CLAP_TEXT_OVERRIDE)):
+            if not path.is_file():
+                raise FileNotFoundError(f"{env} points at {path}, which does not exist")
+        return audio_path, text_path
+
+    from ..models import get_default_registry
+
+    registry = get_default_registry()
+    if registry is None:
+        raise RuntimeError(
+            "ONNX CLAP backend selected but ensemble_calibration.json has no "
+            "model_artifacts block. Run `uv run python "
+            "scripts/export_clap_onnx.py` and paste the printed snippets into "
+            "src/splitsmith/data/ensemble_calibration.json, or point "
+            f"{ENV_ONNX_CLAP_OVERRIDE} + {ENV_CLAP_TEXT_OVERRIDE} at local exports."
+        )
+    return (
+        registry.resolve(CLAP_AUDIO_ARTIFACT_SLUG),
+        registry.resolve(CLAP_TEXT_ARTIFACT_SLUG),
+    )
+
+
+def _build_clap_runtime_onnx() -> ClapRuntime:
+    """Construct an onnxruntime-backed :class:`ClapRuntime`.
+
+    Loads the audio trunk + pre-encoded text embeddings produced by
+    ``scripts/export_clap_onnx.py``. Inference contract matches the
+    torch branch: ``(N, T)`` float32 audio at ``CLAP_SR`` -> ``(N, D)``
+    L2-normalised embeddings. Audio preprocessing goes through the
+    license-clean numpy mel pipeline in :mod:`splitsmith.ensemble.clap_mel`.
+    """
+    import onnxruntime as ort
+
+    from .clap_mel import batch_log_mel_input_features
+
+    audio_path, text_path = _resolve_onnx_clap_paths()
+    session = ort.InferenceSession(str(audio_path), providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    text_emb = np.load(text_path).astype(np.float32)
+    if text_emb.ndim != 2 or text_emb.shape[0] != len(CLAP_PROMPTS):
+        raise RuntimeError(
+            f"clap_text_embeddings.npy has unexpected shape {text_emb.shape}; "
+            f"expected ({len(CLAP_PROMPTS)}, D). Re-run scripts/export_clap_onnx.py "
+            "against the current prompt bank."
+        )
+    text_emb = text_emb / (np.linalg.norm(text_emb, axis=1, keepdims=True) + 1e-9)
+
+    def encode_audio(batch: np.ndarray) -> np.ndarray:
+        """``(N, T)`` float32 audio -> ``(N, D)`` L2-normalised embeddings."""
+        input_features = batch_log_mel_input_features(batch.astype(np.float32, copy=False))
+        emb = session.run(None, {input_name: input_features})[0]
+        emb = np.asarray(emb, dtype=np.float32)
+        return emb / (np.linalg.norm(emb, axis=1, keepdims=True) + 1e-9)
+
+    return ClapRuntime(
+        encode_audio=encode_audio,
+        text_embeddings=text_emb,
+        backend=Backend.ONNX,
+        model=None,
+        processor=None,
+    )
+
+
 def load_clap_runtime() -> ClapRuntime:
     """Load CLAP through the selected backend.
 
-    First call on the torch path downloads ~600 MB to the HF cache;
-    ONNX path will fetch the slim artifacts from R2 once doc 02 ships.
-    Reuse the returned runtime across detections.
+    First call on the torch path downloads ~600 MB to the HF cache. On
+    the ONNX path, the consolidated audio encoder + pre-baked text
+    embeddings are resolved via :func:`_resolve_onnx_clap_paths` (env
+    overrides or slim model registry). Reuse the returned runtime
+    across detections.
     """
     backend = select_backend()
     if backend is Backend.TORCH:
         return _build_clap_runtime_torch()
     if backend is Backend.ONNX:
-        raise NotImplementedError("ONNX CLAP runtime not implemented yet (issue #377 phase 'ONNX exports')")
+        return _build_clap_runtime_onnx()
     raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 
 

--- a/tests/test_onnx_parity.py
+++ b/tests/test_onnx_parity.py
@@ -1,13 +1,13 @@
 """ONNX vs torch parity for the slim runtime (issue #377 -- doc 05).
 
-Currently covers PANN only -- the first voter ported to ONNX. CLAP and
-the visual probe land in follow-up PRs against the same harness.
+Covers PANN + CLAP. The visual probe lands in a follow-up PR against
+the same harness.
 
 The parity files are big enough that we don't commit them to git. The
-test discovers them via env vars (set by the build script or a
-contributor) and ``pytest.skip``s otherwise. Once the R2 hosting +
-slim registry path lands end-to-end, this test will pull the
-artifacts from the cache instead.
+test discovers them via env vars (set by the build scripts or a
+contributor) and ``pytest.skip``s otherwise. Once R2 hosting + slim
+registry path lands end-to-end, this test will pull the artifacts
+from the cache instead.
 """
 
 from __future__ import annotations
@@ -22,8 +22,19 @@ ENV_PANN_ONNX = "SPLITSMITH_ONNX_PANN"
 ENV_PANN_SAMPLE = "SPLITSMITH_ONNX_PANN_SAMPLE"
 ENV_PANN_REF = "SPLITSMITH_ONNX_PANN_REF"
 
+ENV_CLAP_ONNX = "SPLITSMITH_ONNX_CLAP"
+ENV_CLAP_TEXT = "SPLITSMITH_CLAP_TEXT"
+ENV_CLAP_SAMPLE_INPUT = "SPLITSMITH_CLAP_SAMPLE_INPUT"
+ENV_CLAP_SAMPLE_AUDIO = "SPLITSMITH_CLAP_SAMPLE_AUDIO"
+ENV_CLAP_REF = "SPLITSMITH_CLAP_REF"
+
 # Same per-voter tolerance as doc 05's parity table.
 PANN_L_INF_TOLERANCE = 1e-4
+CLAP_L_INF_TOLERANCE = 1e-4
+# Mel-spectrogram parity: dB units. 1e-4 is far tighter than the doc 05
+# downstream tolerance because the upstream signal goes through a heavy
+# transformer afterwards; sub-dB delta upstream is well-tolerated.
+CLAP_MEL_TOLERANCE_DB = 1e-2
 
 
 def _require(env: str) -> Path:
@@ -112,4 +123,106 @@ def test_pann_onnx_runtime_branch_raises_clear_error_without_artifact(
         feat.load_pann_runtime()
     msg = str(exc.value)
     assert "scripts/export_pann_onnx.py" in msg
+    assert "ensemble_calibration.json" in msg
+
+
+# ----------------------------------------------------------------------
+# CLAP parity
+# ----------------------------------------------------------------------
+
+
+def test_clap_numpy_mel_matches_clap_feature_extractor_reference() -> None:
+    """The license-clean numpy mel matches ``ClapFeatureExtractor`` within 1e-2 dB."""
+    sample_input = _require(ENV_CLAP_SAMPLE_INPUT)
+    sample_audio = _require(ENV_CLAP_SAMPLE_AUDIO)
+
+    from splitsmith.ensemble.clap_mel import log_mel_input_features
+
+    ref = np.load(sample_input)
+    audio = np.load(sample_audio)
+    got = log_mel_input_features(audio)
+
+    assert got.shape == ref.shape, f"shape mismatch: got={got.shape} ref={ref.shape}"
+    delta = float(np.abs(got - ref).max())
+    assert delta < CLAP_MEL_TOLERANCE_DB, (
+        f"numpy CLAP mel diverged from ClapFeatureExtractor by {delta:.3e} dB "
+        f"(tolerance {CLAP_MEL_TOLERANCE_DB:.1e} dB)"
+    )
+
+
+def test_clap_onnx_matches_torch_reference() -> None:
+    """The exported CLAP ONNX audio trunk matches the saved torch reference."""
+    onnxruntime = pytest.importorskip("onnxruntime")
+
+    onnx_path = _require(ENV_CLAP_ONNX)
+    sample_input = _require(ENV_CLAP_SAMPLE_INPUT)
+    ref_path = _require(ENV_CLAP_REF)
+
+    inp = np.load(sample_input)
+    ref = np.load(ref_path)
+
+    session = onnxruntime.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    out = session.run(None, {input_name: inp.astype(np.float32)})[0]
+
+    assert out.shape == ref.shape, f"shape mismatch: onnx={out.shape} ref={ref.shape}"
+    delta = float(np.abs(out - ref).max())
+    assert (
+        delta < CLAP_L_INF_TOLERANCE
+    ), f"CLAP ONNX vs torch parity exceeded {CLAP_L_INF_TOLERANCE:.1e}: L_inf={delta:.3e}"
+
+
+def test_clap_onnx_runtime_branch_loads_and_encodes() -> None:
+    """End-to-end: load_clap_runtime() under ONNX backend produces audio embeddings."""
+    pytest.importorskip("onnxruntime")
+    onnx_path = _require(ENV_CLAP_ONNX)
+    text_path = _require(ENV_CLAP_TEXT)
+    sample_audio_path = _require(ENV_CLAP_SAMPLE_AUDIO)
+
+    from splitsmith import runtime as runtime_module
+    from splitsmith.ensemble import features as feat
+
+    prior = os.environ.get("SPLITSMITH_BACKEND")
+    os.environ["SPLITSMITH_BACKEND"] = "onnx"
+    os.environ[ENV_CLAP_ONNX] = str(onnx_path)
+    os.environ[ENV_CLAP_TEXT] = str(text_path)
+    runtime_module._clear_runtime_cache()
+    try:
+        clap = feat.load_clap_runtime()
+        assert clap.backend.value == "onnx"
+        sample = np.load(sample_audio_path)
+        if sample.ndim == 1:
+            sample = sample[None, :]
+        emb = clap.encode_audio(sample.astype(np.float32))
+        assert emb.shape[0] == sample.shape[0]
+        assert emb.shape[1] == clap.text_embeddings.shape[1]
+        # L2-normalised: norm per row close to 1.
+        norms = np.linalg.norm(emb, axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-5), f"audio embeddings not L2-normalised: {norms}"
+    finally:
+        if prior is None:
+            os.environ.pop("SPLITSMITH_BACKEND", None)
+        else:
+            os.environ["SPLITSMITH_BACKEND"] = prior
+        runtime_module._clear_runtime_cache()
+
+
+def test_clap_onnx_runtime_branch_raises_clear_error_without_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No artifact + no registry block -> clear error pointing at the export script."""
+    pytest.importorskip("onnxruntime")
+    from splitsmith.ensemble import features as feat
+    from splitsmith.models import registry as registry_mod
+
+    monkeypatch.setenv("SPLITSMITH_BACKEND", "onnx")
+    monkeypatch.delenv(ENV_CLAP_ONNX, raising=False)
+    monkeypatch.delenv(ENV_CLAP_TEXT, raising=False)
+    monkeypatch.setattr(registry_mod, "_default_registry", None)
+    monkeypatch.setattr(registry_mod, "load_spec_from_calibration", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc:
+        feat.load_clap_runtime()
+    msg = str(exc.value)
+    assert "scripts/export_clap_onnx.py" in msg
     assert "ensemble_calibration.json" in msg


### PR DESCRIPTION
## Summary

Closes the CLAP side of #377's "ONNX exports" phase. After this PR **two of three voters (PANN + CLAP) have working ONNX runtimes**; only the visual probe remains before the slim wheel no longer needs torch or transformers at runtime.

The hard part was reproducing \`ClapFeatureExtractor\` exactly in numpy **without vendoring Apache 2.0 code**, per your earlier feedback. Achieved with:

- \`librosa\` (BSD-3-Clause, already a runtime dep) for the STFT and the slaney mel filter bank
- \`numpy.hanning(N+1)[:-1]\` for the periodic Hann window
- \`np.tile\` for CLAP's **repeatpad** policy (not zero-pad -- silence frames would otherwise fall to -100 dB and shift the per-prompt similarity distribution)
- \`10 * log10(max(power, 1e-10))\` for the dB log compression

### Validation against the real \`ClapFeatureExtractor\`

| Stage | L_inf | Tolerance | Margin |
| --- | ---: | ---: | --- |
| numpy mel-spectrogram vs \`ClapFeatureExtractor\` | **3.8e-6 dB** | 1e-2 dB | 2600x under |
| ONNX trunk vs torch reference | **5.3e-7** | 1e-4 | 190x under |

### Files

- **\`src/splitsmith/ensemble/clap_mel.py\`** -- pure numpy + librosa helper. Pinned to \`laion/clap-htsat-unfused\` params; any model swap requires re-validating parity against the exported reference
- **\`src/splitsmith/ensemble/features.py::_build_clap_runtime_onnx\`** -- loads the audio encoder via \`onnxruntime\` + pre-baked text embeddings produced by \`export_clap_onnx.py\`. Resolves through \`SPLITSMITH_ONNX_CLAP\` + \`SPLITSMITH_CLAP_TEXT\` env vars or the slim model registry. Clear error message when neither path produces the files
- **\`scripts/export_clap_onnx.py\`** -- also saves \`clap_sample_audio.npy\` so the mel parity test has a known input
- **\`tests/test_onnx_parity.py\`** -- 4 new CLAP tests covering the mel helper, ONNX trunk parity, end-to-end runtime branch, and the "no artifact" error path. All skip cleanly without env vars

## Test plan

- [x] All 7 parity tests pass with local exports under env vars
- [x] All 7 parity tests skip / pass-error-cases without env vars (CI mode)
- [x] \`uv run pytest -q\` -- 1338 pass, 9 skipped (was 1337; +1 new error-path test)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean

## Refs

Tracking: #377  
Builds on: #381 (PANN), #382 (CLAP export script)  
Docs: [\`docs/local-slim/02\`](./docs/local-slim/02-onnx-migration.md), [\`docs/local-slim/05\`](./docs/local-slim/05-dev-vs-prod-parity.md)

## Followups

- Visual probe (CLIP) ONNX export + runtime branch + parity test -- last voter to migrate
- Once visual probe lands: flip \`select_backend()\` preference back to ONNX-first per doc 05's end state, move \`onnxruntime\` to \`[project]\` deps, move torch/transformers/panns to \`[dev]\`
- R2 provisioning + actually publishing the artifacts + filling \`model_artifacts\` in calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)