### PR TITLE
feat(saas): wire S3Storage in hosted mode + raw upload endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@
 # What ships:
 # - Python 3.11 (matches the wheel's ``requires-python``).
 # - uv for dependency install (faster + lockfile-aware).
-# - The core dependency set: no ``[dev]`` extras, so torch /
-#   transformers / panns-inference stay out of the hosted-mode
-#   container. The slim ONNX runtime + scikit-learn cover voter
-#   B + C inference paths.
+# - ``[project]`` deps + ``[project.optional-dependencies].hosted``:
+#   the core local-mode set plus the runtime hosted-mode deps
+#   (SQLAlchemy + alembic + asyncpg + aiosqlite + python-ulid +
+#   boto3). The dev group (torch / transformers / panns / mypy / ruff
+#   / moto / etc.) stays out -- the slim ONNX runtime + scikit-learn
+#   cover voter B + C inference paths.
 # - ffmpeg + ffprobe via the OS package manager so trim / shot-detect
 #   workers can still execute when a real shooter / match is uploaded.
 
@@ -51,14 +53,17 @@ COPY alembic ./alembic
 # Install dependencies only. ``--no-install-project`` skips the
 # splitsmith package itself, so this layer is invalidated only when
 # ``pyproject.toml`` / ``uv.lock`` change -- a source-only edit reuses
-# the ~500 MB wheel install on the next build.
-RUN uv sync --frozen --no-dev --no-install-project
+# the wheel install on the next build. ``--extra hosted`` pulls the
+# hosted-mode runtime deps (alembic + sqlalchemy + asyncpg + boto3 +
+# ...). Without it the container would boot with the local-mode wheel
+# only and ``splitsmith serve`` would crash on the first alembic call.
+RUN uv sync --frozen --no-dev --extra hosted --no-install-project
 
 # Now bring in the source and install the package itself into the
 # already-warm venv. ``--frozen`` ensures the build still fails if
 # the lockfile and pyproject have drifted.
 COPY src ./src
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --extra hosted
 
 # Hand the working directory to the non-root user so anything the
 # server writes (logs, the optional ``~/.splitsmith`` config) lands

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,15 @@ COPY pyproject.toml uv.lock README.md ./
 COPY alembic.ini ./
 COPY alembic ./alembic
 
-# Install dependencies + the package itself into a uv-managed venv
-# under ``/app/.venv``. ``--frozen`` ensures the build fails if
-# ``uv.lock`` and ``pyproject.toml`` have drifted.
+# Install dependencies only. ``--no-install-project`` skips the
+# splitsmith package itself, so this layer is invalidated only when
+# ``pyproject.toml`` / ``uv.lock`` change -- a source-only edit reuses
+# the ~500 MB wheel install on the next build.
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Now bring in the source and install the package itself into the
+# already-warm venv. ``--frozen`` ensures the build still fails if
+# the lockfile and pyproject have drifted.
 COPY src ./src
 RUN uv sync --frozen --no-dev
 

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -159,14 +159,29 @@ later steps are blocked on earlier ones.
 
 ### Storage (doc 03)
 
-- [ ] `S3Storage` implementation (fsspec-backed, R2 endpoint).
-- [ ] `MemoryStorage` for tests.
+- [x] `S3Storage` implementation (boto3 against R2 / S3 / MinIO),
+  shipped in #415 alongside `FilesystemStorage`. Shared
+  path-traversal guard, structural Protocol round-trip tests via
+  ``moto``.
+- [x] `Storage` slot on `AppState`, wired per-user in hosted mode
+  (`users/<user_id>/` prefix) from `SPLITSMITH_S3_*` env vars.
+  Local mode leaves it `None`; the desktop continues to write
+  `raw/<name>` symlinks via `pathlib.Path`.
+- [x] First hosted upload route: `POST /api/me/raw/upload` streams
+  to S3 via `upload_stream` (boto3 multipart), atomic + idempotent
+  overwrite, server-computed sha256 returned to the client, optional
+  `X-Content-SHA256` verifier that rolls back on mismatch. The
+  desktop is unchanged -- this route 503s outside hosted mode.
+- [-] `MemoryStorage` for tests. Deferred: `moto`-backed
+  `S3Storage` + `tmp_path`-backed `FilesystemStorage` cover the
+  test matrix without a third impl.
 - [ ] Per-project storage layout standardised; existing local
   project directories remain compatible.
 - [ ] `signed_url` implementation for both backends.
 - [ ] Reindex helper (rebuild `projects` rows from R2 walk).
-- [ ] Per-user prefix decision (`users/<id>/projects/<id>/` vs
-  `projects/<id>/`) -- pin during implementation.
+- [x] Per-user prefix decision pinned: `users/<user_id>/...`
+  (project-id scoping nests under that once the `projects` table
+  lands).
 
 ### ACL + projects (doc 02)
 
@@ -181,12 +196,18 @@ later steps are blocked on earlier ones.
 
 ### Uploads (doc 05)
 
+- [~] Single-shot raw upload as the v1 stopgap: `POST /api/me/raw/upload`
+  streams an `UploadFile` to S3 via `boto3` multipart, idempotent on
+  retry, server-computed sha256 returned (and verified against an
+  optional `X-Content-SHA256` header). Resume-from-byte-N is out of
+  scope here -- tus is the upgrade path.
 - [ ] tus-py-server wired with S3 backend pointing at R2.
 - [ ] `upload_sessions` table + lifecycle (24h expiry + cron abort).
 - [ ] `POST /api/v1/uploads` to start a session.
 - [ ] tus-js-client integration in the browser SPA.
 - [ ] Browser audio extraction (WebAudio -> 16 kHz mono WAV).
-- [ ] Sha256 verification on upload completion.
+- [x] Sha256 verification on upload completion (single-shot today;
+  tus extends this to the resumed-chunks flow).
 
 ### Compute (doc 04)
 

--- a/docs/saas-readiness/HOSTED-LOCAL.md
+++ b/docs/saas-readiness/HOSTED-LOCAL.md
@@ -148,19 +148,60 @@ separation.** Anything you POST is owned by the loopback user.
 `MagicLinkAuth` + vendor selection lands separately; until then,
 treat the stack as single-tenant and do not point it at the internet.
 
-### No upload / storage pipeline
+### Upload / storage pipeline (partial)
 
