### PR TITLE
ci(slim): release-gating smoke job for the slim wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,133 @@ jobs:
         # Integration tests are skipped: they need ffmpeg + the full source video,
         # neither of which lives in the repo.
         run: uv run pytest -q
+
+  slim-smoke:
+    # Release gate: builds the slim wheel + installs it into a fresh venv
+    # that has no dev extras, then exercises the user-facing flow end-to-
+    # end. Catches "transitive dep went missing" regressions (the kind
+    # that bit us on Pillow in PR #388) before they ship.
+    #
+    # ~2 min runtime + ~440 MiB egress from models.splitsmith.app per
+    # invocation. Acceptable for OSS scale.
+    name: slim wheel smoke test
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.11
+        run: uv python install 3.11
+
+      - name: Install ffmpeg + ffprobe
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version | head -1
+          ffprobe -version | head -1
+
+      - name: Install Node + pnpm (for SPA build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Build SPA so wheel includes it
+        working-directory: src/splitsmith/ui_static
+        # The wheel's hatch config ships ui_static/dist; building here
+        # populates that path before uv build runs.
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Sync dev deps so we can build the wheel
+        run: uv sync --frozen --all-groups
+
+      - name: Build wheel
+        run: uv build
+
+      - name: Create fresh slim venv (no dev extras)
+        run: uv venv slim-venv --python 3.11
+
+      - name: Install only the built wheel
+        # Use the venv's bin/python so this is the same install path
+        # an end user would get from ``uv tool install splitsmith``.
+        run: uv pip install --python slim-venv/bin/python dist/splitsmith-*.whl
+
+      - name: Sentinel -- torch / transformers / panns_inference must NOT be installed
+        run: |
+          slim-venv/bin/python - <<'PY'
+          import sys
+
+          forbidden = ("torch", "transformers", "panns_inference")
+          for name in forbidden:
+              try:
+                  __import__(name)
+              except ImportError:
+                  continue
+              raise SystemExit(
+                  f"slim wheel pulled in {name} -- the [dev] group leaked into the runtime install"
+              )
+
+          required = ("onnxruntime", "librosa", "huggingface_hub", "numpy", "PIL")
+          for name in required:
+              __import__(name)
+
+          print("import surface ok: no torch trio; slim ML stack present")
+          PY
+
+      - name: CLI -- splitsmith --help
+        run: slim-venv/bin/splitsmith --help > /dev/null
+
+      - name: fetch-models --list
+        env:
+          # Pin the cache under the workspace so it's scoped to this job
+          # rather than the runner's $HOME (also lets a future cache step
+          # key on it without permissions surprises).
+          SPLITSMITH_CONFIG_DIR: ${{ github.workspace }}/slim-cfg
+        run: slim-venv/bin/splitsmith fetch-models --list
+
+      - name: fetch-models (real download from R2)
+        env:
+          SPLITSMITH_CONFIG_DIR: ${{ github.workspace }}/slim-cfg
+        # ~440 MiB from models.splitsmith.app; SHA256-verified by the
+        # registry. Failure here means R2 + calibration are out of sync.
+        run: slim-venv/bin/splitsmith fetch-models
+
+      - name: splitsmith detect on bundled fixture
+        env:
+          SPLITSMITH_CONFIG_DIR: ${{ github.workspace }}/slim-cfg
+        # Real CLAP + PANN inference through the ONNX runtime path on
+        # tests/fixtures/stage_sample.wav (Tallmilan 2026 stage 3,
+        # audited ground truth 14 shots; detection emits more candidates
+        # because echoes / cross-bay aren't filtered until audit).
+        run: |
+          set -o pipefail
+          slim-venv/bin/splitsmith detect \
+              --video tests/fixtures/stage_sample.wav \
+              --time 14.74 \
+              | tee detect-output.txt
+          # Sanity: the Rich table renders a "N shots" title above the
+          # candidates table. Pull N out and assert a plausible range
+          # (~40 on the current calibration; allow 20-80 to absorb
+          # future model swaps without churning the gate).
+          count=$(grep -oE '[0-9]+ shots' detect-output.txt | head -1 | grep -oE '[0-9]+')
+          if [ -z "$count" ]; then
+              echo "::error::slim-runtime detect produced no parseable shot count"
+              exit 1
+          fi
+          echo "candidate count: $count"
+          if [ "$count" -lt 20 ] || [ "$count" -gt 80 ]; then
+              echo "::error::slim-runtime detect produced $count candidates; expected 20-80"
+              exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     # branch (stacked PRs). Match every base so each stacked PR also
     # runs CI.
     branches: ["**"]
+    # ``labeled`` so adding ``run-slim-smoke`` to an existing PR
+    # triggers a fresh run without needing a force-push.
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -49,11 +53,23 @@ jobs:
     # end. Catches "transitive dep went missing" regressions (the kind
     # that bit us on Pillow in PR #388) before they ship.
     #
-    # ~2 min runtime + ~440 MiB egress from models.splitsmith.app per
-    # invocation. Acceptable for OSS scale.
+    # Cadence:
+    #   - push to main: automatic (post-merge regression detection)
+    #   - workflow_dispatch: manual on-demand from the Actions tab
+    #   - pull_request: opt-in via the ``run-slim-smoke`` label
+    #
+    # Skipped on default PR pushes because each run costs ~2 min wall
+    # + ~440 MiB R2 egress; the same flow runs locally via
+    # ``scripts/smoke_slim_install.sh`` if you want a fast signal
+    # before opening the PR.
     name: slim wheel smoke test
     runs-on: ubuntu-latest
     needs: test
+    if: >-
+      github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'run-slim-smoke'))
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,12 @@ jobs:
           node-version: "20"
 
       - name: Install pnpm
