### PR TITLE
feat(slim): move heavy ML deps to [dev], promote onnxruntime to runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
         run: uv python install 3.11
 
       - name: Sync dependencies
-        run: uv sync --frozen
+        # --all-groups so the dev group (torch / transformers /
+        # panns-inference + the ONNX export tools + lint + tests) is
+        # installed alongside the slim runtime deps. The shipped wheel
+        # is still slim; CI has to exercise both backends.
+        run: uv sync --frozen --all-groups
 
       - name: Lint (ruff)
         run: uv run ruff check src tests scripts

--- a/docs/local-slim/05-dev-vs-prod-parity.md
+++ b/docs/local-slim/05-dev-vs-prod-parity.md
@@ -13,8 +13,15 @@ test.
 
 | Backend          | Used by                                  | Models live where | Imports |
 | ---------------- | ---------------------------------------- | ----------------- | ------- |
-| **ONNX Runtime** | All end users with the slim wheel install. The default everywhere onnxruntime is installed. | `~/.splitsmith/models/artifacts/<sha>/...` (doc 03) | `onnxruntime`, `numpy` |
-| **Torch**        | Contributors with the dev extras installed who want to debug a model against the original PyTorch checkpoints. | `~/.cache/huggingface/hub/` and `~/panns_data/` | `torch`, `transformers`, `panns_inference` |
+| **ONNX Runtime** | All end users with the slim wheel install (the only backend available when torch isn't installed). | `~/.splitsmith/models/artifacts/<sha>/...` (doc 03) | `onnxruntime`, `numpy`, `librosa` |
+| **Torch**        | Contributors with the dev extras installed. Preferred when both backends are importable so the local model caches under `~/.cache/huggingface/hub/` and `~/panns_data/` continue to work without R2. | `~/.cache/huggingface/hub/` and `~/panns_data/` | `torch`, `transformers`, `panns_inference` |
+
+`select_backend()` resolves to torch when `import torch` succeeds,
+falling back to onnxruntime when only `import onnxruntime` succeeds.
+End users on the slim wheel have only `onnxruntime` installed; they
+reach the ONNX branch by elimination. Contributors with the dev
+extras can opt into ONNX explicitly via `SPLITSMITH_BACKEND=onnx`
+when debugging a slim-runtime regression.
 
 The two backends are equally first-class for **inference**. The
 parity test is bidirectional: changes to either backend must keep

--- a/docs/local-slim/06-slim-progress.md
+++ b/docs/local-slim/06-slim-progress.md
@@ -32,55 +32,48 @@ detection inside the <300 MB on-disk target.
 
 ### Foundation -- backend abstraction in the codebase
 
-These can ship before any ONNX artifact exists. Each is a refactor
-that makes today's torch code pass through a backend selector
-without behavioural change.
-
-- [ ] Add `src/splitsmith/ensemble/backend.py` with the `Backend`
-  enum and `select_backend()`. ONNX path raises NotImplementedError
-  for now. (See doc 05.)
-- [ ] Refactor `load_clap_runtime`, `load_pann_runtime`,
-  `load_visual_runtime` to return a typed runtime dataclass with
-  numpy-in / numpy-out callables. Today's torch implementation
-  becomes the torch branch of the selector. (See doc 05.)
-- [ ] Refactor `compute_clap_similarities`,
-  `compute_pann_gunshot_probs`, and CLIP visual inference to call
-  the typed callable rather than the model directly. No `import
-  torch` in these functions. (See doc 02.)
-- [ ] Add `tests/test_no_torch_in_prod_path.py` -- patches
-  `sys.modules['torch']` to None and runs a tiny detection. Becomes
-  a regression sentinel for accidental torch imports. (See doc 05.)
+- [x] `src/splitsmith/ensemble/backend.py` with `Backend` enum +
+  `select_backend()`. **PR #378.** Preference: torch wins when both
+  installed (dev path with model caches); ONNX wins when only
+  onnxruntime is installed (slim wheel). End users on the slim wheel
+  reach the ONNX branch by elimination.
+- [x] `load_clap_runtime`, `load_pann_runtime`,
+  `load_visual_runtime` return typed runtime dataclasses with numpy
+  callables. **PR #378.**
+- [x] `compute_*` functions go through the typed callable; no
+  module-level torch imports. **PR #378.**
+- [x] `tests/test_no_torch_in_prod_path.py` sentinel. **PR #378.**
 
 ### ONNX exports
 
-- [ ] Extend `scripts/build_ensemble_artifacts.py` with a `--onnx`
-  flag that exports `clap_audio_encoder.onnx`,
-  `clap_text_embeddings.npy`, `pann_cnn14.onnx`,
-  `clip_visual_encoder.onnx`. (See doc 02.)
-- [ ] Pre-bake CLAP text embeddings from the locked prompt bank;
-  write `clap_text_embeddings.npy` and a sibling JSON with prompt
-  order. (See doc 02.)
-- [ ] Vendor a small PANN CNN14 export script that loads the
-  upstream `Cnn14_mAP=0.431.pth` checkpoint and traces a
-  `(1, 320000)` forward pass to ONNX. (See doc 02.)
-- [ ] Validate `optimum.exporters.onnx` covers CLAP cleanly. If not,
-  add a manual `torch.onnx.export` fallback. (Doc 00 open question.)
-- [ ] Write a NumPy mel-spectrogram helper that matches
-  `transformers.ClapProcessor`'s output exactly. (See doc 02 open
-  questions; required for parity.)
-- [ ] Add `model_artifacts` block writer to the build script -- per
-  artifact: filename, sha256, size, R2 URL. Writes into
-  `src/splitsmith/data/ensemble_calibration.json`. (See doc 02.)
+- [x] PANN CNN14 export (`scripts/export_pann_onnx.py`) -- raw audio
+  in, gunshot probability out; mel-spec layer baked into the graph.
+  **PR #381 + #84 spike.**
+- [x] CLAP audio encoder export + pre-baked text embeddings
+  (`scripts/export_clap_onnx.py`). **PR #382.**
+- [x] Pure-numpy mel-spectrogram for CLAP (no Apache-2.0 vendoring;
+  uses BSD-3 librosa + numpy primitives). Parity vs
+  `ClapFeatureExtractor`: L_inf 3.8e-6 dB. **PR #383.**
+- [-] CLIP visual encoder export. Deferred to v2 with Voter E ONNX
+  migration; Voter E is off by default (`enable_voter_e=False`,
+  gated by `SPLITSMITH_ENABLE_VOTER_E`) and explicitly out of slim
+  v1. To use Voter E today, install dev extras
+  (`uv sync --all-groups`) so the torch backend stays available.
+- [ ] `--upload` step on the export scripts: SHA256 + size +
+  filename + R2 URL written into a `model_artifacts` block in
+  `ensemble_calibration.json` and uploaded via `wrangler r2 object
+  put`. Manual snippet emission already works; wrapper still TODO.
 
 ### Parity testing
 
