### PR TITLE
refactor(state): match_root reads only the per-request ContextVar (Tier 1 step)

### DIFF
--- a/docs/saas-readiness/10-singleton-elimination.md
+++ b/docs/saas-readiness/10-singleton-elimination.md
@@ -59,6 +59,14 @@ singleton. The fallback IS the violation.
 
 **Elimination path:**
 
+0. **(in progress)** `state.match_root` reads ContextVar only --
+   the singleton fallback for match-level operations is gone.
+   `/api/match/*` endpoints now 409 ``no_project`` unless the
+   request comes through `/api/matches/{match_id}/`. This was the
+   smallest defensible first cut: only ~10 test callsites needed
+   the prefix, and `shooter_root` still has its singleton fallback
+   so the bulk of shooter-scoped routes are unchanged. Next cuts
+   chip away at `shooter_root` and `shooter_project`.
 1. Make `/api/matches/{match_id}/...` the only accepted prefix for
    project-scoped routes. Delete the bare-path route table or have
    it 404. The middleware becomes mandatory rather than a fallback.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -625,21 +625,21 @@ class AppState:
 
     @property
     def match_root(self) -> Path:
-        """The bound match folder. 409 ``not_a_match`` for legacy projects."""
-        if self._bound_root is None:
+        """The match folder resolved from the request URL's
+        ``/api/matches/{match_id}/`` prefix.
+
+        Tier 1 of the singleton-elimination work (doc 10): match-level
+        operations are addressable only by URL, never via a process-
+        level bind. The alias middleware sets ``current_match_root``
+        after validating ``match_id``; this accessor reads only from
+        there. A bare-path request (no prefix) gets 409 ``no_project``.
+        Legacy single-shooter projects don't have a ``match_id`` and
+        are unreachable via match-level routes by construction.
+        """
+        scoped = current_match_root.get()
+        if scoped is None:
             raise _no_project_error()
-        if self._bound_kind != "match":
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "code": "not_a_match",
-                    "message": (
-                        "Bound project is a legacy single-shooter layout. "
-                        "Match-level operations require a Match folder."
-                    ),
-                },
-            )
-        return self._bound_root
+        return scoped
 
     def shooter_root(self, slug: str) -> Path:
         """Resolve ``slug`` to the shooter's project directory on disk.

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5501,8 +5501,9 @@ def test_list_match_shooters_returns_active_and_others(tmp_path: Path, _user_con
         json={"path": str(target.resolve())},
     )
     assert resp.status_code == 200
+    match_id = app.state.splitsmith_state.bound_match_id
 
-    listing = client.get("/api/match/shooters")
+    listing = client.get(f"/api/matches/{match_id}/match/shooters")
     assert listing.status_code == 200, listing.text
     body = listing.json()
     assert body["match_name"] == "Multi-shooter"
@@ -5524,7 +5525,8 @@ def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_ho
         "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
-    resp = client.post("/api/match/shooters", json={"name": "Johan Larsson"})
+    match_id = app.state.splitsmith_state.bound_match_id
+    resp = client.post(f"/api/matches/{match_id}/match/shooters", json={"name": "Johan Larsson"})
     assert resp.status_code == 200
     body = resp.json()
     slugs = [s["slug"] for s in body["shooters"]]
@@ -5552,7 +5554,8 @@ def test_remove_match_shooter_drops_dir(tmp_path: Path, _user_config_home: Path)
         "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
-    resp = client.delete("/api/match/shooters/jl")
+    match_id = app.state.splitsmith_state.bound_match_id
+    resp = client.delete(f"/api/matches/{match_id}/match/shooters/jl")
     assert resp.status_code == 200
     assert not match_model.Match.shooter_root(target, "jl").exists()
 
@@ -6433,16 +6436,44 @@ def test_match_id_alias_rewrites_to_existing_route(tmp_path: Path, _user_config_
 
 
 def test_match_id_alias_resolves_match_level_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
-    """A real match-level endpoint works through both prefixes."""
+    """A real match-level endpoint works through the /api/matches/
+    prefix; the bare-path form 409s after Tier 1 of the singleton-
+    elimination work (doc 10) -- match-level operations are
+    addressable only by URL, never via a process-level bind."""
     app, match, _ = _make_match_app(tmp_path)
     client = TestClient(app)
 
-    direct = client.get("/api/match/shooters")
     aliased = client.get(f"/api/matches/{match.match_id}/match/shooters")
+    bare = client.get("/api/match/shooters")
 
-    assert direct.status_code == 200
     assert aliased.status_code == 200
-    assert direct.json() == aliased.json()
+    assert bare.status_code == 409
+    assert bare.json()["detail"]["code"] == "no_project"
+
+
+def test_match_root_no_singleton_fallback(tmp_path: Path, _user_config_home: Path) -> None:
+    """Tier 1 of doc 10: ``state.match_root`` reads only from the
+    per-request ContextVar set by the alias middleware. Even when a
+    project is bound on the singleton, a bare-path request must 409
+    rather than silently resolve via ``_bound_root``.
+    """
+    from splitsmith.ui.server import _no_project_error
+
+    app, _bound_match, _ = _make_match_app(tmp_path)
+    state = app.state.splitsmith_state
+
+    # The singleton IS bound (matches.bound state is set by
+    # _make_match_app via create_app(project_root=...)).
+    assert state.bound_match_id is not None
+
+    # Yet match_root refuses to resolve without a ContextVar.
+    with pytest.raises(HTTPException) as exc:
+        _ = state.match_root
+    assert exc.value.status_code == 409
+    # Mirror the error code _no_project_error emits so a future
+    # rename of the code keeps this test honest.
+    expected_code = _no_project_error().detail["code"]
+    assert exc.value.detail["code"] == expected_code
 
 
 def test_match_id_alias_unknown_id_returns_404(tmp_path: Path, _user_config_home: Path) -> None:


### PR DESCRIPTION
## Summary
First concrete cut of Tier 1 from `docs/saas-readiness/10-singleton-elimination.md`. Tier 1 (killing `AppState._bound_root` entirely) is too big for one PR; this is the smallest defensible first step toward it.

- `state.match_root` reads only the per-request `current_match_root` ContextVar (set by the `/api/matches/{match_id}/` alias middleware). The `self._bound_root` fallback for match-level operations is gone.
- `/api/match/*` endpoints are addressable only via the URL prefix; the bare-path form 409s even when a project is bound.
- Legacy single-shooter projects don't have a `match_id` so the old `not_a_match` 409 path was redundant once the singleton fallback was gone.
- `shooter_root` / `shooter_project` still have their singleton fallback -- those come out in subsequent cuts. `_bound_root` itself stays for now because shooter resolution still uses it.
- 3 test callsites migrated to `/api/matches/{match_id}/match/...` prefix. The existing alias-equivalence test (`test_match_id_alias_resolves_match_level_endpoint`) flipped from "bare and aliased return same payload" to "bare 409s, aliased 200" -- the explicit intent.
- New regression test `test_match_root_no_singleton_fallback` proves the accessor refuses to resolve via the singleton even when the bound state is populated.

## Test plan
- [x] `uv run pytest tests/test_ui_server.py -k 'match_root_no_singleton or match_id_alias'` -- 7 tests pass
- [x] `uv run pytest tests/` -- 1398 pass, 0 fail (pre-existing `test_marking_reviewed_kicks_off_shot_detect` + `test_sigterm_to_main_exits_clean` deselected; both reproduce on clean main)
- [x] `uv run ruff check` + `uv run black` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)