### PR TITLE
refactor(state): shooter_root drops the Match-folder singleton fallback (Tier 1 step 2)

### DIFF
--- a/docs/saas-readiness/10-singleton-elimination.md
+++ b/docs/saas-readiness/10-singleton-elimination.md
@@ -59,14 +59,20 @@ singleton. The fallback IS the violation.
 
 **Elimination path:**
 
-0. **(in progress)** `state.match_root` reads ContextVar only --
-   the singleton fallback for match-level operations is gone.
-   `/api/match/*` endpoints now 409 ``no_project`` unless the
-   request comes through `/api/matches/{match_id}/`. This was the
-   smallest defensible first cut: only ~10 test callsites needed
-   the prefix, and `shooter_root` still has its singleton fallback
-   so the bulk of shooter-scoped routes are unchanged. Next cuts
-   chip away at `shooter_root` and `shooter_project`.
+0. **(in progress)** Two cuts landed so far:
+   - `state.match_root` reads ContextVar only -- the singleton
+     fallback for match-level operations is gone. `/api/match/*`
+     endpoints 409 ``no_project`` unless the request comes through
+     `/api/matches/{match_id}/`.
+   - `state.shooter_root(slug)` drops the **Match-folder** singleton
+     fallback. A bound Match folder no longer answers
+     `/api/shooters/{slug}/...` bare-path requests. The **legacy
+     single-shooter** fallback survives because legacy projects
+     don't have a `match_id` and can't be addressed via the URL
+     prefix; legacy elimination is a separate question (migrate
+     to Match folders, or drop legacy support entirely).
+   Both cuts had remarkably small blast radius -- the bulk of
+   tests use legacy projects and were unaffected.
 1. Make `/api/matches/{match_id}/...` the only accepted prefix for
    project-scoped routes. Delete the bare-path route table or have
    it 404. The middleware becomes mandatory rather than a fallback.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -652,22 +652,29 @@ class AppState:
         (the SPA derives it from ``competitor_name`` via :func:`legacy_slug`)
         so callers don't need to special-case the legacy layout.
 
