### PR TITLE
refactor(state): retire the bound singleton entirely (Tier 1 step 4)

### DIFF
--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -92,13 +92,14 @@ Process-level state that must come out before the abstractions can do
 anything useful in a multi-tenant deployment. Ordering matters --
 later steps are blocked on earlier ones.
 
-- [ ] **Tier 1:** kill `AppState._bound_root` + `_bound_kind` +
-  `_bound_name` + `_bound_match_id`. Make
-  `/api/matches/{match_id}/...` the only project-scoped prefix;
-  delete the bare-path fallback in the route table. CLI / picker
-  resolve to a `match_id` and open the browser at
-  `/match/<match_id>` instead of binding server-side. Precondition
-  for storage callsite migration.
+- [x] **Tier 1:** kill `AppState._bound_root` + `_bound_kind` +
+  `_bound_name` + `_bound_match_id`. Done across four steps
+  (PRs #409, #410, #411, #412). Match identity is per-request via
+  the `/api/matches/{match_id}/` URL prefix; the alias middleware
+  sets a ContextVar and `state.shooter_root` / `state.match_root`
+  read it. The picker registers matches in `state.matches` and
+  returns a HealthResponse so the SPA can navigate by URL --
+  there is no server-side bound state to flip.
 - [ ] **Tier 2:** move `JobRegistry` off in-memory `dict` to the
   `compute_jobs` table (Postgres in hosted; SQLite in local if/when
   the desktop needs job persistence). Same handler-facing interface;

--- a/docs/saas-readiness/10-singleton-elimination.md
+++ b/docs/saas-readiness/10-singleton-elimination.md
@@ -37,16 +37,30 @@ agnostic shared resources. Not violations.
 
 ## What is a singleton violation (and must come out)
 
-### Tier 1 -- blocks every other migration
+### Tier 1 -- DONE (PRs #409, #410, #411, #412)
 
 **`AppState._bound_root` + `_bound_kind` + `_bound_name` +
-`_bound_match_id`** (`splitsmith.ui.server`).
+`_bound_match_id`** -- all gone. The four cuts:
 
-"The currently open project". A process-wide singleton. Every
-shooter-scoped property (`bound_root`, `match_root`,
-`shooter_root(slug)`, `shooter_project(slug)`) reads it. Two
-concurrent requests for different projects from different tenants
-would race on it -- whichever bind ran last wins.
+- Step 1 (#409): `state.match_root` -> ContextVar-only.
+- Step 2 (#410): `state.shooter_root(slug)` -> ContextVar-only for
+  Match folders.
+- Step 3 (#411): retired the legacy single-shooter layout.
+- Step 4 (#412): deleted `_bound_*` fields, `bind_match`, `unbind`,
+  `is_bound`, `bound_root`, `bound_name`, `bound_match_id`,
+  `_health_after_bind`, `state.unbind`, the
+  `/api/me/recent-projects/unbind` endpoint, and renamed the
+  internal bind helper to `_register_match_at` so its sole job is
+  to register the match in `state.matches` + record the open. The
+  picker bind endpoint still returns a HealthResponse with
+  ``match_id`` + ``default_shooter_slug`` so the SPA can navigate
+  to ``/match/<match_id>`` -- there's no server-side state for it
+  to flip.
+
+What was actually a process-wide singleton (every shooter-scoped
+property `bound_root` / `match_root` / `shooter_root(slug)` /
+`shooter_project(slug)` reading the same fields, racing under
+concurrent multi-tenant requests):
 
 The `current_match_root` / `current_match_id` ContextVars (#353
 Phase 3) were a partial step toward per-request scoping: when a URL

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -574,19 +574,15 @@ class AppState:
     server. Every shooter-scoped request must carry the slug in its
     path; the SPA's URL is the single source of truth.
 
-    The server can boot without a bound project (``splitsmith ui`` with
-    no ``--project``); in that mode every scoped property raises 409
-    ``no_project`` and the SPA stays on the picker.
-
-    The singleton bind that survives (``_bound_root`` + ``bind_match``)
-    is purely a holdover for the picker + CLI boot path. Tier 1 step 4
-    will retire it entirely; for now it doesn't influence request
-    resolution at all -- only the URL prefix does.
+    There is no notion of a "bound" project on the server -- the URL
+    prefix ``/api/matches/{match_id}/`` carries match identity per
+    request, and the alias middleware resolves it via
+    :class:`MatchRegistry`. ``splitsmith ui --project <path>`` and
+    the SPA picker register matches in :attr:`matches` and emit a
+    URL the browser navigates to; the server itself never has a
+    "current open project" state.
     """
 
-    _bound_root: Path | None = None
-    _bound_name: str | None = None
-    _bound_match_id: str | None = None
     jobs: JobRegistry = field(default_factory=JobRegistry)
     matches: MatchRegistry = field(default_factory=MatchRegistry)
     # Auth backend. ``LoopbackAuth`` in local mode (every request
@@ -609,21 +605,6 @@ class AppState:
     # Idempotency latch for /api/shutdown: first call kicks the drain
     # thread, subsequent calls return 202 without rescheduling.
     shutdown_initiated: bool = False
-
-    @property
-    def is_bound(self) -> bool:
-        return self._bound_root is not None
-
-    @property
-    def bound_name(self) -> str | None:
-        return self._bound_name
-
-    @property
-    def bound_root(self) -> Path:
-        """The bound Match folder's on-disk root."""
-        if self._bound_root is None:
-            raise _no_project_error()
-        return self._bound_root
 
     @property
     def match_root(self) -> Path:
@@ -670,26 +651,15 @@ class AppState:
         inside a Match folder owns its own ``project.json``)."""
         return MatchProject.load(self.shooter_root(slug))
 
-    @property
-    def bound_match_id(self) -> str | None:
-        """The bound match's stable id, or ``None`` when unbound."""
-        return self._bound_match_id
-
-    def bind_match(self, root: Path, name: str) -> None:
-        self._bound_root = root
-        self._bound_name = name
-        # Load to ensure ``match_id`` is materialised (Match.load runs the
-        # v3 -> v4 migration on the fly), then pin it into the registry so
-        # the id resolves immediately even before the next recents refresh.
+    def register_match(self, root: Path) -> str | None:
+        """Load the match at ``root`` and pin its ``match_id`` into
+        the registry so the alias middleware can resolve it
+        immediately. Returns the match_id (``None`` if the on-disk
+        file somehow lacks one)."""
         match = match_model.Match.load(root)
-        self._bound_match_id = match.match_id
         if match.match_id:
             self.matches.register(match.match_id, root)
-
-    def unbind(self) -> None:
-        self._bound_root = None
-        self._bound_name = None
-        self._bound_match_id = None
+        return match.match_id
 
 
 def _any_active_job(state: AppState) -> Job | None:
@@ -1820,23 +1790,24 @@ class FsListing(BaseModel):
     suggested_starts: list[SuggestedStart]
 
 
-def _bind_project_to_state(
+def _register_match_at(
     state: AppState,
     root: Path,
     fallback_name: str,
-) -> str:
-    """Initialise ``root`` on disk if needed, load its env files, record
-    the open in ``~/.splitsmith/projects.json``, and bind it on ``state``.
+) -> tuple[str, str | None]:
+    """Validate ``root`` is a Match folder, record its open in
+    ``~/.splitsmith/projects.json``, load its env files, and pin its
+    ``match_id`` into :attr:`AppState.matches`. Returns
+    ``(display_name, match_id)``.
 
-    Used both at startup (when ``--project`` was passed) and at runtime
-    (when the SPA POSTs to /api/user/recent-projects/bind). Returns the
-    on-disk display name so the caller can echo it back.
+    Tier 1 step 4 of doc 10: this used to bind the match on the
+    process singleton. The singleton is gone -- a request resolves
+    its match via the URL prefix instead, and the SPA navigates to
+    ``/match/<match_id>`` after this call returns.
 
-    ``root`` must be a Match folder (carries ``match.json``). The legacy
-    single-shooter ``MatchProject`` layout was retired in Tier 1 step 3
-    of doc 10 -- a hosted-mode user cannot ship a bare on-disk project,
-    and the local-mode picker is going URL-only too. Non-match paths
-    return 400 ``not_a_match``.
+    ``root`` must be a Match folder (carries ``match.json``). The
+    legacy single-shooter layout was retired in step 3. Non-match
+    paths return 400 ``not_a_match``.
     """
     resolved = root.resolve()
     if not match_model.is_match_folder(resolved):
@@ -1871,8 +1842,9 @@ def _bind_project_to_state(
     loaded_env = _load_env_files(resolved)
     if loaded_env:
         logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
-    state.bind_match(resolved, name)
-    return name
+    if match.match_id:
+        state.matches.register(match.match_id, resolved)
+    return name, match.match_id
 
 
 def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail:
@@ -2007,7 +1979,7 @@ def create_app(
     # so per-project overrides still win.
     _load_env_files(project_root)
     if project_root is not None:
-        _bind_project_to_state(
+        _register_match_at(
             state,
             project_root,
             fallback_name=project_name or project_root.name or "match",
@@ -2172,25 +2144,37 @@ def create_app(
         cached = CachingScoreboardClient(http, cache_dir)
         return _ScoreboardClientCtx(cached, owns_close=True, inner_http=http)
 
-    def _health_after_bind(recorded_name: str) -> HealthResponse:
-        """Build a HealthResponse from the currently-bound match."""
-        match = match_model.Match.load(state.bound_root)
+    def _register_response(root: Path, name: str, match_id: str | None) -> HealthResponse:
+        """Build a HealthResponse for a freshly-registered match.
+
+        Tier 1 step 4 of doc 10 retired the bound-state concept on
+        the server, but the picker / create-match flow still need a
+        way to learn the resolved ``match_id`` + default shooter so
+        the SPA can navigate to ``/match/<match_id>``. That's what
+        this response is for; the live ``/api/health`` route never
+        returns these fields anymore.
+        """
+        match = match_model.Match.load(root)
         shooters = sorted(match.shooters)
         default_slug = shooters[0] if shooters else None
         return HealthResponse(
             bound=True,
-            project_name=recorded_name,
-            project_root=str(state.bound_root),
+            project_name=name,
+            project_root=str(root),
             kind="match",
             default_shooter_slug=default_slug,
-            match_id=state.bound_match_id,
+            match_id=match_id,
         )
 
     @app.get("/api/health", response_model=HealthResponse)
     def health() -> HealthResponse:
-        if not state.is_bound:
-            return HealthResponse(bound=False)
-        return _health_after_bind(state.bound_name or "")
+        """Process-level health. Tier 1 step 4 of doc 10 retired
+        the bound-state concept on the server -- match identity is
+        per-request via the URL prefix, not per-process. The SPA
+        relies on the URL for navigation; ``/api/health`` is now
+        purely a "the server is up" check (plus version + status).
+        """
+        return HealthResponse(bound=False)
 
     @app.get("/api/models/status")
     def models_status() -> dict[str, Any]:
@@ -2376,7 +2360,7 @@ def create_app(
             shutil.rmtree(tmp, ignore_errors=True)
 
         if bind:
-            _bind_project_to_state(state, result.project_root, fallback_name=result.project_name)
+            _register_match_at(state, result.project_root, fallback_name=result.project_name)
 
         return JSONResponse(
             {
@@ -6512,10 +6496,15 @@ def create_app(
     def reveal_file(req: RevealRequest) -> JSONResponse:
         """Reveal a file in the OS file manager.
 
-        Restricted to paths inside the current project root so the endpoint
-        can never be coerced into opening arbitrary locations. macOS uses
-        ``open -R`` (selects the file in Finder); Linux uses ``xdg-open``
+        Restricted to paths inside the request-scoped match root so
+        the endpoint can never be coerced into opening arbitrary
+        locations. macOS uses ``open -R``; Linux uses ``xdg-open``
         on the parent dir; Windows uses ``explorer /select``.
+
+        Tier 1 step 4 of doc 10 dropped the singleton bound root --
+        callers must hit this through ``/api/matches/{match_id}/files/reveal``
+        so the alias middleware sets ``current_match_root``; bare-path
+        callers 409 ``no_project``.
         """
         target = Path(req.path).expanduser()
         try:
@@ -6523,11 +6512,11 @@ def create_app(
         except (OSError, FileNotFoundError) as exc:
             raise HTTPException(status_code=404, detail=f"not found: {target}") from exc
         try:
-            resolved.relative_to(state.bound_root.resolve())
+            resolved.relative_to(state.match_root.resolve())
         except ValueError as exc:
             raise HTTPException(
                 status_code=400,
-                detail="reveal path must be inside the bound project root",
+                detail="reveal path must be inside the match folder",
             ) from exc
         _reveal_in_file_manager(resolved)
         return JSONResponse({"revealed": str(resolved)})
@@ -6649,14 +6638,14 @@ def create_app(
             except OSError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
         try:
-            recorded = _bind_project_to_state(
+            recorded, match_id = _register_match_at(
                 state,
                 target,
                 fallback_name=req.name or target.name or "match",
             )
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return _health_after_bind(recorded)
+        return _register_response(target.resolve(), recorded, match_id)
 
     @app.post("/api/match/create-manual")
     def create_match_manual(req: CreateMatchManualRequest) -> HealthResponse:
@@ -6736,14 +6725,14 @@ def create_app(
                 )
         legacy.save(shooter_root)
 
-        # Bind via the match folder so _bind_project_to_state records it as
-        # kind="match" and binds the first shooter without registering the
-        # shooter subdir as a separate legacy project in recent-projects.
+        # Register the match folder so the alias middleware can
+        # resolve its id immediately; record it in recent-projects
+        # so the picker has the entry pinned to the top.
         try:
-            recorded = _bind_project_to_state(state, target, fallback_name=req.name)
+            recorded, match_id = _register_match_at(state, target, fallback_name=req.name)
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return _health_after_bind(recorded)
+        return _register_response(target.resolve(), recorded, match_id)
 
     @app.post("/api/match/create-from-scoreboard")
     def create_match_from_scoreboard(
@@ -6856,13 +6845,13 @@ def create_app(
                     exc.detail,
                 )
 
-        # See create_match_manual: bind via the match folder, not a
-        # shooter dir, so recent-projects only gets a kind="match" entry.
+        # Register the match folder so recent-projects gets a
+        # kind="match" entry and the alias middleware resolves the id.
         try:
-            recorded = _bind_project_to_state(state, target, fallback_name=req.name)
+            recorded, match_id = _register_match_at(state, target, fallback_name=req.name)
         except OSError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return _health_after_bind(recorded)
+        return _register_response(target.resolve(), recorded, match_id)
 
     # ----------------------------------------------------------------------
     # Shooters management (#324)
@@ -7048,14 +7037,13 @@ def create_app(
         except OSError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        # Bind the new match. ``_bind_project_to_state`` records the match
-        # in recent-projects (kind="match") and switches state.bound_root
-        # to the match folder; shooters are addressed by slug from there.
+        # Register the new match so recent-projects gets a kind="match"
+        # entry and the alias middleware can resolve the id immediately.
         try:
-            recorded = _bind_project_to_state(state, output, fallback_name=match.name)
+            recorded, match_id = _register_match_at(state, output, fallback_name=match.name)
         except OSError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
-        return _health_after_bind(recorded)
+        return _register_response(output.resolve(), recorded, match_id)
 
     @app.get("/api/match/shooters", response_model=ShooterListResponse)
     def list_match_shooters() -> ShooterListResponse:
@@ -7549,16 +7537,9 @@ def create_app(
         proj.save(shooter_root)
         return get_beep_queue()
 
-    @app.post("/api/me/recent-projects/unbind")
-    def unbind_recent_project(user: User = Depends(get_current_user)) -> HealthResponse:
-        """Drop the bound project so the SPA returns to the picker.
-
-        Equivalent to a `splitsmith ui` boot with no ``--project``;
-        useful when the user wants to switch projects without leaving
-        the browser tab.
-        """
-        state.unbind()
-        return HealthResponse(bound=False)
+    # ``/api/me/recent-projects/unbind`` was deleted in Tier 1
+    # step 4 of doc 10. There is no server-side bound state to
+    # clear; the SPA picker navigates between matches by URL.
 
     @app.get("/api/me/scoreboard-identity")
     def get_scoreboard_identity(user: User = Depends(get_current_user)) -> JSONResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,12 +47,17 @@ def scaffold_match(
 
 
 def bound_match_id(app) -> str:
-    """Read the bound match id from a test app's state.
-    Tests use it to construct ``/api/matches/{match_id}/...`` URLs.
+    """Read the registered match id from a test app's state.
+
+    Post Tier 1 step 4 of doc 10, the server has no "bound" project --
+    matches are registered in :attr:`AppState.matches` and addressed
+    by URL. Tests typically scaffold a single Match folder; this
+    helper returns that match's id so they can construct
+    ``/api/matches/{match_id}/...`` URLs.
     """
-    mid = app.state.splitsmith_state.bound_match_id
-    assert mid is not None, "expected create_app(project_root=match_folder) to bind a match_id"
-    return mid
+    ids = app.state.splitsmith_state.matches.known_ids()
+    assert len(ids) == 1, f"expected exactly one match registered, got {len(ids)}: {ids}"
+    return ids[0]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_coach_api.py
+++ b/tests/test_coach_api.py
@@ -59,7 +59,7 @@ def _bootstrap(tmp_path: Path) -> tuple[TestClient, Path, str]:
     audit_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
     app = create_app(project_root=root, project_name="Coach Match")
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
     return TestClient(app), audit_file, f"/api/matches/{match_id}"
 
 
@@ -155,7 +155,7 @@ def test_get_coach_clamps_beep_to_pre_buffer_when_trimmed(tmp_path: Path) -> Non
 
     app = create_app(project_root=root, project_name="Trimmed Match")
     client = TestClient(app)
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.get(f"{base}/shooters/me/stages/1/coach")
     assert resp.status_code == 200, resp.text
@@ -206,7 +206,7 @@ def test_get_coach_returns_null_when_no_audit(tmp_path: Path) -> None:
     project.save(shooter_root)
     app = create_app(project_root=root, project_name="Empty")
     client = TestClient(app)
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.get(f"{base}/shooters/me/stages/1/coach")
     assert resp.status_code == 200

--- a/tests/test_relink_api.py
+++ b/tests/test_relink_api.py
@@ -53,7 +53,7 @@ def test_link_status_reports_ok_for_intact_links(tmp_path: Path) -> None:
     root, ids = _setup_project(tmp_path, ["a.mp4"])
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.get(f"{base}/shooters/me/videos/link-status")
     assert resp.status_code == 200
@@ -68,7 +68,7 @@ def test_link_status_reports_broken_after_target_removed(tmp_path: Path) -> None
     (tmp_path / "originals" / "a.mp4").unlink()
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     [entry] = client.get(f"{base}/shooters/me/videos/link-status").json()["entries"]
     assert entry["status"] == "broken"
@@ -81,7 +81,7 @@ def test_relink_scan_reports_unique_candidate(tmp_path: Path) -> None:
     (share / "a.mp4").write_bytes(b"")
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.post(
         f"{base}/shooters/me/videos/relink/scan",
@@ -105,7 +105,7 @@ def test_relink_scan_reports_ambiguous_candidates(tmp_path: Path) -> None:
     (share / "y" / "a.mp4").write_bytes(b"")
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     [entry] = client.post(
         f"{base}/shooters/me/videos/relink/scan",
@@ -120,7 +120,7 @@ def test_relink_scan_400_on_missing_root(tmp_path: Path) -> None:
     root, _ = _setup_project(tmp_path, ["a.mp4"])
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.post(
         f"{base}/shooters/me/videos/relink/scan",
@@ -136,7 +136,7 @@ def test_relink_apply_rewrites_symlinks(tmp_path: Path) -> None:
     new_target.write_bytes(b"")
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.post(
         f"{base}/shooters/me/videos/relink/apply",
@@ -156,7 +156,7 @@ def test_relink_apply_rejects_missing_target(tmp_path: Path) -> None:
     root, ids = _setup_project(tmp_path, ["a.mp4"])
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.post(
         f"{base}/shooters/me/videos/relink/apply",
@@ -170,7 +170,7 @@ def test_relink_apply_rejects_unknown_video_id(tmp_path: Path) -> None:
     target = tmp_path / "originals" / "a.mp4"
     _app = create_app(project_root=root, project_name="x")
     client = TestClient(_app)
-    match_id = _app.state.splitsmith_state.bound_match_id
+    match_id = _app.state.splitsmith_state.matches.known_ids()[0]
     base = f"/api/matches/{match_id}"
     resp = client.post(
         f"{base}/shooters/me/videos/relink/apply",

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -76,9 +76,14 @@ class _MatchClient:
         return self._app
 
     def _rewrite(self, url: str) -> str:
-        match_id = self._app.state.splitsmith_state.bound_match_id
-        if match_id is None:
+        # Pick the registered match -- tests scaffold a single
+        # match folder per app. With zero (unbound) or more than
+        # one (multi-match alias tests), the rewriter passes the
+        # URL through so the test builds the prefix explicitly.
+        ids = self._app.state.splitsmith_state.matches.known_ids()
+        if len(ids) != 1:
             return url
+        match_id = ids[0]
         for prefix in _SCOPED_PREFIXES:
             if url.startswith(prefix):
                 rest = url[len("/api/") :]
@@ -153,7 +158,13 @@ def _wait_for_job(client, job_id: str, *, timeout: float = 5.0) -> dict:
     raise AssertionError(f"job {job_id} did not finish within {timeout}s")
 
 
-def test_health_returns_project_info(tmp_path: Path) -> None:
+def test_health_reports_unbound(tmp_path: Path) -> None:
+    """Tier 1 step 4 of doc 10 retired the bound-state concept on
+    the server. ``/api/health`` is now purely a "process up" check
+    -- it never reports a bound project, even when one is registered
+    on ``state.matches``. The SPA reads match identity from the URL,
+    not from health.
+    """
     app = _match_create_app(project_root=tmp_path / "match", project_name="Test Match")
     client = _MatchClient(app)
 
@@ -161,8 +172,8 @@ def test_health_returns_project_info(tmp_path: Path) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
-    assert body["project_name"] == "Test Match"
-    assert body["bound"] is True
+    assert body["bound"] is False
+    assert body["project_name"] is None
 
 
 def test_get_project_returns_full_dump(tmp_path: Path) -> None:
@@ -5442,21 +5453,23 @@ def test_bind_recent_project_refuses_non_match_path(tmp_path: Path, _user_config
     assert resp.json()["detail"]["code"] == "not_a_match"
 
 
-def test_unbind_returns_to_unbound_state(tmp_path: Path, _user_config_home: Path) -> None:
-    """Post Tier 1 step 3 of doc 10, `unbind` clears the singleton
-    bind (so /api/health reports unbound) but doesn't unregister
-    the match from ``state.matches`` -- URLs that carry the
-    ``match_id`` continue to resolve. The "current open project"
-    concept is going URL-only; unbind is mostly a picker-UX hook."""
+def test_unbind_endpoint_is_gone(tmp_path: Path, _user_config_home: Path) -> None:
+    """Tier 1 step 4 of doc 10: ``/api/me/recent-projects/unbind``
+    was deleted because there's no server-side bound state to clear
+    anymore -- match identity is per-request via the URL prefix.
+    The SPA picker navigates between matches by URL.
+    """
     app = _match_create_app(project_root=tmp_path / "match", project_name="x")
     raw = TestClient(app)
 
-    assert raw.get("/api/health").json()["bound"] is True
+    assert raw.get("/api/health").json()["bound"] is False
     resp = raw.post("/api/me/recent-projects/unbind")
-    assert resp.status_code == 200
-    assert resp.json()["bound"] is False
-    # Bare-path shooter access still 409s -- the singleton bind is
-    # gone (and was never the resolution path anyway after step 3).
+    # FastAPI returns 405 for an unknown method on a known prefix
+    # or 404 when the path itself is unrouted; either is acceptable
+    # confirmation that the endpoint is gone.
+    assert resp.status_code in (404, 405)
+    # Bare-path shooter access 409s because the singleton fallback
+    # has been gone since step 2.
     assert raw.get("/api/shooters/me/project").status_code == 409
 
 
@@ -5669,7 +5682,7 @@ def test_list_match_shooters_returns_active_and_others(tmp_path: Path, _user_con
         json={"path": str(target.resolve())},
     )
     assert resp.status_code == 200
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
 
     listing = client.get(f"/api/matches/{match_id}/match/shooters")
     assert listing.status_code == 200, listing.text
@@ -5693,7 +5706,7 @@ def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_ho
         "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
     resp = client.post(f"/api/matches/{match_id}/match/shooters", json={"name": "Johan Larsson"})
     assert resp.status_code == 200
     body = resp.json()
@@ -5722,7 +5735,7 @@ def test_remove_match_shooter_drops_dir(tmp_path: Path, _user_config_home: Path)
         "/api/me/recent-projects/bind",
         json={"path": str(target.resolve())},
     )
-    match_id = app.state.splitsmith_state.bound_match_id
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
     resp = client.delete(f"/api/matches/{match_id}/match/shooters/jl")
     assert resp.status_code == 200
     assert not match_model.Match.shooter_root(target, "jl").exists()
@@ -6609,7 +6622,11 @@ def _make_match_app(tmp_path: Path):
 
 
 def test_match_id_alias_rewrites_to_existing_route(tmp_path: Path, _user_config_home: Path) -> None:
-    """``/api/matches/{match_id}/health`` resolves to the same health route."""
+    """``/api/matches/{match_id}/health`` resolves to the same health
+    route. Health is identical on both prefixes -- after Tier 1
+    step 4 of doc 10 it doesn't echo back the bound state or the
+    match id; it's a process-level "we're up" check.
+    """
     app, match, _ = _make_match_app(tmp_path)
     client = _MatchClient(app)
 
@@ -6618,10 +6635,9 @@ def test_match_id_alias_rewrites_to_existing_route(tmp_path: Path, _user_config_
 
     assert direct.status_code == 200
     assert aliased.status_code == 200
-    # Same payload on either prefix: the middleware strips the
-    # match-id segment and hands off to the existing handler.
     assert direct.json() == aliased.json()
-    assert aliased.json()["match_id"] == match.match_id
+    assert direct.json()["bound"] is False
+    assert direct.json()["match_id"] is None
 
 
 def test_match_id_alias_resolves_match_level_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
@@ -6657,8 +6673,9 @@ def test_shooter_root_no_match_singleton_fallback(tmp_path: Path, _user_config_h
     app, _bound_match, _ = _make_match_app(tmp_path)
     state = app.state.splitsmith_state
 
-    # The singleton IS bound to a Match folder.
-    assert state.bound_match_id is not None
+    # The match IS registered (`_make_match_app` calls
+    # `_register_match_at`).
+    assert state.matches.known_ids(), "expected the test match to be registered"
 
     # Yet shooter_root refuses to resolve a known slug without the
     # ContextVar set by the alias middleware.
@@ -6680,9 +6697,9 @@ def test_match_root_no_singleton_fallback(tmp_path: Path, _user_config_home: Pat
     app, _bound_match, _ = _make_match_app(tmp_path)
     state = app.state.splitsmith_state
 
-    # The singleton IS bound (matches.bound state is set by
-    # _make_match_app via _match_create_app(project_root=...)).
-    assert state.bound_match_id is not None
+    # The match IS registered (`_make_match_app` calls
+    # `_register_match_at`).
+    assert state.matches.known_ids(), "expected the test match to be registered"
 
     # Yet match_root refuses to resolve without a ContextVar.
     with pytest.raises(HTTPException) as exc:
@@ -6707,7 +6724,7 @@ def test_match_id_alias_unknown_id_returns_404(tmp_path: Path, _user_config_home
 def test_match_id_alias_serves_non_bound_match(tmp_path: Path, _user_config_home: Path) -> None:
     """A non-bound match resolves independently of the bound singleton (#353 Phase 3 PR C).
 
-    PR B briefly enforced ``match_id == state.bound_match_id``; PR C
+    PR B briefly enforced ``match_id == state.matches.known_ids()``; PR C
     drops that check because the middleware sets a per-request
     ContextVar -- two tabs on different matches each get their own
     scope. Both match ids must be served when both are registered.


### PR DESCRIPTION
## Summary
Final cut of Tier 1 from `docs/saas-readiness/10-singleton-elimination.md`. With #409 / #410 stripping the singleton fallback from `match_root` / `shooter_root`, and #411 retiring legacy single-shooter projects, the `_bound_*` fields had nothing they actually drove -- they were a holdover for the picker UX and the `/api/health` response.

## Production
- Deleted: `AppState._bound_root`, `_bound_name`, `_bound_match_id`, `is_bound`, `bound_name`, `bound_root`, `bound_match_id`, `bind_match`, `unbind`.
- Added `state.register_match(root)` -- pins the match_id into the registry so the alias middleware can resolve it.
- Renamed `_bind_project_to_state` -> `_register_match_at`: same on-disk side effects (record_project_open, env load, register in matches), no state mutation. Returns `(name, match_id)`.
- Added `_register_response(root, name, match_id)` for the picker / create-match handlers to return a HealthResponse the SPA navigates from.
- `/api/health` is now a process-level "we're up" check -- `bound` is always False; `project_name`, `project_root`, `kind`, `match_id`, `default_shooter_slug` are always null. The SPA reads match identity from the URL.
- Deleted `POST /api/me/recent-projects/unbind` -- there's no server-side bound state to clear.
- `/api/files/reveal` now scopes its allowed-path check against per-request `state.match_root` (via ContextVar) instead of the singleton. Bare-path callers 409.

## Tests
- `tests/conftest.py::bound_match_id` reads from `state.matches.known_ids()` (asserting exactly one registered match).
- `_MatchClient._rewrite` derives the URL prefix from `state.matches` rather than the gone `bound_match_id`.
- `test_health_returns_project_info` -> `test_health_reports_unbound` asserts the new contract.
- `test_unbind_returns_to_unbound_state` -> `test_unbind_endpoint_is_gone` asserts the endpoint 404s/405s.
- `test_match_id_alias_rewrites_to_existing_route` no longer asserts `match_id` in health response.
- `test_shooter_root_no_match_singleton_fallback` and `test_match_root_no_singleton_fallback` updated to assert the match is *registered* rather than *bound*.
- 11 callers of `bound_match_id` in test_coach_api / test_relink_api / test_ui_server migrated to `state.matches.known_ids()[0]`.

## Test plan
- [x] `uv run pytest tests/` -- 1397 pass, 16 skipped, 0 fail
- [x] `uv run ruff check` + `uv run black` clean

## Tier 1 status: DONE
After this PR, the singleton elimination map is `[x]`. The next tier per doc 10 is the in-memory `JobRegistry` (move to Postgres `compute_jobs` for hosted; SQLite for local desktop persistence if ever needed). Tier 3 (user_config -> per-user Postgres rows) and Tier 4 (CLI `--project` -> URL emission) follow after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)