### PR TITLE
test(ui): fix latent race in test_trim_invalidates_when_beep_changes

### DIFF
--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2464,11 +2464,15 @@ def test_trim_invalidates_when_beep_changes(tmp_path: Path, monkeypatch) -> None
     # cache and auto-fires a re-trim job; we wait for it to finish.
     resp = client.post("/api/shooters/me/stages/1/beep", json={"beep_time": 7.5})
     assert resp.status_code == 200
-    # The auto-fired job is the active trim job.
+    # Pick the most-recently-submitted trim job, not the first match
+    # in the list. ``_wait_for_job`` on Run #1 (already SUCCEEDED)
+    # would return immediately and race the auto-fired Run #3
+    # worker; the latest entry is the one we actually need to wait
+    # on. (JobRegistry preserves insertion order in ``list()``.)
     jobs = client.get("/api/me/jobs").json()
-    active = next((j for j in jobs if j["kind"] == "trim" and j["stage_number"] == 1), None)
-    assert active is not None, "override_beep should auto-fire a trim job"
-    final = _wait_for_job(client, active["id"])
+    trims = [j for j in jobs if j["kind"] == "trim" and j["stage_number"] == 1]
+    assert trims, "override_beep should auto-fire a trim job"
+    final = _wait_for_job(client, trims[-1]["id"])
     assert final["status"] == "succeeded"
     assert len(invocations) == 2, "new beep_time must invalidate the trim cache"
     assert invocations[1]["beep_time"] == pytest.approx(7.5)


### PR DESCRIPTION
## Summary

CI on main went red after #420 with ``test_trim_invalidates_when_beep_changes`` failing ``assert 1 == 2``. Investigating: the test had a latent race that my async-handler conversion in #420 exposed on the Linux CI runner.

## What was happening

The test ran three trim jobs end-to-end:
1. Cold trim -> ``trim.trim_video`` called once (``invocations == 1``)
2. Same params -> cache hit, no call (``invocations == 1``)
3. ``POST /beep`` with a new ``beep_time`` -> auto-fires Run #3 trim, expected to call ``trim.trim_video`` again (``invocations == 2``)

To pick up the auto-fired job, the test did::

    jobs = client.get("/api/me/jobs").json()
    active = next((j for j in jobs if j["kind"] == "trim" and j["stage_number"] == 1), None)

``next()`` returns the **first** match -- Run #1's already-SUCCEEDED trim. ``_wait_for_job`` on that id returned immediately, so the ``len(invocations) == 2`` assert fired before Run #3's worker had landed its call.

## Why it didn't surface earlier

When ``override_beep`` was ``def`` (sync), FastAPI ran it in its threadpool, giving the executor's worker thread more wall-clock time to invoke ``trim.trim_video`` before the next test step. The async conversion in #420 made the handler return faster on the event loop, exposing the race -- on my Mac the worker still finished quickly enough to hide it; on the CI runner it didn't.

## Fix

Pick the **last** matching trim job (the one just submitted by the auto-chain) instead of the first. ``JobRegistry.list()`` preserves insertion order so ``trims[-1]`` is the auto-fired job.

## Test plan

- [x] ``pytest tests/test_ui_server.py::test_trim_invalidates_when_beep_changes`` passes locally.
- [ ] Full CI passes (the actual gate this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)