-- [ ] Add `tests/test_onnx_parity.py` with per-voter L_inf checks
-  against the existing fixtures. Tolerances from doc 05. (See doc 05.)
-- [ ] Add the end-to-end parity test: full ensemble on each fixture,
-  compare consensus shot times exact, signal arrays within ±15 ms.
-  (See doc 05.)
-- [ ] Wire the parity tests into the dev-extras CI matrix. (See
-  doc 04.)
+- [x] `tests/test_onnx_parity.py` for PANN + CLAP. Each test
+  pytest.skip()s when its env-var-resolved artifact isn't present so
+  CI without the export-time toolchain still runs cleanly. **PR
+  #381 + #383.**
+- [ ] End-to-end full-ensemble parity test once R2 + artifact upload
+  lands so CI can pull artifacts on demand.
+- [ ] Wire the parity tests into the dev-extras CI matrix (today
+  they run locally with env vars set).
 
 ### Model hosting infrastructure
 
@@ -97,41 +90,43 @@ without behavioural change.
 
 ### Slim runtime model layer
 
-- [ ] Add `src/splitsmith/models/` module: manifest schema parsing,
-  download with sha256 verification, on-disk cache layout under
-  `~/.splitsmith/models/`, lock file. (See doc 03.)
-- [ ] Use `huggingface_hub`'s download helper (pointed at our own
-  URL) for resumable HTTP + etag caching. (See doc 03.)
-- [ ] Implement typed failure modes (`NetworkUnreachable`,
-  `HttpError`, `HashMismatch`) and clear user-facing messages.
-  (See doc 03.)
-- [ ] Add the `splitsmith fetch-models` CLI command with
-  `--verify` / `--force` / `--list` flags. (See doc 03 + doc 04.)
-- [ ] Wire the FastAPI server's `/api/models/status` endpoint and
-  the frontend overlay that shows download progress when artifacts
-  are missing or in-flight. (See doc 03.)
+- [x] `src/splitsmith/models/` module: manifest parsing, on-disk
+  cache layout, SHA256 streaming verify, exclusive cross-process
+  lock. **PR #379.**
+- [x] httpx-only resumable download with retry on transient network
+  failure; no retry on hash mismatch. **PR #379.** (huggingface_hub's
+  helper deferred -- httpx covers the v1 contract.)
+- [x] Typed failure modes (`NetworkUnreachable`, `HttpError`,
+  `HashMismatch`). **PR #379.**
+- [x] `splitsmith fetch-models --list / --verify / --force` CLI.
+  **PR #379.**
+- [x] `GET /api/models/status` endpoint reports per-artifact
+  present / missing / mismatched. Frontend overlay still TODO; the
+  endpoint is in place for the SPA to consume. **PR #379.**
 
 ### `pyproject.toml` changes
 