-MinIO is up and the splitsmith container has `SPLITSMITH_S3_*` env
-vars set, but no API codepath consumes them yet. `S3Storage` (the
-class from #415) exists but is not wired into the upload routes.
-Uploads + downloads still go through filesystem paths; in the
-container those paths are container-local and lost on `down -v`.
+MinIO is up, the splitsmith container has `SPLITSMITH_S3_*` env vars
+set, and the hosted boot constructs a per-user `S3Storage` (scoped to
+`users/<user_id>/`). One ingress route is wired today:
 
-Practical effect: workflows that need source video on disk
-(detect-beep, trim, shot-detect, export) don't have a way to
-deliver that video into the container yet. You can scaffold an
-empty Match folder via `POST /api/match/create-manual` but you
-can't ingest footage.
+| Endpoint | Behaviour | Backed by |
+|----------|-----------|-----------|
+| `POST /api/me/raw/upload` | Stream a raw video into `users/<user_id>/raw/<filename>` in MinIO. Returns `{path, size, sha256, filename}`. | `S3Storage.upload_stream` (boto3 multipart) |
+
+Robustness model (doc 05 calls the full tus answer out as the v2
+goal; this is the v1 single-shot):
+
+- The write is atomic. S3 PUT / boto3 multipart only publishes the
+  object on completion; a connection drop leaves no torn object
+  visible. R2's lifecycle rule sweeps aborted multiparts.
+- Re-uploads are safe. A retry with the same filename overwrites
+  the previous object atomically; clients that hit a transient
+  failure can POST the same file again.
+- The server computes sha256 during streaming and returns it so
+  clients can detect transit corruption end-to-end. If the client
+  knows the hash up front, `X-Content-SHA256: <hex>` triggers
+  server-side verification; mismatch rolls the upload back
+  (deletes the just-written object) and returns 422.
+- **Resume-from-byte-N is not implemented** -- a client that loses
+  Wi-Fi at 90% of a 30 GB upload restarts from byte 0. The full tus
+  protocol + `upload_sessions` table lands in a follow-up PR.
+
+What's still **not** wired:
+
+- No GET / signed-URL download path -- the worker can't yet read
+  these uploads back. Bytes go in, nothing reads them out.
+- The rest of the ingest pipeline (detect-beep, trim, shot-detect,
+  export) still expects filesystem paths. A worker download-cache
+  step has to translate `users/<id>/raw/<file>` keys into a local
+  path before ffmpeg / detection runs.
+- `match.json` doesn't know about uploaded files yet; there is no
+  `raw_videos` array per doc 05.
+- Local mode does not call this route. The desktop UI continues to
+  reference user-chosen footage via `raw/<name>` symlinks; the
+  storage slot stays `None` and the endpoint returns 503 outside
+  hosted mode.
+
+Smoke it from the host:
+
+```bash
+echo "fake video bytes" > /tmp/clip.mp4
+curl -F "file=@/tmp/clip.mp4" http://localhost:5174/api/me/raw/upload
+# -> {"path":"raw/clip.mp4","size":17,"sha256":"<hex>","filename":"clip.mp4"}
+
+# Verify the object landed inside MinIO under the loopback user's prefix:
+docker exec splitsmith-minio-1 mc alias set local http://localhost:9000 splitsmith splitsmithsplitsmith
+docker exec splitsmith-minio-1 mc ls -r local/splitsmith-uploads
+```
 
 ### Slim model install -- shot detection partly degraded
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,30 @@ dependencies = [
 splitsmith = "splitsmith.cli:app"
 splitsmith-server = "splitsmith.ui.embedded:main"
 
+[project.optional-dependencies]
+# Hosted-mode runtime deps. ``splitsmith ui`` (local mode) doesn't import
+# any of these -- the SQLAlchemy stores, alembic migration runner, and
+# S3Storage backend are all lazy-imported behind ``SPLITSMITH_MODE=hosted``.
+# Install with ``pip install splitsmith[hosted]`` for the wheel, or
+# ``uv sync --extra hosted`` (which the production Dockerfile does).
+hosted = [
+    # SaaS-foundation DB layer (doc 02). SQLAlchemy 2.x async +
+    # Alembic for migrations. ``aiosqlite`` covers the SQLite-backed
+    # smoke tests + local hosted-mode runs; ``asyncpg`` is the
+    # production dialect.
+    "sqlalchemy[asyncio]>=2.0.30",
+    "alembic>=1.13.0",
+    "asyncpg>=0.29.0",
+    "aiosqlite>=0.20.0",
+    "python-ulid>=3.0.0",
+    # ``S3Storage`` backend (doc 03). Wheel-installs ``boto3`` so the
+    # hosted runtime can upload to R2 / S3 / MinIO. The local-mode
+    # wheel still skips this because ``boto3`` only imports inside
+    # ``S3Storage.__init__`` (and ``__init__`` only runs in hosted
+    # mode -- see ``_apply_hosted_mode_wiring``).
+    "boto3>=1.35.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -94,12 +118,22 @@ exclude = [
 
 [dependency-groups]
 dev = [
+    # Self-extra: pulls in the hosted-mode runtime deps so the dev env
+    # can exercise the hosted code paths (alembic, sqlalchemy, asyncpg,
+    # aiosqlite, python-ulid, boto3). Declared once in
+    # ``[project.optional-dependencies].hosted``; contributors don't
+    # have to re-list them here.
+    "splitsmith[hosted]",
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
     "ruff>=0.4.0",
     "black>=24.0.0",
     "mypy>=1.10.0",
     "respx>=0.21.1",
+    # In-memory S3 mock for ``test_s3_storage.py`` +
+    # ``test_hosted_raw_upload.py``. Dev-only; production never
+    # imports moto.
+    "moto[s3]>=5.0.0",
     # Ensemble sweep analysis (issue #281 follow-up). pyarrow for the
     # signals/runs parquet store, matplotlib for the PNG plot layer.
     # Dev-only: the production API does not read these files.
@@ -119,27 +153,6 @@ dev = [
     "torch>=2.11.0",
     "transformers>=5.7.0",
     "panns-inference>=0.1.1",
-    # S3 multipart upload to Cloudflare R2 (scripts/upload_model_artifacts.py)
-    # AND the hosted-mode ``S3Storage`` backend in ``splitsmith.storage``.
-    # wrangler caps single PUTs at 300 MiB; PANN's consolidated ONNX
-    # is ~312 MiB so we route through R2's S3-compatible endpoint.
-    "boto3>=1.35.0",
-    # In-memory S3 mock for ``test_s3_storage.py`` -- lets us verify
-    # the hosted ``S3Storage`` backend round-trips correctly without
-    # standing up a real bucket. Dev-only; the production wheel
-    # pulls boto3 only when ``S3Storage`` is actually constructed.
-    "moto[s3]>=5.0.0",
-    # SaaS-foundation DB layer (doc 02). SQLAlchemy 2.x async +
-    # Alembic for migrations. Tests run against SQLite in-memory
-    # via aiosqlite; the hosted backend will use asyncpg against
-    # Postgres. Lives in the dev group because the local-mode
-    # wheel doesn't need any of them -- hosted backends import
-    # lazily, same shape as boto3 for S3Storage.
-    "sqlalchemy[asyncio]>=2.0.30",
-    "alembic>=1.13.0",
-    "asyncpg>=0.29.0",
-    "aiosqlite>=0.20.0",
-    "python-ulid>=3.0.0",
 ]
 
 [tool.ruff]

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -559,16 +559,20 @@ def serve(
 
     if not skip_migrations:
         console.print(f"[green]splitsmith serve[/]: applying migrations against [bold]{db_url}[/]")
+        # Stream stdout/stderr straight through so ``docker compose logs``
+        # shows alembic progress live. ``capture_output`` looked clean but
+        # made a 3-minute cold-cache ``uv run`` invocation look like a
+        # process hang -- the container went unhealthy while alembic was
+        # still chugging silently.
         result = _subprocess.run(
             ["uv", "run", "alembic", "upgrade", "head"],
             env={**_os.environ, "SPLITSMITH_DATABASE_URL": db_url},
             cwd=Path(__file__).resolve().parent.parent.parent,
-            capture_output=True,
-            text=True,
         )
         if result.returncode != 0:
-            console.print("[red]alembic upgrade head failed:[/]")
-            console.print(result.stderr)
+            console.print(
+                "[red]alembic upgrade head failed[/] -- see the migration output above."
+            )
             raise typer.Exit(2)
 
     console.print(

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -575,9 +575,7 @@ def serve(
             cwd=Path(__file__).resolve().parent.parent.parent,
         )
         if result.returncode != 0:
-            console.print(
-                "[red]alembic upgrade head failed[/] -- see the migration output above."
-            )
+            console.print("[red]alembic upgrade head failed[/] -- see the migration output above.")
             raise typer.Exit(2)
 
     console.print(

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -544,6 +544,7 @@ def serve(
     """
     import os as _os
     import subprocess as _subprocess
+    import sys as _sys
 
     from .ui.server import serve as _serve
 
@@ -559,13 +560,17 @@ def serve(
 
     if not skip_migrations:
         console.print(f"[green]splitsmith serve[/]: applying migrations against [bold]{db_url}[/]")
-        # Stream stdout/stderr straight through so ``docker compose logs``
-        # shows alembic progress live. ``capture_output`` looked clean but
-        # made a 3-minute cold-cache ``uv run`` invocation look like a
-        # process hang -- the container went unhealthy while alembic was
-        # still chugging silently.
+        # Call ``alembic`` directly from this process's venv rather than
+        # ``uv run alembic``. ``uv run`` re-syncs the project before
+        # invoking the script, and without ``--no-dev`` that pulls the
+        # whole dev dep set (torch + CUDA wheels, ~2 GB) every cold
+        # cache -- on a fresh container image it can mask the actual
+        # migration as a multi-minute "hang" and tip the healthcheck
+        # over. The splitsmith CLI is itself running from the venv, so
+        # ``alembic`` lives next to ``sys.executable``.
+        alembic_bin = Path(_sys.executable).parent / "alembic"
         result = _subprocess.run(
-            ["uv", "run", "alembic", "upgrade", "head"],
+            [str(alembic_bin), "upgrade", "head"],
             env={**_os.environ, "SPLITSMITH_DATABASE_URL": db_url},
             cwd=Path(__file__).resolve().parent.parent.parent,
         )

--- a/src/splitsmith/storage.py
+++ b/src/splitsmith/storage.py
@@ -31,7 +31,7 @@ import tempfile
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Protocol
+from typing import BinaryIO, Protocol
 
 from pydantic import BaseModel
 
@@ -58,6 +58,16 @@ class Storage(Protocol):
 
     def write_bytes(self, path: str, data: bytes) -> None:
         """Atomic write. Replaces an existing object at the same path."""
+
+    def upload_stream(self, path: str, fileobj: BinaryIO) -> int:
+        """Atomic write that streams from ``fileobj`` instead of buffering.
+
+        Returns the byte count consumed from the stream. For
+        multi-GB uploads (raw match footage) this avoids loading
+        the whole payload into memory the way ``write_bytes`` does.
+        ``fileobj`` must be readable in binary mode; the implementation
+        reads to EOF.
+        """
 
     def exists(self, path: str) -> bool:
         """Return True iff an object exists at the path."""
@@ -132,6 +142,32 @@ class FilesystemStorage:
                 pass
             raise
 
+    def upload_stream(self, path: str, fileobj: BinaryIO) -> int:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=target.name + ".",
+            suffix=".tmp",
+            dir=target.parent,
+        )
+        total = 0
+        try:
+            with os.fdopen(fd, "wb") as out:
+                while True:
+                    chunk = fileobj.read(1 << 20)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    total += len(chunk)
+            Path(tmp_name).replace(target)
+        except Exception:
+            try:
+                Path(tmp_name).unlink()
+            except FileNotFoundError:
+                pass
+            raise
+        return total
+
     def exists(self, path: str) -> bool:
         return self._resolve(path).exists()
 
@@ -180,6 +216,25 @@ class FilesystemStorage:
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+
+class _CountingReader:
+    """Wrap a binary file-like so we can report bytes consumed.
+
+    boto3's ``upload_fileobj`` doesn't tell you how many bytes it
+    streamed; callers want the size for the response payload + audit
+    log. We can't trust the source's reported size (UploadFile may
+    advertise -1) so we count what actually went over the wire.
+    """
+
+    def __init__(self, inner: BinaryIO) -> None:
+        self._inner = inner
+        self.bytes_read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._inner.read(size)
+        self.bytes_read += len(chunk)
+        return chunk
 
 
 def _validate_relative_key(key: str) -> str:
@@ -266,6 +321,17 @@ class S3Storage:
         # full, or the put fails and the old object (if any) survives.
         # No temp-and-rename dance needed.
         self._client.put_object(Bucket=self._bucket, Key=self._key(path), Body=data)
+
+    def upload_stream(self, path: str, fileobj: BinaryIO) -> int:
+        # boto3's ``upload_fileobj`` switches to multipart automatically
+        # for streams larger than the configured threshold (8 MiB by
+        # default), so multi-GB raw footage doesn't sit in memory.
+        # The upload is atomic on completion (the final CompleteMultipart
+        # call commits the object); partial failures leave no visible
+        # object behind, matching the put_object contract.
+        counter = _CountingReader(fileobj)
+        self._client.upload_fileobj(counter, self._bucket, self._key(path))
+        return counter.bytes_read
 
     def exists(self, path: str) -> bool:
         from botocore.exceptions import ClientError

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -72,6 +72,7 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -86,9 +87,20 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, BinaryIO, Literal
 
-from fastapi import Body, Depends, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi import (
+    Body,
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -126,6 +138,7 @@ from ..fixture_schema import (
 )
 from ..match_registry import MatchRegistry
 from ..runtime import runtime as process_runtime
+from ..storage import Storage
 from . import audio as audio_helpers
 from . import exports as export_helpers
 from . import match_exports as match_export_helpers
@@ -613,6 +626,15 @@ class AppState:
     # with one wired to the local ``_get_ensemble_runtime`` so test
     # monkeypatches and the shared model cache still work.
     compute: ComputeBackend = field(default_factory=LocalComputeBackend)
+    # Tenant-scoped object storage. ``None`` in local mode -- the
+    # desktop codepaths read/write the user's chosen project folder
+    # directly via ``pathlib.Path`` and never consult this slot. In
+    # hosted mode (``SPLITSMITH_MODE=hosted``) ``_apply_hosted_mode_wiring``
+    # constructs a per-user :class:`S3Storage` scoped to
+    # ``users/<user_id>/`` so the upload endpoints can stream raw
+    # footage into R2 / MinIO without ever touching the API
+    # container's filesystem. See ``docs/saas-readiness/03-storage-layer.md``.
+    storage: Storage | None = None
     # Stop callback registered by :func:`splitsmith.ui.embedded.run_embedded`
     # so the /api/shutdown route can ask uvicorn to exit. None under the
     # ``splitsmith ui`` CLI path -- Ctrl-C via _JobAwareServer.handle_exit
@@ -1952,6 +1974,58 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
 
 SPLITSMITH_MODE_ENV = "SPLITSMITH_MODE"
 SPLITSMITH_DATABASE_URL_ENV = "SPLITSMITH_DATABASE_URL"
+# S3 / R2 / MinIO wiring. ``SPLITSMITH_S3_BUCKET`` is the single
+# switch: when set in hosted mode, ``_apply_hosted_mode_wiring``
+# constructs an ``S3Storage``. The remaining vars must accompany it
+# (the boot fails loud if the bucket is set but creds are missing).
+SPLITSMITH_S3_BUCKET_ENV = "SPLITSMITH_S3_BUCKET"
+SPLITSMITH_S3_ENDPOINT_URL_ENV = "SPLITSMITH_S3_ENDPOINT_URL"
+SPLITSMITH_S3_REGION_ENV = "SPLITSMITH_S3_REGION"
+SPLITSMITH_S3_ACCESS_KEY_ID_ENV = "SPLITSMITH_S3_ACCESS_KEY_ID"
+SPLITSMITH_S3_SECRET_ACCESS_KEY_ENV = "SPLITSMITH_S3_SECRET_ACCESS_KEY"
+
+
+class _HashingReader:
+    """Wrap a binary stream so we hash the bytes as they're consumed.
+
+    boto3's ``upload_fileobj`` reads from this in chunks; we forward
+    the chunks to the inner hash object so the server can return a
+    sha256 without a second pass. Pairs with ``storage.upload_stream``.
+    """
+
+    def __init__(self, inner: BinaryIO, digest: Any) -> None:
+        self._inner = inner
+        self._digest = digest
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._inner.read(size)
+        if chunk:
+            self._digest.update(chunk)
+        return chunk
+
+
+def _sanitize_raw_filename(name: str | None) -> str:
+    """Validate a user-supplied upload filename.
+
+    Strict: anything that isn't a clean basename is a 400. Browsers
+    pass the result of the OS file picker which is always a basename;
+    a request that includes path separators is almost always a client
+    bug, and failing loud surfaces it before the storage layer guard
+    rewrites the surprise into a confusing 500.
+    """
+    if not name:
+        raise HTTPException(status_code=400, detail="filename is required")
+    stripped = name.strip()
+    if stripped in {"", ".", ".."}:
+        raise HTTPException(status_code=400, detail=f"invalid filename: {name!r}")
+    if "/" in stripped or "\\" in stripped:
+        raise HTTPException(status_code=400, detail=f"invalid filename: {name!r}")
+    # ``Path(name).name`` would silently strip path parts; double-check
+    # the identity holds so we don't accept a weirdly-encoded traversal
+    # the storage guard would later reject mid-write.
+    if Path(stripped).name != stripped:
+        raise HTTPException(status_code=400, detail=f"invalid filename: {name!r}")
+    return stripped
 
 
 def _hosted_mode_active() -> bool:
@@ -2020,6 +2094,54 @@ def _apply_hosted_mode_wiring(state: AppState) -> None:
     state.recent_projects = PostgresRecentProjectsStore(session_factory, user_id=user_id)
     state.scoreboard_identity = PostgresScoreboardIdentityStore(session_factory, user_id=user_id)
     state.jobs = PostgresJobBackend(session_factory, user_id=user_id)
+    state.storage = _build_hosted_storage(user_id)
+
+
+def _build_hosted_storage(user_id: str) -> Storage | None:
+    """Construct the per-user :class:`S3Storage` from ``SPLITSMITH_S3_*``
+    env vars, or return ``None`` if the bucket is unset.
+
+    Hosted mode without S3 wiring is a valid configuration -- a
+    developer iterating on the Postgres-backed stores doesn't need
+    MinIO running just to hit ``/api/me/recent-projects``. The
+    upload endpoint guards on ``state.storage is None`` and returns
+    a 503 in that case, so the contract is "set the bucket to get
+    upload support, leave it unset to disable that surface".
+
+    When the bucket *is* set, the rest of the credentials must be
+    present too -- a half-configured S3 wiring would crash on the
+    first request, which is worse than failing loud at boot.
+    """
+    from ..storage import S3Storage
+
+    bucket = os.environ.get(SPLITSMITH_S3_BUCKET_ENV, "").strip()
+    if not bucket:
+        return None
+    endpoint = os.environ.get(SPLITSMITH_S3_ENDPOINT_URL_ENV, "").strip() or None
+    region = os.environ.get(SPLITSMITH_S3_REGION_ENV, "").strip() or "auto"
+    access_key = os.environ.get(SPLITSMITH_S3_ACCESS_KEY_ID_ENV, "").strip()
+    secret_key = os.environ.get(SPLITSMITH_S3_SECRET_ACCESS_KEY_ENV, "").strip()
+    if not access_key or not secret_key:
+        raise RuntimeError(
+            f"{SPLITSMITH_S3_BUCKET_ENV} is set but "
+            f"{SPLITSMITH_S3_ACCESS_KEY_ID_ENV} / "
+            f"{SPLITSMITH_S3_SECRET_ACCESS_KEY_ENV} are missing"
+        )
+
+    import boto3
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+    )
+    # Per-user prefix is the multi-tenant isolation boundary: every
+    # caller gets their own ``users/<id>/`` namespace and can't
+    # construct a key that escapes it (the path-traversal guard
+    # inside ``S3Storage._key`` enforces this).
+    return S3Storage(bucket=bucket, prefix=f"users/{user_id}/", client=client)
 
 
 def create_app(
@@ -2471,6 +2593,102 @@ def create_app(
                 "project_root": str(result.project_root),
                 "project_name": result.project_name,
                 "manifest": result.manifest,
+            }
+        )
+
+    @app.post("/api/me/raw/upload")
+    async def upload_raw_video(
+        file: UploadFile = File(...),
+        x_content_sha256: str | None = Header(default=None),
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Stream a raw video into hosted-mode object storage.
+
+        Hosted-only: returns 503 when ``state.storage`` is unwired,
+        which is the local-mode default. The desktop ``splitsmith ui``
+        flow writes raw videos to disk via ``raw/<name>`` symlinks and
+        never calls this endpoint -- the existing path-based codepaths
+        are unchanged.
+
+        Robustness model (doc 05 calls the full tus answer out as the
+        v2 goal; this is the v1 idempotent single-shot):
+
+        - The write is atomic. S3 PUT (or boto3's multipart) only
+          publishes the object on completion; a connection drop
+          leaves no torn object visible. Aborted multiparts get
+          swept by R2's lifecycle rule.
+        - Re-uploads are safe. A successful retry overwrites the
+          previous object atomically; clients that hit a transient
+          error can just POST the same file again.
+        - The server computes sha256 during streaming and returns it
+          in the response so the client can detect transit corruption
+          end-to-end. If the client knows the hash up front it can
+          send ``X-Content-SHA256`` -- mismatch rolls the upload back
+          (deletes the just-written object) and returns 422 so the
+          retry path is "POST again with the corrected bytes".
+
+        Resume-from-byte-N (tus) is deliberately not in this PR; see
+        ``docs/saas-readiness/05-uploads-and-streaming.md``.
+        """
+        storage = state.storage
+        if storage is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "raw video upload is hosted-mode only; "
+                    "local mode writes raw/<name> symlinks via the desktop UI"
+                ),
+            )
+
+        name = _sanitize_raw_filename(file.filename)
+        key = f"raw/{name}"
+
+        # Wrap the spooled body so we count bytes + hash in one pass
+        # while boto3 streams to S3. UploadFile.file is the underlying
+        # sync SpooledTemporaryFile that boto3 can ``.read()`` from
+        # directly -- starlette has already spooled the multipart body
+        # by the time this handler runs.
+        source: BinaryIO = file.file
+        source.seek(0)
+        digest = hashlib.sha256()
+        hashing = _HashingReader(source, digest)
+
+        try:
+            size = storage.upload_stream(key, hashing)
+        except Exception as exc:
+            # boto3's TransferManager aborts the multipart on its
+            # own; re-raise as a clean 500 so the client sees a
+            # retryable failure instead of a half-typed exception.
+            raise HTTPException(status_code=500, detail=f"upload failed: {exc}") from exc
+
+        sha256_hex = digest.hexdigest()
+
+        if x_content_sha256 and x_content_sha256.lower() != sha256_hex:
+            # The bytes that hit S3 don't match what the client said
+            # they were sending. Roll the object back so a subsequent
+            # GET doesn't serve corrupted content.
+            try:
+                storage.delete(key)
+            except Exception:
+                # Best-effort: if delete fails, R2's lifecycle still
+                # has the object; surfacing the original mismatch is
+                # more useful than the cleanup failure.
+                pass
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error": "sha256_mismatch",
+                    "expected": x_content_sha256,
+                    "actual": sha256_hex,
+                },
+            )
+
+        return JSONResponse(
+            {
+                "path": key,
+                "size": size,
+                "sha256": sha256_hex,
+                "filename": name,
             }
         )
 

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -159,60 +159,89 @@ export function MatchShell() {
       window.removeEventListener("splitsmith:no-project", onNoProject);
   }, []);
 
+  // Tracks whether the match_id in the URL resolved against the server.
+  // ``null`` while the first listMatchShooters call is pending so the
+  // bound-check redirect doesn't fire pre-emptively on every mount; flips
+  // to ``true`` on a successful load or ``false`` when the alias
+  // middleware 404s the id (unknown / deleted match).
+  const [matchValid, setMatchValid] = useState<boolean | null>(null);
+
   useEffect(() => {
     let alive = true;
+    // Match-scoped requests inherit the ``urlMatchId`` from
+    // ``window.location`` (see ``scopeRequestPath`` in api.ts), so we
+    // don't read ``/api/health.bound`` to decide whether to fetch --
+    // doc 10 Tier 1 step 4 retired that field and it now always returns
+    // false. The URL prefix is the source of truth; the alias
+    // middleware validates the id on every request and 404s on miss.
     api
       .getHealth()
       .then((h) => {
         if (alive) setHealth(h);
-        if (h?.bound) {
-          // Sidebar stage list needs *some* shooter's project to render
-          // status. URL slug wins; otherwise fall back to the server's
-          // default shooter (alphabetically-first match shooter, or the
-          // legacy slug for single-shooter projects).
-          const fetchSlug = slug ?? h.default_shooter_slug ?? null;
-          if (fetchSlug) {
-            api
-              .getProject(fetchSlug)
-              .then((p) => {
-                if (alive) setProject(p);
-              })
-              .catch(() => {
-                if (alive) setProject(null);
-              });
-          } else {
-            setProject(null);
-          }
-          api
-            .listMatchShooters()
-            .then((r) => {
-              if (alive) setShooters(r.shooters);
-            })
-            .catch(() => {
-              // 409 no_match when the bound project is a standalone legacy
-              // single-shooter project (not a Match). Leave empty.
-              if (alive) setShooters([]);
-            });
-          // Beep-review pending count drives the sidebar badge so the
-          // operator can spot pending beep work without opening the
-          // page. Cheap GET; refresh on every shell load.
-          api
-            .getBeepQueue()
-            .then((q) => {
-              if (alive) setBeepReviewPending(q.pending_count);
-            })
-            .catch(() => {
-              if (alive) setBeepReviewPending(0);
-            });
-        }
       })
       .catch(() => {
         if (alive) setHealth(null);
       });
+
+    // Sidebar stage list needs *some* shooter's project to render
+    // status. URL slug wins; otherwise we wait for the shooter list
+    // below and pick the first one. ``getProject`` is shooter-scoped
+    // so it only fires when we already know which slug to use.
+    if (slug) {
+      api
+        .getProject(slug)
+        .then((p) => {
+          if (alive) setProject(p);
+        })
+        .catch(() => {
+          if (alive) setProject(null);
+        });
+    } else {
+      setProject(null);
+    }
+
+    api
+      .listMatchShooters()
+      .then((r) => {
+        if (!alive) return;
+        setShooters(r.shooters);
+        setMatchValid(true);
+        // No URL slug -> fall back to the alphabetically-first shooter
+        // so the sidebar has stage status to show.
+        if (!slug && r.shooters.length > 0) {
+          api
+            .getProject(r.shooters[0].slug)
+            .then((p) => {
+              if (alive) setProject(p);
+            })
+            .catch(() => {
+              if (alive) setProject(null);
+            });
+        }
+      })
+      .catch(() => {
+        if (!alive) return;
+        setShooters([]);
+        // Unknown match_id (alias middleware 404) -- bounce to picker.
+        // Other failures (409 no_match for legacy single-shooter
+        // projects) also land here; the picker handles both.
+        setMatchValid(false);
+      });
+    // Beep-review pending count drives the sidebar badge so the
+    // operator can spot pending beep work without opening the
+    // page. Cheap GET; refresh on every shell load.
+    api
+      .getBeepQueue()
+      .then((q) => {
+        if (alive) setBeepReviewPending(q.pending_count);
+      })
+      .catch(() => {
+        if (alive) setBeepReviewPending(0);
+      });
     return () => {
       alive = false;
     };
-  }, [refreshKey, slug]);
+  }, [refreshKey, slug, urlMatchId]);
 
   // Currently-viewed stage, parsed from the URL. The shell mounts
   // above several stage-bearing routes (/audit/:slug/:stage,
@@ -252,7 +281,11 @@ export function MatchShell() {
     }));
   }, [project, activeStageFromUrl]);
 
