### PR TITLE
feat(storage): S3Storage backend wrapping boto3 (R2 / S3 / minio)

### DIFF
--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -46,14 +46,15 @@ before that would entrench the singleton.
 
 - [~] Extract `Storage` interface; replace direct `pathlib.Path` use
   in project layout with `FilesystemStorage` calls.
-  (See 03-storage-layer.md.) Protocol + `FilesystemStorage` shipped
-  with atomic temp+rename writes and a path-traversal guard. Not
-  yet wired into `AppState` -- local mode opens projects at
-  arbitrary user-chosen paths, so the right scope is per-project
-  rather than a process singleton. Migration of existing callsites
-  (recent-projects index, audit JSON, project state) is iterative
-  follow-up work; the Protocol is sync today and goes async if
-  ``S3Storage`` ever needs it.
+  (See 03-storage-layer.md.) Protocol + `FilesystemStorage` (local)
+  + `S3Storage` (hosted, boto3) both shipped, with shared
+  path-traversal guard and structural-Protocol round-trip tests
+  via ``moto``. Not yet wired into `AppState` -- local mode opens
+  projects at arbitrary user-chosen paths and hosted mode wants a
+  per-request per-tenant factory, so the right scope is per-project,
+  not a process singleton. Migration of existing callsites
+  (audit JSON, project state) is iterative follow-up work; the
+  Protocol stays sync today.
 - [x] Extract `Auth` interface; introduce `LoopbackAuth`; route
   every API handler through `auth.authenticate_request`.
   (See 02-tenancy-and-identity.md.) Interface + `LoopbackAuth` +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,10 +119,16 @@ dev = [
     "torch>=2.11.0",
     "transformers>=5.7.0",
     "panns-inference>=0.1.1",
-    # S3 multipart upload to Cloudflare R2 (scripts/upload_model_artifacts.py).
+    # S3 multipart upload to Cloudflare R2 (scripts/upload_model_artifacts.py)
+    # AND the hosted-mode ``S3Storage`` backend in ``splitsmith.storage``.
     # wrangler caps single PUTs at 300 MiB; PANN's consolidated ONNX
     # is ~312 MiB so we route through R2's S3-compatible endpoint.
     "boto3>=1.35.0",
+    # In-memory S3 mock for ``test_s3_storage.py`` -- lets us verify
+    # the hosted ``S3Storage`` backend round-trips correctly without
+    # standing up a real bucket. Dev-only; the production wheel
+    # pulls boto3 only when ``S3Storage`` is actually constructed.
+    "moto[s3]>=5.0.0",
 ]
 
 [tool.ruff]

