### PR TITLE
feat(slim): R2 publish + boto3 multipart + calibration model_artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ dev = [
     "torch>=2.11.0",
     "transformers>=5.7.0",
     "panns-inference>=0.1.1",
+    # S3 multipart upload to Cloudflare R2 (scripts/upload_model_artifacts.py).
+    # wrangler caps single PUTs at 300 MiB; PANN's consolidated ONNX
+    # is ~312 MiB so we route through R2's S3-compatible endpoint.
+    "boto3>=1.35.0",
 ]
 
 [tool.ruff]

--- a/scripts/upload_model_artifacts.py
+++ b/scripts/upload_model_artifacts.py
@@ -4,17 +4,25 @@ End-to-end maintainer workflow (issue #377 -- doc 02 + doc 03):
 
 1. Run ``scripts/export_pann_onnx.py`` and
    ``scripts/export_clap_onnx.py`` to produce ``build/onnx-spike/``.
-2. Authenticate Wrangler against the Cloudflare account that owns
-   ``splitsmith.app`` (``wrangler login`` -- one-time per machine).
-3. Run this script. It SHA256s each artifact, runs
-   ``wrangler r2 object put splitsmith-models/artifacts/<sha>/<filename>``,
-   then patches the ``model_artifacts`` block in
+2. Provide R2 credentials. Two paths:
+   - **boto3 path (recommended, no size limit)**: set
+     ``R2_ACCESS_KEY_ID`` + ``R2_SECRET_ACCESS_KEY`` env vars
+     (create the keys at
+     ``https://dash.cloudflare.com/?to=/:account/r2/api-tokens``).
+     This routes uploads through R2's S3-compatible endpoint with
+     multipart support; needed for the PANN artifact which is
+     ~312 MiB (above wrangler's 300 MiB single-PUT cap).
+   - **wrangler fallback**: run ``wrangler login`` once. Works for
+     artifacts under 300 MiB.
+3. Run this script. It SHA256s each artifact, uploads to
+   ``splitsmith-models/artifacts/<sha>/<filename>``, then patches
+   the ``model_artifacts`` block in
    ``src/splitsmith/data/ensemble_calibration.json``. The next wheel
    build picks up the new SHAs; existing wheels keep working because
    the SHA-keyed URLs are immutable.
 
 The script is idempotent: re-running with the same artifacts is a
-no-op (Wrangler reports "already exists"). When an artifact's SHA
+no-op (object content matches existing). When an artifact's SHA
 changes (re-export with different upstream weights, opset bump),
 the new entry coexists with the old one in R2 -- doc 03 mandates
 that old SHAs stay reachable so older wheels keep working.
@@ -30,6 +38,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -41,6 +50,10 @@ DEFAULT_BUCKET = "splitsmith-models"
 DEFAULT_BASE_URL = "https://models.splitsmith.app"
 DEFAULT_BUILD_DIR = Path("build/onnx-spike")
 DEFAULT_CALIBRATION = Path("src/splitsmith/data/ensemble_calibration.json")
+DEFAULT_ACCOUNT_ID = "e1854db8e2a989281305b1b229319c31"
+ENV_R2_ACCESS_KEY_ID = "R2_ACCESS_KEY_ID"
+ENV_R2_SECRET_ACCESS_KEY = "R2_SECRET_ACCESS_KEY"
+ENV_CF_ACCOUNT_ID = "CF_ACCOUNT_ID"
 
 
 @dataclass(frozen=True)
@@ -82,7 +95,13 @@ def _wrangler_put(
     dry_run: bool,
     wrangler_bin: str,
 ) -> None:
-    cmd = [wrangler_bin, "r2", "object", "put", f"{bucket}/{key}", f"--file={file}"]
+    # ``--remote`` targets the real R2 bucket. Without it, wrangler v4+
+    # writes to a local emulator under ``.wrangler/state/`` and silently
+    # reports "Upload complete"; the artifact never reaches R2. Burned
+    # us once on 2026-05-23 -- the bucket was empty after a successful-
+    # looking run. The flag is a no-op on older wrangler that didn't
+    # have local emulation.
+    cmd = [wrangler_bin, "r2", "object", "put", f"{bucket}/{key}", f"--file={file}", "--remote"]
     if dry_run:
         print(f"  DRY-RUN: would run {' '.join(cmd)}")
         return
@@ -94,12 +113,60 @@ def _wrangler_put(
         raise SystemExit(f"wrangler r2 object put failed (rc={result.returncode})")
 
 
+def _s3_put(
+    s3_client,
+    bucket: str,
+    key: str,
+    file: Path,
+    *,
+    dry_run: bool,
+) -> None:
+    """Upload via R2's S3-compatible endpoint. Auto-multipart for large files."""
+    if dry_run:
+        print(f"  DRY-RUN: would S3 PUT s3://{bucket}/{key} ({file.stat().st_size / 1024 / 1024:.1f} MiB)")
+        return
+    print(f"  S3 PUT s3://{bucket}/{key}")
+    # ``upload_file`` uses S3TransferManager which multipart-uploads
+    # files above 8 MiB by default. No special handling needed for the
+    # 300 MiB+ PANN artifact.
+    s3_client.upload_file(
+        Filename=str(file),
+        Bucket=bucket,
+        Key=key,
+        ExtraArgs={"ContentType": "application/octet-stream"},
+    )
+
+
+def _make_s3_client(account_id: str):
+    """Build a boto3 S3 client pointed at R2's S3-compatible endpoint."""
+    try:
+        import boto3
+    except ImportError as exc:
+        raise SystemExit(
+            "boto3 is required for the S3 upload path. Install with "
+            "`uv sync --all-groups` or unset R2_ACCESS_KEY_ID to fall "
+            "back to the wrangler path."
+        ) from exc
+    access_key = os.environ[ENV_R2_ACCESS_KEY_ID]
+    secret_key = os.environ[ENV_R2_SECRET_ACCESS_KEY]
+    return boto3.client(
+        "s3",
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+    )
+
+
 def _load_calibration(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
 def _save_calibration(path: Path, payload: dict) -> None:
-    serialised = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    # Preserve insertion order; sorting alphabetically would churn the
+    # whole file every time the build script runs even when only the
+    # ``model_artifacts`` block changed.
+    serialised = json.dumps(payload, indent=2) + "\n"
     path.write_text(serialised)
 
 
@@ -112,13 +179,27 @@ def upload_all(
     calibration_path: Path,
     dry_run: bool,
     wrangler_bin: str,
+    use_s3: bool,
+    account_id: str,
+    force_upload: bool = False,
 ) -> dict[str, dict]:
+    """Upload-and-pin each artifact; skip the network call when bytes already match.
+
+    The R2 keys are content-addressed (``artifacts/<sha>/<filename>``)
+    so a re-export that produced identical bytes lands at the same URL
+    that the calibration JSON already pins. In that case we skip the
+    S3 PUT entirely -- saves the upload bandwidth and makes it safe to
+    invoke this script on every commit. ``force_upload=True`` bypasses
+    the skip for cache-wipe / disaster-recovery scenarios.
+    """
     base_url = base_url.rstrip("/")
     payload = _load_calibration(calibration_path)
     block = dict(payload.get("model_artifacts") or {})
     existing_base_url = block.get("base_url")
+    s3_client = _make_s3_client(account_id) if (use_s3 and not dry_run) else None
 
     updated: dict[str, dict] = {}
+    skipped = 0
     for spec in artifacts:
         local = build_dir / spec.local_filename
         if not local.is_file():
@@ -130,7 +211,19 @@ def upload_all(
         size_bytes = local.stat().st_size
         key = f"artifacts/{sha}/{spec.remote}"
         print(f"\n  {spec.slug}: {local} ({size_bytes/1024/1024:.1f} MiB, sha={sha[:12]}...)")
-        _wrangler_put(bucket, key, local, dry_run=dry_run, wrangler_bin=wrangler_bin)
+
+        existing = block.get(spec.slug) or {}
+        already_pinned = existing.get("sha256") == sha and existing.get("filename") == spec.remote
+        if already_pinned and not force_upload:
+            print("    skip: calibration already pins this SHA; R2 object is immutable")
+            updated[spec.slug] = existing
+            skipped += 1
+            continue
+
+        if use_s3:
+            _s3_put(s3_client, bucket, key, local, dry_run=dry_run)
+        else:
+            _wrangler_put(bucket, key, local, dry_run=dry_run, wrangler_bin=wrangler_bin)
         entry = {
             "filename": spec.remote,
             "sha256": sha,
@@ -147,6 +240,8 @@ def upload_all(
     if dry_run:
         print("\n  DRY-RUN: would write the following model_artifacts block:")
         print(json.dumps(block, indent=2))
+    elif skipped == len(updated):
+        print(f"\n  no changes -- all {skipped} artifact(s) already pinned in {calibration_path}")
     else:
         _save_calibration(calibration_path, payload)
         print(f"\n  wrote model_artifacts -> {calibration_path}")
@@ -165,6 +260,28 @@ def main() -> None:
     p.add_argument("--calibration", type=Path, default=DEFAULT_CALIBRATION)
     p.add_argument("--wrangler", default="wrangler", help="Wrangler binary on PATH or absolute path.")
     p.add_argument(
+        "--account-id",
+        default=os.environ.get(ENV_CF_ACCOUNT_ID, DEFAULT_ACCOUNT_ID),
+        help=(
+            f"Cloudflare account ID for the S3-compatible endpoint. "
+            f"Default: ${ENV_CF_ACCOUNT_ID} env var, then the splitsmith.app account."
+        ),
+    )
+    p.add_argument(
+        "--force-wrangler",
+        action="store_true",
+        help="Skip the boto3/S3 path even when R2 creds are set (useful for testing).",
+    )
+    p.add_argument(
+        "--force-upload",
+        action="store_true",
+        help=(
+            "Upload even when the calibration JSON already pins the local file's "
+            "SHA (used for cache-wipe / disaster recovery). Without this flag, "
+            "unchanged artifacts are skipped to save bandwidth."
+        ),
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help="Compute SHA / report what would happen, but don't upload or modify calibration.",
@@ -178,12 +295,24 @@ def main() -> None:
     )
     args = p.parse_args()
 
-    if not args.dry_run and shutil.which(args.wrangler) is None:
+    use_s3 = (
+        not args.force_wrangler
+        and ENV_R2_ACCESS_KEY_ID in os.environ
+        and ENV_R2_SECRET_ACCESS_KEY in os.environ
+    )
+    if not args.dry_run and not use_s3 and shutil.which(args.wrangler) is None:
         raise SystemExit(
-            f"{args.wrangler!r} not on PATH. Install via `npm install -g wrangler`, " "then `wrangler login`."
+            f"{args.wrangler!r} not on PATH and no R2 S3 credentials set. Either "
+            "install wrangler (`npm install -g wrangler && wrangler login`) or "
+            f"export {ENV_R2_ACCESS_KEY_ID} + {ENV_R2_SECRET_ACCESS_KEY} for the "
+            "boto3 path."
         )
     if not args.calibration.is_file():
         raise SystemExit(f"calibration JSON not found at {args.calibration}")
+    if use_s3:
+        print(f"upload path: S3 (boto3) via {args.account_id}.r2.cloudflarestorage.com")
+    else:
+        print("upload path: wrangler")
 
     to_upload = [a for a in KNOWN_ARTIFACTS if a.slug not in set(args.skip)]
     if not to_upload:
@@ -197,6 +326,9 @@ def main() -> None:
         calibration_path=args.calibration,
         dry_run=args.dry_run,
         wrangler_bin=args.wrangler,
+        use_s3=use_s3,
+        account_id=args.account_id,
+        force_upload=args.force_upload,
     )
     if args.dry_run:
         print("\nDry-run complete. Re-run without --dry-run to actually upload.")

--- a/src/splitsmith/data/ensemble_calibration.json
+++ b/src/splitsmith/data/ensemble_calibration.json
@@ -224,5 +224,25 @@
     "missing_video_fixtures": []
   },
   "n_mined_negatives_used": 0,
-  "mining_source_fixtures": []
+  "mining_source_fixtures": [],
+  "model_artifacts": {
+    "pann_cnn14": {
+      "filename": "pann_cnn14.onnx",
+      "sha256": "8cce942c0c42adea31dcd3d7ee3e6cc1920a877b9977209265aaf4b180a7c81b",
+      "size_bytes": 327411500,
+      "url": "https://models.splitsmith.app/artifacts/8cce942c0c42adea31dcd3d7ee3e6cc1920a877b9977209265aaf4b180a7c81b/pann_cnn14.onnx"
+    },
+    "clap_audio_encoder": {
+      "filename": "clap_audio.onnx",
+      "sha256": "9a736ca337c59cba54d62380c3d36b27f0b1bfd8f00e0f418d6d03578bcca0c7",
+      "size_bytes": 119594930,
+      "url": "https://models.splitsmith.app/artifacts/9a736ca337c59cba54d62380c3d36b27f0b1bfd8f00e0f418d6d03578bcca0c7/clap_audio.onnx"
+    },
+    "clap_text_embeddings": {
+      "filename": "clap_text_embeddings.npy",
+      "sha256": "85c6b195aefe9894512846558177edfbc24c351db0021a07452a7be2973589e4",
+      "size_bytes": 20608,
+      "url": "https://models.splitsmith.app/artifacts/85c6b195aefe9894512846558177edfbc24c351db0021a07452a7be2973589e4/clap_text_embeddings.npy"
+    }
+  }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -934,6 +962,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2786,6 +2823,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3028,6 +3077,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "boto3" },
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "onnx" },
@@ -3067,6 +3117,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=24.0.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "onnx", specifier = ">=1.16.0" },


### PR DESCRIPTION
## Summary

**The slim runtime is now operational end-to-end.** PANN + CLAP audio encoder + CLAP text embeddings are live at \`models.splitsmith.app\`; the shipped calibration JSON pins their SHAs; \`uv tool install splitsmith\` produces a working slim wheel that fetches artifacts on first detection.

| Slug | Size | URL HTTP status |
| --- | ---: | --- |
| pann_cnn14 | 312 MiB | 200 |
| clap_audio_encoder | 114 MiB | 200 |
| clap_text_embeddings | 20 KiB | 200 |

## Why boto3

- \`wrangler v4\` caps single-PUT at **300 MiB**; PANN's consolidated ONNX is **312 MiB**.
- Cloudflare's native R2 API endpoint caps at ~100 MiB.
- R2's **S3-compatible endpoint** with boto3's S3TransferManager auto-multipart handles 312 MiB cleanly (and any future size).
- Wrangler stays as the fallback for under-300-MiB artifacts when only \`wrangler login\` is available.

## Idempotency / version management

How model URLs relate to app versions (answering your question):

- URLs are **content-addressed**: \`artifacts/<sha256>/<filename>\`. Identical exports produce identical URLs.
- The wheel's \`ensemble_calibration.json\` pins SHAs; that JSON is the only file that needs to change when models change.
- The upload helper now **reads the existing model_artifacts block and skips the S3 PUT** for any slug whose calibration-pinned SHA matches the local file. Validated: re-running the upload after the first one shows "skip: calibration already pins this SHA" for all three artifacts (zero network).
- **Bumping wheel version for non-model reasons costs nothing**: the calibration JSON stays bit-identical, the R2 URLs stay valid, slim wheel users hit a cache HIT on the SHA-keyed URL.
- **Re-export with new weights** produces a new SHA -> new URL. The new entry coexists with the old one in R2 (per doc 03 immutability), so older wheels in the wild keep working forever.
- \`--force-upload\` bypasses the skip for cache-wipe / disaster recovery.

## Other fixes

- \`--remote\` flag added to the wrangler fallback path. Wrangler v4 defaults to a **local emulator** under \`.wrangler/state/\` and silently reports "Upload complete" without hitting the net -- I hit this trying the first upload and the bucket stayed empty.
- Preserve key order when rewriting calibration JSON. The previous \`sort_keys=True\` churned ~80 unrelated lines per upload; now the diff is just the model_artifacts block appended.

## Test plan

- [x] \`wrangler r2 bucket create splitsmith-models\` + custom domain bind to \`models.splitsmith.app\`
- [x] \`set -a; source .env.local; set +a; uv run python scripts/upload_model_artifacts.py\` -- uploads via S3 multipart, all three artifacts land
- [x] \`curl -sI https://models.splitsmith.app/artifacts/.../...\` -- 200 on all three
- [x] Re-run upload helper -- all three skip; zero network cost
- [x] \`uv run pytest -q\` -- 1338 pass, 9 skipped
- [x] \`uv run ruff check src tests scripts\` -- clean
- [x] \`uv run black --check src tests scripts\` -- clean

## Followups (still slim v1 doc 06)

- README install rewrite around \`uv tool install splitsmith\` + \`splitsmith fetch-models\` (next small PR)
- Release gating CI job: \`uv build\` + install into clean venv + \`fetch-models\` against staging + smoke detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)