### PR TITLE
fix(release): trim sdist + dedup PyPI publish workflows

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,12 +2,14 @@ name: Publish to PyPI
 
 on:
   # Tag-triggered: ``git tag v0.2.0 && git push origin v0.2.0`` from a human
-  # (or PAT-authenticated automation) fires this. release-please-created tags
-  # don't trigger this because GitHub's GITHUB_TOKEN can't fire downstream
-  # workflows -- the auto-flow's publish job lives inside release-please.yml
-  # as a same-workflow dependent job instead.
+  # fires this directly.
   push:
     tags: ['v*']
+  # Callable from release-please.yml so the automatic release flow uses the
+  # same publish steps. The OIDC ``job_workflow_ref`` claim points at THIS
+  # workflow when called, so one PyPI trusted publisher
+  # (workflow filename ``publish-pypi.yml``) covers both code paths.
+  workflow_call:
   # Manual on-demand from the Actions tab; honour ``tag`` input so re-publish
   # after a transient PyPI / OIDC outage doesn't need a new tag.
   workflow_dispatch:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,59 +35,15 @@ jobs:
           manifest-file: .github/release-please-manifest.json
 
   publish-pypi:
-    # Gated on a real release being cut this run -- not every push
-    # to main. The release-please PR merge is the trigger.
-    name: publish to PyPI
+    # Auto-publish path: release-please cut a release in the previous job.
+    # Calls the same reusable workflow that the tag-push path uses, so the
+    # actual publish steps + PyPI trusted-publisher claims live in exactly
+    # one place (publish-pypi.yml). One PyPI publisher entry suffices because
+    # the OIDC ``job_workflow_ref`` claim points at the CALLED workflow.
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/splitsmith
+    uses: ./.github/workflows/publish-pypi.yml
     permissions:
-      # Required for PyPI trusted publishing (OIDC). No API token in
-      # secrets; PyPI verifies the workflow identity against the
-      # configured publisher on pypi.org/manage/account/publishing/.
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # release-please tagged the release commit; check it out
-          # so the wheel embeds the right version + CHANGELOG.
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-
-      - name: Install Python 3.11
-        run: uv python install 3.11
-
-      - name: Install Node + pnpm (for SPA build)
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install pnpm
-        # Version comes from the root package.json packageManager field.
-        uses: pnpm/action-setup@v4
-
-      - name: Build SPA so wheel includes it
-        working-directory: src/splitsmith/ui_static
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
-
-      - name: Sync build deps
-        run: uv sync --frozen --all-groups
-
-      - name: Build sdist + wheel
-        run: uv build
-
-      - name: Publish to PyPI
-        # ``--trusted-publishing automatic`` makes uv pick up the
-        # OIDC token from the GitHub Actions runner; no PYPI_TOKEN
-        # needed in repo secrets.
-        run: uv publish --trusted-publishing automatic
+    secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,27 @@ exclude = [
   "**/ui_static/dist/**/*.map",
 ]
 
+[tool.hatch.build.targets.sdist]
+# Test fixtures are ~140 MB of audio (above PyPI's default 100 MB per-file
+# limit) and never needed by anyone installing from sdist. Build / dev
+# outputs, design docs, maintainer scripts, and the SPA source tree are
+# also excluded -- they live in git for contributors; nobody source-builds
+# the wheel needs them.
+include = [
+  "src/splitsmith/**",
+  "README.md",
+  "LICENSE*",
+  "CHANGELOG.md",
+  "pyproject.toml",
+  "uv.lock",
+]
+exclude = [
+  "**/__pycache__",
+  "**/*.pyc",
+  "**/ui_static/node_modules",
+  "**/ui_static/dist/**/*.map",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0.0",


### PR DESCRIPTION
## Summary

Two fixes uncovered by the v0.2.0 publish attempt:

1. **sdist 148 MB -> 1.3 MB.** The wheel correctly excludes \`tests/fixtures/*.wav\` (~140 MB of audio); the sdist's default rules pulled them in and tripped PyPI's 100 MB per-file limit. Added \`[tool.hatch.build.targets.sdist]\` with explicit \`include\` (src + README + LICENSE + CHANGELOG + pyproject + uv.lock). Wheel unchanged at 806 KB.

2. **One PyPI publisher, not two.** Refactored \`publish-pypi.yml\` as a reusable workflow (\`on: workflow_call:\`) and have \`release-please.yml\` invoke it via \`uses: ./.github/workflows/publish-pypi.yml\`. The OIDC \`job_workflow_ref\` claim points at the **called** workflow regardless of trigger, so one trusted publisher entry on PyPI (workflow filename \`publish-pypi.yml\`) covers both tag-push (manual / hand-cut) and release-please-merged (automatic) code paths. No more duplicate publish steps to keep in sync.

## After merge

1. Delete the stale \`v0.2.0\` tag + GitHub Release (the previous publish attempts failed; nothing on PyPI references this tag).
2. Re-tag from the fix commit: \`git tag v0.2.0 && git push origin v0.2.0\`.
3. Recreate the GitHub Release.
4. Tag push fires \`publish-pypi.yml\` directly -- should succeed with the OIDC publisher now matching + sdist under the limit.

## Test plan

- [x] \`uv build\` locally -> sdist 1.3 MB, wheel 806 KB
- [x] \`uv run ruff check src tests scripts\` clean
- [x] YAML lint passes on both workflows
- [ ] Tag push fires publish-pypi.yml + reaches \`uv publish\` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)