### PR TITLE
feat(auth): introduce Auth abstraction with LoopbackAuth + GET /api/me

### DIFF
--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -40,14 +40,16 @@ abstraction without behavioural change.
 - [ ] Extract `Storage` interface; replace direct `pathlib.Path` use
   in project layout with `FilesystemStorage` calls.
   (See 03-storage-layer.md.)
-- [~] Extract `Auth` interface; introduce `LoopbackAuth`; route
+- [x] Extract `Auth` interface; introduce `LoopbackAuth`; route
   every API handler through `auth.authenticate_request`.
   (See 02-tenancy-and-identity.md.) Interface + `LoopbackAuth` +
-  `GET /api/me` landed, and every `/api/me/*` route is now gated
-  by the `get_current_user` dep. Remaining: thread the dep through
-  the rest of the API surface (project, stage, video, fixture
-  endpoints) so hosted-mode 401s land at the gate, not the
-  handler.
+  `GET /api/me` landed; every `/api/me/*` route gated by the
+  `get_current_user` dep; an `_auth_gate` ASGI middleware now
+  resolves `state.auth` on every `/api/*` request and 401s when
+  the backend returns anonymous, with a small allowlist
+  (`/api/health`, `/api/server/features`, `/api/shutdown`). In
+  local mode `LoopbackAuth` never 401s; the wiring activates when
+  a hosted backend swaps in.
 - [ ] Extract `ComputeBackend` interface; wrap today's ensemble
   pipeline as `LocalComputeBackend`. The orchestration in
   `cli.py` and the FastAPI server call the backend, not the

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -43,8 +43,11 @@ abstraction without behavioural change.
 - [~] Extract `Auth` interface; introduce `LoopbackAuth`; route
   every API handler through `auth.authenticate_request`.
   (See 02-tenancy-and-identity.md.) Interface + `LoopbackAuth` +
-  `GET /api/me` landed; routing existing handlers through the
-  backend is the next iteration.
+  `GET /api/me` landed, and every `/api/me/*` route is now gated
+  by the `get_current_user` dep. Remaining: thread the dep through
+  the rest of the API surface (project, stage, video, fixture
+  endpoints) so hosted-mode 401s land at the gate, not the
+  handler.
 - [ ] Extract `ComputeBackend` interface; wrap today's ensemble
   pipeline as `LocalComputeBackend`. The orchestration in
   `cli.py` and the FastAPI server call the backend, not the

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -40,9 +40,11 @@ abstraction without behavioural change.
 - [ ] Extract `Storage` interface; replace direct `pathlib.Path` use
   in project layout with `FilesystemStorage` calls.
   (See 03-storage-layer.md.)
-- [ ] Extract `Auth` interface; introduce `LoopbackAuth`; route
+- [~] Extract `Auth` interface; introduce `LoopbackAuth`; route
   every API handler through `auth.authenticate_request`.
-  (See 02-tenancy-and-identity.md.)
+  (See 02-tenancy-and-identity.md.) Interface + `LoopbackAuth` +
+  `GET /api/me` landed; routing existing handlers through the
+  backend is the next iteration.
 - [ ] Extract `ComputeBackend` interface; wrap today's ensemble
   pipeline as `LocalComputeBackend`. The orchestration in
   `cli.py` and the FastAPI server call the backend, not the

