### PR TITLE
fix(hosted): NullPool for asyncpg loop-binding + HOSTED-LOCAL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ All commands run as `uv run splitsmith <subcommand>`. Pass `--help` for the full
 | command | purpose |
 |---|---|
 | `ui` | Production SPA. Persistent project state on disk; the main entry point. |
+| `serve` | Hosted-mode API server (Postgres-backed). Preview; see [Hosted mode below](#hosted-mode-preview). |
 | `detect` | One-shot beep + shot detection preview. No files written. |
 | `single` | Full pipeline on one video with an explicit stage time. |
 | `process` | Batch over an SSI Scoreboard stage JSON, matching videos to stages by timestamp. |
@@ -133,6 +134,20 @@ All commands run as `uv run splitsmith <subcommand>`. Pass `--help` for the full
 | `audit-apply` | Merge an audited candidates CSV back into a fixture JSON. |
 | `fcpxml` | Regenerate a timeline from a hand-edited splits CSV. |
 | `mcp` | Model Context Protocol server; pairs with the `/splitsmith-match` Claude Code skill. |
+
+## Hosted mode (preview)
+
+The SaaS-foundation ladder ships a Postgres-backed hosted variant of the server alongside the desktop `ui` mode. Workers, jobs, and per-user state persist in Postgres + MinIO instead of `~/.splitsmith/`. The whole stack boots locally via `docker compose up`:
+
+```bash
+docker compose up --build
+curl http://localhost:5174/api/health
+curl http://localhost:5174/api/me/recent-projects
+```
+
+This is **preview-only**: one loopback user, no real authentication, no SPA bundle, no upload pipeline yet. Workers still run in-process inside the API container (no separate `worker` command -- one container is both HTTP and the executor pool).
+
+See [`docs/saas-readiness/HOSTED-LOCAL.md`](docs/saas-readiness/HOSTED-LOCAL.md) for the complete inventory of what works today, what doesn't, validation recipes, teardown, and the architecture diagram. The broader SaaS plan lives under [`docs/saas-readiness/`](docs/saas-readiness/).
 
 ## Configuration
 

--- a/docs/saas-readiness/HOSTED-LOCAL.md
+++ b/docs/saas-readiness/HOSTED-LOCAL.md
@@ -1,0 +1,322 @@
+# Hosted-mode preview: `docker compose up` on your laptop
+
+Reference for running the SaaS-foundation stack locally on a fresh
+checkout. Used to validate that the Postgres-backed stores work
+end-to-end before the production SaaS infrastructure exists.
+
+This is a **preview**. There is only one user (the loopback
+operator), no real authentication, and several feature areas don't
+have hosted-mode codepaths yet -- see [What works today](#what-works-today)
+below.
+
+## Prerequisites
+
+- Docker Engine 20.10+ with the Compose v2 plugin (`docker compose
+  version` must succeed).
+- The following host ports must be free:
+  - `5174` -- splitsmith API
+  - `5432` -- Postgres (exposed so you can `psql` into it for debugging)
+  - `9000` / `9001` -- MinIO S3 API + web console
+- ~500 MB free disk for the splitsmith image + Postgres / MinIO volumes.
+
+That's it. No Python, ffmpeg, or auth-vendor credentials needed on
+the host -- everything runs inside containers.
+
+## Quick start
+
+```bash
+git clone https://github.com/mandakan/splitsmith.git
+cd splitsmith
+docker compose up --build
+```
+
+First boot takes 60-90 seconds (image build + Postgres healthcheck +
+Alembic migrations). Subsequent boots are ~10 seconds because the
+image is cached.
+
+When the API is ready you'll see:
+
+```
+splitsmith-1  | INFO:     Uvicorn running on http://0.0.0.0:5174 (Press CTRL+C to quit)
+```
+
+## Validation
+
+In another terminal:
+
+```bash
+# Process liveness
+curl -s http://localhost:5174/api/health
+# -> {"status":"ok","version":"0.3.0","bound":false,...}
+
+# The Postgres-backed recent-projects store
+curl -s http://localhost:5174/api/me/recent-projects
+# -> {"projects": []}
+
+# The Postgres-backed scoreboard-identity store
+curl -s http://localhost:5174/api/me/scoreboard-identity
+# -> null
+
+# The Postgres-backed job backend
+curl -s http://localhost:5174/api/me/jobs
+# -> []
+
+# The hosted loopback user (proves the auth bootstrap landed)
+curl -s http://localhost:5174/api/me
+# -> {"id":"01K...","email":"loopback@hosted.local","display_name":"Hosted Operator"}
+
+# psql into Postgres to inspect the schema directly
+docker exec splitsmith-postgres-1 psql -U splitsmith -d splitsmith \
+  -c '\dt'
+# -> alembic_version, compute_jobs, recent_projects, users
+```
+
+The driver smoke test that codifies the same flow is in
+`tests/test_hosted_docker_smoke.py`; run it with:
+
+```bash
+pytest -m docker
+```
+
+## What works today
+
+The hosted preview ships the persistence layer that the
+SaaS-foundation ladder (#416-422) introduced. Everything below is
+served from Postgres rather than `~/.splitsmith/*.json` or the
+process-local job registry.
+
+### Per-user state
+
+| Endpoint | Behaviour | Backed by |
+|----------|-----------|-----------|
+| `GET /api/me` | Loopback hosted user (id + email) | `HostedLoopbackAuth` (bootstrapped row in `users`) |
+| `GET /api/me/recent-projects` | List recent project entries | `recent_projects` table |
+| `POST /api/me/recent-projects/forget` | Remove an entry by path | `recent_projects` table |
+| `POST /api/me/recent-projects/bind` | Bind a path as recent | `recent_projects` table (path must resolve to a real Match folder; in-container that means a mounted volume) |
+| `GET /api/me/scoreboard-identity` | Read pinned SSI identity | `users.scoreboard_identity` JSON column |
+| `PUT /api/me/scoreboard-identity` | Pin an identity | `users.scoreboard_identity` JSON column |
+| `DELETE /api/me/scoreboard-identity` | Unpin the identity | `users.scoreboard_identity` JSON column |
+| `GET /api/me/jobs` | List job snapshots | `compute_jobs` table |
+| `GET /api/me/jobs/{id}` | Single job snapshot | `compute_jobs` table |
+| `POST /api/me/jobs/{id}/cancel` | Request cooperative cancel | `compute_jobs` table |
+| `POST /api/me/jobs/{id}/acknowledge` | Dismiss a failed job | `compute_jobs` table |
+| `POST /api/me/jobs/acknowledge-failures` | Dismiss all failures | `compute_jobs` table |
+
+### Server-level
+
+| Endpoint | Behaviour |
+|----------|-----------|
+| `GET /api/health` | Process liveness + version |
+| `GET /api/server/features` | Lab feature flag |
+| `GET /api/models/status` | Slim-model registry status (likely "no models" in the slim install) |
+
+### Restart durability
+
+Job state persists across container restarts. A job that was
+`pending` or `running` at the moment of restart is swept to `failed`
+with `error="server restarted before this job finished"` -- the SPA
+sees a real terminal state instead of polling forever.
+
+Try it:
+
+```bash
+# Restart just the splitsmith container; postgres + minio stay up.
+docker compose restart splitsmith
+
+# The recent-projects list still has what you put in it.
+curl -s http://localhost:5174/api/me/recent-projects
+```
+
+## What does NOT work yet
+
+The hosted preview is intentionally narrow. These areas don't have
+hosted-mode codepaths and either won't function or will function in
+local-machine-only mode:
+
+### No SPA frontend
+
+The Dockerfile doesn't build `ui_static/dist`, so visiting
+`http://localhost:5174/` returns nothing useful. The API works;
+the SPA does not. Drive it with `curl` or `httpie` instead.
+
+### No real authentication
+
+`HostedLoopbackAuth` upserts one row in `users` (email
+`loopback@hosted.local`) and resolves every request to it.
+**There is no login flow, no session token, no per-user data
+separation.** Anything you POST is owned by the loopback user.
+`MagicLinkAuth` + vendor selection lands separately; until then,
+treat the stack as single-tenant and do not point it at the internet.
+
+### No upload / storage pipeline
+
+MinIO is up and the splitsmith container has `SPLITSMITH_S3_*` env
+vars set, but no API codepath consumes them yet. `S3Storage` (the
+class from #415) exists but is not wired into the upload routes.
+Uploads + downloads still go through filesystem paths; in the
+container those paths are container-local and lost on `down -v`.
+
+Practical effect: workflows that need source video on disk
+(detect-beep, trim, shot-detect, export) don't have a way to
+deliver that video into the container yet. You can scaffold an
+empty Match folder via `POST /api/match/create-manual` but you
+can't ingest footage.
+
+### Slim model install -- shot detection partly degraded
+
+The Docker image uses the slim runtime (`uv sync --no-dev`), which
+ships the ONNX-based voter B + voter C path. Heavy torch /
+transformers / panns-inference are intentionally absent. Implications:
+
+- Voter E (the optional visual probe) and the lab eval flow are
+  unavailable.
+- Model weights aren't bundled in the image. `_maybe_submit_model_download`
+  fires on boot and tries to fetch them from the URLs in the
+  shipped calibration; if those URLs require auth or your
+  container has no outbound HTTP, the job ends in `failed` (which
+  is fine -- it just means shot detection wouldn't work until the
+  weights are present).
+
+### Workers: monolith, not a separate fleet
+
+There is **no `splitsmith worker` command**. The hosted preview is
+intentionally serve-all-in-one:
+
+- `PostgresJobBackend` writes job rows to Postgres on submit.
+- The **same** `splitsmith serve` process runs a
+  `ThreadPoolExecutor` that pops those jobs and executes them.
+- One container = HTTP server + worker pool. Scaling the container
+  scales both; there is no separate "API tier" vs "worker tier"
+  split yet.
+
+Practical effect: submitting via `POST /api/...` just works, the
+container runs the work, and `GET /api/me/jobs/{id}` reflects
+progress + terminal state. You don't need to start anything
+separately. You don't need a queue broker; Postgres is the
+durability layer but not the work-stealing queue yet.
+
+On container restart, any `pending` / `running` row is swept to
+`failed` with `error="server restarted before this job finished"`
+-- no other process will resume them.
+
+**What's missing for a real worker fleet** (deferred to a follow-up PR):
+
+- A `splitsmith worker` CLI that boots a long-lived process which
+  pops jobs from a real queue and registers task handlers by name.
+- A Postgres-native queue layer ([Procrastinate](https://procrastinate.readthedocs.io/)
+  is the planned pick -- reuses our existing DB; no Redis
+  dependency). It would land a sibling `procrastinate_jobs` table
+  alongside `compute_jobs`.
+- A `submit()` shape change from `fn=callable` (closure-passing)
+  to `task_name + args` (worker-side registered tasks) -- this
+  cascades through ~30 callsites in `server.py`.
+
+Until then, two splitsmith containers pointed at the same Postgres
+would each only see / dispatch their own submissions; cross-container
+work-stealing doesn't exist.
+
+### Workflows that touch the local filesystem
+
+`splitsmith ui` (local mode) opens recent projects from paths on
+your laptop. In the container the filesystem is ephemeral, so the
+recent-projects binding flow only works for paths that exist
+inside the container -- there are no useful ones unless you mount
+a volume.
+
+## Teardown + state reset
+
+```bash
+# Stop containers, keep volumes (so a re-up resumes Postgres state)
+docker compose down
+
+# Stop + wipe volumes (fresh DB on next up)
+docker compose down -v
+
+# Full clean including images (forces a rebuild next time)
+docker compose down -v
+docker rmi splitsmith-splitsmith
+```
+
+The smoke test (`tests/test_hosted_docker_smoke.py`) runs
+`down -v` at the end of every session so consecutive runs always
+start from an empty Postgres.
+
+## Troubleshooting
+
+### "Container is unhealthy" right after `docker compose up`
+
+The Compose healthcheck runs every 5s and gates on `/api/health`
+returning 200. The API needs ~10-30s after the container starts to
+finish migrations + bootstrap. Watch the logs instead:
+
+```bash
+docker compose logs -f splitsmith
+```
+
+Once you see `Uvicorn running on http://0.0.0.0:5174` the API is
+live, even if Compose still shows `unhealthy` for a few more seconds.
+
+### "Task ... got Future ... attached to a different loop"
+
+You're on an older version. Pull main; #423 introduced `NullPool`
+for the hosted engine, which fixes the asyncpg event-loop binding
+crash.
+
+### Postgres "could not receive data from client"
+
+Normal -- shows up in Postgres logs every time the splitsmith
+container exits cleanly. Ignore.
+
+### Port already in use
+
+Pick another host port in `docker-compose.yml`:
+
+```yaml
+services:
+  splitsmith:
+    ports:
+      - "8174:5174"   # left side = host port
+```
+
+## Architecture recap
+
+```
+        +----------------------+
+        |  docker compose      |
+        +----------+-----------+
+                   |
+       +-----------+-----------+
+       |           |           |
+  +----v----+ +---v----+ +----v----------+
+  | postgres| | minio  | | splitsmith    |
+  | (5432)  | | (9000) | | api (5174)    |
+  +---------+ +--------+ +----+----------+
+                              |
+                              |  splitsmith serve
+                              |    SPLITSMITH_MODE=hosted
+                              |    SPLITSMITH_DATABASE_URL=...
+                              |
+                   +----------v---------+
+                   |  HostedLoopbackAuth|  -> upserts users row
+                   |  PostgresRecent... |  -> recent_projects table
+                   |  PostgresScoreb... |  -> users.scoreboard_identity
+                   |  PostgresJobBack...|  -> compute_jobs table
+                   +--------------------+
+```
+
+The same `create_app` factory powers both local mode
+(`splitsmith ui`) and hosted mode (`splitsmith serve`). The only
+runtime switch is `SPLITSMITH_MODE=hosted`, which gates the
+`_apply_hosted_mode_wiring` call inside `create_app`.
+
+## Related docs
+
+- [`01-deployment-modes.md`](01-deployment-modes.md) -- the
+  two-modes design and what each contains.
+- [`02-tenancy-and-identity.md`](02-tenancy-and-identity.md) --
+  the auth + identity model the future `MagicLinkAuth` lands into.
+- [`04-compute-backends.md`](04-compute-backends.md) -- the worker
+  dispatch model `PostgresJobBackend` plugs into.
+- [`10-singleton-elimination.md`](10-singleton-elimination.md) --
+  the doc that drove the AppState refactor every Postgres-backed
+  store followed.

--- a/src/splitsmith/db/engine.py
+++ b/src/splitsmith/db/engine.py
@@ -8,9 +8,10 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 
 
-def create_engine(url: str, *, echo: bool = False) -> AsyncEngine:
+def create_engine(url: str, *, echo: bool = False, pool_disabled: bool = False) -> AsyncEngine:
     """Build an async SQLAlchemy engine.
 
     ``url`` shapes the backend:
@@ -23,8 +24,24 @@ def create_engine(url: str, *, echo: bool = False) -> AsyncEngine:
 
     ``echo=True`` dumps every SQL statement to stdout -- useful
     for debugging; never set this in production.
+
+    ``pool_disabled=True`` uses :class:`NullPool` so every
+    ``session()`` opens a fresh DB connection and closes it on
+    release. Required when the engine is shared across multiple
+    short-lived event loops (each ``asyncio.run`` call), as is the
+    case for the hosted-mode boot path + the
+    :class:`PostgresJobBackend` worker thread pool. asyncpg
+    connections are event-loop-bound; a pooled connection created
+    in loop A and reused in loop B crashes with "attached to a
+    different loop". NullPool sidesteps the issue at the cost of a
+    per-call TCP handshake -- acceptable for the call rates here
+    (handler I/O + worker callbacks, not OLTP-style hot loops).
+    Local-mode SQLite/aiosqlite is forgiving and doesn't need this.
     """
-    return create_async_engine(url, echo=echo)
+    kwargs: dict = {"echo": echo}
+    if pool_disabled:
+        kwargs["poolclass"] = NullPool
+    return create_async_engine(url, **kwargs)
 
 
 def sessionmaker(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2000,7 +2000,14 @@ def _apply_hosted_mode_wiring(state: AppState) -> None:
             f"{SPLITSMITH_MODE_ENV}=hosted requires {SPLITSMITH_DATABASE_URL_ENV} "
             "to be set (e.g. postgresql+asyncpg://user:pass@host/db)"
         )
-    engine = create_engine(url)
+    # ``pool_disabled=True`` because the hosted-mode boot path runs
+    # multiple short-lived event loops (HostedLoopbackAuth bootstrap,
+    # PostgresJobBackend sweep, each worker thread's asyncio.run).
+    # asyncpg connections are loop-bound; a pooled connection from
+    # the bootstrap loop would crash on first reuse from the FastAPI
+    # request loop with "attached to a different loop". See
+    # ``splitsmith.db.engine.create_engine`` for the full rationale.
+    engine = create_engine(url, pool_disabled=True)
     session_factory = sessionmaker(engine)
 
     # HostedLoopbackAuth's ``__init__`` runs ``asyncio.run`` to


### PR DESCRIPTION
## Summary

\`docker compose up\` against the hosted stack from #421 crashed on boot with:

\`\`\`
RuntimeError: Task <... PostgresJobBackend._sweep_stuck_jobs_on_boot()>
got Future <...> attached to a different loop
\`\`\`

## Cause

\`HostedLoopbackAuth.__init__\` and \`PostgresJobBackend.__init__\` each call \`asyncio.run(...)\` -- two short-lived event loops at boot. asyncpg connections are loop-bound; SQLAlchemy's default pool cached the connection from the first \`asyncio.run\` and asyncpg rejected the reuse from the second loop.

The \`PostgresJobBackend\` worker threads have the same problem at runtime: each call wraps with \`asyncio.run\` and would reuse a pooled connection from a previous loop.

aiosqlite (the local-test backend) is forgiving about loop binding, so unit tests passed; asyncpg in production is strict.

## Fix

Thread a \`pool_disabled\` flag through \`db.engine.create_engine\` that selects \`sqlalchemy.pool.NullPool\`. Hosted-mode wiring opts in. NullPool opens a fresh connection per session and closes it on release -- no cross-loop sharing possible. Per-call TCP handshake cost is fine at the call rates here (handler I/O + worker callbacks, not OLTP hot loops). Local-mode SQLite keeps the default pool.

## Verified manually

Brought the stack up via \`docker compose up --build\`:

- \`curl localhost:5174/api/health\` -> \`{\"status\":\"ok\",...}\`
- \`curl localhost:5174/api/me/recent-projects\` -> \`{\"projects\": []}\` (served from Postgres)
- \`psql\` into the postgres container confirms exactly one \`users\` row with the loopback email and a real ULID id.

## Test plan

- [x] All four backend test suites still pass against SQLite (48 passed):
  - \`tests/test_hosted_mode_boot.py\`
  - \`tests/test_postgres_job_backend.py\`
  - \`tests/test_recent_projects_store.py\`
  - \`tests/test_scoreboard_identity_store.py\`
- [x] Live \`docker compose up\` smoke shown above.

## Future work (not in this PR)

The right long-term fix is a single persistent event loop with a normal pool, achievable by moving the boot-time bootstrap into FastAPI's \`startup\` lifespan event. That's a larger refactor; NullPool is the smallest fix that unblocks the smoke today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)