### PR TITLE
feat(ui): auto-prefetch slim models on UI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ You need: `uv` and `ffmpeg`/`ffprobe` on PATH. See [Install](#install) for OS-sp
 
 ```bash
 uv tool install splitsmith                       # slim runtime, ~100 MB
-splitsmith fetch-models                          # ~440 MB ONNX artifacts; one-time
+splitsmith ui --project ~/matches/your-match     # auto-fetches ~440 MB of models on first launch
+```
 
+The UI kicks off the model prefetch as a background job the moment the server boots; the Jobs panel shows progress and the rest of the app (ingest, beep review) stays responsive while it runs. Shot detection waits on the download to finish.
+
+Prefer the CLI? `splitsmith single` runs the envelope-only detector and needs no model artifacts:
+
+```bash
 # Bring your own head-cam clip and stage time (or use any IPSC video at hand)
 splitsmith single \
     --video path/to/your_stage.mp4 \
@@ -44,12 +50,6 @@ splitsmith single \
 
 ls -la ./demo_analysis/
 cat ./demo_analysis/stage3_per-told-me-to-do-it_report.txt
-```
-
-For the full ingest -> audit -> export workflow with persistent project state, use the UI:
-
-```bash
-splitsmith ui --project ~/matches/your-match
 ```
 
 The repo ships a real Stage 3 audio sample at `tests/fixtures/stage-shots-tallmilan-2026-stage3-s97dcec94.wav` (Tallmilan 2026, 14.74s, 14 audited shots) plus its sibling JSON with ground-truth shot times. The companion source MP4 is gitignored -- bring your own video to exercise the full ingest pipeline.
@@ -79,11 +79,10 @@ The repo ships a real Stage 3 audio sample at `tests/fixtures/stage-shots-tallmi
 
 ```bash
 uv tool install splitsmith                       # from PyPI
-splitsmith fetch-models                          # pre-fetch ONNX artifacts (optional)
 splitsmith ui --project ~/matches/your-match
 ```
 
-Detection models (~440 MB total) download from `models.splitsmith.app` on first detection -- pre-fetch with `splitsmith fetch-models`. No torch, transformers, or panns_inference in the install.
+Detection models (~440 MB total) are auto-fetched from `models.splitsmith.app` into `~/.splitsmith/models/` in the background as soon as `splitsmith ui` starts; the SPA's Jobs panel shows progress. Pre-fetch in a one-shot run with `splitsmith fetch-models` if you'd rather pay the download up front (CI, metered connections, etc.). No torch, transformers, or panns_inference in the install. The CLI `single` / `process` / `detect` commands use only the envelope-based Voter A and need no model artifacts at all.
 
 ### Option 2: from source (required for contributors)
 
@@ -92,8 +91,7 @@ git clone https://github.com/mandakan/splitsmith.git
 cd splitsmith
 uv sync                                          # slim runtime deps only (~100 MB)
 (cd src/splitsmith/ui_static && pnpm install && pnpm build)
-uv run splitsmith fetch-models                   # ~440 MB ONNX artifacts; one-time
-uv run splitsmith --help
+uv run splitsmith --help                         # `splitsmith ui` auto-fetches ~440 MB of models on first launch
 ```
 
 Source checkouts also need **Node.js 20+ and `pnpm`** to build the SPA:
@@ -113,7 +111,7 @@ uv run pytest -q -m integration                  # ffmpeg/ffprobe-backed tests
 
 ## Runtime backends (slim ONNX vs dev torch)
 
-The shipped runtime uses [ONNX Runtime](https://onnxruntime.ai/) for Voter B (CLAP) and Voter D (PANN gunshot probability, folded into Voter C). The slim install carries no torch, no transformers, no panns_inference. The first detection downloads ~440 MB of ONNX artifacts from `models.splitsmith.app` into `~/.splitsmith/models/` (pre-fetch with `splitsmith fetch-models`).
+The shipped runtime uses [ONNX Runtime](https://onnxruntime.ai/) for Voter B (CLAP) and Voter D (PANN gunshot probability, folded into Voter C). The slim install carries no torch, no transformers, no panns_inference. Artifacts (~440 MB) auto-download from `models.splitsmith.app` into `~/.splitsmith/models/` as a background job the moment `splitsmith ui` boots; `splitsmith fetch-models` is still around for scripted prefetch (CI, metered connections).
 
 The dev backend (torch + transformers + panns_inference) lives in the `[dev]` group and is required for: re-running `scripts/build_ensemble_artifacts.py`, the ONNX export scripts (`scripts/export_pann_onnx.py`, `scripts/export_clap_onnx.py`), and enabling Voter E (CLIP visual probe -- off by default; turn on with `SPLITSMITH_ENABLE_VOTER_E=1` after `uv sync --all-groups`).
 

--- a/site/index.html
+++ b/site/index.html
@@ -1178,6 +1178,7 @@ footer.colophon {
     <div class="snippet">
 <pre class="quickstart" data-copy="uv tool install splitsmith
 splitsmith ui"><span class="comment"># Install from PyPI and launch the UI</span>
+<span class="comment"># The UI auto-downloads ~440 MB of detection models in the background on first boot.</span>
 <span class="prompt">$</span> <span class="kw">uv</span> tool install splitsmith
 <span class="prompt">$</span> <span class="kw">splitsmith</span> ui</pre>
       <button class="copy-btn" type="button" aria-label="Copy commands">
@@ -1185,7 +1186,7 @@ splitsmith ui"><span class="comment"># Install from PyPI and launch the UI</span
       </button>
     </div>
 
-    <p class="snippet-alt">Prefer the CLI? Run the full pipeline on a single clip:</p>
+    <p class="snippet-alt">Prefer the CLI? The envelope-only single-clip path needs no model download:</p>
 
     <div class="snippet">
 <pre class="quickstart" data-copy="splitsmith single \

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -66,6 +66,10 @@ JOB_PRIORITY: dict[str, int] = {
     "trim": 1,
     # Slow ensemble; happily yields its slot to incoming beep/trim work.
     "shot_detect": 2,
+    # Background prefetch of slim ONNX artifacts on first UI launch.
+    # Lower than DEFAULT so any user-initiated work that arrives while
+    # the download is still queued jumps ahead.
+    "model_download": 9,
 }
 DEFAULT_JOB_PRIORITY: int = 3
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -100,6 +100,7 @@ from .. import cleanup as cleanup_module
 from .. import coach as coach_module
 from .. import coach_distributions as coach_distributions_module
 from .. import ensemble as ensemble_module
+from .. import models as model_layer
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
@@ -790,6 +791,96 @@ def _get_ensemble_runtime() -> ensemble_module.EnsembleRuntime:
                 with_voter_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
                 _ENSEMBLE_RUNTIME = ensemble_module.load_ensemble_runtime(with_voter_e=with_voter_e)
     return _ENSEMBLE_RUNTIME
+
+
+def _run_model_download_job(handle: JobHandle) -> None:
+    """Prefetch every missing slim ONNX artifact from R2.
+
+    Submitted by :func:`_maybe_submit_model_download` at server startup
+    when ``registry.status()`` reports anything other than ``present``
+    so the audit hot path doesn't pay a ~440 MB stall on the user's
+    first shot-detect click.
+
+    Progress feeds the job snapshot as a single 0..1 fraction across the
+    sum of pending-artifact sizes; the SPA's Jobs panel renders it from
+    there. The download itself is locked via the registry's cache lock,
+    so a concurrent ``registry.resolve()`` from an early shot-detect
+    will block on this job rather than racing it.
+    """
+    registry = model_layer.get_default_registry()
+    if registry is None:
+        return
+    pending = [s for s in registry.status() if s.state != "present"]
+    if not pending:
+        return
+    total_bytes = sum(s.size_bytes for s in pending)
+    completed_bytes = 0
+    for i, status in enumerate(pending, start=1):
+        handle.check_cancel()
+        slug_bytes = status.size_bytes
+        slug_label = f"({i}/{len(pending)}) {status.slug}"
+        handle.update(
+            progress=completed_bytes / total_bytes if total_bytes else None,
+            message=f"Downloading {slug_label}",
+        )
+
+        def _progress(
+            seen: int,
+            _total: int | None,
+            *,
+            base: int = completed_bytes,
+            cap: int = slug_bytes,
+        ) -> None:
+            if total_bytes:
+                handle.update(progress=(base + min(seen, cap)) / total_bytes)
+
+        try:
+            registry.resolve(status.slug, progress=_progress)
+        except model_layer.NetworkUnreachable as exc:
+            raise RuntimeError(
+                f"network unreachable while fetching {status.slug}: {exc}. "
+                "Reconnect and the next first-detect will retry."
+            ) from exc
+        except model_layer.HashMismatch as exc:
+            raise RuntimeError(
+                f"integrity check failed for {status.slug}: {exc}. "
+                "The mirror may have been updated -- run `uv tool upgrade splitsmith`."
+            ) from exc
+        completed_bytes += slug_bytes
+    handle.update(progress=1.0, message="Models ready")
+    handle.set_result(
+        {
+            "artifacts": [s.slug for s in pending],
+            "bytes": total_bytes,
+        }
+    )
+
+
+def _maybe_submit_model_download(state: AppState) -> None:
+    """Kick off the slim-artifact prefetch on startup when anything is missing.
+
+    No-op when the registry is unavailable (older calibrations without
+    a ``model_artifacts`` block, or the torch dev install), when every
+    artifact is already cached + verified, or when a previous job is
+    still active (idempotent across reloads of an embedded host).
+    """
+    try:
+        registry = model_layer.get_default_registry()
+    except Exception:  # pragma: no cover -- defensive; never block boot on this
+        logger.exception("model registry unavailable; skipping startup prefetch")
+        return
+    if registry is None:
+        return
+    missing = [s for s in registry.status() if s.state != "present"]
+    if not missing:
+        return
+    if state.jobs.find_active(kind="model_download") is not None:
+        return
+    try:
+        state.jobs.submit(kind="model_download", fn=_run_model_download_job)
+    except ShutdownInProgressError:
+        # Server is already winding down; nothing to do.
+        return
 
 
 class HealthResponse(BaseModel):
@@ -1959,6 +2050,11 @@ def create_app(
     # outside the closure.
     app.state.splitsmith_state = state
 
+    # Kick off the slim ONNX prefetch in the background if any artifact
+    # is missing. Runs whether or not a project is bound, so the first
+    # shot-detect after the user picks a match finds the cache primed.
+    _maybe_submit_model_download(state)
+
     @app.exception_handler(ShutdownInProgressError)
     async def _shutdown_in_progress_handler(request: Request, exc: ShutdownInProgressError) -> JSONResponse:
         """Map ShutdownInProgressError to 503 across every submit() callsite."""
@@ -2095,15 +2191,27 @@ def create_app(
         ship the ``model_artifacts`` calibration block (today's torch
         path) return ``available=False`` so the frontend doesn't draw
         the overlay at all.
-        """
-        from .. import models as model_layer
 
+        ``active_job`` carries the background prefetch job submitted by
+        :func:`_maybe_submit_model_download` when artifacts are missing
+        at startup. The SPA uses ``progress`` + ``message`` to render a
+        non-blocking indicator while the user ingests; the Jobs panel
+        still shows the same job through the regular ``/api/me/jobs``
+        feed.
+        """
         registry = model_layer.get_default_registry()
         if registry is None:
-            return {"available": False, "artifacts": [], "missing": [], "mismatched": []}
+            return {
+                "available": False,
+                "artifacts": [],
+                "missing": [],
+                "mismatched": [],
+                "active_job": None,
+            }
         statuses = registry.status()
         missing = [s.slug for s in statuses if s.state == "missing"]
         mismatched = [s.slug for s in statuses if s.state == "mismatched"]
+        active_job = state.jobs.find_active(kind="model_download")
         return {
             "available": True,
             "cache_root": str(registry.root),
@@ -2118,6 +2226,16 @@ def create_app(
             ],
             "missing": missing,
             "mismatched": mismatched,
+            "active_job": (
+                {
+                    "id": active_job.id,
+                    "status": active_job.status,
+                    "progress": active_job.progress,
+                    "message": active_job.message,
+                }
+                if active_job is not None
+                else None
+            ),
         }
 
     @app.post("/api/shutdown", status_code=202)

--- a/src/splitsmith/ui_static/src/components/Jobs.tsx
+++ b/src/splitsmith/ui_static/src/components/Jobs.tsx
@@ -25,6 +25,7 @@ import {
   AlertTriangle,
   ArrowDownToLine,
   ChevronRight,
+  CloudDownload,
   Crosshair,
   Pause,
   Volume2,
@@ -53,6 +54,7 @@ const KIND_LABEL: Record<string, string> = {
   export: "Export stage",
   match_export: "Match export",
   audio_extract: "Audio extract",
+  model_download: "Download models",
 };
 
 const KIND_ICON: Record<string, ReactNode> = {
@@ -62,6 +64,7 @@ const KIND_ICON: Record<string, ReactNode> = {
   export: <ArrowDownToLine className="size-3.5" />,
   match_export: <ArrowDownToLine className="size-3.5" />,
   audio_extract: <Volume2 className="size-3.5" />,
+  model_download: <CloudDownload className="size-3.5" />,
 };
 
 function kindLabel(kind: string): string {

--- a/tests/test_models_layer.py
+++ b/tests/test_models_layer.py
@@ -414,7 +414,13 @@ def test_models_status_endpoint_reports_unavailable_when_no_block(
     resp = client.get("/api/models/status")
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"available": False, "artifacts": [], "missing": [], "mismatched": []}
+    assert body == {
+        "available": False,
+        "artifacts": [],
+        "missing": [],
+        "mismatched": [],
+        "active_job": None,
+    }
 
 
 def test_models_status_endpoint_lists_artifacts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -439,3 +445,126 @@ def test_models_status_endpoint_lists_artifacts(monkeypatch: pytest.MonkeyPatch,
     assert body["mismatched"] == []
     assert body["artifacts"][0]["slug"] == "clap_audio_encoder"
     assert body["artifacts"][0]["state"] == "present"
+
+
+# ----------------------------------------------------------------------
+# Startup prefetch (auto-submit on `splitsmith ui` boot)
+# ----------------------------------------------------------------------
+
+
+def test_create_app_auto_submits_model_download_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Startup hook submits a ``model_download`` job iff something is missing.
+
+    Replaces the worker with a no-op so the test doesn't pull from R2;
+    we only assert that a job is queued + runs.
+    """
+    from splitsmith.ui import server as server_mod
+    from splitsmith.ui.server import create_app
+
+    spec, _artifact, _payload = _make_spec()
+    # Empty cache -> the one artifact in the spec is "missing".
+    registry = ModelRegistry(spec, root=tmp_path / "cache")
+    monkeypatch.setattr(registry_mod, "_default_registry", registry)
+    # Don't actually fetch anything; just record that the worker was called.
+    invoked: list[str] = []
+    monkeypatch.setattr(
+        server_mod,
+        "_run_model_download_job",
+        lambda handle: invoked.append(handle.id),
+    )
+
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    state = app.state.splitsmith_state
+    # Wait for the executor to pick up the queued job and the worker to run.
+    state.jobs.wait_for_drain(timeout_s=2.0)
+    assert invoked, "model_download worker was never invoked"
+    kinds = [j.kind for j in state.jobs.list()]
+    assert kinds == ["model_download"]
+
+
+def test_run_model_download_job_aggregates_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Worker normalizes per-artifact bytes into a single 0..1 fraction.
+
+    Builds a two-artifact spec, hijacks ``download_to`` so each call
+    streams its expected size to the destination + invokes the progress
+    callback once with ``(seen=full, total=full)``. The job's recorded
+    progress samples should march monotonically from 0 toward 1, ending
+    at exactly 1.0 with ``message="Models ready"``.
+    """
+    from splitsmith.ui.server import _run_model_download_job
+
+    payload_a = b"first-artifact-bytes"
+    payload_b = b"second-artifact-larger-payload"
+    spec = ModelArtifactsSpec.model_validate(
+        {
+            "slug_a": {
+                "filename": "a.onnx",
+                "sha256": _sha256(payload_a),
+                "size_bytes": len(payload_a),
+                "url": "https://example.test/a.onnx",
+            },
+            "slug_b": {
+                "filename": "b.onnx",
+                "sha256": _sha256(payload_b),
+                "size_bytes": len(payload_b),
+                "url": "https://example.test/b.onnx",
+            },
+        }
+    )
+    artifact_a = spec.artifact("slug_a")
+    artifact_b = spec.artifact("slug_b")
+    assert artifact_a is not None and artifact_b is not None
+    registry = ModelRegistry(spec, root=tmp_path / "cache")
+    monkeypatch.setattr(registry_mod, "_default_registry", registry)
+
+    payloads = {artifact_a.url: payload_a, artifact_b.url: payload_b}
+
+    def _fake_download(url, dest, *, expected_size, progress, **_kw):  # type: ignore[no-untyped-def]
+        data = payloads[url]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        if progress is not None:
+            progress(len(data), len(data))
+
+    monkeypatch.setattr(registry_mod, "download_to", _fake_download)
+
+    from splitsmith.ui.jobs import JobRegistry
+
+    jobs = JobRegistry()
+    submitted = jobs.submit(kind="model_download", fn=_run_model_download_job)
+    jobs.wait_for_drain(timeout_s=2.0)
+    final = jobs.get(submitted.id)
+    assert final is not None
+    assert final.status == "succeeded"
+    assert final.progress == 1.0
+    assert final.message == "Models ready"
+    assert final.result == {
+        "artifacts": ["slug_a", "slug_b"],
+        "bytes": len(payload_a) + len(payload_b),
+    }
+
+
+def test_create_app_skips_model_download_when_all_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Don't queue a no-op job when every artifact is already cached."""
+    from fastapi.testclient import TestClient
+
+    from splitsmith.ui.server import create_app
+
+    spec, artifact, payload = _make_spec()
+    dest = cache_mod.artifact_path(artifact, root=tmp_path / "cache")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(payload)
+    registry = ModelRegistry(spec, root=tmp_path / "cache")
+    monkeypatch.setattr(registry_mod, "_default_registry", registry)
+
+    app = create_app(project_root=tmp_path / "match", project_name="x")
+    client = TestClient(app)
+    body = client.get("/api/models/status").json()
+    assert body["active_job"] is None
+    assert [j.kind for j in app.state.splitsmith_state.jobs.list()] == []

--- a/tests/test_models_layer.py
+++ b/tests/test_models_layer.py
@@ -484,9 +484,7 @@ def test_create_app_auto_submits_model_download_when_missing(
     assert kinds == ["model_download"]
 
 
-def test_run_model_download_job_aggregates_progress(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_run_model_download_job_aggregates_progress(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Worker normalizes per-artifact bytes into a single 0..1 fraction.
 
     Builds a two-artifact spec, hijacks ``download_to`` so each call

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "splitsmith"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

`splitsmith ui` now kicks off the slim ONNX prefetch (~440 MB) as a background `model_download` job the moment the FastAPI app boots. The user can ingest videos and review beeps while the download streams from `models.splitsmith.app`; the first shot-detect blocks on the same `ModelRegistry` cache lock the prefetch holds, so it lands on a verified cache without racing.

The README + marketing-site quickstart are corrected to match: the explicit `splitsmith fetch-models` step disappears from the user-facing path (the UI handles it). The command stays around for scripted prefetch (CI, metered connections). Both docs now note that the CLI `single` / `process` / `detect` envelope-only paths need no model artifacts at all.

### What changed

- **`src/splitsmith/ui/jobs.py`** — new `model_download` priority entry (9, lower than DEFAULT so user-initiated work jumps ahead).
- **`src/splitsmith/ui/server.py`** — `_run_model_download_job` worker that iterates `registry.status()`, calls `registry.resolve(slug, progress=...)` per pending artifact, and aggregates progress into a single 0..1 fraction across the sum of pending sizes. `_maybe_submit_model_download` is called from `create_app()` and no-ops when the registry is unavailable, all artifacts are present, or a job is already active. `/api/models/status` grows an `active_job` field so the SPA can render a non-blocking indicator without going through the Jobs panel.
- **`src/splitsmith/ui_static/src/components/Jobs.tsx`** — adds `model_download` to `KIND_LABEL` ("Download models") + `KIND_ICON` (`CloudDownload`) so the existing Jobs panel renders the new job kind correctly.
- **`README.md` / `site/index.html`** — quickstart cleanup; reflects that auto-prefetch handles the slim install path and that CLI flows need no models.
- **`tests/test_models_layer.py`** — coverage for the three new behaviours: startup auto-submit when missing, no-op when all present, and worker progress aggregation against a mocked `download_to`.

## Test plan

- [x] `uv run pytest tests/test_models_layer.py` — 26 passed
- [x] `uv run pytest tests/ -k "not integration"` — 1295 passed, 16 skipped
- [x] `uv run ruff check src/splitsmith/ui/server.py src/splitsmith/ui/jobs.py tests/test_models_layer.py` — clean
- [x] `(cd src/splitsmith/ui_static && pnpm typecheck && pnpm build)` — clean
- [x] End-to-end smoke: `_maybe_submit_model_download` against the live R2 mirror actually pulled `pann_cnn14`, `clap_audio_encoder`, `clap_text_embeddings` from `models.splitsmith.app` (verified via the registry's INFO logs).
- [ ] Manually verify on a fresh `~/.splitsmith/models/` that the Jobs panel renders the new row + progress while ingest still feels responsive.

https://claude.ai/code/session_01ENCf1shQas79b9q8pX4HyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENCf1shQas79b9q8pX4HyV)_