--- a/src/splitsmith/storage.py
+++ b/src/splitsmith/storage.py
@@ -180,3 +180,140 @@ class FilesystemStorage:
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+
+def _validate_relative_key(key: str) -> str:
+    """Reject absolute / traversing keys before we hand them to a
+    backend. The same guard ``FilesystemStorage._resolve`` runs --
+    factored out so ``S3Storage`` doesn't have to reimplement it.
+    """
+    rel = Path(key)
+    if rel.is_absolute() or any(part == ".." for part in rel.parts):
+        raise ValueError(f"path must be relative and contain no '..': {key!r}")
+    return key
+
+
+class S3Storage:
+    """Hosted-mode implementation backed by an S3-compatible bucket.
+
+    Targets Cloudflare R2 in production (doc 03) but works against
+    AWS S3, MinIO, and the ``moto`` in-memory mock used in tests --
+    they're all the same S3 API. Construct one instance per
+    tenant-scoped prefix; the bucket itself is process-wide.
+
+    Path semantics match :class:`FilesystemStorage`: keys are
+    relative to ``prefix``, ``/`` separators (POSIX-style), no
+    leading ``/``, no ``..``. The class uses S3's ``Key`` directly,
+    so a `prefix` of ``"projects/abc/"`` plus a `path` of
+    ``"audit/stage1.json"`` produces the S3 key
+    ``"projects/abc/audit/stage1.json"``.
+
+    boto3 is imported lazily so a local-mode install that never
+    constructs an S3Storage doesn't pay the import cost.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: str | None = None,
+        region_name: str = "auto",
+        client: object | None = None,
+    ) -> None:
+        self._bucket = bucket
+        # Normalize the prefix: no leading slash, exactly one trailing
+        # slash when non-empty. ``""`` means "the bucket root".
+        prefix = prefix.strip("/")
+        self._prefix = f"{prefix}/" if prefix else ""
+        if client is not None:
+            self._client = client
+        else:
+            import boto3
+
+            self._client = boto3.client(
+                "s3",
+                endpoint_url=endpoint_url,
+                region_name=region_name,
+            )
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    @property
+    def prefix(self) -> str:
+        return self._prefix
+
+    def _key(self, path: str) -> str:
+        _validate_relative_key(path)
+        return f"{self._prefix}{path}"
+
+    def read_bytes(self, path: str) -> bytes:
+        from botocore.exceptions import ClientError
+
+        try:
+            response = self._client.get_object(Bucket=self._bucket, Key=self._key(path))
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404"):
+                raise FileNotFoundError(f"no object at {path!r}") from exc
+            raise
+        return response["Body"].read()
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        # S3 PUT is atomic: either the new object becomes visible in
+        # full, or the put fails and the old object (if any) survives.
+        # No temp-and-rename dance needed.
+        self._client.put_object(Bucket=self._bucket, Key=self._key(path), Body=data)
+
+    def exists(self, path: str) -> bool:
+        from botocore.exceptions import ClientError
+
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=self._key(path))
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404", "NotFound"):
+                return False
+            raise
+        return True
+
+    def stat(self, path: str) -> StorageObject | None:
+        from botocore.exceptions import ClientError
+
+        try:
+            head = self._client.head_object(Bucket=self._bucket, Key=self._key(path))
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404", "NotFound"):
+                return None
+            raise
+        return StorageObject(
+            path=path,
+            size=int(head["ContentLength"]),
+            etag=head.get("ETag", "").strip('"') or None,
+            last_modified=head.get("LastModified"),
+        )
+
+    def list(self, prefix: str) -> Iterator[StorageObject]:
+        _validate_relative_key(prefix) if prefix else None
+        full_prefix = self._key(prefix) if prefix else self._prefix
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=full_prefix):
+            for obj in page.get("Contents", []) or []:
+                key = obj["Key"]
+                # Strip the storage-root prefix so callers see paths
+                # relative to their scope, matching FilesystemStorage.
+                rel_key = key[len(self._prefix) :] if self._prefix else key
+                yield StorageObject(
+                    path=rel_key,
+                    size=int(obj["Size"]),
+                    etag=obj.get("ETag", "").strip('"') or None,
+                    last_modified=obj.get("LastModified"),
+                )
+
+    def delete(self, path: str) -> None:
+        # S3 ``delete_object`` is a no-op when the key doesn't exist
+        # (same contract as :class:`FilesystemStorage.delete`).
+        self._client.delete_object(Bucket=self._bucket, Key=self._key(path))

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -1,0 +1,197 @@
+"""Tests for the hosted-mode ``S3Storage`` backend.
+
+Uses the ``moto`` in-memory S3 mock so the round-trip exercises
+the real boto3 client without standing up MinIO or a live bucket.
+The same Protocol assertions as ``test_storage.py``, plus the
+metadata fields (``etag``, ``last_modified``) that the
+filesystem backend doesn't populate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+moto = pytest.importorskip("moto")
+import boto3  # noqa: E402
+from moto import mock_aws  # noqa: E402
+
+from splitsmith.storage import S3Storage, StorageObject  # noqa: E402
+
+BUCKET = "splitsmith-test"
+
+
+@pytest.fixture
+def s3_client():
+    """Spin up an in-memory S3 with one bucket. Yields a boto3
+    client so tests can both seed via the backend under test and
+    inspect via the raw client when needed.
+    """
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET)
+        yield client
+
+
+def _storage(s3_client, *, prefix: str = "") -> S3Storage:
+    return S3Storage(bucket=BUCKET, prefix=prefix, client=s3_client)
+
+
+def test_round_trip_write_then_read(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("hello.txt", b"world")
+
+    assert storage.read_bytes("hello.txt") == b"world"
+
+
+def test_write_overwrites_existing(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("k", b"v1")
+    storage.write_bytes("k", b"v2")
+
+    assert storage.read_bytes("k") == b"v2"
+
+
+def test_read_missing_key_raises_file_not_found(s3_client) -> None:
+    storage = _storage(s3_client)
+
+    with pytest.raises(FileNotFoundError):
+        storage.read_bytes("nope")
+
+
+def test_exists_returns_true_after_write(s3_client) -> None:
+    storage = _storage(s3_client)
+    assert not storage.exists("k")
+
+    storage.write_bytes("k", b"v")
+    assert storage.exists("k")
+
+
+def test_stat_returns_none_for_missing(s3_client) -> None:
+    storage = _storage(s3_client)
+
+    assert storage.stat("nope") is None
+
+
+def test_stat_returns_size_etag_last_modified(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("k", b"hello")
+
+    info = storage.stat("k")
+    assert isinstance(info, StorageObject)
+    assert info.path == "k"
+    assert info.size == 5
+    # S3 returns an ETag (md5 for non-multipart) and a Last-Modified.
+    # FilesystemStorage doesn't, so this is a per-backend richer field.
+    assert info.etag is not None
+    assert info.last_modified is not None
+
+
+def test_list_walks_objects_under_prefix(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("a.txt", b"x")
+    storage.write_bytes("nested/b.txt", b"x")
+    storage.write_bytes("nested/deep/c.txt", b"x")
+
+    paths = sorted(obj.path for obj in storage.list(""))
+    assert paths == ["a.txt", "nested/b.txt", "nested/deep/c.txt"]
+
+
+def test_list_with_prefix_narrows_to_subtree(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("a/1.txt", b"x")
+    storage.write_bytes("a/2.txt", b"x")
+    storage.write_bytes("b/3.txt", b"x")
+
+    paths = sorted(obj.path for obj in storage.list("a"))
+    assert paths == ["a/1.txt", "a/2.txt"]
+
+
+def test_list_missing_prefix_yields_nothing(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("a.txt", b"x")
+
+    assert list(storage.list("nope")) == []
+
+
+def test_delete_removes_object(s3_client) -> None:
+    storage = _storage(s3_client)
+    storage.write_bytes("k", b"v")
+
+    storage.delete("k")
+
+    assert not storage.exists("k")
+
+
+def test_delete_missing_is_noop(s3_client) -> None:
+    storage = _storage(s3_client)
+    # S3 delete_object is a 204 for missing keys; the wrapper
+    # preserves the same no-op contract FilesystemStorage gives.
+    storage.delete("nope")
+
+
+# Path-traversal guard: same set as test_storage.py so the two
+# backends present identical safety contracts.
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/etc/passwd",
+        "../escape.txt",
+        "nested/../../escape.txt",
+        "a/../../b",
+    ],
+)
+def test_traversal_or_absolute_paths_rejected(s3_client, bad_path: str) -> None:
+    storage = _storage(s3_client)
+
+    with pytest.raises(ValueError, match="must be relative"):
+        storage.write_bytes(bad_path, b"x")
+
+
+def test_prefix_scopes_writes_and_reads(s3_client) -> None:
+    """Multi-tenant key isolation: one ``S3Storage`` per tenant
+    prefix means the keys callers pass never collide with another
+    tenant's, even though they use the same simple paths like
+    ``audit/stage1.json``.
+    """
+    alice = _storage(s3_client, prefix="users/alice/projects/m1/")
+    bob = _storage(s3_client, prefix="users/bob/projects/m1/")
+
+    alice.write_bytes("audit/stage1.json", b"alice")
+    bob.write_bytes("audit/stage1.json", b"bob")
+
+    assert alice.read_bytes("audit/stage1.json") == b"alice"
+    assert bob.read_bytes("audit/stage1.json") == b"bob"
+
+    # The raw S3 view confirms the actual keys carry the prefix
+    # (and that the two tenants live in disjoint key spaces).
+    listed = sorted(obj["Key"] for obj in s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", []))
+    assert listed == [
+        "users/alice/projects/m1/audit/stage1.json",
+        "users/bob/projects/m1/audit/stage1.json",
+    ]
+
+
+def test_prefix_list_returns_relative_paths(s3_client) -> None:
+    """The list() result strips the storage-root prefix so callers
+    see the same shape they wrote (matches FilesystemStorage).
+    """
+    storage = _storage(s3_client, prefix="users/alice/projects/m1/")
+    storage.write_bytes("audit/stage1.json", b"x")
+    storage.write_bytes("audit/stage2.json", b"x")
+
+    paths = sorted(obj.path for obj in storage.list("audit"))
+    assert paths == ["audit/stage1.json", "audit/stage2.json"]
+
+
+def test_satisfies_storage_protocol() -> None:
+    """Structural-typing assertion: ``S3Storage`` is a
+    drop-in :class:`Storage` so handlers typed against the
+    Protocol can accept either backend.
+    """
+    from splitsmith.storage import Storage
+
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET)
+        store: Storage = S3Storage(bucket=BUCKET, client=client)
+        assert store is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1480,6 +1480,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/e9/c38202162db2e76623176be9f1dbc9aa41228ffa91ee8da2d3986082c3e3/moto-5.2.1.tar.gz", hash = "sha256:ccb2f3e1dfa82e50e054bda98b0be708d244d2668364dcc1d45e8d3de6091bde", size = 8634437, upload-time = "2026-05-10T19:11:57.286Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/79/8085b7c1ecd48d0535c3c8444a1d8df2926e457dce8e55fabc332a382c9c/moto-5.2.1-py3-none-any.whl", hash = "sha256:19d2fbd6e613aa5b4e364c52cd5d3cea371643a0f4210689a703227bd2924c5c", size = 6671379, upload-time = "2026-05-10T19:11:53.543Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2142,6 +2166,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2665,6 +2698,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+]
+
+[[package]]
 name = "respx"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3080,6 +3127,7 @@ dev = [
     { name = "black" },
     { name = "boto3" },
     { name = "matplotlib" },
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "onnx" },
     { name = "onnxscript" },
@@ -3121,6 +3169,7 @@ dev = [
     { name = "black", specifier = ">=24.0.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "matplotlib", specifier = ">=3.9.0" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "onnx", specifier = ">=1.16.0" },
     { name = "onnxscript", specifier = ">=0.1.0" },
@@ -3657,4 +3706,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
## Summary
Second concrete impl of the `Storage` Protocol from `splitsmith.storage` (the first being `FilesystemStorage` in #407). Targets Cloudflare R2 in production per doc 03; works against AWS S3 and MinIO unchanged (S3-compatible API), and against the in-memory `moto` mock used in tests.

First concrete hosted backend in the SaaS series -- validates that the abstraction actually accommodates a real second implementation.

- `S3Storage(bucket, prefix, endpoint_url, region_name, client)`. `client` is the injection point for tests. `prefix` carries the tenant + project scope so callers pass simple relative paths like `audit/stage1.json` and the wrapper builds the full S3 key.
- `boto3` is imported lazily inside `__init__` so a local-mode install that never constructs an `S3Storage` doesn't pay the import cost. (boto3 is in the dev group only today; the wheel doesn't ship it.)
- S3 PUT is atomic on its own -- no temp-and-rename dance needed. The path-traversal guard factors to a module-level `_validate_relative_key` so both backends reject the same attack shapes.
- `stat` populates `etag` + `last_modified` (S3's HEAD-object headers); `FilesystemStorage` leaves etag null. Same `StorageObject` shape; richer per-backend metadata.
- `list` walks via `list_objects_v2` paginator and strips the storage-root prefix so callers see the same shape they wrote.

## Tests
- 18 tests using `moto[s3]` (added to dev group): round-trip, overwrite, missing-key, exists/stat metadata, list with/without prefix, delete (including missing no-op), four traversal-guard attack shapes, multi-tenant prefix isolation, structural-Protocol assertion.
- `test_prefix_scopes_writes_and_reads` is the multi-tenancy proof: two `S3Storage` instances with different tenant prefixes write the same simple path (`audit/stage1.json`) and the raw S3 view confirms disjoint keys (`users/alice/...` vs `users/bob/...`).

## Test plan
- [x] `uv run pytest tests/` -- 1420 pass, 16 skipped, 0 fail (1402 baseline + 18 new)
- [x] `uv run ruff check src/ tests/` -- clean
- [x] `uv run black --check src/ tests/` -- clean

## What this doesn't do
- No `AppState.storage` wiring. Per `[[stateless-multitenant]]`, hosted mode wants a per-request per-tenant storage factory (after the auth check resolves the user), not a process singleton. That lands with the actual hosted PR.
- No docker-compose harness. With `moto` covering the test path, the harness is optional -- it earns its keep when there's a second hosted service (MagicLinkAuth, PostgresJobBackend) to wire together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)