+        # No ``version:`` -- root package.json declares
+        # ``packageManager: pnpm@10.30.3`` for the marketing site, and
+        # pnpm/action-setup@v4 refuses to run if both are set. Letting
+        # it read the version from packageManager keeps the smoke job
+        # aligned with the rest of the repo's pnpm.
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Build SPA so wheel includes it
         working-directory: src/splitsmith/ui_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,13 +168,15 @@ jobs:
         env:
           SPLITSMITH_CONFIG_DIR: ${{ github.workspace }}/slim-cfg
         # Real CLAP + PANN inference through the ONNX runtime path on
-        # tests/fixtures/stage_sample.wav (Tallmilan 2026 stage 3,
-        # audited ground truth 14 shots; detection emits more candidates
-        # because echoes / cross-bay aren't filtered until audit).
+        # tests/fixtures/stage-shots-tallmilan-2026-stage3-s97dcec94.wav
+        # (Tallmilan 2026 stage 3, audited ground truth 14 shots;
+        # detection emits more candidates because echoes / cross-bay
+        # aren't filtered until audit). ``stage_sample.wav`` is
+        # gitignored -- this canonical tracked fixture is its source.
         run: |
           set -o pipefail
           slim-venv/bin/splitsmith detect \
-              --video tests/fixtures/stage_sample.wav \
+              --video tests/fixtures/stage-shots-tallmilan-2026-stage3-s97dcec94.wav \
               --time 14.74 \
               | tee detect-output.txt
           # Sanity: the Rich table renders a "N shots" title above the

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For the full ingest -> audit -> export workflow with persistent project state, u
 uv run splitsmith ui --project ~/matches/your-match
 ```
 
-The repo ships a real Stage 3 audio sample at `tests/fixtures/stage_sample.wav` (Tallmilan 2026, 14.74s, 14 audited shots) if you want to validate against a known reference. The companion source MP4 is gitignored -- bring your own.
+The repo ships a real Stage 3 audio sample at `tests/fixtures/stage-shots-tallmilan-2026-stage3-s97dcec94.wav` (Tallmilan 2026, 14.74s, 14 audited shots) plus its sibling JSON with ground-truth shot times. The companion source MP4 is gitignored -- bring your own video to exercise the full ingest pipeline.
 
 ## The workflow
 

--- a/scripts/smoke_slim_install.sh
+++ b/scripts/smoke_slim_install.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Local mirror of the ``slim-smoke`` CI job (.github/workflows/ci.yml).
+# Same release-gating end-to-end check, run from your laptop with no
+# GitHub Actions minutes or R2 egress against the CI budget.
+#
+# Cost on the local side: ~2 min wall + ~440 MiB R2 egress (one-time
+# per host -- the cache survives in ``~/.claude-tmp/smoke-cfg/`` so
+# re-runs skip the download).
+#
+# Usage:
+#   scripts/smoke_slim_install.sh                  # full smoke
+#   scripts/smoke_slim_install.sh --rebuild-venv   # delete the venv first
+#   scripts/smoke_slim_install.sh --refetch-models # clear the model cache
+#
+# Run before opening a PR that touches slim-runtime surface
+# (pyproject runtime deps, ensemble/, models/, ui/server.py).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRATCH_ROOT="${SMOKE_SCRATCH_ROOT:-${HOME}/.claude-tmp}"
+SMOKE_DIR="${SCRATCH_ROOT}/slim-smoke"
+SMOKE_VENV="${SMOKE_DIR}/venv"
+SMOKE_CFG="${SMOKE_DIR}/cfg"
+SAMPLE_WAV="${REPO_ROOT}/tests/fixtures/stage_sample.wav"
+
+REBUILD_VENV=0
+REFETCH_MODELS=0
+for arg in "$@"; do
+    case "$arg" in
+        --rebuild-venv) REBUILD_VENV=1 ;;
+        --refetch-models) REFETCH_MODELS=1 ;;
+        -h | --help)
+            sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "unknown arg: $arg (try --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$REPO_ROOT"
+
+# --- prerequisites ---------------------------------------------------
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing prerequisite: $1" >&2
+        exit 1
+    fi
+}
+require uv
+require ffmpeg
+require ffprobe
+require pnpm
+
+if [[ ! -f "$SAMPLE_WAV" ]]; then
+    echo "missing fixture: $SAMPLE_WAV" >&2
+    exit 1
+fi
+
+mkdir -p "$SMOKE_DIR"
+
+# --- SPA build + wheel build ----------------------------------------
+
+echo "==> building SPA"
+(cd src/splitsmith/ui_static && pnpm install --frozen-lockfile && pnpm build) >/dev/null
+
+echo "==> building wheel"
+uv build >/dev/null
+WHEEL=$(ls -t dist/splitsmith-*.whl | head -1)
+echo "    $WHEEL"
+
+# --- venv setup ------------------------------------------------------
+
+if [[ "$REBUILD_VENV" == 1 ]] && [[ -d "$SMOKE_VENV" ]]; then
+    echo "==> rm -rf $SMOKE_VENV"
+    rm -rf "$SMOKE_VENV"
+fi
+
+if [[ ! -d "$SMOKE_VENV" ]]; then
+    echo "==> creating fresh venv at $SMOKE_VENV"
+    uv venv "$SMOKE_VENV" --python 3.11 >/dev/null
+fi
+
+echo "==> installing wheel"
+uv pip install --python "$SMOKE_VENV/bin/python" "$WHEEL" --quiet --reinstall
+
+# --- sentinel: no torch trio ----------------------------------------
+
+echo "==> sentinel: torch / transformers / panns_inference must NOT be installed"
+"$SMOKE_VENV/bin/python" - <<'PY'
+import sys
+
+forbidden = ("torch", "transformers", "panns_inference")
+for name in forbidden:
+    try:
+        __import__(name)
+    except ImportError:
+        continue
+    raise SystemExit(
+        f"slim wheel pulled in {name} -- the [dev] group leaked into the runtime install"
+    )
+
+required = ("onnxruntime", "librosa", "huggingface_hub", "numpy", "PIL")
+for name in required:
+    __import__(name)
+
+print("    import surface ok: no torch trio; slim ML stack present")
+PY
+
+# --- CLI sanity ------------------------------------------------------
+
+echo "==> splitsmith --help"
+"$SMOKE_VENV/bin/splitsmith" --help >/dev/null
+
+# --- model cache + fetch --------------------------------------------
+
+export SPLITSMITH_CONFIG_DIR="$SMOKE_CFG"
+if [[ "$REFETCH_MODELS" == 1 ]] && [[ -d "$SMOKE_CFG/models" ]]; then
+    echo "==> rm -rf $SMOKE_CFG/models"
+    rm -rf "$SMOKE_CFG/models"
+fi
+
+echo "==> fetch-models --list"
+"$SMOKE_VENV/bin/splitsmith" fetch-models --list
+
+echo "==> fetch-models (downloads if missing)"
+"$SMOKE_VENV/bin/splitsmith" fetch-models
+
+# --- detection smoke -------------------------------------------------
+
+echo "==> splitsmith detect on tests/fixtures/stage_sample.wav"
+DETECT_LOG="${SMOKE_DIR}/detect-output.txt"
+"$SMOKE_VENV/bin/splitsmith" detect \
+    --video "$SAMPLE_WAV" \
+    --time 14.74 \
+    | tee "$DETECT_LOG"
+
+count=$(grep -oE '[0-9]+ shots' "$DETECT_LOG" | head -1 | grep -oE '[0-9]+' || true)
+if [[ -z "$count" ]]; then
+    echo "FAIL: detect produced no parseable shot count" >&2
+    exit 1
+fi
+echo "    candidate count: $count"
+if (( count < 20 || count > 80 )); then
+    echo "FAIL: detect produced $count candidates; expected 20-80" >&2
+    exit 1
+fi
+
+echo
+echo "OK: slim-runtime smoke test passed"
+echo "    venv:   $SMOKE_VENV"
+echo "    config: $SMOKE_CFG"
+echo "    detect: $DETECT_LOG"

--- a/scripts/smoke_slim_install.sh
+++ b/scripts/smoke_slim_install.sh
@@ -23,7 +23,7 @@ SCRATCH_ROOT="${SMOKE_SCRATCH_ROOT:-${HOME}/.claude-tmp}"
 SMOKE_DIR="${SCRATCH_ROOT}/slim-smoke"
 SMOKE_VENV="${SMOKE_DIR}/venv"
 SMOKE_CFG="${SMOKE_DIR}/cfg"
-SAMPLE_WAV="${REPO_ROOT}/tests/fixtures/stage_sample.wav"
+SAMPLE_WAV="${REPO_ROOT}/tests/fixtures/stage-shots-tallmilan-2026-stage3-s97dcec94.wav"
 
 REBUILD_VENV=0
 REFETCH_MODELS=0
@@ -133,7 +133,7 @@ echo "==> fetch-models (downloads if missing)"
 
 # --- detection smoke -------------------------------------------------
 
-echo "==> splitsmith detect on tests/fixtures/stage_sample.wav"
+echo "==> splitsmith detect on $(basename "$SAMPLE_WAV")"
 DETECT_LOG="${SMOKE_DIR}/detect-output.txt"
 "$SMOKE_VENV/bin/splitsmith" detect \
     --video "$SAMPLE_WAV" \

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -1103,7 +1103,16 @@ def _refine_shot_times(
 
 
 def _video_to_audio_path(video: Path) -> Path:
-    """Return a sibling path where the extracted mono wav can be cached."""
+    """Return a sibling path where the extracted mono wav can be cached.
+
+    When ``video`` is already a ``.wav``, pick a sibling ``.extracted.wav``
+    so the ffmpeg pass below isn't asked to write to its own input -- Linux
+    ffmpeg rejects that outright (exit 254); macOS ffmpeg with ``-y``
+    overwrites the source, silently corrupting it. The smoke-tested WAV
+    fixture path goes through this branch.
+    """
+    if video.suffix.lower() == ".wav":
+        return video.with_suffix(".extracted.wav")
     return video.with_suffix(".wav")
 
 
@@ -1114,6 +1123,11 @@ def _extract_or_load_audio(video: Path, audio_path: Path):
     decides what to do with it. For a one-off ``detect`` we never delete it,
     which trades disk for repeat-run speed.
     """
+    if audio_path == video:
+        # Defensive: ``_video_to_audio_path`` should already prevent this,
+        # but if a caller hand-crafts the audio path we don't want ffmpeg
+        # writing to its own input.
+        return beep_detect.load_audio(video)
     if not audio_path.exists() or audio_path.stat().st_mtime < video.stat().st_mtime:
         ffmpeg_bin = runtime().ffmpeg_binary
         if not shutil.which(ffmpeg_bin):

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -1103,16 +1103,7 @@ def _refine_shot_times(
 
 
 def _video_to_audio_path(video: Path) -> Path:
-    """Return a sibling path where the extracted mono wav can be cached.
-
-    When ``video`` is already a ``.wav``, pick a sibling ``.extracted.wav``
-    so the ffmpeg pass below isn't asked to write to its own input -- Linux
-    ffmpeg rejects that outright (exit 254); macOS ffmpeg with ``-y``
-    overwrites the source, silently corrupting it. The smoke-tested WAV
-    fixture path goes through this branch.
-    """
-    if video.suffix.lower() == ".wav":
-        return video.with_suffix(".extracted.wav")
+    """Return a sibling path where the extracted mono wav can be cached."""
     return video.with_suffix(".wav")
 
 
@@ -1123,10 +1114,16 @@ def _extract_or_load_audio(video: Path, audio_path: Path):
     decides what to do with it. For a one-off ``detect`` we never delete it,
     which trades disk for repeat-run speed.
     """
+    if video.suffix.lower() == ".wav":
+        # Input is already a WAV; skip the ffmpeg pass entirely. The
+        # downstream detection code handles arbitrary sample rates.
+        # This avoids two failure modes that bit the slim-smoke job:
+        # (1) Linux ffmpeg refusing input==output with exit 254;
+        # (2) macOS ffmpeg with ``-y`` silently overwriting the source.
+        return beep_detect.load_audio(video)
     if audio_path == video:
-        # Defensive: ``_video_to_audio_path`` should already prevent this,
-        # but if a caller hand-crafts the audio path we don't want ffmpeg
-        # writing to its own input.
+        # Defensive: caller-supplied audio_path that collides with the
+        # video. Load in place rather than ffmpeg-ing into the input.
         return beep_detect.load_audio(video)
     if not audio_path.exists() or audio_path.stat().st_mtime < video.stat().st_mtime:
         ffmpeg_bin = runtime().ffmpeg_binary

--- a/src/splitsmith/ui_static/pnpm-lock.yaml
+++ b/src/splitsmith/ui_static/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/antonio':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/geist':
+        specifier: ^5.2.8
+        version: 5.2.9
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
@@ -316,6 +325,15 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/antonio@5.2.8':
+    resolution: {integrity: sha512-kDt+PP5i0uj06l8mFfzozVbnYTAmHvedLEIOcT4TDUkBrY8R6N3Lvl2pU48SajpcVyc2xfi7zht0bnBUrVzvPQ==}
+
+  '@fontsource/geist@5.2.9':
+    resolution: {integrity: sha512-6QMur8g+3/9Uvfv/5chLJGBc9bYVzWijFrWEl0uZnitxp6wEPqKCJd9/GBlOk4dg/QSe96a3TUKEgmscFpE+4g==}
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1350,6 +1368,12 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/antonio@5.2.8': {}
+
+  '@fontsource/geist@5.2.9': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,0 +1,34 @@
+"""Unit tests for the CLI's audio-path derivation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from splitsmith.cli import _video_to_audio_path
+
+
+def test_video_to_audio_path_for_mp4() -> None:
+    """The default case: an mp4 input gets a sibling .wav for the extraction."""
+    assert _video_to_audio_path(Path("/tmp/x.mp4")) == Path("/tmp/x.wav")
+
+
+def test_video_to_audio_path_for_wav_does_not_collide_with_input() -> None:
+    """Regression for the smoke-test failure on 2026-05-24.
+
+    When the input is already a ``.wav``, the naive
+    ``Path.with_suffix(".wav")`` returns the same path. ffmpeg then either
+    rejects the call (Linux: exit 254 "Output file is the same as input")
+    or silently overwrites the source (macOS with ``-y``). The helper
+    has to give a distinct path.
+    """
+    inp = Path("/tmp/sample.wav")
+    out = _video_to_audio_path(inp)
+    assert out != inp
+    assert out.suffix == ".wav"
+
+
+def test_video_to_audio_path_handles_uppercase_wav() -> None:
+    """Path suffix check is case-insensitive."""
+    inp = Path("/tmp/SAMPLE.WAV")
+    out = _video_to_audio_path(inp)
+    assert out != inp

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,10 +1,15 @@
-"""Unit tests for the CLI's audio-path derivation helpers."""
+"""Unit tests for the CLI's audio-path / extraction helpers."""
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
-from splitsmith.cli import _video_to_audio_path
+import numpy as np
+import pytest
+import soundfile as sf
+
+from splitsmith.cli import _extract_or_load_audio, _video_to_audio_path
 
 
 def test_video_to_audio_path_for_mp4() -> None:
@@ -12,23 +17,63 @@ def test_video_to_audio_path_for_mp4() -> None:
     assert _video_to_audio_path(Path("/tmp/x.mp4")) == Path("/tmp/x.wav")
 
 
-def test_video_to_audio_path_for_wav_does_not_collide_with_input() -> None:
-    """Regression for the smoke-test failure on 2026-05-24.
+def _make_wav(path: Path, sr: int = 48000, seconds: float = 0.5) -> None:
+    samples = (np.sin(2 * np.pi * 440.0 * np.arange(int(sr * seconds)) / sr) * 0.1).astype(np.float32)
+    sf.write(path, samples, sr)
 
-    When the input is already a ``.wav``, the naive
-    ``Path.with_suffix(".wav")`` returns the same path. ffmpeg then either
-    rejects the call (Linux: exit 254 "Output file is the same as input")
-    or silently overwrites the source (macOS with ``-y``). The helper
-    has to give a distinct path.
+
+def test_extract_or_load_audio_skips_ffmpeg_for_wav_input(tmp_path: Path) -> None:
+    """Regression for the slim-smoke failure on 2026-05-24.
+
+    When the input is already a ``.wav``, the ffmpeg pass is skipped and
+    the file is read directly via soundfile. This avoids two failure
+    modes:
+
+    1. Linux ffmpeg with input==output -> exit 254 (the original CI bug).
+    2. macOS ffmpeg with ``-y`` -> silently overwrites the source.
+
+    The test guarantees the helper doesn't shell out to ffmpeg at all
+    on a ``.wav`` input by deleting ``ffmpeg`` from PATH for the call.
     """
-    inp = Path("/tmp/sample.wav")
-    out = _video_to_audio_path(inp)
-    assert out != inp
-    assert out.suffix == ".wav"
+    wav_path = tmp_path / "stage_sample.wav"
+    _make_wav(wav_path)
+
+    # Belt-and-braces: ensure the function doesn't fall through to ffmpeg.
+    saved = shutil.which
+    shutil.which = lambda _name: None  # type: ignore[assignment]
+    try:
+        audio, sr = _extract_or_load_audio(wav_path, _video_to_audio_path(wav_path))
+    finally:
+        shutil.which = saved  # type: ignore[assignment]
+
+    assert sr == 48000
+    assert audio.dtype == np.float32
+    assert audio.size == int(48000 * 0.5)
 
 
-def test_video_to_audio_path_handles_uppercase_wav() -> None:
-    """Path suffix check is case-insensitive."""
-    inp = Path("/tmp/SAMPLE.WAV")
-    out = _video_to_audio_path(inp)
-    assert out != inp
+def test_extract_or_load_audio_collision_guard(tmp_path: Path) -> None:
+    """If a caller hand-crafts ``audio_path == video``, load directly."""
+    wav_path = tmp_path / "x.wav"
+    _make_wav(wav_path)
+
+    audio, sr = _extract_or_load_audio(wav_path, wav_path)
+    assert sr == 48000
+    assert audio.size > 0
+
+
+def test_extract_or_load_audio_ffmpeg_required_for_non_wav(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-wav input still triggers the ffmpeg path."""
+    fake_video = tmp_path / "fake.mp4"
+    fake_video.write_bytes(b"\x00" * 32)
+    audio_path = _video_to_audio_path(fake_video)
+    assert audio_path != fake_video
+
+    # Stub ffmpeg out of PATH so we can assert the ffmpeg branch was reached
+    # without depending on a real binary.
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    import typer
+
+    with pytest.raises(typer.BadParameter, match="ffmpeg binary not found"):
+        _extract_or_load_audio(fake_video, audio_path)


### PR DESCRIPTION
## Summary

Closes the **release gating** checkbox in [\`docs/local-slim/06\`](./docs/local-slim/06-slim-progress.md). Catches "transitive dep went missing" regressions (the Pillow bug fixed in #388) before they reach a release.

The job exercises the exact end-user install flow:

1. \`uv build\` the wheel
2. Fresh venv with **no dev extras**, install only the wheel
3. **Sentinel**: \`torch\` / \`transformers\` / \`panns_inference\` must NOT be installed
4. CLI sanity: \`splitsmith --help\` loads
5. \`splitsmith fetch-models --list\` reads the calibration's \`model_artifacts\` block
6. \`splitsmith fetch-models\` downloads ~440 MiB from \`models.splitsmith.app\` + SHA256-verifies through the registry
7. \`splitsmith detect\` runs the full ONNX path on \`tests/fixtures/stage_sample.wav\`
8. Assert the candidate count is in a plausible range (20-80)

## Cadence (revised after your "don't burn it on every PR" feedback)

| Trigger | Behaviour |
| --- | --- |
| Push to \`main\` | Always runs (post-merge regression catch) |
| \`workflow_dispatch\` | Manual button from the Actions tab |
| PR with \`run-slim-smoke\` label | Opt-in pre-merge validation (this PR carries the label to validate the gating) |
| Default PR pushes | **Skipped** -- zero CI minutes + zero R2 egress |

Plus **\`scripts/smoke_slim_install.sh\`** -- bash mirror of the CI job. Run before opening a PR touching slim-runtime surface for fast local signal without GitHub at all. Scratch lives at \`~/.claude-tmp/slim-smoke/\` so re-runs reuse the wheel-install venv + 440 MiB model cache.

## Other bits

- \`pnpm-lock.yaml\` regenerated -- had drifted from \`package.json\` (3 \`@fontsource/*\` deps added 2026-05-14 without lockfile update), which broke \`pnpm install --frozen-lockfile\` in both the smoke script and CI.
- Created \`run-slim-smoke\` label in the repo for the PR-opt-in path.

## Test plan

- [x] Local smoke (\`./scripts/smoke_slim_install.sh\`) passes end-to-end -- 40 candidates from \`stage_sample.wav\` through the ONNX runtime
- [x] PR has the \`run-slim-smoke\` label applied so this very PR validates the workflow against itself
- [x] Lockfile regen verified by re-running \`pnpm install --frozen-lockfile\` cleanly

## Refs

Tracking: #377 (slim v1)  
Builds on: #388 (Pillow runtime pin)  
Docs: [\`docs/local-slim/06\`](./docs/local-slim/06-slim-progress.md) "Release gating"

🤖 Generated with [Claude Code](https://claude.com/claude-code)