-  if (health && !health.bound) {
+  // Bounce to the picker when the URL's match_id didn't resolve on the
+  // server -- typically a stale bookmark or a deleted match. ``null``
+  // means "still loading", so we render the shell shell-of-loading
+  // states rather than flashing the picker on first paint.
+  if (matchValid === false) {
     return <Navigate to="/pick" replace />;
   }
 

--- a/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
+++ b/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
@@ -489,14 +489,21 @@ function ScoreboardVariant({
     setCreating(true);
     onError(null);
     try {
-      await api.createMatchFromScoreboard({
+      const health = await api.createMatchFromScoreboard({
         project_folder: projectFolder,
         name: selected.name,
         match_id: selected.id,
         content_type: selected.content_type,
         competitors: picks,
       });
-      navigate("/", { replace: true });
+      // Use the match_id from the create response so we land on the
+      // canonical /match/:matchId/ route. Navigating to "/" would
+      // bounce via LegacyMatchRedirect through /api/health, which no
+      // longer carries bound-state (doc 10 Tier 1 step 4) and so falls
+      // through to /pick.
+      navigate(health.match_id ? `/match/${health.match_id}/` : "/pick", {
+        replace: true,
+      });
     } catch (e) {
       setCreating(false);
       onError(e instanceof ApiError ? e.detail : String(e));
@@ -1215,7 +1222,7 @@ function ManualVariant({
     setCreating(true);
     onError(null);
     try {
-      await api.createMatchManual({
+      const health = await api.createMatchManual({
         name: name.trim(),
         project_folder: folder.trim(),
         match_date: matchDate || null,
@@ -1233,7 +1240,9 @@ function ManualVariant({
           division: shooterDivision,
         },
       });
-      navigate("/", { replace: true });
+      navigate(health.match_id ? `/match/${health.match_id}/` : "/pick", {
+        replace: true,
+      });
     } catch (e) {
       setCreating(false);
       onError(e instanceof ApiError ? e.detail : String(e));

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -69,11 +69,18 @@ export function Home() {
   const href = useMatchHref();
   const ctx = useOutletContext<MatchShellOutletContext>();
   const project = ctx?.project ?? null;
-  // Slug used for slug-bearing nav links from this page. Lifted off the
-  // health snapshot the shell already loaded, so Home doesn't need its
-  // own fetch. Falls back to "/shooters" routing when no default exists.
-  const navSlug = ctx?.health?.default_shooter_slug ?? null;
   const [shooters, setShooters] = useState<ShooterListEntry[]>([]);
+  // Slug used for slug-bearing nav links from this page. The
+  // ``/api/health.default_shooter_slug`` field this used to read was
+  // retired with the bound-state singleton (doc 10 Tier 1 step 4) and
+  // now always returns null, which made "Add shooter footage" silently
+  // fall back to the Shooters page even on single-shooter matches.
+  // Pick the alphabetically-first shooter to match the server's old
+  // ``default_shooter_slug`` derivation in ``_register_response``.
+  const navSlug = useMemo<string | null>(() => {
+    if (shooters.length === 0) return null;
+    return [...shooters].sort((a, b) => a.slug.localeCompare(b.slug))[0].slug;
+  }, [shooters]);
 
   useEffect(() => {
     let alive = true;

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,6 +89,7 @@ _ME_ROUTES_REQUIRING_AUTH: list[tuple[str, str, str]] = [
     ("PUT", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
     ("DELETE", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
     ("POST", "/api/me/projects/import", "/api/me/projects/import"),
+    ("POST", "/api/me/raw/upload", "/api/me/raw/upload"),
 ]
 
 

--- a/tests/test_hosted_mode_boot.py
+++ b/tests/test_hosted_mode_boot.py
@@ -114,6 +114,8 @@ def test_create_app_swaps_in_postgres_backends(hosted_db: str) -> None:
     assert isinstance(state.recent_projects, PostgresRecentProjectsStore)
     assert isinstance(state.scoreboard_identity, PostgresScoreboardIdentityStore)
     assert isinstance(state.jobs, PostgresJobBackend)
+    # No S3 env vars set in this fixture -> storage stays unwired.
+    assert state.storage is None
 
     expected_uid = state.auth.user_id
     # Probe the private attr so the test fails loudly if a future
@@ -123,6 +125,54 @@ def test_create_app_swaps_in_postgres_backends(hosted_db: str) -> None:
     assert state.recent_projects._user_id == expected_uid
     assert state.scoreboard_identity._user_id == expected_uid
     assert state.jobs._user_id == expected_uid
+
+
+def test_hosted_storage_wired_when_bucket_env_set(
+    hosted_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``SPLITSMITH_S3_BUCKET`` is set in hosted mode the boot
+    must construct an :class:`S3Storage` scoped under the loopback
+    user's ``users/<id>/`` prefix. Boto3's client construction is
+    lazy -- we don't need a real bucket to assert the wiring landed.
+    """
+    pytest.importorskip("moto")
+    from moto import mock_aws
+
+    from splitsmith.storage import S3Storage
+
+    monkeypatch.setenv("SPLITSMITH_S3_BUCKET", "splitsmith-test")
+    monkeypatch.setenv("SPLITSMITH_S3_ENDPOINT_URL", "http://minio:9000")
+    monkeypatch.setenv("SPLITSMITH_S3_REGION", "us-east-1")
+    monkeypatch.setenv("SPLITSMITH_S3_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("SPLITSMITH_S3_SECRET_ACCESS_KEY", "secret")
+
+    from splitsmith.ui.server import create_app
+
+    with mock_aws():
+        app = create_app()
+    state = app.state.splitsmith_state
+
+    assert isinstance(state.storage, S3Storage)
+    assert state.storage.bucket == "splitsmith-test"
+    assert state.storage.prefix == f"users/{state.auth.user_id}/"
+
+
+def test_hosted_storage_misconfig_bucket_without_creds_fails_loud(
+    hosted_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Half-configured S3 wiring is worse than no wiring -- the boot
+    must raise so a typo'd creds doesn't 500 the upload endpoint
+    on the first request."""
+    monkeypatch.setenv("SPLITSMITH_S3_BUCKET", "splitsmith-test")
+    monkeypatch.delenv("SPLITSMITH_S3_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("SPLITSMITH_S3_SECRET_ACCESS_KEY", raising=False)
+
+    from splitsmith.ui.server import create_app
+
+    with pytest.raises(RuntimeError, match="SPLITSMITH_S3_ACCESS_KEY_ID"):
+        create_app()
 
 
 def test_recent_projects_round_trip_through_hosted_app(hosted_db: str) -> None:
@@ -177,3 +227,7 @@ def test_create_app_skips_hosted_wiring_when_mode_unset(
     assert isinstance(state.recent_projects, JsonRecentProjectsStore)
     assert isinstance(state.scoreboard_identity, JsonScoreboardIdentityStore)
     assert isinstance(state.jobs, JobRegistry)
+    # Storage stays unwired in local mode regardless of any S3 env
+    # vars that happen to be set -- desktop reads/writes the user's
+    # chosen project folder directly via pathlib.
+    assert state.storage is None

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -1,0 +1,244 @@
+"""End-to-end tests for ``POST /api/me/raw/upload``.
+
+Hosted-only endpoint that streams an UploadFile into ``state.storage``
+under ``raw/<name>``. Local mode never wires storage, so the route
+must return 503 there.
+
+These tests drive the FastAPI app directly via :class:`TestClient`
+against a ``moto`` S3 mock so we exercise the same boto3 codepath
+production hits. They prove the Path B robustness contract:
+
+- atomic / idempotent overwrites (re-upload same path is safe),
+- server-computed sha256 returned to the client,
+- ``X-Content-SHA256`` mismatch rolls the object back + 422s,
+- filename sanitization rejects path traversal at the route layer
+  before the storage guard sees it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+moto = pytest.importorskip("moto")
+import boto3  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from moto import mock_aws  # noqa: E402
+
+from splitsmith.db import Base, create_engine  # noqa: E402
+from splitsmith.storage import S3Storage  # noqa: E402
+
+BUCKET = "splitsmith-uploads-test"
+
+
+@pytest.fixture
+def hosted_db(tmp_path: Path) -> Iterator[str]:
+    """SQLite-backed hosted DB so ``create_app`` doesn't need Postgres.
+
+    Mirrors the fixture in ``test_hosted_mode_boot.py``. File-backed
+    so workers on a thread pool see the same schema.
+    """
+    db_path = tmp_path / "raw_upload.sqlite"
+    url = f"sqlite+aiosqlite:///{db_path}"
+
+    engine = create_engine(url)
+
+    async def _create_all() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create_all())
+
+    prior_url = os.environ.get("SPLITSMITH_DATABASE_URL")
+    prior_mode = os.environ.get("SPLITSMITH_MODE")
+    os.environ["SPLITSMITH_DATABASE_URL"] = url
+    os.environ["SPLITSMITH_MODE"] = "hosted"
+    try:
+        yield url
+    finally:
+        if prior_url is None:
+            os.environ.pop("SPLITSMITH_DATABASE_URL", None)
+        else:
+            os.environ["SPLITSMITH_DATABASE_URL"] = prior_url
+        if prior_mode is None:
+            os.environ.pop("SPLITSMITH_MODE", None)
+        else:
+            os.environ["SPLITSMITH_MODE"] = prior_mode
+
+
+@pytest.fixture
+def hosted_client(hosted_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[TestClient, S3Storage]]:
+    """Boot the FastAPI app in hosted mode against a moto bucket.
+
+    Replaces ``_build_hosted_storage`` so the S3Storage instance is
+    constructed with a client bound to the mock S3 backend that's
+    already created the bucket. This avoids the chicken-and-egg of
+    "the wiring needs a bucket to exist before boto3 will GET it".
+    """
+    monkeypatch.setenv("SPLITSMITH_S3_BUCKET", BUCKET)
+    monkeypatch.setenv("SPLITSMITH_S3_ENDPOINT_URL", "http://moto")
+    monkeypatch.setenv("SPLITSMITH_S3_REGION", "us-east-1")
+    monkeypatch.setenv("SPLITSMITH_S3_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("SPLITSMITH_S3_SECRET_ACCESS_KEY", "secret")
+
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+
+        from splitsmith.ui import server as server_mod
+
+        def _stub_build_storage(user_id: str) -> S3Storage:
+            return S3Storage(bucket=BUCKET, prefix=f"users/{user_id}/", client=s3)
+
+        monkeypatch.setattr(server_mod, "_build_hosted_storage", _stub_build_storage)
+
+        app = server_mod.create_app()
+        with TestClient(app) as client:
+            yield client, app.state.splitsmith_state.storage
+
+
+def test_upload_returns_path_size_sha256(hosted_client) -> None:
+    client, storage = hosted_client
+    payload = b"hello raw video " * 1000  # 16 KB
+    digest = hashlib.sha256(payload).hexdigest()
+
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": ("GH010023.mp4", io.BytesIO(payload), "video/mp4")},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "path": "raw/GH010023.mp4",
+        "size": len(payload),
+        "sha256": digest,
+        "filename": "GH010023.mp4",
+    }
+    # The bytes landed under the per-user tenant prefix.
+    assert storage.read_bytes("raw/GH010023.mp4") == payload
+
+
+def test_upload_idempotent_overwrite(hosted_client) -> None:
+    """A retry with the same filename must overwrite cleanly. This is
+    the v1 robustness story (resume-from-byte-N is doc 05's tus
+    follow-up; safe re-upload is what we ship today)."""
+    client, storage = hosted_client
+    first = b"first attempt; client dropped at 90%"
+    second = b"second attempt; complete payload" * 4
+
+    client.post(
+        "/api/me/raw/upload",
+        files={"file": ("clip.mp4", io.BytesIO(first), "video/mp4")},
+    )
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": ("clip.mp4", io.BytesIO(second), "video/mp4")},
+    )
+
+    assert resp.status_code == 200
+    assert storage.read_bytes("raw/clip.mp4") == second
+
+
+def test_upload_sha256_match_passes(hosted_client) -> None:
+    client, _ = hosted_client
+    payload = b"\x00\x01\x02" * 4096
+    digest = hashlib.sha256(payload).hexdigest()
+
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": ("clip.mp4", io.BytesIO(payload), "video/mp4")},
+        headers={"X-Content-SHA256": digest},
+    )
+
+    assert resp.status_code == 200
+
+
+def test_upload_sha256_mismatch_rolls_back(hosted_client) -> None:
+    """A declared sha256 that doesn't match the streamed bytes must
+    422 *and* delete the just-written object so a later GET can't
+    serve corrupted content."""
+    client, storage = hosted_client
+    payload = b"real bytes"
+    bogus = "0" * 64
+
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": ("clip.mp4", io.BytesIO(payload), "video/mp4")},
+        headers={"X-Content-SHA256": bogus},
+    )
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "sha256_mismatch"
+    assert detail["expected"] == bogus
+    # Rollback: nothing visible at the key.
+    assert not storage.exists("raw/clip.mp4")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../escape.mp4",
+        "/etc/passwd",
+        "..\\windows\\hosts",
+        ".",
+        "..",
+    ],
+)
+def test_upload_rejects_unsafe_filenames(hosted_client, name: str) -> None:
+    client, _ = hosted_client
+
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": (name, io.BytesIO(b"x"), "video/mp4")},
+    )
+
+    assert resp.status_code == 400
+
+
+def test_upload_503_when_storage_unwired(
+    hosted_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``SPLITSMITH_S3_BUCKET`` the boot leaves
+    ``state.storage`` as None -- the endpoint must refuse cleanly."""
+    monkeypatch.delenv("SPLITSMITH_S3_BUCKET", raising=False)
+
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/me/raw/upload",
+            files={"file": ("clip.mp4", io.BytesIO(b"x"), "video/mp4")},
+        )
+
+    assert resp.status_code == 503
+    assert "hosted-mode only" in resp.json()["detail"]
+
+
+def test_local_mode_endpoint_still_503(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Sanity-check the desktop case: with ``SPLITSMITH_MODE`` unset
+    the route still exists but returns 503, proving local-mode
+    behaviour is untouched (the desktop UI doesn't call this route at
+    all -- raw videos live behind ``raw/<name>`` symlinks)."""
+    monkeypatch.delenv("SPLITSMITH_MODE", raising=False)
+    monkeypatch.delenv("SPLITSMITH_S3_BUCKET", raising=False)
+
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/me/raw/upload",
+            files={"file": ("clip.mp4", io.BytesIO(b"x"), "video/mp4")},
+        )
+
+    assert resp.status_code == 503

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -43,6 +43,29 @@ def test_round_trip_write_then_read(s3_client) -> None:
     assert storage.read_bytes("hello.txt") == b"world"
 
 
+def test_upload_stream_round_trip(s3_client) -> None:
+    """boto3 upload_fileobj path must land the same bytes as put_object
+    and report the streamed size back to the caller."""
+    import io
+
+    storage = _storage(s3_client)
+    # Larger than the default 8 MiB multipart threshold would force a
+    # multipart upload against real S3; moto handles either path.
+    payload = b"X" * 17 + b"end"
+    written = storage.upload_stream("raw/clip.bin", io.BytesIO(payload))
+
+    assert written == len(payload)
+    assert storage.read_bytes("raw/clip.bin") == payload
+
+
+def test_upload_stream_rejects_traversal(s3_client) -> None:
+    import io
+
+    storage = _storage(s3_client)
+    with pytest.raises(ValueError, match="must be relative"):
+        storage.upload_stream("../escape.bin", io.BytesIO(b"x"))
+
+
 def test_write_overwrites_existing(s3_client) -> None:
     storage = _storage(s3_client)
     storage.write_bytes("k", b"v1")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -16,6 +16,29 @@ def test_round_trip_write_then_read(tmp_path: Path) -> None:
     assert storage.read_bytes("hello.txt") == b"world"
 
 
+def test_upload_stream_writes_full_payload(tmp_path: Path) -> None:
+    """Streaming write must land the same bytes as ``write_bytes``."""
+    import io
+
+    storage = FilesystemStorage(tmp_path)
+    payload = b"X" * (2 << 20) + b"tail"  # 2 MiB + sentinel; > one read chunk
+    written = storage.upload_stream("raw/clip.bin", io.BytesIO(payload))
+
+    assert written == len(payload)
+    assert storage.read_bytes("raw/clip.bin") == payload
+    # Atomic rename should leave no temp siblings behind.
+    siblings = sorted(p.name for p in (tmp_path / "raw").iterdir())
+    assert siblings == ["clip.bin"]
+
+
+def test_upload_stream_rejects_traversal(tmp_path: Path) -> None:
+    import io
+
+    storage = FilesystemStorage(tmp_path)
+    with pytest.raises(ValueError, match="must be relative"):
+        storage.upload_stream("../escape.bin", io.BytesIO(b"x"))
+
+
 def test_write_creates_parent_directories(tmp_path: Path) -> None:
     """Callers should not have to mkdir themselves -- a project's
     on-disk layout has many nested folders and forcing every writer

--- a/uv.lock
+++ b/uv.lock
@@ -3291,13 +3291,19 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.dev-dependencies]
-dev = [
+[package.optional-dependencies]
+hosted = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "asyncpg" },
-    { name = "black" },
     { name = "boto3" },
+    { name = "python-ulid" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
     { name = "matplotlib" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy" },
@@ -3307,16 +3313,19 @@ dev = [
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "python-ulid" },
     { name = "respx" },
     { name = "ruff" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "splitsmith", extra = ["hosted"] },
     { name = "torch" },
     { name = "transformers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", marker = "extra == 'hosted'", specifier = ">=0.20.0" },
+    { name = "alembic", marker = "extra == 'hosted'", specifier = ">=1.13.0" },
+    { name = "asyncpg", marker = "extra == 'hosted'", specifier = ">=0.29.0" },
+    { name = "boto3", marker = "extra == 'hosted'", specifier = ">=1.35.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
@@ -3329,22 +3338,21 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-ulid", marker = "extra == 'hosted'", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.13.0" },
     { name = "soundfile", specifier = ">=0.12.1" },
+    { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'hosted'", specifier = ">=2.0.30" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
+provides-extras = ["hosted"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "alembic", specifier = ">=1.13.0" },
-    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "black", specifier = ">=24.0.0" },
-    { name = "boto3", specifier = ">=1.35.0" },
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.10.0" },
@@ -3354,10 +3362,9 @@ dev = [
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "respx", specifier = ">=0.21.1" },
     { name = "ruff", specifier = ">=0.4.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
+    { name = "splitsmith", extras = ["hosted"] },
     { name = "torch", specifier = ">=2.11.0" },
     { name = "transformers", specifier = ">=5.7.0" },
 ]


### PR DESCRIPTION
## Summary

- Wires `S3Storage` into hosted mode behind `SPLITSMITH_MODE=hosted`. Local-mode desktop is **untouched** -- `state.storage` stays `None` and the new endpoint 503s outside hosted mode.
- Adds `POST /api/me/raw/upload` -- the first end-to-end S3 codepath. Streams to `users/<user_id>/raw/<filename>` via boto3 multipart, server-computed sha256, idempotent overwrite on retry, optional `X-Content-SHA256` rolls back on mismatch.
- Extends the `Storage` Protocol with `upload_stream(path, fileobj) -> int` so multi-GB raw footage doesn't sit in memory.

## Robustness model (Path B per doc 05)

- **Atomic writes.** S3 PUT / boto3 multipart only publishes on completion; a dropped connection leaves no torn object visible. R2 lifecycle sweeps aborted multiparts.
- **Safe re-upload.** Retry with the same filename overwrites cleanly -- clients that hit a transient failure POST again, no fatal errors.
- **Transit verification.** Server returns sha256 in the response. Clients that know the hash up front can send `X-Content-SHA256: <hex>`; mismatch deletes the just-written object and 422s.
- **Resume-from-byte-N is explicitly deferred** to a tus follow-up per doc 05.

## What this does NOT do

- No GET / signed-URL download path yet -- bytes go in, nothing reads them out.
- The detect / trim / shot-detect / export pipeline still expects filesystem paths. A worker download-cache step has to translate S3 keys into a local path before this is useful end-to-end.
- `match.json` doesn't track uploaded files (no `raw_videos` array yet).

## Files

| Area | Change |
|------|--------|
| `src/splitsmith/storage.py` | `upload_stream` on Protocol + both impls; `_CountingReader` for boto3 byte tracking |
| `src/splitsmith/ui/server.py` | `AppState.storage`; `_build_hosted_storage` reads `SPLITSMITH_S3_*`; `POST /api/me/raw/upload`; filename sanitizer + `_HashingReader` |
| `tests/test_storage.py` + `test_s3_storage.py` | round-trip + traversal-guard tests for `upload_stream` |
| `tests/test_hosted_mode_boot.py` | S3 wired when bucket env set; unwired when not; half-configured boot fails loud |
| `tests/test_hosted_raw_upload.py` (new) | 11 cases: round-trip, idempotent retry, sha256 match/mismatch+rollback, filename sanitization, 503 local mode |
| `tests/test_auth.py` | adds `POST /api/me/raw/upload` to the auth-gate coverage list |
| `docs/saas-readiness/HOSTED-LOCAL.md` | upload pipeline moved from \"doesn't work\" to \"partial\" with curl smoke |
| `docs/saas-readiness/09-saas-progress.md` | storage foundation + single-shot upload marked shipped; `users/<id>/` prefix pinned |

## Test plan

- [x] `uv run pytest tests/test_storage.py tests/test_s3_storage.py tests/test_hosted_mode_boot.py tests/test_hosted_raw_upload.py tests/test_auth.py` -- all green (85 passed)
- [x] Full suite: 1492 passed, 16 skipped, 1 pre-existing flake (`test_sigterm_to_main_exits_clean`, unrelated -- documented on main)
- [x] `uv run ruff check src tests` -- clean
- [x] `uv run black --check src tests` -- clean
- [ ] Smoke against the live docker-compose stack: `docker compose up --build` then `curl -F \"file=@/tmp/clip.mp4\" http://localhost:5174/api/me/raw/upload` and inspect MinIO with `mc ls -r local/splitsmith-uploads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)