--- a/src/splitsmith/auth.py
+++ b/src/splitsmith/auth.py
@@ -1,0 +1,62 @@
+"""Auth abstraction for the FastAPI server.
+
+The interface lets the same handlers run in two modes:
+
+- **Local mode** -- single-operator desktop app. ``LoopbackAuth``
+  resolves every request to a fixed sentinel user.
+- **Hosted mode** -- multi-tenant SaaS. A future ``MagicLinkAuth``
+  resolves cookies/headers against the picked auth provider.
+
+The hosted-mode methods (``begin_login`` / ``complete_login`` /
+``end_session``) are not in the Protocol yet; they get added when the
+hosted backend lands so we don't ship an interface no caller exercises.
+See ``docs/saas-readiness/02-tenancy-and-identity.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fastapi import Request
+from pydantic import BaseModel
+
+LOOPBACK_USER_ID = "local"
+LOOPBACK_USER_EMAIL = "local@splitsmith"
+
+
+class User(BaseModel):
+    """Identity of the caller behind a request.
+
+    ``id`` is the stable foreign key used everywhere user identity is
+    embedded (project ownership, ACL rows, sync sentinels). In local
+    mode it is the literal string ``"local"``; in hosted mode it is
+    the database ULID.
+    """
+
+    id: str
+    email: str
+    display_name: str | None = None
+
+
+class AuthBackend(Protocol):
+    async def authenticate_request(self, request: Request) -> User | None:
+        """Return the authenticated user, or ``None`` for anonymous.
+
+        Middleware decides whether ``None`` is allowed for a given
+        route -- this method only reports who the caller is.
+        """
+
+
+class LoopbackAuth:
+    """Local-mode backend. Every request resolves to the same user.
+
+    The request object is ignored on purpose: there are no cookies, no
+    bearer tokens, no headers to parse. The desktop process is the
+    operator; one process = one user.
+    """
+
+    def __init__(self) -> None:
+        self._user = User(id=LOOPBACK_USER_ID, email=LOOPBACK_USER_EMAIL)
+
+    async def authenticate_request(self, request: Request) -> User:
+        return self._user

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -48,6 +48,7 @@ Endpoints (locked v1 surface):
   GET  /api/fixture/peaks?path=...  -- waveform peaks for a fixture's sibling WAV
   GET  /api/fixture/audio?path=...  -- serve the fixture's sibling WAV (Range)
   GET  /api/fixture/video?path=...  -- serve a fixture-bound video file (Range)
+  GET  /api/me                      -- current operator (LoopbackAuth user in local mode)
   GET  /api/user/recent-projects    -- recently-opened MatchProject roots (#75)
   POST /api/user/recent-projects/forget -- drop one entry from the list
   POST /api/user/recent-projects/bind   -- switch the in-memory project
@@ -104,6 +105,7 @@ from .. import models as model_layer
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
+from ..auth import AuthBackend, LoopbackAuth, User
 from ..config import (
     BeepDetectConfig,
     CoachAutoClassifyConfig,
@@ -567,6 +569,10 @@ class AppState:
     _bound_match_id: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
     matches: MatchRegistry = field(default_factory=MatchRegistry)
+    # Auth backend. ``LoopbackAuth`` in local mode (every request
+    # resolves to the same sentinel user); a hosted-mode backend will
+    # be injected here when SaaS lands. See ``splitsmith.auth``.
+    auth: AuthBackend = field(default_factory=LoopbackAuth)
     # Stop callback registered by :func:`splitsmith.ui.embedded.run_embedded`
     # so the /api/shutdown route can ask uvicorn to exit. None under the
     # ``splitsmith ui`` CLI path -- Ctrl-C via _JobAwareServer.handle_exit
@@ -4223,6 +4229,20 @@ def create_app(
             fn=lambda h, sl=slug, r=reset: _run_shot_detect(h, sl, stage_number, reset=r),
         )
         return JSONResponse(job.model_dump(mode="json"))
+
+    @app.get("/api/me", response_model=User)
+    async def get_me(request: Request) -> User:
+        """Return the operator behind this request.
+
+        Local mode always resolves to the ``LoopbackAuth`` sentinel
+        user (id ``"local"``); hosted mode will resolve cookies to a
+        real database user. The SPA reads this once on mount so the
+        same code path works in both modes.
+        """
+        user = await state.auth.authenticate_request(request)
+        if user is None:
+            raise HTTPException(status_code=401, detail="not authenticated")
+        return user
 
     @app.get("/api/me/jobs", response_model=list[Job])
     def list_jobs() -> list[Job]:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -87,7 +87,7 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import Body, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi import Body, Depends, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -2061,6 +2061,20 @@ def create_app(
     # shot-detect after the user picks a match finds the cache primed.
     _maybe_submit_model_download(state)
 
+    async def get_current_user(request: Request) -> User:
+        """FastAPI dependency: resolve the operator behind a request.
+
+        Every ``/api/me/*`` handler depends on this so the auth gate
+        lives in the request pipeline, not in handler bodies. In local
+        mode ``LoopbackAuth`` always returns the sentinel user (no 401
+        path is ever exercised); in hosted mode an unauthenticated
+        request short-circuits here before any handler runs.
+        """
+        user = await state.auth.authenticate_request(request)
+        if user is None:
+            raise HTTPException(status_code=401, detail="not authenticated")
+        return user
+
     @app.exception_handler(ShutdownInProgressError)
     async def _shutdown_in_progress_handler(request: Request, exc: ShutdownInProgressError) -> JSONResponse:
         """Map ShutdownInProgressError to 503 across every submit() callsite."""
@@ -2346,6 +2360,7 @@ def create_app(
         dest_root: str = Form(...),
         overwrite: bool = Form(False),
         bind: bool = Form(False),
+        user: User = Depends(get_current_user),
     ) -> JSONResponse:
         """Restore an archive produced by ``GET /api/project/export``.
 
@@ -4231,7 +4246,7 @@ def create_app(
         return JSONResponse(job.model_dump(mode="json"))
 
     @app.get("/api/me", response_model=User)
-    async def get_me(request: Request) -> User:
+    def get_me(user: User = Depends(get_current_user)) -> User:
         """Return the operator behind this request.
 
         Local mode always resolves to the ``LoopbackAuth`` sentinel
@@ -4239,18 +4254,15 @@ def create_app(
         real database user. The SPA reads this once on mount so the
         same code path works in both modes.
         """
-        user = await state.auth.authenticate_request(request)
-        if user is None:
-            raise HTTPException(status_code=401, detail="not authenticated")
         return user
 
     @app.get("/api/me/jobs", response_model=list[Job])
-    def list_jobs() -> list[Job]:
+    def list_jobs(user: User = Depends(get_current_user)) -> list[Job]:
         """Snapshot of all retained jobs (active + recently finished)."""
         return state.jobs.list()
 
     @app.get("/api/me/jobs/{job_id}", response_model=Job)
-    def get_job(job_id: str) -> Job:
+    def get_job(job_id: str, user: User = Depends(get_current_user)) -> Job:
         """Poll a single job. SPA polls ~1 Hz while a job is active."""
         job = state.jobs.get(job_id)
         if job is None:
@@ -4258,7 +4270,7 @@ def create_app(
         return job
 
     @app.post("/api/me/jobs/acknowledge-failures", response_model=list[Job])
-    def acknowledge_all_failures() -> list[Job]:
+    def acknowledge_all_failures(user: User = Depends(get_current_user)) -> list[Job]:
         """Mark every currently-unacknowledged FAILED job as seen (issue #73).
 
         Used by the JobsPanel "Dismiss all failures" header action. Returns
@@ -4268,7 +4280,7 @@ def create_app(
         return state.jobs.acknowledge_all_failures()
 
     @app.post("/api/me/jobs/{job_id}/acknowledge", response_model=Job)
-    def acknowledge_job(job_id: str) -> Job:
+    def acknowledge_job(job_id: str, user: User = Depends(get_current_user)) -> Job:
         """Mark a single failed job as seen (issue #73).
 
         No-op for jobs that aren't failed or are already acknowledged --
@@ -4281,7 +4293,7 @@ def create_app(
         return job
 
     @app.post("/api/me/jobs/{job_id}/cancel", response_model=Job)
-    def cancel_job(job_id: str) -> Job:
+    def cancel_job(job_id: str, user: User = Depends(get_current_user)) -> Job:
         """Request cooperative cancellation of a running or pending job.
 
         The registry sets ``cancel_requested=True`` and (for trim jobs)
@@ -6587,7 +6599,10 @@ def create_app(
     # scoreboard import flow can prefill 'me' instead of asking each project.
 
     @app.get("/api/me/recent-projects")
-    def list_recent_projects(detail: bool = Query(False)) -> JSONResponse:
+    def list_recent_projects(
+        detail: bool = Query(False),
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
         """Return the recent-projects list.
 
         ``detail=false`` (default) returns the raw
@@ -6604,7 +6619,10 @@ def create_app(
         return JSONResponse({"projects": [p.model_dump(mode="json") for p in projects]})
 
     @app.post("/api/me/recent-projects/forget")
-    def forget_recent_project(req: ForgetRecentProjectRequest) -> JSONResponse:
+    def forget_recent_project(
+        req: ForgetRecentProjectRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
         removed = user_config.remove_recent_project(Path(req.path))
         projects = user_config.get_recent_projects()
         return JSONResponse(
@@ -6615,7 +6633,10 @@ def create_app(
         )
 
     @app.post("/api/me/recent-projects/bind")
-    def bind_recent_project(req: BindRecentProjectRequest) -> HealthResponse:
+    def bind_recent_project(
+        req: BindRecentProjectRequest,
+        user: User = Depends(get_current_user),
+    ) -> HealthResponse:
         """Switch the in-memory project. Used by the SPA picker route.
 
         Accepts a path that already exists on disk (a previously-opened
@@ -7542,7 +7563,7 @@ def create_app(
         return get_beep_queue()
 
     @app.post("/api/me/recent-projects/unbind")
-    def unbind_recent_project() -> HealthResponse:
+    def unbind_recent_project(user: User = Depends(get_current_user)) -> HealthResponse:
         """Drop the bound project so the SPA returns to the picker.
 
         Equivalent to a `splitsmith ui` boot with no ``--project``;
@@ -7553,7 +7574,7 @@ def create_app(
         return HealthResponse(bound=False)
 
     @app.get("/api/me/scoreboard-identity")
-    def get_scoreboard_identity() -> JSONResponse:
+    def get_scoreboard_identity(user: User = Depends(get_current_user)) -> JSONResponse:
         # "Not pinned yet" is a normal state, not an error -- return a
         # 200 with a null body so the SPA doesn't have to catch a 404
         # on every page load and DevTools doesn't log a failed request.
@@ -7563,7 +7584,10 @@ def create_app(
         return JSONResponse(identity.model_dump(mode="json"))
 
     @app.put("/api/me/scoreboard-identity")
-    def put_scoreboard_identity(req: ScoreboardIdentityRequest) -> JSONResponse:
+    def put_scoreboard_identity(
+        req: ScoreboardIdentityRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
         identity = user_config.ScoreboardIdentity(
             shooter_id=req.shooter_id,
             display_name=req.display_name,
@@ -7575,7 +7599,7 @@ def create_app(
         return JSONResponse(identity.model_dump(mode="json"))
 
     @app.delete("/api/me/scoreboard-identity")
-    def delete_scoreboard_identity() -> JSONResponse:
+    def delete_scoreboard_identity(user: User = Depends(get_current_user)) -> JSONResponse:
         user_config.clear_scoreboard_identity()
         return JSONResponse({"ok": True})
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -496,6 +496,19 @@ def _raise_scoreboard_http(exc: ScoreboardError) -> None:
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
+# /api/* paths the auth gate lets through without resolving a user.
+# Anything else under /api/* requires ``state.auth.authenticate_request``
+# to return a non-None User -- see the ``_auth_gate`` middleware inside
+# ``create_app``. Non-/api/* paths (SPA static, /docs) are exempt by
+# prefix, not by this list.
+_PUBLIC_API_PATHS: frozenset[str] = frozenset(
+    {
+        "/api/health",
+        "/api/server/features",
+        "/api/shutdown",
+    }
+)
+
 
 def _is_loopback(request: Request) -> bool:
     """Reject /api/shutdown from non-loopback callers.
@@ -2143,6 +2156,36 @@ def create_app(
         finally:
             current_match_root.reset(root_token)
             current_match_id.reset(id_token)
+
+    # ----------------------------------------------------------------------
+    # Auth gate middleware (saas-readiness step)
+    # ----------------------------------------------------------------------
+    #
+    # Every ``/api/*`` request is resolved through ``state.auth`` before
+    # the route handler runs. ``LoopbackAuth`` always returns a user, so
+    # in local mode this middleware never 401s -- the wiring exists so a
+    # hosted-mode backend can swap in and the 401 path activates without
+    # touching any route. Non-``/api/*`` paths (SPA static, ``/docs``,
+    # ``/openapi.json``) pass through untouched -- auth happens at the
+    # API layer, not the asset layer. The allowlist below names the few
+    # ``/api/*`` endpoints that must stay anonymous: process health and
+    # the feature flag the SPA reads on mount (both are needed before a
+    # user is established) plus ``/api/shutdown`` (which has its own
+    # loopback gate that's stricter than auth).
+    @app.middleware("http")
+    async def _auth_gate(request, call_next):
+        path = request.url.path
+        if not path.startswith("/api/"):
+            return await call_next(request)
+        if path in _PUBLIC_API_PATHS:
+            return await call_next(request)
+        user = await state.auth.authenticate_request(request)
+        if user is None:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "not authenticated"},
+            )
+        return await call_next(request)
 
     # ----------------------------------------------------------------------
     # API

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,47 @@
+"""Tests for the auth abstraction and the /api/me endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from splitsmith.auth import LOOPBACK_USER_EMAIL, LOOPBACK_USER_ID, LoopbackAuth, User
+from splitsmith.ui.server import create_app
+
+
+def test_loopback_auth_returns_singleton_user() -> None:
+    backend = LoopbackAuth()
+
+    # The request is intentionally ignored -- LoopbackAuth never reads
+    # headers or cookies. Pass None to make that contract explicit.
+    user = asyncio.run(backend.authenticate_request(None))  # type: ignore[arg-type]
+
+    assert isinstance(user, User)
+    assert user.id == LOOPBACK_USER_ID
+    assert user.email == LOOPBACK_USER_EMAIL
+
+
+def test_api_me_returns_loopback_user(tmp_path: Path) -> None:
+    app = create_app(project_root=tmp_path / "match", project_name="Auth Test Match")
+    client = TestClient(app)
+
+    resp = client.get("/api/me")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == LOOPBACK_USER_ID
+    assert body["email"] == LOOPBACK_USER_EMAIL
+
+
+def test_api_me_works_when_unbound() -> None:
+    """Auth resolves above the bound-project check -- the picker
+    page needs to know the operator before any project exists."""
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.get("/api/me")
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == LOOPBACK_USER_ID

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 
 from splitsmith.auth import LOOPBACK_USER_EMAIL, LOOPBACK_USER_ID, LoopbackAuth, User
 from splitsmith.ui.server import create_app
+
+
+class _AnonymousAuth:
+    """Test double: an auth backend that resolves every request to
+    anonymous. Stands in for the hosted-mode case where no cookie
+    is present -- the dep should 401 before the handler runs."""
+
+    async def authenticate_request(self, request: Request) -> User | None:
+        return None
 
 
 def test_loopback_auth_returns_singleton_user() -> None:
@@ -45,3 +56,69 @@ def test_api_me_works_when_unbound() -> None:
 
     assert resp.status_code == 200
     assert resp.json()["id"] == LOOPBACK_USER_ID
+
+
+# Every /api/me/* route should be gated by the get_current_user dep,
+# so swapping the backend to one that returns anonymous should make
+# them all 401. Each entry is (method, template, concrete_url) -- the
+# template is what FastAPI registers; the concrete URL is what the
+# TestClient actually hits. ``test_me_route_coverage_matches_app``
+# below fails if a new route lands without an entry here.
+_ME_ROUTES_REQUIRING_AUTH: list[tuple[str, str, str]] = [
+    ("GET", "/api/me", "/api/me"),
+    ("GET", "/api/me/jobs", "/api/me/jobs"),
+    ("GET", "/api/me/jobs/{job_id}", "/api/me/jobs/does-not-exist"),
+    ("POST", "/api/me/jobs/acknowledge-failures", "/api/me/jobs/acknowledge-failures"),
+    ("POST", "/api/me/jobs/{job_id}/acknowledge", "/api/me/jobs/does-not-exist/acknowledge"),
+    ("POST", "/api/me/jobs/{job_id}/cancel", "/api/me/jobs/does-not-exist/cancel"),
+    ("GET", "/api/me/recent-projects", "/api/me/recent-projects"),
+    ("POST", "/api/me/recent-projects/forget", "/api/me/recent-projects/forget"),
+    ("POST", "/api/me/recent-projects/bind", "/api/me/recent-projects/bind"),
+    ("POST", "/api/me/recent-projects/unbind", "/api/me/recent-projects/unbind"),
+    ("GET", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
+    ("PUT", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
+    ("DELETE", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
+    ("POST", "/api/me/projects/import", "/api/me/projects/import"),
+]
+
+
+@pytest.mark.parametrize(
+    "method,url",
+    [(m, url) for m, _, url in _ME_ROUTES_REQUIRING_AUTH],
+)
+def test_anonymous_request_gets_401_on_me_routes(method: str, url: str) -> None:
+    app = create_app()
+    app.state.splitsmith_state.auth = _AnonymousAuth()
+    client = TestClient(app)
+
+    resp = client.request(method, url)
+
+    # 401 means the auth dep fired before the handler. Anything else
+    # (404, 422, 200) means the handler ran first and the dep was
+    # bypassed.
+    assert resp.status_code == 401, (
+        f"{method} {url} returned {resp.status_code}, expected 401 -- "
+        "did this route forget Depends(get_current_user)?"
+    )
+
+
+def test_me_route_coverage_matches_app() -> None:
+    """Guard rail: every registered /api/me/* route appears in the
+    401 parametrize list above. Catches new routes that ship without
+    the auth gate.
+    """
+    app = create_app()
+    registered: set[tuple[str, str]] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        if not path or not path.startswith("/api/me"):
+            continue
+        for method in methods:
+            if method == "HEAD":
+                continue
+            registered.add((method, path))
+
+    covered = {(m, tmpl) for m, tmpl, _ in _ME_ROUTES_REQUIRING_AUTH}
+    missing = registered - covered
+    assert not missing, f"new /api/me/* routes not covered by the 401 gate test: {sorted(missing)}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -122,3 +122,69 @@ def test_me_route_coverage_matches_app() -> None:
     covered = {(m, tmpl) for m, tmpl, _ in _ME_ROUTES_REQUIRING_AUTH}
     missing = registered - covered
     assert not missing, f"new /api/me/* routes not covered by the 401 gate test: {sorted(missing)}"
+
+
+# The auth gate middleware sits in front of every /api/* route, not
+# just /api/me/*. Picking a few representative non-/api/me endpoints
+# proves the middleware (rather than per-route Depends) is what does
+# the gating. If the middleware regresses, ``/api/me/*`` would still
+# pass via Depends and only these would fail -- which is the point.
+_NON_ME_AUTHED_ROUTES: list[tuple[str, str]] = [
+    ("GET", "/api/project"),
+    ("GET", "/api/jobs"),
+    ("GET", "/api/fs/list"),
+    ("GET", "/api/stages/1/audit"),
+]
+
+
+@pytest.mark.parametrize("method,url", _NON_ME_AUTHED_ROUTES)
+def test_anonymous_request_gets_401_on_non_me_routes(method: str, url: str) -> None:
+    app = create_app()
+    app.state.splitsmith_state.auth = _AnonymousAuth()
+    client = TestClient(app)
+
+    resp = client.request(method, url)
+
+    assert resp.status_code == 401, (
+        f"{method} {url} returned {resp.status_code}, expected 401 -- "
+        "did the _auth_gate middleware regress?"
+    )
+
+
+# Paths the gate must let through anonymously. Health + features are
+# read before any user is established; ``/api/shutdown`` carries its
+# own loopback gate and answers 202 / 403 on its own terms. The list
+# is duplicated from ``_PUBLIC_API_PATHS`` on purpose -- this test
+# fails loudly if someone trims the allowlist without thinking about
+# what depends on it.
+_PUBLIC_PATHS: list[tuple[str, str]] = [
+    ("GET", "/api/health"),
+    ("GET", "/api/server/features"),
+]
+
+
+@pytest.mark.parametrize("method,url", _PUBLIC_PATHS)
+def test_public_paths_bypass_auth_gate(method: str, url: str) -> None:
+    app = create_app()
+    app.state.splitsmith_state.auth = _AnonymousAuth()
+    client = TestClient(app)
+
+    resp = client.request(method, url)
+
+    # Anything but 401 is fine -- the handler's own response (200,
+    # 4xx, etc.) just proves auth didn't short-circuit it.
+    assert resp.status_code != 401, f"{method} {url} returned 401; the public allowlist should let it through"
+
+
+def test_non_api_paths_bypass_auth_gate() -> None:
+    """SPA static assets (and anything not under /api/*) are served
+    without an auth check -- auth lives at the API layer."""
+    app = create_app()
+    app.state.splitsmith_state.auth = _AnonymousAuth()
+    client = TestClient(app)
+
+    # The SPA may or may not be built in the test env; either way the
+    # auth gate should not be the one rejecting the request.
+    resp = client.get("/")
+
+    assert resp.status_code != 401


### PR DESCRIPTION
## Summary
Completes the v1 SaaS-foundation auth bullet from `docs/saas-readiness/09-saas-progress.md`.

- Extract `AuthBackend` Protocol and ship `LoopbackAuth` (local-mode singleton, request-ignored). Wired into `AppState.auth`.
- `get_current_user` FastAPI dependency that closes over `state.auth`, returns `User` or 401s anonymous.
- `GET /api/me` so the SPA has a single mount-time identity read that works the same in local mode now and hosted mode later.
- Per-route `Depends(get_current_user)` on every `/api/me/*` handler (14 routes).
- `_auth_gate` ASGI middleware now gates **every** `/api/*` request, not just `/api/me/*`. Small allowlist for routes that must stay anonymous: `/api/health`, `/api/server/features`, `/api/shutdown` (loopback-gated separately). Non-`/api/*` paths (SPA static, `/docs`, `/openapi.json`) bypass by prefix.

Local-mode behaviour is unchanged -- `LoopbackAuth` never returns None, so the 401 path is dead code today. When `MagicLinkAuth` drops in, the 401 activates uniformly across all 125 routes without touching any handler.

Scope kept tight: `begin_login` / `complete_login` are deliberately NOT in the Protocol yet -- they get added when `MagicLinkAuth` lands. ACL middleware (`require_project_member`) is the next foundation slice.

## Test plan
- [x] `uv run pytest tests/test_auth.py` -- 25 tests pass:
  - LoopbackAuth returns the singleton user
  - `GET /api/me` works bound + unbound
  - Every `/api/me/*` route 401s when `state.auth` returns None (parametrized over all 14)
  - Coverage guard test fails if a new `/api/me/*` route ships without an entry
  - Representative non-`/api/me/*` routes (`/api/project`, `/api/jobs`, `/api/fs/list`, `/api/stages/1/audit`) 401 anonymous via the middleware
  - Public allowlist paths (`/api/health`, `/api/server/features`) bypass the gate
  - Non-`/api/*` paths bypass the gate
- [x] `uv run pytest tests/test_ui_*.py tests/test_relink_api.py tests/test_coach_api.py` -- 404 pass; pre-existing `test_sigterm_to_main_exits_clean` reproduces on clean main and is unrelated
- [x] `uv run ruff check` + `uv run black` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)