### PR TITLE
feat(compute): introduce ComputeBackend abstraction with LocalComputeBackend

### DIFF
--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -50,19 +50,22 @@ abstraction without behavioural change.
   (`/api/health`, `/api/server/features`, `/api/shutdown`). In
   local mode `LoopbackAuth` never 401s; the wiring activates when
   a hosted backend swaps in.
-- [~] Extract `ComputeBackend` interface; wrap today's ensemble
+- [x] Extract `ComputeBackend` interface; wrap today's ensemble
   pipeline as `LocalComputeBackend`. The orchestration in
   `cli.py` and the FastAPI server call the backend, not the
   ensemble directly.
   (See 04-compute-backends.md.) Protocol + `LocalComputeBackend`
   shipped; `state.compute` wired in `create_app`; the shot-
   detect worker (per-stage + bulk) goes through
-  `state.compute.detect_stage`. CLI orchestration (``splitsmith
-  cli.py``) and `splitsmith.mcp.detect_tools` still call the
-  ensemble directly. Auxiliary endpoints that use the runtime
-  for non-detect purposes (CLAP probes for promote-secondary,
-  calibrated-camera-models) keep direct runtime access until the
-  Protocol exposes those methods.
+  `state.compute.detect_stage`. ``cli.py``'s ``detect`` /
+  ``process`` commands run the older single-voter
+  ``shot_detect.detect_shots`` path, not the ensemble, so there
+  was nothing to migrate there. Dev/lab surfaces (``lab_cli``,
+  ``splitsmith.mcp.detect_tools``, ``/api/lab/*``) and auxiliary
+  endpoints that use the runtime for non-detect work (CLAP
+  probes for promote-secondary, calibrated-camera-models) keep
+  direct runtime access -- hosted mode would never run those
+  paths and the Protocol stays narrow until something needs more.
 - [ ] Add a `splitsmith serve` entry point alongside `splitsmith ui`.
   Same code; different mode wiring at startup.
 - [ ] Add `docker compose` for hosted-mode dev (Postgres + LocalStack

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -50,11 +50,19 @@ abstraction without behavioural change.
   (`/api/health`, `/api/server/features`, `/api/shutdown`). In
   local mode `LoopbackAuth` never 401s; the wiring activates when
   a hosted backend swaps in.
-- [ ] Extract `ComputeBackend` interface; wrap today's ensemble
+- [~] Extract `ComputeBackend` interface; wrap today's ensemble
   pipeline as `LocalComputeBackend`. The orchestration in
   `cli.py` and the FastAPI server call the backend, not the
   ensemble directly.
-  (See 04-compute-backends.md.)
+  (See 04-compute-backends.md.) Protocol + `LocalComputeBackend`
+  shipped; `state.compute` wired in `create_app`; the shot-
+  detect worker (per-stage + bulk) goes through
+  `state.compute.detect_stage`. CLI orchestration (``splitsmith
+  cli.py``) and `splitsmith.mcp.detect_tools` still call the
+  ensemble directly. Auxiliary endpoints that use the runtime
+  for non-detect purposes (CLAP probes for promote-secondary,
+  calibrated-camera-models) keep direct runtime access until the
+  Protocol exposes those methods.
 - [ ] Add a `splitsmith serve` entry point alongside `splitsmith ui`.
   Same code; different mode wiring at startup.
 - [ ] Add `docker compose` for hosted-mode dev (Postgres + LocalStack

--- a/src/splitsmith/compute.py
+++ b/src/splitsmith/compute.py
@@ -1,0 +1,115 @@
+"""Compute backend abstraction for shot detection.
+
+The interface lets the same orchestration code drive two execution
+modes:
+
+- **Local mode** -- ``LocalComputeBackend`` runs the ensemble in
+  this process. This is what ``splitsmith ui`` does today.
+- **Hosted mode** -- a future ``RemoteComputeBackend`` will ship
+  audio (or a storage pointer) to a cloud worker and poll for the
+  result.
+
+The Protocol is intentionally narrow today: a single ``detect_stage``
+method returning an ``EnsembleResult``. Progress reporting,
+``health()``, and the ``AudioRef`` tagged union from
+``docs/saas-readiness/04-compute-backends.md`` get added when the
+remote backend lands and actually needs them.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+
+from . import ensemble as ensemble_pkg
+from .ensemble.api import EnsembleConfig, EnsembleResult, EnsembleRuntime, load_ensemble_runtime
+
+
+class ComputeBackend(Protocol):
+    name: str
+
+    def detect_stage(
+        self,
+        *,
+        audio: np.ndarray,
+        sample_rate: int,
+        beep_time_in_clip: float,
+        stage_time_seconds: float,
+        expected_rounds: int | None = None,
+        ensemble_config: EnsembleConfig | None = None,
+        camera_class: str | None = None,
+        camera_make: str | None = None,
+        camera_model: str | None = None,
+        video_path: Path | None = None,
+        source_beep_time: float | None = None,
+    ) -> EnsembleResult:
+        """Run the shot-detection ensemble for a single stage."""
+
+
+class LocalComputeBackend:
+    """Runs the ensemble in this process.
+
+    ``runtime_loader`` is injected so the server can hand us its
+    existing module-level lazy-loader (which test code already
+    monkeypatches). When called outside the server -- e.g. from a
+    standalone script -- the default ``load_ensemble_runtime`` is
+    used, which actually downloads / instantiates the heavy models.
+    """
+
+    name = "local"
+
+    def __init__(
+        self,
+        *,
+        runtime_loader: Callable[[], EnsembleRuntime] | None = None,
+    ) -> None:
+        self._runtime_loader = runtime_loader or load_ensemble_runtime
+        self._runtime: EnsembleRuntime | None = None
+        self._lock = threading.Lock()
+
+    def _ensure_runtime(self) -> EnsembleRuntime:
+        if self._runtime is None:
+            with self._lock:
+                if self._runtime is None:
+                    self._runtime = self._runtime_loader()
+        return self._runtime
+
+    def detect_stage(
+        self,
+        *,
+        audio: np.ndarray,
+        sample_rate: int,
+        beep_time_in_clip: float,
+        stage_time_seconds: float,
+        expected_rounds: int | None = None,
+        ensemble_config: EnsembleConfig | None = None,
+        camera_class: str | None = None,
+        camera_make: str | None = None,
+        camera_model: str | None = None,
+        video_path: Path | None = None,
+        source_beep_time: float | None = None,
+    ) -> EnsembleResult:
+        runtime = self._ensure_runtime()
+        # Call through the package binding so tests that monkeypatch
+        # ``splitsmith.ensemble.detect_shots_ensemble`` still intercept
+        # us. ``ensemble.api.detect_shots_ensemble`` is the same
+        # function but a different attribute path that monkeypatch
+        # doesn't replace.
+        return ensemble_pkg.detect_shots_ensemble(
+            audio,
+            sample_rate,
+            beep_time_in_clip,
+            stage_time_seconds,
+            runtime,
+            expected_rounds=expected_rounds,
+            ensemble_config=ensemble_config,
+            camera_class=camera_class,
+            camera_make=camera_make,
+            camera_model=camera_model,
+            video_path=video_path,
+            source_beep_time=source_beep_time,
+        )

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -106,6 +106,7 @@ from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
 from ..auth import AuthBackend, LoopbackAuth, User
+from ..compute import ComputeBackend, LocalComputeBackend
 from ..config import (
     BeepDetectConfig,
     CoachAutoClassifyConfig,
@@ -586,6 +587,14 @@ class AppState:
     # resolves to the same sentinel user); a hosted-mode backend will
     # be injected here when SaaS lands. See ``splitsmith.auth``.
     auth: AuthBackend = field(default_factory=LoopbackAuth)
+    # Compute backend. ``LocalComputeBackend`` runs the shot-detection
+    # ensemble in this process; a hosted ``RemoteComputeBackend`` will
+    # ship audio to a cloud worker. See ``splitsmith.compute`` and
+    # ``docs/saas-readiness/04-compute-backends.md``. The default uses
+    # ``load_ensemble_runtime`` directly; ``create_app`` overrides this
+    # with one wired to the local ``_get_ensemble_runtime`` so test
+    # monkeypatches and the shared model cache still work.
+    compute: ComputeBackend = field(default_factory=LocalComputeBackend)
     # Stop callback registered by :func:`splitsmith.ui.embedded.run_embedded`
     # so the /api/shutdown route can ask uvicorn to exit. None under the
     # ``splitsmith ui`` CLI path -- Ctrl-C via _JobAwareServer.handle_exit
@@ -2038,6 +2047,14 @@ def create_app(
     nav entry). Hidden by default; opt in via ``splitsmith ui --lab``.
     """
     state = AppState()
+    # Route the compute backend through the module-level lazy loader so
+    # the shared cache + existing test monkeypatches on
+    # ``_get_ensemble_runtime`` still apply. The lambda re-resolves the
+    # name on every call so ``monkeypatch.setattr(server, "_get_ensemble_runtime", ...)``
+    # in tests takes effect even though the backend was constructed
+    # before the patch ran. When the hosted backend lands this swap
+    # point is where the picker would inject a ``RemoteComputeBackend``.
+    state.compute = LocalComputeBackend(runtime_loader=lambda: _get_ensemble_runtime())
     # Populate the match-id registry from recent projects so id -> path
     # lookups resolve without waiting for a picker bind. Cheap (one
     # match.json read per recent entry; legacy projects are skipped).
@@ -4077,8 +4094,6 @@ def create_app(
                 expected_rounds = raw
 
         handle.update(progress=0.2, message="Loading ensemble models...")
-        runtime = _get_ensemble_runtime()
-
         handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
         audio_array, sr = beep_detect.load_audio(audit.audio_path)
         # Camera-class dispatch (issue #143). When the primary's mount
@@ -4091,12 +4106,11 @@ def create_app(
         # AND the source video to be reachable.
         enable_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
         ensemble_cfg = ensemble_module.EnsembleConfig(enable_voter_e=enable_e)
-        result = ensemble_module.detect_shots_ensemble(
-            audio_array,
-            sr,
-            beep_in_clip,
-            stg.time_seconds,
-            runtime,
+        result = state.compute.detect_stage(
+            audio=audio_array,
+            sample_rate=sr,
+            beep_time_in_clip=beep_in_clip,
+            stage_time_seconds=stg.time_seconds,
             expected_rounds=expected_rounds,
             ensemble_config=ensemble_cfg,
             camera_class=cam_class,

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,0 +1,155 @@
+"""Tests for the compute backend abstraction."""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+from splitsmith.compute import LocalComputeBackend
+from splitsmith.ensemble.api import EnsembleConfig, EnsembleResult
+
+
+class _FakeRuntime:
+    """Stand-in for the heavy ensemble runtime; we never actually
+    use its attributes -- we monkeypatch ``detect_shots_ensemble``
+    so the backend's call into it sees the fake and skips real
+    model loading."""
+
+
+def test_local_backend_lazy_loads_runtime_only_once(monkeypatch) -> None:
+    """``runtime_loader`` should be invoked at most once per backend
+    instance, even across concurrent ``detect_stage`` calls."""
+    load_calls = 0
+    load_lock = threading.Lock()
+
+    def _loader():
+        nonlocal load_calls
+        with load_lock:
+            load_calls += 1
+        return _FakeRuntime()
+
+    captured: list[dict] = []
+
+    def _fake_detect(audio, sr, beep, stage_time, runtime, **kwargs):
+        captured.append({"beep": beep, "stage_time": stage_time, **kwargs})
+        return EnsembleResult(candidates=[], consensus=2, expected_rounds=kwargs.get("expected_rounds"))
+
+    import splitsmith.ensemble as ensemble_pkg
+
+    monkeypatch.setattr(ensemble_pkg, "detect_shots_ensemble", _fake_detect)
+
+    backend = LocalComputeBackend(runtime_loader=_loader)
+    audio = np.zeros(1024, dtype=np.float32)
+
+    backend.detect_stage(audio=audio, sample_rate=48000, beep_time_in_clip=0.5, stage_time_seconds=10.0)
+    backend.detect_stage(audio=audio, sample_rate=48000, beep_time_in_clip=0.5, stage_time_seconds=10.0)
+
+    assert load_calls == 1, "runtime loader should be memoised"
+    assert len(captured) == 2
+
+
+def test_local_backend_calls_through_package_binding_so_patches_work(monkeypatch) -> None:
+    """If ``LocalComputeBackend`` called the function via the
+    ``ensemble.api`` module attribute, this monkeypatch would not
+    intercept. The package-binding indirection in the backend is
+    what makes the existing test suite's pattern work."""
+    sentinel = EnsembleResult(candidates=[], consensus=99, expected_rounds=42)
+
+    import splitsmith.ensemble as ensemble_pkg
+
+    monkeypatch.setattr(ensemble_pkg, "detect_shots_ensemble", lambda *a, **kw: sentinel)
+
+    backend = LocalComputeBackend(runtime_loader=lambda: _FakeRuntime())
+    result = backend.detect_stage(
+        audio=np.zeros(1, dtype=np.float32),
+        sample_rate=48000,
+        beep_time_in_clip=0.0,
+        stage_time_seconds=1.0,
+    )
+
+    assert result is sentinel
+
+
+def test_local_backend_forwards_keyword_arguments(monkeypatch) -> None:
+    """All optional kwargs surface unmodified to ``detect_shots_ensemble``.
+
+    Regression guard: if a refactor drops a parameter, the existing
+    shot-detect endpoint silently loses behaviour (e.g. voter E,
+    camera-class dispatch, apriori boost) without any test failing
+    on the call site itself.
+    """
+    seen: dict = {}
+
+    def _fake_detect(audio, sr, beep, stage_time, runtime, **kwargs):
+        seen.update(kwargs)
+        return EnsembleResult(candidates=[], consensus=2)
+
+    import splitsmith.ensemble as ensemble_pkg
+
+    monkeypatch.setattr(ensemble_pkg, "detect_shots_ensemble", _fake_detect)
+
+    cfg = EnsembleConfig()
+    backend = LocalComputeBackend(runtime_loader=lambda: _FakeRuntime())
+    backend.detect_stage(
+        audio=np.zeros(1, dtype=np.float32),
+        sample_rate=48000,
+        beep_time_in_clip=0.5,
+        stage_time_seconds=10.0,
+        expected_rounds=8,
+        ensemble_config=cfg,
+        camera_class="handheld",
+        camera_make="GoPro",
+        camera_model="HERO12",
+        video_path=None,
+        source_beep_time=1.23,
+    )
+
+    assert seen["expected_rounds"] == 8
+    assert seen["ensemble_config"] is cfg
+    assert seen["camera_class"] == "handheld"
+    assert seen["camera_make"] == "GoPro"
+    assert seen["camera_model"] == "HERO12"
+    assert seen["source_beep_time"] == 1.23
+
+
+def test_local_backend_name_is_local() -> None:
+    """The ``name`` attribute is what observability code keys on
+    (job records, log lines). Lock it down so a rename here doesn't
+    silently invalidate dashboards downstream."""
+    assert LocalComputeBackend().name == "local"
+
+
+def test_state_compute_is_swappable_by_tests() -> None:
+    """The whole point of the abstraction: tests (and the eventual
+    hosted picker) can replace ``state.compute`` to redirect every
+    detect call without touching the orchestrator. If this breaks,
+    the abstraction has leaked."""
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    state = app.state.splitsmith_state
+
+    sentinel_result = EnsembleResult(candidates=[], consensus=7)
+
+    class _RecordingBackend:
+        name = "recording"
+
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def detect_stage(self, **kwargs):
+            self.calls.append(kwargs)
+            return sentinel_result
+
+    fake = _RecordingBackend()
+    state.compute = fake
+
+    result = state.compute.detect_stage(
+        audio=np.zeros(1, dtype=np.float32),
+        sample_rate=48000,
+        beep_time_in_clip=0.0,
+        stage_time_seconds=1.0,
+    )
+    assert result is sentinel_result
+    assert len(fake.calls) == 1


### PR DESCRIPTION
## Summary
Second v1 SaaS-foundation step from `docs/saas-readiness/09-saas-progress.md`, after #405 (auth).

- New `ComputeBackend` Protocol in `src/splitsmith/compute.py` -- one method, `detect_stage`. Progress reporting, `health()`, and the `AudioRef` tagged union from doc 04 get added when the remote backend actually needs them, not now.
- `LocalComputeBackend` lazy-loads its runtime via an injectable `runtime_loader` callback. `create_app` wires it to the existing module-level `_get_ensemble_runtime` so the shared model cache and the existing test monkeypatches keep working without duplication.
- The backend calls the ensemble via its **package** binding (`splitsmith.ensemble.detect_shots_ensemble`), not the api-module binding -- otherwise `monkeypatch.setattr(ensemble_pkg, ...)` in the existing tests would no-op.
- `state.compute` field on `AppState`; `_run_shot_detect` (used by both `/api/stages/{n}/shot-detect` and the bulk `/api/stages/shot-detect` endpoint) now goes through `state.compute.detect_stage`.
- Auxiliary endpoints that use the runtime for non-detect purposes (CLAP probes for promote-secondary, calibrated-camera-models, Lab) keep direct runtime access -- the Protocol intentionally doesn't grow `clap_probe` until something needs it. CLI orchestration and `splitsmith.mcp.detect_tools` also stay on direct access for follow-up iterations.

When `RemoteComputeBackend` lands, the swap point is one line in `create_app`.

## Test plan
- [x] `uv run pytest tests/test_compute.py` -- 5 new tests pass: runtime loader is memoised, package-binding indirection works, all kwargs forward, `name == "local"`, `state.compute` is swappable
- [x] `uv run pytest tests/test_ui_server.py -k shot_detect` -- 9 of 10 shot-detect tests pass; the one failure (`test_marking_reviewed_kicks_off_shot_detect`) reproduces on clean main with the same ffmpeg-on-fake-mp4 error, unrelated
- [x] `uv run pytest tests/test_ui_server.py tests/test_compute.py tests/test_auth.py` -- 270 pass
- [x] `uv run ruff check` + `uv run black` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)