-- [ ] Remove `torch`, `transformers`, `panns-inference` from
-  `[project] dependencies`. (See doc 04.)
-- [ ] Add `onnxruntime>=1.20.0` and `huggingface_hub>=0.26.0` to
-  `[project] dependencies`. (See doc 04.)
-- [ ] Move `torch`, `transformers`, `panns-inference` into
-  `[dependency-groups] dev`; add `optimum` and `onnx`. (See doc 04.)
-- [ ] Add `[project.optional-dependencies] gpu =
-  ["onnxruntime-gpu"]`. (See doc 04.)
-- [ ] Update `[tool.hatch.build.targets.wheel] exclude` to drop
-  `**/data/onnx/**`. (See doc 04.)
+- [x] `torch`, `transformers`, `panns-inference` moved to
+  `[dependency-groups] dev`. **PR #384.**
+- [x] `onnxruntime>=1.20.0` + `huggingface_hub>=0.26.0` promoted to
+  `[project] dependencies`. **PR #384.**
+- [x] `onnx` + `onnxscript` kept in `[dev]` alongside torch for the
+  export scripts + parity tests. **PR #384.**
+- [-] `[project.optional-dependencies] gpu = ["onnxruntime-gpu"]`.
+  Deferred until measured demand from a CUDA user; CPU path covers
+  the desktop app at responsive cold-start times.
+- [-] `[tool.hatch.build.targets.wheel] exclude` for `**/data/onnx/**`.
+  Not needed yet -- no ONNX files live under `src/splitsmith/data/`.
+  Reconsider when the R2 upload tooling lands.
 
 ### ffmpeg + install UX
 
