### PR TITLE
feat(storage): introduce Storage abstraction with FilesystemStorage

### DIFF
--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -37,9 +37,16 @@ These can ship before any hosted-mode infrastructure exists. Each is
 a refactor that makes today's local-mode code pass through the
 abstraction without behavioural change.
 
-- [ ] Extract `Storage` interface; replace direct `pathlib.Path` use
+- [~] Extract `Storage` interface; replace direct `pathlib.Path` use
   in project layout with `FilesystemStorage` calls.
-  (See 03-storage-layer.md.)
+  (See 03-storage-layer.md.) Protocol + `FilesystemStorage` shipped
+  with atomic temp+rename writes and a path-traversal guard. Not
+  yet wired into `AppState` -- local mode opens projects at
+  arbitrary user-chosen paths, so the right scope is per-project
+  rather than a process singleton. Migration of existing callsites
+  (recent-projects index, audit JSON, project state) is iterative
+  follow-up work; the Protocol is sync today and goes async if
+  ``S3Storage`` ever needs it.
 - [x] Extract `Auth` interface; introduce `LoopbackAuth`; route
   every API handler through `auth.authenticate_request`.
   (See 02-tenancy-and-identity.md.) Interface + `LoopbackAuth` +

--- a/src/splitsmith/storage.py
+++ b/src/splitsmith/storage.py
@@ -1,0 +1,182 @@
+"""Storage abstraction for project file IO.
+
+The interface lets the same project code read/write files in two
+modes:
+
+- **Local mode** -- ``FilesystemStorage`` wraps ``pathlib.Path`` and
+  writes go through a temp-file + atomic rename so partial writes
+  never appear at the canonical path.
+- **Hosted mode** -- a future ``S3Storage`` will wrap an
+  S3-compatible client (Cloudflare R2 in production). When it lands
+  the dependency on fsspec earns its keep; today pathlib is enough.
+
+The Protocol is intentionally narrow today: bytes IO + a handful of
+metadata methods. ``open_stream``, ``signed_url``, and the JSON
+helpers from ``docs/saas-readiness/03-storage-layer.md`` get added
+when a callsite actually needs them.
+
+Scoping: paths passed to a ``Storage`` instance are **relative to
+its root**. The root is opaque to callers -- it might be a local
+directory, a bucket prefix, or an in-memory namespace. Multiple
+``Storage`` instances may coexist (one per project root in local
+mode; per-tenant prefixes in hosted mode); there is no global
+storage singleton.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel
+
+
+class StorageObject(BaseModel):
+    """Metadata for a single object in storage.
+
+    ``etag`` is None for backends that don't compute one (local FS
+    today). ``last_modified`` is None when the backend reports no
+    mtime (rare; some in-memory test backends).
+    """
+
+    path: str
+    size: int
+    etag: str | None = None
+    last_modified: datetime | None = None
+
+
+class Storage(Protocol):
+    """Project-scoped byte storage. Paths are relative to the root."""
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the object's bytes. Raises ``FileNotFoundError`` if absent."""
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Atomic write. Replaces an existing object at the same path."""
+
+    def exists(self, path: str) -> bool:
+        """Return True iff an object exists at the path."""
+
+    def stat(self, path: str) -> StorageObject | None:
+        """Return metadata, or None if the path doesn't exist."""
+
+    def list(self, prefix: str) -> Iterator[StorageObject]:
+        """Yield every object whose path starts with ``prefix``.
+
+        ``prefix=''`` walks the whole storage root. Returned paths
+        are relative to the root (same as ``read_bytes`` accepts).
+        Order is unspecified.
+        """
+
+    def delete(self, path: str) -> None:
+        """Remove the object. No-op if absent."""
+
+
+class FilesystemStorage:
+    """Local-disk implementation backed by ``pathlib.Path``.
+
+    Writes go through a sibling temp file + ``os.replace`` so a
+    crash mid-write can't leave a torn file at the canonical path.
+    Tests construct one of these against ``tmp_path``; production
+    constructs one against the user's chosen project root.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root)
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _resolve(self, path: str) -> Path:
+        # Reject absolute paths and ``..`` traversal up front so a
+        # caller can't accidentally write outside the storage root.
+        # In hosted mode the same check protects against tenant-
+        # crossing prefixes that bypass the bucket scope.
+        rel = Path(path)
+        if rel.is_absolute() or any(part == ".." for part in rel.parts):
+            raise ValueError(f"path must be relative and contain no '..': {path!r}")
+        return self._root / rel
+
+    def read_bytes(self, path: str) -> bytes:
+        return self._resolve(path).read_bytes()
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # ``delete=False`` so the temp file survives the context; we
+        # close it before the rename so Windows-style locks don't
+        # interfere (the production target is POSIX but the test
+        # suite runs on macOS / Linux either way).
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=target.name + ".",
+            suffix=".tmp",
+            dir=target.parent,
+        )
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+            Path(tmp_name).replace(target)
+        except Exception:
+            # Best-effort cleanup; if the rename succeeded the temp
+            # is already gone. Suppress because we want to re-raise
+            # the original write error, not a cleanup error.
+            try:
+                Path(tmp_name).unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+    def exists(self, path: str) -> bool:
+        return self._resolve(path).exists()
+
+    def stat(self, path: str) -> StorageObject | None:
+        target = self._resolve(path)
+        if not target.exists():
+            return None
+        st = target.stat()
+        return StorageObject(
+            path=path,
+            size=st.st_size,
+            last_modified=datetime.fromtimestamp(st.st_mtime).astimezone(),
+        )
+
+    def list(self, prefix: str) -> Iterator[StorageObject]:
+        # Resolve the prefix to a directory if it points at one, or
+        # treat it as a filename prefix within the storage root if
+        # not. ``prefix=''`` walks everything from the root.
+        if prefix:
+            base = self._resolve(prefix)
+        else:
+            base = self._root
+        if not base.exists():
+            return
+        if base.is_file():
+            st = base.stat()
+            yield StorageObject(
+                path=str(base.relative_to(self._root).as_posix()),
+                size=st.st_size,
+                last_modified=datetime.fromtimestamp(st.st_mtime).astimezone(),
+            )
+            return
+        for p in base.rglob("*"):
+            if not p.is_file():
+                continue
+            st = p.stat()
+            yield StorageObject(
+                path=str(p.relative_to(self._root).as_posix()),
+                size=st.st_size,
+                last_modified=datetime.fromtimestamp(st.st_mtime).astimezone(),
+            )
+
+    def delete(self, path: str) -> None:
+        target = self._resolve(path)
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,154 @@
+"""Tests for the storage abstraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.storage import FilesystemStorage, StorageObject
+
+
+def test_round_trip_write_then_read(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("hello.txt", b"world")
+
+    assert storage.read_bytes("hello.txt") == b"world"
+
+
+def test_write_creates_parent_directories(tmp_path: Path) -> None:
+    """Callers should not have to mkdir themselves -- a project's
+    on-disk layout has many nested folders and forcing every writer
+    to manage them duplicates concerns."""
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("shooters/abc/audits/2026.json", b"{}")
+
+    assert (tmp_path / "shooters" / "abc" / "audits" / "2026.json").read_bytes() == b"{}"
+
+
+def test_write_is_atomic_via_temp_and_rename(tmp_path: Path) -> None:
+    """A crash mid-write must not leave a torn file at the canonical
+    path. We can't easily simulate a crash, but we can prove the
+    rename path leaves no temp files lying around on success."""
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("data.bin", b"first version" * 100)
+    storage.write_bytes("data.bin", b"second version" * 100)
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert siblings == ["data.bin"], f"temp file leaked: {siblings}"
+
+
+def test_write_overwrites_existing(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("k", b"v1")
+    storage.write_bytes("k", b"v2")
+
+    assert storage.read_bytes("k") == b"v2"
+
+
+def test_read_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        storage.read_bytes("nope")
+
+
+def test_exists_returns_true_after_write(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    assert not storage.exists("k")
+
+    storage.write_bytes("k", b"v")
+    assert storage.exists("k")
+
+
+def test_stat_returns_none_for_missing(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+
+    assert storage.stat("nope") is None
+
+
+def test_stat_returns_size_for_existing(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("k", b"hello")
+
+    info = storage.stat("k")
+    assert isinstance(info, StorageObject)
+    assert info.path == "k"
+    assert info.size == 5
+    assert info.last_modified is not None
+
+
+def test_list_walks_subdirectories(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("a.txt", b"x")
+    storage.write_bytes("nested/b.txt", b"x")
+    storage.write_bytes("nested/deep/c.txt", b"x")
+
+    paths = sorted(obj.path for obj in storage.list(""))
+    assert paths == ["a.txt", "nested/b.txt", "nested/deep/c.txt"]
+
+
+def test_list_with_prefix_narrows_to_subtree(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("a/1.txt", b"x")
+    storage.write_bytes("a/2.txt", b"x")
+    storage.write_bytes("b/3.txt", b"x")
+
+    paths = sorted(obj.path for obj in storage.list("a"))
+    assert paths == ["a/1.txt", "a/2.txt"]
+
+
+def test_list_missing_prefix_yields_nothing(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+
+    assert list(storage.list("nope")) == []
+
+
+def test_delete_removes_file(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("k", b"v")
+
+    storage.delete("k")
+
+    assert not storage.exists("k")
+
+
+def test_delete_missing_is_noop(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    # No exception even though the path was never written.
+    storage.delete("nope")
+
+
+def test_delete_removes_directory_recursively(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("dir/a.txt", b"x")
+    storage.write_bytes("dir/nested/b.txt", b"x")
+
+    storage.delete("dir")
+
+    assert list(storage.list("dir")) == []
+
+
+# Path-traversal guard tests: every method that takes a path goes
+# through ``_resolve``, which must reject absolute paths and ``..``
+# parts. Without this guard a caller (or a malicious request body
+# in hosted mode) could write outside the storage root.
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/etc/passwd",
+        "../escape.txt",
+        "nested/../../escape.txt",
+        "a/../../b",
+    ],
+)
+def test_traversal_or_absolute_paths_rejected(tmp_path: Path, bad_path: str) -> None:
+    storage = FilesystemStorage(tmp_path)
+
+    with pytest.raises(ValueError, match="must be relative"):
+        storage.write_bytes(bad_path, b"x")
+
+
+def test_root_property_reflects_constructor(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    assert storage.root == tmp_path


### PR DESCRIPTION
## Summary
Third v1 SaaS-foundation step from `docs/saas-readiness/09-saas-progress.md`, after #405 (auth) and #406 (compute).

- New `Storage` Protocol in `src/splitsmith/storage.py` -- narrow surface: bytes IO + exists / stat / list / delete. `open_stream`, `signed_url`, and JSON helpers from doc 03 land when a callsite actually needs them.
- `FilesystemStorage` wraps `pathlib.Path`. Writes go through a sibling temp file + `Path.replace` so a crash mid-write can't leave a torn file at the canonical path. Path-traversal guard rejects absolute paths and `..` components -- protects local mode against accidents and hosted mode against tenant escape.
- Sync rather than async because the surrounding codebase is sync; the async question reopens when `S3Storage` arrives.
- **Not yet wired into `AppState`** -- local mode opens projects at arbitrary user-chosen paths, so the right scope is per-project rather than a process singleton. Iteration 2 picks the first callsite (likely the user-config recent-projects JSON, which does have a single `~/.splitsmith/` root) and wires from there.
- `fsspec` intentionally not added as a dependency yet; per the project's "no new deps without asking" rule it earns its place when `S3Storage` lands.

## Test plan
- [x] `uv run pytest tests/test_storage.py` -- 19 tests pass: round-trip IO, atomic-write leaves no temp siblings, overwrite, missing-file `FileNotFoundError`, exists / stat behaviour, recursive list with and without prefix, delete of file and directory, traversal guard rejects 4 attack shapes, `root` property
- [x] `uv run ruff check` + `uv run black` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)