-        Resolution order (#353 Phase 3 PR C):
+        Resolution order (Tier 1 of doc 10, in progress):
 
         1. ``current_match_root`` ContextVar -- set by the
-           ``/api/matches/{match_id}/...`` alias middleware. This is the
-           per-request path; multiple tabs on different matches stay
-           isolated because each request carries its own context.
-        2. ``self._bound_root`` -- the legacy singleton. Kept as a
-           fallback for legacy bare ``/api/shooters/{slug}/...`` traffic
-           (clients that haven't migrated to the new prefix yet) and for
-           the picker boot path.
+           ``/api/matches/{match_id}/...`` alias middleware. The
+           authoritative path for Match-folder projects; multiple
+           tabs on different matches stay isolated because each
+           request carries its own context.
+        2. ``self._bound_root`` when ``_bound_kind == "legacy"``
+           -- single-shooter pre-redesign projects don't have a
+           ``match_id`` so they can't be addressed via URL prefix.
+           This fallback stays until legacy projects are either
+           migrated to Match folders or dropped.
+
+        Notably absent: the Match-folder singleton fallback. After
+        this step, Match-folder requests MUST come through the
+        ``/api/matches/{match_id}/`` prefix; a bare-path request
+        against a bound Match folder 409s ``no_project``.
         """
         scoped_root = current_match_root.get()
         if scoped_root is not None:
             # Per-request scope is always a Match folder (the middleware
             # rejects legacy projects upstream). Validate the slug and
-            # resolve under that root, ignoring the singleton.
+            # resolve under that root.
             match = match_model.Match.load(scoped_root)
             if slug not in match.shooters:
                 raise HTTPException(
@@ -679,13 +686,10 @@ class AppState:
             raise _no_project_error()
         if self._bound_kind == "legacy":
             return self._bound_root
-        match = match_model.Match.load(self._bound_root)
-        if slug not in match.shooters:
-            raise HTTPException(
-                status_code=404,
-                detail=f"shooter {slug!r} is not registered on this match",
-            )
-        return match_model.Match.shooter_root(self._bound_root, slug)
+        # Match folder bound on the singleton but no URL prefix on
+        # this request -- refuse rather than silently resolving via
+        # the bound singleton. See doc 10 Tier 1.
+        raise _no_project_error()
 
     def shooter_project(self, slug: str) -> MatchProject:
         """Load the legacy ``MatchProject`` for ``slug``."""

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -6451,6 +6451,30 @@ def test_match_id_alias_resolves_match_level_endpoint(tmp_path: Path, _user_conf
     assert bare.json()["detail"]["code"] == "no_project"
 
 
+def test_shooter_root_no_match_singleton_fallback(tmp_path: Path, _user_config_home: Path) -> None:
+    """Tier 1 of doc 10 (step 2): with a Match folder bound on the
+    singleton, ``state.shooter_root(slug)`` still refuses to resolve
+    without a per-request ContextVar. The Match-folder singleton
+    fallback is gone; only the legacy single-shooter fallback
+    survives (covered separately by the legacy test pattern).
+    """
+    from splitsmith.ui.server import _no_project_error
+
+    app, _bound_match, _ = _make_match_app(tmp_path)
+    state = app.state.splitsmith_state
+
+    # The singleton IS bound to a Match folder.
+    assert state.bound_match_id is not None
+
+    # Yet shooter_root refuses to resolve a known slug without the
+    # ContextVar set by the alias middleware.
+    with pytest.raises(HTTPException) as exc:
+        state.shooter_root("mathias")
+    assert exc.value.status_code == 409
+    expected_code = _no_project_error().detail["code"]
+    assert exc.value.detail["code"] == expected_code
+
+
 def test_match_root_no_singleton_fallback(tmp_path: Path, _user_config_home: Path) -> None:
     """Tier 1 of doc 10: ``state.match_root`` reads only from the
     per-request ContextVar set by the alias middleware. Even when a
@@ -6511,16 +6535,18 @@ def test_match_id_alias_serves_non_bound_match(tmp_path: Path, _user_config_home
 
 
 def test_match_id_alias_contextvar_isolates_per_request(tmp_path: Path, _user_config_home: Path) -> None:
-    """``state.shooter_root(slug)`` honours the per-request contextvar (#353 Phase 3 PR C).
+    """``state.shooter_root(slug)`` resolves Match-folder requests
+    only via the per-request ``current_match_root`` ContextVar.
 
-    Directly exercises ``current_match_root`` instead of going through
-    HTTP so the assertion can observe the resolved path without coupling
-    to a specific endpoint's storage layout.
+    Tier 1 of doc 10 (step 2): a bound Match folder no longer
+    silently resolves shooter slugs via the singleton when the
+    request didn't carry an ``/api/matches/{match_id}/`` prefix.
+    The ContextVar is the only path; bare access 409s.
     """
     from splitsmith import match_model, user_config
     from splitsmith.ui.server import current_match_root
 
-    app, bound_match, bound_root = _make_match_app(tmp_path)
+    app, _bound_match, _bound_root = _make_match_app(tmp_path)
     other_root = tmp_path / "other-match"
     other = match_model.Match.init(other_root, name="Other Match")
     other_shooter = match_model.Shooter(slug="alice", name="Alice")
@@ -6528,14 +6554,17 @@ def test_match_id_alias_contextvar_isolates_per_request(tmp_path: Path, _user_co
     user_config.record_project_open(other_root, other.name, kind="match")
 
     state = app.state.splitsmith_state
-    # No contextvar set -> falls back to bound singleton; ``alice`` isn't
-    # on the bound match, so 404.
+
+    # No contextvar set -> Match-folder singleton no longer
+    # answers; 409 ``no_project`` regardless of which slug is
+    # requested.
     with pytest.raises(HTTPException) as exc:
         state.shooter_root("alice")
-    assert exc.value.status_code == 404
+    assert exc.value.status_code == 409
+    assert exc.value.detail["code"] == "no_project"
 
-    # Set the contextvar to point at the OTHER match (simulating what
-    # the middleware does on /api/matches/{other.match_id}/...). Now
+    # Set the contextvar to point at the OTHER match (simulating
+    # what the middleware does on /api/matches/{other.match_id}/).
     # ``alice`` resolves under the other match's shooter dir.
     token = current_match_root.set(other_root)
     try:
@@ -6544,16 +6573,11 @@ def test_match_id_alias_contextvar_isolates_per_request(tmp_path: Path, _user_co
     finally:
         current_match_root.reset(token)
 
-    # After reset the singleton fallback returns -- ``alice`` 404s on
-    # the bound match again, proving the contextvar didn't leak.
+    # After reset, bare access 409s again -- the contextvar didn't
+    # leak across "requests" and the singleton doesn't paper over.
     with pytest.raises(HTTPException) as exc:
-        state.shooter_root("alice")
-    assert exc.value.status_code == 404
-
-    # The bound match's own shooter ``mathias`` still resolves via the
-    # singleton fallback with no contextvar set.
-    resolved = state.shooter_root("mathias")
-    assert resolved == match_model.Match.shooter_root(bound_root, "mathias")
+        state.shooter_root("mathias")
+    assert exc.value.status_code == 409
 
 
 def test_match_id_alias_missing_segment_returns_400(tmp_path: Path, _user_config_home: Path) -> None:


### PR DESCRIPTION
## Summary
Second concrete cut of Tier 1 from `docs/saas-readiness/10-singleton-elimination.md`, after #409 (match_root). Same shape: drop one singleton fallback, smallest defensible blast radius.

- `state.shooter_root(slug)` used to fall back to `self._bound_root` for **any** bound kind. Now it only falls back for `_bound_kind == "legacy"`.
- A bound Match folder no longer answers `/api/shooters/{slug}/...` bare-path requests; the client must go through `/api/matches/{match_id}/` so the alias middleware sets `current_match_root`.
- The legacy single-shooter fallback survives because legacy projects don't have a `match_id` -- they can't be addressed via the URL prefix. Legacy elimination is a separate decision (migrate to Match folders, or drop legacy support entirely).

Smaller than I expected. Predicted 60+ tests would need migration; reality: one. The bulk of test_ui_server.py tests use `MatchProject.init` (legacy), which is unaffected. Only `test_match_id_alias_contextvar_isolates_per_request` relied on the Match-folder fallback and needed updating to the new contract. Added a regression test mirroring step 1's `test_match_root_no_singleton_fallback`.

## Test plan
- [x] `uv run pytest tests/test_ui_server.py -k 'shooter_root_no_match or match_root_no_singleton or contextvar_isolates'` -- 3 pass
- [x] `uv run pytest tests/` -- 1398 pass, 0 fail (pre-existing `test_marking_reviewed_kicks_off_shot_detect` + `test_sigterm_to_main_exits_clean` deselected; both reproduce on clean main)
- [x] `uv run ruff check` + `uv run black` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)