-- [ ] First-launch ffmpeg check with friendly install instructions
-  per OS. Cache the positive result in
-  `~/.splitsmith/state.json` for 24h. (See doc 04.)
-- [ ] README install section rewrite: `uv tool install splitsmith`
-  as the primary path; `splitsmith fetch-models` as the optional
-  pre-fetch step. (See doc 04.)
+- [x] First-launch ffmpeg check + 24h positive-result cache in
+  `state.json`; platform-aware install hints (darwin / linux /
+  win32). **PR #380.**
+- [ ] README install section rewrite around `uv tool install
+  splitsmith` + optional `splitsmith fetch-models`. Pending the R2
+  hosting phase landing so the upgrade story is true.
 
 ### Release gating
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,16 @@ dependencies = [
     # Auto-loads <project>/.env / .env.local so SPLITSMITH_SSI_TOKEN works
     # without the user having to ``export`` it before launching the UI.
     "python-dotenv>=1.0.0",
-    # Ensemble shot-detection runtime (issue #31). Heavy ML deps live in
-    # the runtime path because the production audit UI needs voters
-    # B (CLAP), C (GBDT), and D (PANN) to seed shots[] correctly.
-    # Re-evaluate later if first-launch model download or wheel size
-    # becomes a problem.
+    # Ensemble shot-detection runtime. Voter C (GBDT) lives via
+    # scikit-learn + joblib. Voters B (CLAP) and D (PANN, folded into
+    # C as a feature) use the slim ONNX runtime path (#377). Heavy
+    # torch / transformers / panns-inference moved to [dev] -- they
+    # power the export scripts + the optional Voter E visual probe,
+    # not the shipped audit hot path.
     "scikit-learn>=1.8.0",
     "joblib>=1.4.0",
-    "torch>=2.11.0",
-    "panns-inference>=0.1.1",
-    "transformers>=5.7.0",
+    "onnxruntime>=1.20.0",
+    "huggingface_hub>=0.26.0",
     # Model Context Protocol server (issue #211). Wraps the existing
     # HTTP / library APIs as tools any MCP-aware client can drive.
     # Stdio transport is the default; SSE comes for free.
@@ -80,13 +80,18 @@ dev = [
     "matplotlib>=3.9.0",
     # ONNX export tooling (docs/local-slim/02). Needed when running
     # scripts/export_*_onnx.py and tests/test_onnx_parity.py. The
-    # slim runtime path imports only ``onnxruntime``; ``onnxruntime``
-    # stays in [dev] until all three voters have ONNX branches and the
-    # full slim path replaces torch in [project] dependencies (see doc
-    # 06 "pyproject.toml changes" phase).
+    # slim runtime imports ``onnxruntime`` (in [project] deps); this
+    # group pulls in the export-side tools.
     "onnx>=1.16.0",
-    "onnxruntime>=1.20.0",
     "onnxscript>=0.1.0",
+    # Heavy ML libs for: (a) the optional Voter E visual probe (off
+    # by default, requires SPLITSMITH_ENABLE_VOTER_E=1), (b) running
+    # build_ensemble_artifacts.py + export_*_onnx.py against the
+    # upstream torch checkpoints, (c) parity tests against the torch
+    # reference. End users on the slim wheel never see these.
+    "torch>=2.11.0",
+    "transformers>=5.7.0",
+    "panns-inference>=0.1.1",
 ]
 
 [tool.ruff]

--- a/src/splitsmith/ensemble/visual.py
+++ b/src/splitsmith/ensemble/visual.py
@@ -131,8 +131,16 @@ def load_visual_runtime(
             probe, model_id=model_id, device=device, frame_cache_dir=frame_cache_dir
         )
     if backend is Backend.ONNX:
+        # Voter E is opt-in (off by default; gated behind
+        # ``SPLITSMITH_ENABLE_VOTER_E=1`` + ``EnsembleConfig.enable_voter_e``)
+        # and explicitly out of the slim v1 ONNX migration. End users on
+        # the slim wheel never reach here unless they deliberately turn
+        # Voter E on -- in which case they need the dev extras for the
+        # torch CLIP path.
         raise NotImplementedError(
-            "ONNX visual probe runtime not implemented yet " "(issue #377 phase 'ONNX exports')"
+            "Voter E (visual probe) ONNX runtime is not implemented in slim v1. "
+            "To use Voter E, install the dev extras (uv sync --all-groups) so "
+            "the torch backend is available, or unset SPLITSMITH_ENABLE_VOTER_E."
         )
     raise SplitsmithBackendError(f"Unknown backend {backend!r}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3007,11 +3007,12 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "huggingface-hub" },
     { name = "joblib" },
     { name = "librosa" },
     { name = "mcp" },
     { name = "numpy" },
-    { name = "panns-inference" },
+    { name = "onnxruntime" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -3020,8 +3021,6 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "soundfile" },
-    { name = "torch" },
-    { name = "transformers" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -3032,24 +3031,27 @@ dev = [
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "onnx" },
-    { name = "onnxruntime" },
     { name = "onnxscript" },
+    { name = "panns-inference" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "huggingface-hub", specifier = ">=0.26.0" },
     { name = "joblib", specifier = ">=1.4.0" },
     { name = "librosa", specifier = ">=0.10.2" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.26.0" },
-    { name = "panns-inference", specifier = ">=0.1.1" },
+    { name = "onnxruntime", specifier = ">=1.20.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -3058,8 +3060,6 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.13.0" },
     { name = "soundfile", specifier = ">=0.12.1" },
-    { name = "torch", specifier = ">=2.11.0" },
-    { name = "transformers", specifier = ">=5.7.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
@@ -3070,13 +3070,15 @@ dev = [
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "onnx", specifier = ">=1.16.0" },
-    { name = "onnxruntime", specifier = ">=1.20.0" },
     { name = "onnxscript", specifier = ">=0.1.0" },
+    { name = "panns-inference", specifier = ">=0.1.1" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "respx", specifier = ">=0.21.1" },
     { name = "ruff", specifier = ">=0.4.0" },
+    { name = "torch", specifier = ">=2.11.0" },
+    { name = "transformers", specifier = ">=5.7.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the pyproject phase of #377. **The slim wheel now ships without torch / transformers / panns_inference.** Voter B (CLAP) + Voter D (PANN, folded into C) run through the ONNX runtime path landed in #381 + #383. End users on the slim wheel hit the ONNX branch by elimination -- \`select_backend()\` resolves to torch when importable (dev path with model caches), and to onnxruntime otherwise.

- **\`pyproject.toml\`**
  - Move \`torch>=2.11\`, \`transformers>=5.7\`, \`panns-inference>=0.1.1\` from \`[project] dependencies\` -> \`[dependency-groups] dev\`
  - Promote \`onnxruntime>=1.20\` + \`huggingface_hub>=0.26\` -> \`[project] dependencies\`
  - \`onnx\` + \`onnxscript\` stay in \`[dev]\` for the export scripts + parity tests
- **\`.github/workflows/ci.yml\`** -- \`uv sync --frozen --all-groups\` so CI exercises both backends. The shipped wheel stays slim.
- **\`src/splitsmith/ensemble/visual.py\`** -- \`load_visual_runtime\` ONNX branch raises a clear \`NotImplementedError\` pointing users at \`uv sync --all-groups\`. Voter E is opt-in + off by default (\`enable_voter_e=False\`, gated by \`SPLITSMITH_ENABLE_VOTER_E\`); its ONNX migration is **explicitly deferred to slim v2**.
- **\`docs/local-slim/05\` + \`06\`** -- backend selection table rewritten around "torch wins when importable; ONNX is the slim wheel's only backend by elimination". Completed v1 checkboxes flipped; Voter E moved to v2 with a deferral note.

## Wheel-size impact

Per \`docs/local-slim/01\` baseline numbers:
- \`torch\` (380 MB) -> [dev]
- \`transformers\` (50 MB) -> [dev]
- \`panns-inference\` (~70 KB but drags torch) -> [dev]
- \`onnxruntime\` (~15 MB) -> runtime
- \`huggingface_hub\` (~3-5 MB) -> runtime

Net: ~430 MB removed from the runtime install, ~20 MB added. The shipped slim wheel surface falls from ~1.1 GB to ~100 MB.

## Test plan

- [x] \`uv sync --all-groups\` -- resolves 137 packages, both backends installable
- [x] \`uv run pytest -q\` -- 1338 pass, 9 skipped (unchanged)
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean
- [x] CLI surface unchanged: \`splitsmith ui\` / \`detect\` / \`single\` etc. all still work under dev install (torch backend)
- [ ] **Validates fully only after R2 hosting lands** -- the slim wheel install (\`uv tool install splitsmith\`, no dev extras) would today fail with "no model_artifacts block" when loading CLAP / PANN, because the registry has nothing to resolve. Once the calibration JSON ships with R2 URLs, the slim wheel becomes operational.

## Refs

Tracking: #377  
Builds on: #378 (foundation), #379 (model layer), #380 (ffmpeg check), #381 (PANN), #382 (CLAP export), #383 (CLAP runtime)  
Docs: [\`docs/local-slim/04\`](./docs/local-slim/04-packaging-and-install.md), [\`docs/local-slim/05\`](./docs/local-slim/05-dev-vs-prod-parity.md), [\`docs/local-slim/06\`](./docs/local-slim/06-slim-progress.md)

## Remaining slim v1 work (not in this PR)

- R2 provisioning + manifest upload (needs your Cloudflare access)
- Filling \`model_artifacts\` block in shipped \`ensemble_calibration.json\` with the R2 SHAs from the export scripts
- README rewrite around \`uv tool install splitsmith\` + optional \`splitsmith fetch-models\`
- Release gating CI job (\`uv build\` + slim-wheel smoke detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)