### PR TITLE
fix(portability): pre-release cross-platform audit

### DIFF
--- a/docs/cross-platform-audit.md
+++ b/docs/cross-platform-audit.md
@@ -1,0 +1,78 @@
+# Cross-platform audit
+
+State of the splitsmith codebase against the standard list of macOS-to-Linux
+porting hazards, taken at `2026-05-24` ahead of the first PyPI release. The
+slim wheel runs end-to-end on Ubuntu in CI (`slim-smoke` job) so anything that
+breaks the **detect** path on Linux is already caught. The risks below are the
+ones the smoke job *doesn't* exercise: trim / render, multi-shooter compare,
+overlay rendering, file-manager integration, and locale / XDG edge cases.
+
+## Audited clean -- no change needed
+
+| Concern | Verdict | Evidence |
+|---|---|---|
+| Case-sensitive imports / resources | clean | All 57 `splitsmith.X` import paths match on-disk lowercase casing. Resource lookups via `importlib.resources.files("splitsmith.data").joinpath(...)` use exact-cased filenames (`overlay_theme.json`, `JetBrainsMono-Bold.ttf`, `Antonio-VariableFont.ttf`). The only PascalCase `Path()` literal is `scripts/fetch_dtds.py`'s `Path("Contents/Frameworks/...")` -- intentional macOS-only Final Cut Pro path. |
+| Multiprocessing fork hazards | clean | `multiprocessing.Pool` and `ProcessPoolExecutor` are not used anywhere in `src/`. The only concurrency is `ThreadPoolExecutor` in `ui/jobs.py` and `ui/server.py`. Threads don't share fork's CUDA / MKL / OpenMP-after-init footgun. |
+| Unicode filename normalization (NFC vs NFD) | clean by design | `match_model.py` slugifies shooter and match names via `unicodedata.normalize("NFKD", name).encode("ascii", "ignore")`. Everything that lands on the filesystem is pure ASCII; the original display string lives in JSON. Sidesteps the whole NFC/NFD comparison-mismatch class. |
+| ffmpeg encoder flavor (Debian vs Homebrew) | clean by design | `trim.py:_probe_available_encoders()` parses `ffmpeg -encoders` output and falls back to `libx264` if the requested encoder isn't present. `libx264` + native `aac` are in stock Debian/Ubuntu since well before any LTS target. |
+| Subprocess returncode comparisons | clean | All checks are `== 0` / `!= 0` -- nothing matches specific nonzero values that could differ between Homebrew's binary and Debian's shell-wrapper variants. |
+| `encoding="utf-8"` coverage | one fix, see below | Only one real text-mode `open()` in `src/` lacked the kwarg (the candidates CSV); fixed. |
+| XDG basedir handling | one fix, see below | `runtime.py` and `user_config.py` correctly fell back when `XDG_*_HOME` was empty or unset, but accepted relative paths. Per the freedesktop spec relative values are malformed; fixed. |
+| Hardcoded macOS font paths | one fix, see below | `_FONT_PRESETS` is macOS-heavy but `_FONT_FALLBACKS` includes DejaVu, and the final fallback is PIL's bitmap default. Silent fallback was the real bug -- now logged. |
+| `xdg-open` / `open -R` / `explorer` failure | one fix, see below | The reveal endpoints used to run with `check=False` and swallow nonzero exits. Now propagated as HTTP 500 so the SPA can toast. |
+| Hardcoded `/sbin/mount` | already gated | `ui/server.py:8808` is inside a per-OS branch -- only the macOS path hits the hardcoded binary. Linux uses `/proc/mounts`. Not changed (no real-world failure mode). |
+| Symlinks | clean | `shutil.copytree(..., symlinks=True)` preserves them; reveal endpoint walks the symlink target so registered videos on external storage resolve correctly. |
+| Temp files | clean | All temp work goes through `tempfile`, which respects `$TMPDIR`. No hardcoded `/tmp`. |
+
+## Fixed in this audit
+
+### 1. CSV writes pin UTF-8 (`cli.py`)
+`<stem>-candidates.csv` is written from `audit_prep`. The `Path.open("w", newline="")` call previously inherited the locale encoding, which is `ascii` on Linux with `LANG=C` / `LANG=POSIX`. A non-ASCII shooter or club name would crash with `UnicodeEncodeError`. Now pins `encoding="utf-8"`.
+
+Regression guard: `tests/test_cli_paths.py::test_detect_csv_open_pins_utf8` inspects the source and fails if a future refactor drops the kwarg.
+
+### 2. XDG basedir reject non-absolute values (`runtime.py`, `user_config.py`)
+Per the freedesktop XDG basedir spec, `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` MUST be absolute. The previous code accepted any truthy value, so `XDG_CACHE_HOME=cache` (relative, e.g. a typo) would produce a path relative to CWD that the server would happily write into.
+
+Now: relative values fall through to the platform default with a `logger.warning` so a mistyped override doesn't fail silently.
+
+Tests: `tests/test_runtime.py::test_xdg_*` and `tests/test_user_config.py::test_xdg_config_home_*`, all Linux-only.
+
+### 3. Overlay font tier logging (`overlay_render.py`)
+`_load_font` walks a four-tier fallback chain (explicit path -> bundled `splitsmith-*` font -> `_FONT_PRESETS` -> `_FONT_FALLBACKS` -> `ImageFont.load_default()`). The final tier is PIL's built-in bitmap font, which is significantly lower-quality than any TrueType. On a minimal Linux box without `fonts-dejavu-core`, overlays would render with the bitmap font and look low-res without any indication of why.
+
+Now: each tier choice is logged once per `(font_name, tier)` pair. Bundled and explicit hits are DEBUG; system-path resolution is INFO; the `_FONT_FALLBACKS` walk is WARNING; the PIL bitmap default is WARNING with a `apt install fonts-dejavu-core` hint.
+
+Tests: `tests/test_overlay_render.py::test_load_font_pil_default_fallback_warns` + `test_load_font_bundled_emits_debug_only`.
+
+### 4. Reveal endpoints surface helper failures (`ui/server.py`)
+`/api/files/reveal` and `/api/shooters/{slug}/videos/reveal` previously called `subprocess.run(..., check=False)` and unconditionally returned 200. A headless Linux install without `xdg-open`, a Wayland session without DBUS, or `xdg-open` exiting nonzero would silently no-op -- the SPA had no way to surface the failure.
+
+Now: factored into `_reveal_in_file_manager(resolved)`. Nonzero exit raises `HTTPException(500)`. `OSError` (helper not on PATH) raises `HTTPException(500)`. Windows opts out of the returncode check because `explorer /select,...` exits 1 even on a successful selection.
+
+Tests: `tests/test_ui_server.py::test_videos_reveal_surfaces_nonzero_subprocess_exit` + `test_videos_reveal_surfaces_missing_helper_binary`.
+
+## Deferred -- doc-only
+
+### Multiprocessing start method
+Linux defaults to `fork`; macOS defaults to `spawn`. If we ever add a `multiprocessing.Pool` to the ensemble path, forking after CLAP / PANN / MKL / OpenMP initialization is the classic deadlock/segfault footgun. Right now there are zero `Pool` / `ProcessPoolExecutor` usages, so there's nothing to fix. If we add one, we MUST call `multiprocessing.set_start_method("spawn", force=False)` at engine init.
+
+### MPS device selection
+The ONNX runtime backend doesn't currently advertise the macOS MPS device. Apple Silicon users run CPU-only. This is a feature gap, not a portability bug -- the current setup works correctly everywhere; macOS users just don't get GPU speedup.
+
+### `/sbin/mount` not via `shutil.which`
+`ui/server.py:8808` hardcodes `/sbin/mount` inside the macOS branch. `/sbin/mount` is part of the base system on every supported macOS version. If a sandbox ever moves the binary, the hardcoded path will fail. Not worth a `shutil.which` lookup until something actually breaks.
+
+## Defense-in-depth (optional, not done)
+
+### Extend `slim-smoke` to exercise a trim
+The smoke job currently runs `splitsmith detect` against the bundled fixture, which exercises ffmpeg-as-decoder + CLAP + PANN inference end-to-end. It does NOT exercise `splitsmith trim` (libx264 / aac encode path), `splitsmith fcpxml`, or overlay rendering. A second smoke step would catch libx264-availability regressions on Debian-family hosts. Cost: ~30s + a small fixture. Skipped because the existing encoder probe + universal `libx264` fallback already covers this; revisit if a Linux trim regression slips through.
+
+## Re-audit triggers
+
+Re-run this audit when:
+- A `multiprocessing.Pool` or `ProcessPoolExecutor` lands anywhere in `src/`.
+- A new top-level `Path(...)` literal with mixed casing lands (look for `Path("Capital/...")`).
+- A new `open()` call lands in `src/` without `encoding=`.
+- A new `XDG_*` env-var consumer lands.
+- The target Linux distro shifts to one shipping `ffmpeg` without `libx264` (i.e. an `--enable-gpl=no` build).

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -653,7 +653,8 @@ def audit_prep(
 
     csv_path = output_dir / f"{stem}-candidates.csv"
     stage_end_ms = time * 1000
-    with csv_path.open("w", newline="") as f:
+    # encoding pinned: Linux with LANG=C picks ascii from the locale and crashes on non-ASCII names.
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
         w = _csv.writer(f)
         w.writerow(
             [

--- a/src/splitsmith/overlay_render.py
+++ b/src/splitsmith/overlay_render.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import math
 import platform
 import shutil
@@ -42,6 +43,46 @@ from PIL import Image, ImageDraw, ImageFilter, ImageFont
 from .config import VideoMetadata
 from .fcpxml_gen import probe_video
 from .overlay_theme import OverlayTheme, ThemeName, load_theme
+
+logger = logging.getLogger(__name__)
+
+# Track which (font_name, tier) pairs we've already logged so the
+# resolver doesn't spam one line per frame. Cleared via
+# ``reset_font_log_cache()`` in tests; otherwise process-lifetime.
+_LOGGED_FONT_TIERS: set[tuple[str | None, str]] = set()
+
+
+def reset_font_log_cache() -> None:
+    """Test-only: forget which font-tier choices have been logged."""
+    _LOGGED_FONT_TIERS.clear()
+
+
+def _log_font_choice(font_name: str | None, tier: str, source: str | None) -> None:
+    key = (font_name, tier)
+    if key in _LOGGED_FONT_TIERS:
+        return
+    _LOGGED_FONT_TIERS.add(key)
+    if tier == "explicit":
+        logger.debug("overlay font: using explicit path %s", source)
+    elif tier == "bundled":
+        logger.debug("overlay font %r: using bundled %s", font_name, source)
+    elif tier == "preset-found":
+        logger.info("overlay font %r resolved to system path %s", font_name, source)
+    elif tier == "fallback":
+        logger.warning(
+            "overlay font %r unavailable; using system fallback %s",
+            font_name,
+            source,
+        )
+    elif tier == "pil-default":
+        logger.warning(
+            "overlay font %r unavailable and no system fallback present; "
+            "falling back to PIL's built-in bitmap font (overlay will look low-res). "
+            "Install DejaVu Sans Mono (Debian/Ubuntu: ``apt install fonts-dejavu-core``) "
+            "or pass an explicit ``font_path``.",
+            font_name,
+        )
+
 
 OverlayCodec = Literal["auto", "hevc-alpha", "prores-4444"]
 """Pluggable encoder for the alpha overlay MOV.
@@ -388,11 +429,13 @@ def _load_font(
     font_name: str | None = None,
 ) -> ImageFont.ImageFont:
     if font_path is not None:
+        _log_font_choice(font_name, "explicit", str(font_path))
         return ImageFont.truetype(str(font_path), size=size)
     if font_name is not None:
         key = font_name.lower()
         bundled = _load_bundled_font(key, size)
         if bundled is not None:
+            _log_font_choice(font_name, "bundled", key)
             return bundled
         if key in _BUNDLED_FONTS:
             # Bundled name resolved but the file is missing -- fall through
@@ -406,13 +449,16 @@ def _load_font(
         for candidate in _FONT_PRESETS.get(key, ()):
             p = Path(candidate)
             if p.exists():
+                _log_font_choice(font_name, "preset-found", str(p))
                 return ImageFont.truetype(str(p), size=size)
         # Named preset asked for but no file found -- fall through to the
         # generic discovery list rather than crashing the export.
     for candidate in _FONT_FALLBACKS:
         p = Path(candidate)
         if p.exists():
+            _log_font_choice(font_name, "fallback", str(p))
             return ImageFont.truetype(str(p), size=size)
+    _log_font_choice(font_name, "pil-default", None)
     return ImageFont.load_default()
 
 

--- a/src/splitsmith/runtime.py
+++ b/src/splitsmith/runtime.py
@@ -86,6 +86,28 @@ class Runtime:
         return path
 
 
+def _honour_xdg(env_var: str) -> Path | None:
+    """Return ``$<env_var>`` if it's set to an absolute path.
+
+    Per the freedesktop XDG basedir spec, ``XDG_*_HOME`` values MUST be
+    absolute. Empty / unset / non-absolute fall through to platform
+    defaults. A non-absolute value is logged once so the user can see
+    why their override didn't take effect.
+    """
+    raw = os.environ.get(env_var)
+    if not raw:
+        return None
+    path = Path(raw)
+    if not path.is_absolute():
+        logger.warning(
+            "ignoring %s=%r: XDG basedir values must be absolute paths; falling back to default",
+            env_var,
+            raw,
+        )
+        return None
+    return path
+
+
 def _platform_cache_dir() -> Path:
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Caches" / "splitsmith"
@@ -94,9 +116,9 @@ def _platform_cache_dir() -> Path:
         if base:
             return Path(base) / "splitsmith"
         return Path.home() / "AppData" / "Local" / "splitsmith"
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    if xdg:
-        return Path(xdg) / "splitsmith"
+    xdg = _honour_xdg("XDG_CACHE_HOME")
+    if xdg is not None:
+        return xdg / "splitsmith"
     return Path.home() / ".cache" / "splitsmith"
 
 
@@ -104,9 +126,9 @@ def _platform_user_config_dir() -> Path:
     # Mirror the convention from ``user_config.py`` so both modules
     # agree on where per-user state lives.
     if sys.platform.startswith("linux"):
-        xdg = os.environ.get("XDG_CONFIG_HOME")
-        if xdg:
-            return Path(xdg) / "splitsmith"
+        xdg = _honour_xdg("XDG_CONFIG_HOME")
+        if xdg is not None:
+            return xdg / "splitsmith"
         return Path.home() / ".config" / "splitsmith"
     return Path.home() / ".splitsmith"
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6338,6 +6338,39 @@ def create_app(
             message=(f"Done: {result.stage_count} stages, " f"{result.duration_seconds:.1f}s{anom_suffix}"),
         )
 
+    def _reveal_in_file_manager(resolved: Path) -> None:
+        """Launch the OS file manager for ``resolved``, surfacing failures.
+
+        Without surfacing, a headless / minimal Linux install (no
+        ``xdg-open``) or a Wayland session without DBUS silently
+        swallows the click. Raising on nonzero exit lets the SPA toast.
+        ``explorer /select`` is opted out because it returns 1 even on
+        a successful selection -- treating that as failure would always
+        toast on Windows.
+        """
+        if sys.platform == "darwin":
+            cmd = ["open", "-R", str(resolved)]
+            check_exit = True
+        elif sys.platform.startswith("win"):
+            cmd = ["explorer", f"/select,{resolved}"]
+            check_exit = False
+        else:
+            # xdg-open doesn't support file selection; opening the parent
+            # is the closest cross-distro behaviour.
+            parent = resolved.parent if resolved.is_file() else resolved
+            cmd = ["xdg-open", str(parent)]
+            check_exit = True
+        try:
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"failed to launch file manager: {exc}") from exc
+        if check_exit and proc.returncode != 0:
+            stderr = (proc.stderr or "").strip() or f"exit {proc.returncode}"
+            raise HTTPException(
+                status_code=500,
+                detail=f"file manager refused to open {resolved}: {stderr}",
+            )
+
     @app.post("/api/files/reveal")
     def reveal_file(req: RevealRequest) -> JSONResponse:
         """Reveal a file in the OS file manager.
@@ -6359,18 +6392,7 @@ def create_app(
                 status_code=400,
                 detail="reveal path must be inside the bound project root",
             ) from exc
-        try:
-            if sys.platform == "darwin":
-                subprocess.run(["open", "-R", str(resolved)], check=False)
-            elif sys.platform.startswith("win"):
-                subprocess.run(["explorer", f"/select,{resolved}"], check=False)
-            else:
-                # xdg-open doesn't support file selection; opening the parent
-                # is the closest cross-distro behaviour.
-                parent = resolved.parent if resolved.is_file() else resolved
-                subprocess.run(["xdg-open", str(parent)], check=False)
-        except OSError as exc:
-            raise HTTPException(status_code=500, detail=f"failed to launch file manager: {exc}") from exc
+        _reveal_in_file_manager(resolved)
         return JSONResponse({"revealed": str(resolved)})
 
     @app.post("/api/shooters/{slug}/videos/reveal")
@@ -6395,16 +6417,7 @@ def create_app(
             resolved = target.resolve(strict=True)
         except (OSError, FileNotFoundError) as exc:
             raise HTTPException(status_code=404, detail=f"not found: {target}") from exc
-        try:
-            if sys.platform == "darwin":
-                subprocess.run(["open", "-R", str(resolved)], check=False)
-            elif sys.platform.startswith("win"):
-                subprocess.run(["explorer", f"/select,{resolved}"], check=False)
-            else:
-                parent = resolved.parent if resolved.is_file() else resolved
-                subprocess.run(["xdg-open", str(parent)], check=False)
-        except OSError as exc:
-            raise HTTPException(status_code=500, detail=f"failed to launch file manager: {exc}") from exc
+        _reveal_in_file_manager(resolved)
         return JSONResponse({"revealed": str(resolved)})
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/skip")

--- a/src/splitsmith/user_config.py
+++ b/src/splitsmith/user_config.py
@@ -130,9 +130,20 @@ def user_config_dir() -> Path:
     if override:
         return Path(override).expanduser()
     if sys.platform.startswith("linux"):
-        xdg = os.environ.get(ENV_XDG)
-        if xdg:
-            return Path(xdg).expanduser() / "splitsmith"
+        # Per the freedesktop XDG basedir spec, ``XDG_CONFIG_HOME`` MUST
+        # be an absolute path. Empty / unset / relative -> fall through
+        # to ``~/.config/splitsmith``. A relative value is logged so a
+        # mistyped override doesn't fail silently.
+        xdg_raw = os.environ.get(ENV_XDG)
+        if xdg_raw:
+            xdg_path = Path(xdg_raw).expanduser()
+            if xdg_path.is_absolute():
+                return xdg_path / "splitsmith"
+            logger.warning(
+                "ignoring %s=%r: XDG basedir values must be absolute paths; falling back to ~/.config",
+                ENV_XDG,
+                xdg_raw,
+            )
         return Path.home() / ".config" / "splitsmith"
     return Path.home() / ".splitsmith"
 

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import shutil
 from pathlib import Path
 
@@ -9,6 +10,7 @@ import numpy as np
 import pytest
 import soundfile as sf
 
+from splitsmith import cli
 from splitsmith.cli import _extract_or_load_audio, _video_to_audio_path
 
 
@@ -77,3 +79,19 @@ def test_extract_or_load_audio_ffmpeg_required_for_non_wav(
 
     with pytest.raises(typer.BadParameter, match="ffmpeg binary not found"):
         _extract_or_load_audio(fake_video, audio_path)
+
+
+def test_detect_csv_open_pins_utf8() -> None:
+    """Regression guard for the candidates CSV write.
+
+    On Linux with ``LANG=C`` / ``LANG=POSIX`` Python's text-mode ``open``
+    picks ``ascii`` from the locale and crashes on non-ASCII shooter or
+    club names. Pinning ``encoding="utf-8"`` at the open site sidesteps
+    that. This test fails if a future refactor drops the encoding kwarg.
+    """
+    src = inspect.getsource(cli.audit_prep)
+    open_lines = [line for line in src.splitlines() if "csv_path.open" in line]
+    assert open_lines, "csv_path.open call not found in cli.audit_prep -- did it get renamed?"
+    assert all(
+        'encoding="utf-8"' in line for line in open_lines
+    ), f'csv_path.open must pin encoding="utf-8"; saw: {open_lines}'

--- a/tests/test_overlay_render.py
+++ b/tests/test_overlay_render.py
@@ -208,6 +208,36 @@ def test_available_font_names_includes_known_presets() -> None:
     assert "dejavu-mono" in names
 
 
+def test_load_font_pil_default_fallback_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When neither bundled nor any system font is present we land on PIL's
+    bitmap default and the overlay looks bad. The fallback must log a
+    warning so a packaged Linux user sees *why* their overlays look low-res."""
+    # Keep "dejavu-mono" as a known preset name (so the unknown-name guard
+    # doesn't raise) but give it no candidate paths -- forces the full walk.
+    monkeypatch.setattr(overlay_render, "_FONT_PRESETS", {"dejavu-mono": ()})
+    monkeypatch.setattr(overlay_render, "_FONT_FALLBACKS", ())
+    # Force bundled lookup to miss so we walk the full fallback chain.
+    monkeypatch.setattr(overlay_render, "_load_bundled_font", lambda *_args, **_kw: None)
+    overlay_render.reset_font_log_cache()
+
+    with caplog.at_level("WARNING", logger="splitsmith.overlay_render"):
+        font = overlay_render._load_font(None, 24, font_name="dejavu-mono")
+    assert font is not None
+    assert any("PIL's built-in bitmap font" in rec.message for rec in caplog.records)
+
+
+def test_load_font_bundled_emits_debug_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The happy path (bundled font in the wheel) must not warn."""
+    overlay_render.reset_font_log_cache()
+    with caplog.at_level("WARNING", logger="splitsmith.overlay_render"):
+        overlay_render._load_font(None, 24, font_name="splitsmith-mono")
+    assert not [rec for rec in caplog.records if rec.levelname == "WARNING"]
+
+
 def test_default_template_skips_split_after_fade() -> None:
     """Long after the last shot, the split label fades to zero. The N/M
     and total are still drawn, but the split region is empty."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -95,7 +95,9 @@ def test_default_binary_is_ffmpeg() -> None:
     assert rt.ffprobe_binary == "ffprobe"
 
 
-def test_default_cache_dir_is_platform_specific() -> None:
+def test_default_cache_dir_is_platform_specific(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    _clear_runtime_cache()
     rt = resolve_runtime()
     if sys.platform == "darwin":
         assert rt.cache_dir == Path.home() / "Library" / "Caches" / "splitsmith"
@@ -104,9 +106,56 @@ def test_default_cache_dir_is_platform_specific() -> None:
         # ``~/AppData/Local/splitsmith``. Either is acceptable.
         assert rt.cache_dir.name == "splitsmith"
     else:
-        # Linux: XDG_CACHE_HOME-aware -- with the env var scrubbed by
-        # the fixture, falls back to ``~/.cache/splitsmith``.
         assert rt.cache_dir == Path.home() / ".cache" / "splitsmith"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="XDG only applies on Linux")
+def test_xdg_cache_home_absolute_path_honoured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _clear_runtime_cache()
+    rt = resolve_runtime()
+    assert rt.cache_dir == tmp_path / "splitsmith"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="XDG only applies on Linux")
+def test_xdg_cache_home_relative_path_rejected(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Relative XDG values violate the spec; fall through with a warning."""
+    monkeypatch.setenv("XDG_CACHE_HOME", "not-absolute/cache")
+    _clear_runtime_cache()
+    with caplog.at_level("WARNING", logger="splitsmith.runtime"):
+        rt = resolve_runtime()
+    assert rt.cache_dir == Path.home() / ".cache" / "splitsmith"
+    assert any("XDG_CACHE_HOME" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="XDG only applies on Linux")
+def test_xdg_cache_home_empty_string_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", "")
+    _clear_runtime_cache()
+    rt = resolve_runtime()
+    assert rt.cache_dir == Path.home() / ".cache" / "splitsmith"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="XDG only applies on Linux")
+def test_xdg_config_home_absolute_path_honoured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _clear_runtime_cache()
+    rt = resolve_runtime()
+    assert rt.user_config_dir == tmp_path / "splitsmith"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="XDG only applies on Linux")
+def test_xdg_config_home_relative_path_rejected(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", "rel/path")
+    _clear_runtime_cache()
+    with caplog.at_level("WARNING", logger="splitsmith.runtime"):
+        rt = resolve_runtime()
+    assert rt.user_config_dir == Path.home() / ".config" / "splitsmith"
+    assert any("XDG_CONFIG_HOME" in rec.message for rec in caplog.records)
 
 
 def test_hf_and_torch_home_setdefault(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -3981,6 +3982,67 @@ def test_videos_reveal_404_on_unregistered_path(tmp_path: Path) -> None:
 
     resp = client.post("/api/shooters/me/videos/reveal", json={"path": "raw/missing.mp4"})
     assert resp.status_code == 404
+
+
+def test_videos_reveal_surfaces_nonzero_subprocess_exit(tmp_path: Path) -> None:
+    """Regression: a Linux box without ``xdg-open`` (or a Wayland session
+    without DBUS) used to silently succeed -- the helper exited nonzero
+    and we returned 200. The SPA could not toast the failure. Now we
+    propagate as a 500 so the click visibly fails instead of vanishing.
+    """
+    root = tmp_path / "match"
+    src_dir = tmp_path / "external"
+    src_dir.mkdir()
+    src = src_dir / "VID.mp4"
+    src.write_bytes(b"")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    scan = client.post("/api/shooters/me/videos/scan", json={"source_paths": [str(src)]})
+    assert scan.status_code == 200, scan.text
+
+    def _failing_run(cmd, **_kwargs):  # noqa: ANN001
+        class _R:
+            returncode = 3  # xdg-open: "required tool not found"
+            stderr = "xdg-open: no method available for opening"
+
+        return _R()
+
+    with patch("splitsmith.ui.server.subprocess.run", side_effect=_failing_run):
+        resp = client.post("/api/shooters/me/videos/reveal", json={"path": "raw/VID.mp4"})
+
+    if sys.platform.startswith("win"):
+        # explorer.exe returns 1 on success; we deliberately don't gate on
+        # exit code there. Skip the assertion rather than rewriting the
+        # stub to mimic a non-explorer Windows error path.
+        pytest.skip("Windows opts out of subprocess returncode checking for explorer.exe")
+    assert resp.status_code == 500, resp.text
+    assert "refused to open" in resp.text
+
+
+def test_videos_reveal_surfaces_missing_helper_binary(tmp_path: Path) -> None:
+    """``xdg-open`` / ``open`` / ``explorer`` not on PATH must surface a 500."""
+    root = tmp_path / "match"
+    src_dir = tmp_path / "external"
+    src_dir.mkdir()
+    src = src_dir / "VID.mp4"
+    src.write_bytes(b"")
+
+    app = create_app(project_root=root, project_name="x")
+    client = TestClient(app)
+
+    scan = client.post("/api/shooters/me/videos/scan", json={"source_paths": [str(src)]})
+    assert scan.status_code == 200, scan.text
+
+    def _raise_fnf(cmd, **_kwargs):  # noqa: ANN001
+        raise FileNotFoundError(2, "No such file or directory", cmd[0])
+
+    with patch("splitsmith.ui.server.subprocess.run", side_effect=_raise_fnf):
+        resp = client.post("/api/shooters/me/videos/reveal", json={"path": "raw/VID.mp4"})
+
+    assert resp.status_code == 500, resp.text
+    assert "failed to launch file manager" in resp.text
 
 
 def test_fs_probe_resolves_project_relative_paths(tmp_path: Path) -> None:

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -54,6 +54,42 @@ def test_xdg_config_home_honoured_on_linux(monkeypatch: pytest.MonkeyPatch, tmp_
     assert user_config.user_config_dir() == xdg / "splitsmith"
 
 
+def test_xdg_config_home_relative_path_rejected_on_linux(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """Per the freedesktop spec, XDG basedir values must be absolute.
+
+    A relative override is malformed; we fall through to the default
+    and log the malformed value so a mistyped env var doesn't fail silently.
+    """
+    if not sys.platform.startswith("linux"):
+        pytest.skip("XDG layout only applies on Linux")
+    monkeypatch.delenv(user_config.ENV_HOME, raising=False)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setenv(user_config.ENV_XDG, "rel/config")
+
+    with caplog.at_level("WARNING", logger="splitsmith.user_config"):
+        resolved = user_config.user_config_dir()
+
+    assert resolved == fake_home / ".config" / "splitsmith"
+    assert any("XDG_CONFIG_HOME" in rec.message for rec in caplog.records)
+
+
+def test_xdg_config_home_empty_string_falls_through_on_linux(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    if not sys.platform.startswith("linux"):
+        pytest.skip("XDG layout only applies on Linux")
+    monkeypatch.delenv(user_config.ENV_HOME, raising=False)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setenv(user_config.ENV_XDG, "")
+    assert user_config.user_config_dir() == fake_home / ".config" / "splitsmith"
+
+
 def test_directory_created_lazily_on_first_write(_isolated_user_config: Path, tmp_path: Path) -> None:
     project = tmp_path / "match"
     project.mkdir()


### PR DESCRIPTION
## Summary

Cross-platform audit ahead of the first PyPI release (`v0.2.0` in PR #391).
The full audit is in `docs/cross-platform-audit.md` -- twelve concern
categories assessed, most already clean.

Four concrete fixes shipped:

1. **`encoding="utf-8"` on the candidates CSV (`cli.py`)** -- the only
   real text-mode `open()` in `src/` lacking the kwarg. Crashed on Linux
   with `LANG=C` and non-ASCII shooter / club names. Regression-guarded
   by `tests/test_cli_paths.py::test_detect_csv_open_pins_utf8`.
2. **XDG basedir reject non-absolute (`runtime.py`, `user_config.py`)**
   -- per the freedesktop spec, `XDG_*_HOME` MUST be absolute. Empty /
   unset / non-absolute values now uniformly fall through to the
   platform default with a logger warning. Six tests across the two
   modules.
3. **Overlay font tier logging (`overlay_render.py`)** -- the four-tier
   fallback chain (explicit / bundled / preset / system / PIL default)
   was silent. A packaged Linux box without `fonts-dejavu-core` would
   render overlays with PIL's bitmap font and look low-res with no
   indication of why. Now logs the tier choice once per (font, tier)
   pair, with a `apt install fonts-dejavu-core` hint at the PIL-default
   tier. Two tests.
4. **Reveal endpoints surface helper failures (`ui/server.py`)** -- the
   two reveal endpoints used to run `subprocess.run(..., check=False)`
   and return 200 even when `xdg-open` exited nonzero or the helper
   wasn't on PATH. Headless Linux + Wayland-without-DBUS sessions both
   silently no-op'd. Now factored through `_reveal_in_file_manager()`;
   nonzero exit / FileNotFoundError raise HTTP 500. Windows opts out of
   the returncode check because `explorer /select,...` returns 1 on
   successful selection. Two tests added.

## What's NOT fixed (deferred, docs-only)

- **Multiprocessing start method.** Zero `Pool` / `ProcessPoolExecutor`
  usages anywhere in `src/`, so nothing to set. The audit doc flags this
  as a "must set `spawn` if one is ever added" trigger.
- **MPS device support.** Feature gap, not portability bug. macOS users
  run ONNX CPU-only; that works correctly everywhere.
- **`/sbin/mount` not via `shutil.which`.** Already gated to the macOS
  branch where `/sbin/mount` is always present. No real failure mode.

## Test plan

- [x] `uv run ruff check src tests scripts` -- clean
- [x] `uv run black --check src tests scripts` -- clean
- [x] `uv run pytest -q` -- 1347 passed, 16 skipped (XDG tests skip on
      macOS; will run on Ubuntu in CI)
- [ ] Slim-smoke job opt-in via `run-slim-smoke` label if you want the
      end-to-end Ubuntu signal for this PR; the default smoke run on
      main post-merge will catch anything we missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)