### PR TITLE
feat(saas): hosted-mode SPA cleanup (#425)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -963,10 +963,14 @@ class RecentProjectDetail(BaseModel):
     shooter_count: int = 0
     stage_count: int = 0
     stages_audited: int = 0
+    # Total raw videos attached across all shooters. Drives the
+    # "awaiting footage" status the picker renders before the operator
+    # has uploaded anything (#425).
+    video_count: int = 0
     match_date: str | None = None
     club: str | None = None
     last_modified_at: datetime | None = None
-    status: Literal["in_progress", "exported", "archived", "unknown"] = "unknown"
+    status: Literal["awaiting_footage", "in_progress", "exported", "archived", "unknown"] = "unknown"
     # ``True`` for matches the user created without scoreboard data --
     # surfaces the "manual" pill in the polished picker.
     manual: bool = False
@@ -1001,7 +1005,11 @@ class CreateMatchManualRequest(BaseModel):
     """
 
     name: str
-    project_folder: str
+    # Optional in hosted mode: when omitted (or empty/null) the server
+    # synthesizes ``<SPLITSMITH_PROJECTS_DIR>/users/<user_id>/projects/<slug>/``.
+    # Local mode still requires the field so the user controls where the
+    # match lands on their disk. See ``_resolve_create_target``.
+    project_folder: str | None = None
     match_date: date | None = None
     club: str | None = None
     match_type: str | None = None
@@ -1037,7 +1045,8 @@ class CreateMatchScoreboardRequest(BaseModel):
     the create flow lands the user on a fully-populated match.
     """
 
-    project_folder: str
+    # Optional in hosted mode (see :class:`CreateMatchManualRequest`).
+    project_folder: str | None = None
     name: str
     match_id: int
     content_type: int
@@ -1885,6 +1894,49 @@ async def _register_match_at(
     return name, match.match_id
 
 
+def _resolve_create_target(
+    state: AppState,
+    *,
+    project_folder: str | None,
+    name: str,
+) -> Path:
+    """Resolve the on-disk match folder for ``POST /api/match/create-*``.
+
+    - **Local mode**: ``project_folder`` is required (the user picks
+      where the match lands on their disk). 400 if missing/blank.
+    - **Hosted mode**: ``project_folder`` may be omitted; the server
+      synthesises ``<SPLITSMITH_PROJECTS_DIR>/users/<user_id>/projects/<slug>/``
+      so the SPA never has to expose a host filesystem picker (#425).
+      If a hosted client *does* send a path, it's honoured -- the
+      hosted UI just doesn't expose the input.
+
+    Duplicate-name dedupe is handled by the existing
+    ``match_already_exists`` check downstream, so this function only
+    produces a candidate path.
+    """
+    if project_folder and project_folder.strip():
+        return Path(project_folder).expanduser()
+
+    if not _hosted_mode_active():
+        raise HTTPException(
+            status_code=400,
+            detail="project_folder is required in local mode",
+        )
+
+    root = Path(os.environ.get(SPLITSMITH_PROJECTS_DIR_ENV, "").strip() or SPLITSMITH_PROJECTS_DIR_DEFAULT)
+    user_id = getattr(state.auth, "user_id", None) if state.auth is not None else None
+    if not user_id:
+        # _apply_hosted_mode_wiring guarantees state.auth.user_id is set
+        # in hosted mode; failing loud here is preferable to silently
+        # writing to a shared prefix.
+        raise HTTPException(
+            status_code=500,
+            detail="hosted mode active but auth.user_id is not set",
+        )
+    slug = match_model._slugify(name)
+    return root / "users" / user_id / "projects" / slug
+
+
 def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail:
     """Read on-disk metadata for one recent-project entry.
 
@@ -1926,6 +1978,7 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
             # operator has to hit Save & next at least once on the
             # stage for it to count. Skipped stages don't qualify.
             audited_total = 0
+            video_total = 0
             shooter_names: list[str] = []
             for slug in match.shooters:
                 shooter_root = match_model.Match.shooter_root(path, slug)
@@ -1940,9 +1993,11 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
                     shooter_names.append(shooter.name or slug)
                     continue
                 audited_total += legacy.audited_count(shooter_root)
+                video_total += len(legacy.all_videos())
                 shooter_names.append(shooter.name or slug)
             detail.shooter_names = shooter_names
             detail.stages_audited = audited_total // max(len(match.shooters), 1) if match.shooters else 0
+            detail.video_count = video_total
             metadata_path = path / match_model.MATCH_FILE
         else:
             # Path exists but is not a Match folder -- a pre-Tier-1
@@ -1957,16 +2012,17 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
     except Exception:  # noqa: BLE001 -- defensive: never break listing
         return detail
 
-    # Derive status. "exported" = every stage audited (heuristic); "archived"
-    # = no modification in 180 days; "in_progress" otherwise.
+    # Derive status. "exported" = every stage audited (heuristic);
+    # "archived" = no modification in 180 days;
+    # "awaiting_footage" = the operator hasn't attached any footage yet
+    # (drives the picker pill + footage-gated menu treatment per #425);
+    # "in_progress" otherwise.
     if detail.stage_count > 0 and detail.stages_audited >= detail.stage_count:
         detail.status = "exported"
-    elif detail.last_modified_at is not None:
-        age = datetime.now(UTC) - detail.last_modified_at
-        if age.days > 180:
-            detail.status = "archived"
-        else:
-            detail.status = "in_progress"
+    elif detail.last_modified_at is not None and (datetime.now(UTC) - detail.last_modified_at).days > 180:
+        detail.status = "archived"
+    elif detail.kind == "match" and detail.video_count == 0:
+        detail.status = "awaiting_footage"
     else:
         detail.status = "in_progress"
     return detail
@@ -1983,6 +2039,16 @@ SPLITSMITH_S3_ENDPOINT_URL_ENV = "SPLITSMITH_S3_ENDPOINT_URL"
 SPLITSMITH_S3_REGION_ENV = "SPLITSMITH_S3_REGION"
 SPLITSMITH_S3_ACCESS_KEY_ID_ENV = "SPLITSMITH_S3_ACCESS_KEY_ID"
 SPLITSMITH_S3_SECRET_ACCESS_KEY_ENV = "SPLITSMITH_S3_SECRET_ACCESS_KEY"
+# Hosted-mode project-metadata root. ``match.json`` + per-shooter
+# JSON still lives on the container's filesystem (raw videos are the
+# part that ships to S3 today; persisting match metadata to Postgres
+# is doc 09 work). Defaults to the splitsmith user's home so a fresh
+# container is writable; production deployments mount a volume at
+# this path. The directory layout under here is
+# ``users/<user_id>/projects/<slug>/`` -- the same multi-tenant
+# prefix S3 storage uses.
+SPLITSMITH_PROJECTS_DIR_ENV = "SPLITSMITH_PROJECTS_DIR"
+SPLITSMITH_PROJECTS_DIR_DEFAULT = "/home/splitsmith/data"
 
 
 class _HashingReader:
@@ -6992,8 +7058,13 @@ def create_app(
         directory as the active legacy project so existing endpoints keep
         working. Folder is created if missing; refuses if a ``match.json``
         is already present (use bind to open existing matches).
+
+        ``project_folder`` is optional in hosted mode -- the server
+        synthesises ``users/<user_id>/projects/<slug>/`` under
+        ``$SPLITSMITH_PROJECTS_DIR`` so the SPA doesn't have to expose a
+        host filesystem picker (#425).
         """
-        target = Path(req.project_folder).expanduser()
+        target = _resolve_create_target(state, project_folder=req.project_folder, name=req.name)
         if (target / match_model.MATCH_FILE).exists():
             raise HTTPException(
                 status_code=409,
@@ -7096,7 +7167,7 @@ def create_app(
                 )
             comp_ids_seen.add(pick.selected_competitor_id)
 
-        target = Path(req.project_folder).expanduser()
+        target = _resolve_create_target(state, project_folder=req.project_folder, name=req.name)
         if (target / match_model.MATCH_FILE).exists():
             raise HTTPException(
                 status_code=409,
@@ -7910,12 +7981,20 @@ def create_app(
     def server_features() -> JSONResponse:
         """Surface server-side feature flags to the SPA on first load.
 
-        Today: ``lab`` (the developer-facing Algorithm Lab page; off by
-        default, opt-in via ``splitsmith ui --lab``). The SPA hides the
-        Lab nav entry when this is False so end users don't trip into
-        a multi-second model-loading workflow they didn't ask for.
+        Fields:
+
+        - ``lab`` -- the developer-facing Algorithm Lab page; off by
+          default, opt-in via ``splitsmith ui --lab``. The SPA hides
+          the Lab nav entry when this is False so end users don't trip
+          into a multi-second model-loading workflow they didn't ask
+          for.
+        - ``mode`` -- ``"local"`` (default ``splitsmith ui``) or
+          ``"hosted"`` (``splitsmith serve`` + ``SPLITSMITH_MODE=hosted``).
+          The SPA branches on this to suppress filesystem-picker UX
+          that's meaningless against an ephemeral hosted container.
         """
-        return JSONResponse({"lab": lab_enabled})
+        mode = "hosted" if _hosted_mode_active() else "local"
+        return JSONResponse({"lab": lab_enabled, "mode": mode})
 
     # ----------------------------------------------------------------------
     # Lab: fixture management + ensemble eval + tuning

--- a/src/splitsmith/ui_static/src/components/AddFootageModal.tsx
+++ b/src/splitsmith/ui_static/src/components/AddFootageModal.tsx
@@ -34,6 +34,7 @@ import {
   api,
   type ScanResponse,
 } from "@/lib/api";
+import { useDeploymentMode } from "@/lib/features";
 import { cn } from "@/lib/utils";
 
 export type StorageMode = "symlink" | "copy";
@@ -80,6 +81,15 @@ export function AddFootageModal({
   onImported,
   onStorageChange,
 }: AddFootageModalProps) {
+  // Hosted mode: the SPA upload UX hasn't shipped yet (deferred to the
+  // tus migration in doc 05). Render a placeholder explaining the
+  // curl-only path so the operator isn't dead-ended into a filesystem
+  // picker against the container's ephemeral disk (#425). Hooks below
+  // still run so the Rules of Hooks are satisfied; the branch is in
+  // the returned JSX.
+  const deploymentMode = useDeploymentMode();
+  const hostedMode = deploymentMode === "hosted";
+
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [storage, setStorageState] = useState<StorageMode>(initialStorage);
   const setStorage = useCallback(
@@ -195,6 +205,10 @@ export function AddFootageModal({
 
     setPhase("result");
     onImported(totalImported);
+  }
+
+  if (hostedMode) {
+    return <HostedModePlaceholder onClose={onClose} />;
   }
 
   return (
@@ -707,5 +721,73 @@ function StatusIcon({ state }: { state: ScanState }) {
       aria-label="pending"
       className="inline-block size-2 rounded-full bg-subtle"
     />
+  );
+}
+
+/** Stand-in for the queue + scan flow when the server runs in hosted
+ *  mode. The SPA upload UX is deferred to the tus migration (doc 05);
+ *  meanwhile we surface the curl-only ``POST /api/me/raw/upload`` path
+ *  so the operator has a working route rather than a dead-ended
+ *  filesystem picker (#425). */
+function HostedModePlaceholder({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add footage (hosted mode)"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/70 p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative flex w-full max-w-xl flex-col overflow-hidden rounded-xl border border-rule-strong bg-surface text-ink shadow-[0_24px_48px_-12px_rgba(0,0,0,0.7)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between gap-4 border-b border-rule px-5 py-3.5">
+          <div>
+            <h2 className="font-display text-sm font-bold uppercase tracking-[0.08em] text-ink">
+              Upload from browser (preview)
+            </h2>
+            <p className="mt-0.5 font-mono text-[0.6875rem] uppercase tracking-[0.06em] text-muted">
+              Hosted-mode browser uploads ship with the tus migration.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1.5 text-subtle hover:bg-surface-2 hover:text-ink"
+          >
+            <X className="size-4" />
+          </button>
+        </header>
+        <div className="space-y-4 px-5 py-4 text-[0.8125rem] text-ink-2">
+          <p>
+            The host filesystem picker is disabled because there's no
+            useful path inside the hosted container. While the
+            drag-and-drop upload UX is in flight, you can stream a clip
+            in via curl:
+          </p>
+          <pre className="overflow-x-auto rounded-md border border-rule bg-surface-2 p-3 font-mono text-[0.75rem] text-ink">
+            {"curl -F \"file=@/path/to/clip.mp4\" \\\n  http://<host>:5174/api/me/raw/upload"}
+          </pre>
+          <p className="text-muted">
+            The endpoint stores the upload under
+            <code className="mx-1 rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[0.75rem] text-ink-2">
+              users/&lt;user_id&gt;/raw/
+            </code>
+            in object storage and returns the resulting path + sha256.
+          </p>
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-rule bg-surface-2 px-5 py-3.5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md bg-led-fill px-3.5 py-1.5 font-mono text-[0.6875rem] font-bold uppercase tracking-[0.08em] text-ink shadow-[0_0_0_1px_var(--color-led-fill),0_0_18px_var(--color-led-glow)] hover:bg-led"
+          >
+            Got it
+          </button>
+        </footer>
+      </div>
+    </div>
   );
 }

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -405,6 +405,10 @@ export function MatchShell() {
           awaiting={
             stages.length > 0 && stages.every((s) => s.status === "todo")
           }
+          // ``hasFootage`` is the cross-shooter rollup; any shooter with at
+          // least one attached video unlocks the footage-dependent nav rows
+          // (Audit / Coach / Export). See #425 for the rationale.
+          hasFootage={shooters.some((s) => s.video_count > 0)}
           onStageClick={(n) => {
             const target = slug ?? health?.default_shooter_slug;
             const mid = urlMatchId ?? health?.match_id ?? null;

--- a/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
@@ -69,6 +69,13 @@ interface MatchSidebarProps {
   /** When true the sidebar renders the "no footage yet" sub for the stage
    *  list (matches polished/17). Defaults to false. */
   awaiting?: boolean;
+  /** True when any shooter on this match has at least one video attached.
+   *  When false the footage-dependent nav rows (Audit, Coach, Videos,
+   *  Export) render as disabled rows with an "attach footage first"
+   *  hint instead of dead-ending the operator on an empty surface
+   *  (#425). Defaults to true so callers that haven't been updated
+   *  retain the previous behaviour. */
+  hasFootage?: boolean;
   /** Per-stage click handler. Receives the stage number; the surface that
    *  owns the sidebar decides where to route (audit, compare, ...). */
   onStageClick?: (stage_number: number) => void;
@@ -103,6 +110,7 @@ export function MatchSidebar({
   shooterCount,
   beepReviewPendingCount,
   awaiting = false,
+  hasFootage = true,
   onStageClick,
   shooterSlug,
   matchId,
@@ -110,6 +118,9 @@ export function MatchSidebar({
   onCollapseToggle,
   className,
 }: MatchSidebarProps) {
+  // Footage-dependent rows share the same hint -- centralised so the
+  // copy doesn't drift between Audit / Coach / Videos / Export.
+  const footageHint = "Attach footage to this match before this surface is usable";
   // Prefix every nav row with /match/:matchId when one is in scope, so
   // clicks keep the user inside the match-scoped subtree (#353 Phase 3).
   // Without a match id we fall back to the bare paths -- legacy routes
@@ -192,6 +203,8 @@ export function MatchSidebar({
           to={shooterSlug ? `${base}/audit/${shooterSlug}` : `${base}/shooters`}
           icon={<Crosshair className="size-[15px]" />}
           collapsed={collapsed}
+          disabled={!hasFootage}
+          disabledHint={footageHint}
         >
           Audit
         </SidebarLink>
@@ -199,6 +212,8 @@ export function MatchSidebar({
           to={shooterSlug ? `${base}/coach/${shooterSlug}` : `${base}/shooters`}
           icon={<ClipboardCheck className="size-[15px]" />}
           collapsed={collapsed}
+          disabled={!hasFootage}
+          disabledHint={footageHint}
         >
           Coach
         </SidebarLink>
@@ -231,6 +246,8 @@ export function MatchSidebar({
           to={shooterSlug ? `${base}/export/${shooterSlug}` : `${base}/shooters`}
           icon={<ArrowDownToLine className="size-[15px]" />}
           collapsed={collapsed}
+          disabled={!hasFootage}
+          disabledHint={footageHint}
         >
           Export
         </SidebarLink>
@@ -358,6 +375,8 @@ function SidebarLink({
   badgeKind = "count",
   end,
   collapsed,
+  disabled = false,
+  disabledHint,
   children,
 }: {
   to: string;
@@ -369,6 +388,12 @@ function SidebarLink({
   badgeKind?: "count" | "pending";
   end?: boolean;
   collapsed: boolean;
+  /** Renders as a non-interactive muted row with ``disabledHint`` as a
+   *  tooltip. Used for footage-dependent surfaces when no shooter has
+   *  any video attached yet (#425): clicking would dead-end, so the
+   *  empty state is the row itself. */
+  disabled?: boolean;
+  disabledHint?: string;
   children: ReactNode;
 }) {
   const { pathname } = useLocation();
@@ -378,6 +403,29 @@ function SidebarLink({
   // Pending badges hide at zero; count badges only render when defined.
   const showBadge =
     typeof count === "number" && (badgeKind === "pending" ? count > 0 : true);
+  if (disabled) {
+    if (collapsed) {
+      return (
+        <span
+          aria-disabled="true"
+          title={disabledHint}
+          className="relative flex h-9 cursor-not-allowed items-center justify-center rounded-md text-subtle opacity-60"
+        >
+          <span className="inline-flex">{icon}</span>
+        </span>
+      );
+    }
+    return (
+      <span
+        aria-disabled="true"
+        title={disabledHint}
+        className="flex min-h-9 cursor-not-allowed items-center gap-3 rounded-md border border-transparent px-2.5 py-2 text-[0.8125rem] font-medium text-subtle opacity-60"
+      >
+        <span className="inline-flex shrink-0 text-subtle">{icon}</span>
+        <span>{children}</span>
+      </span>
+    );
+  }
   if (collapsed) {
     return (
       <NavLink

--- a/src/splitsmith/ui_static/src/components/ui/StatusPill.tsx
+++ b/src/splitsmith/ui_static/src/components/ui/StatusPill.tsx
@@ -7,6 +7,9 @@
  *    visible without animation)
  *  - exported: green, solid
  *  - archived: cold grey, hollow
+ *  - awaiting: muted cool, hollow dot -- "not started yet, ready for input"
+ *    (e.g. a freshly-created match with no footage attached, #425). Visually
+ *    distinct from "archived" (stale) and the destructive LED red.
  *  - beep: cyan, used in Developer surfaces
  *
  * A11y: always carries a non-color cue (label text + a shape variation for
@@ -27,6 +30,7 @@ const pillVariants = cva(
           "border-live/40 bg-[color:var(--color-live-glow)] text-live",
         exported: "border-done/40 bg-[color:var(--color-done-glow)] text-done",
         archived: "border-rule bg-transparent text-cold",
+        awaiting: "border-rule-strong bg-surface-2 text-muted",
         beep: "border-beep/40 bg-[color:var(--color-beep-tint)] text-beep",
         led: "border-led/40 bg-[color:var(--color-led-tint)] text-led",
       },
@@ -58,6 +62,7 @@ export function StatusPill({
           tone === "in-progress" && "bg-live",
           tone === "exported" && "bg-done",
           tone === "archived" && "border border-cold bg-transparent",
+          tone === "awaiting" && "border border-muted bg-transparent",
           tone === "beep" && "bg-beep",
           tone === "led" && "bg-led",
           pulse && "animate-pulse",

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1156,10 +1156,18 @@ export interface RecentProjectDetail {
   shooter_count: number;
   stage_count: number;
   stages_audited: number;
+  /** Total raw videos attached across all shooters. Drives the
+   *  "awaiting footage" pill + footage-aware menu treatment (#425). */
+  video_count: number;
   match_date: string | null;
   club: string | null;
   last_modified_at: string | null;
-  status: "in_progress" | "exported" | "archived" | "unknown";
+  status:
+    | "awaiting_footage"
+    | "in_progress"
+    | "exported"
+    | "archived"
+    | "unknown";
   manual: boolean;
   shooter_names: string[];
 }
@@ -1173,7 +1181,10 @@ export interface CreateMatchStageDraft {
 
 export interface CreateMatchManualBody {
   name: string;
-  project_folder: string;
+  /** Optional in hosted mode -- server synthesizes
+   *  ``users/<user_id>/projects/<slug>/`` under ``$SPLITSMITH_PROJECTS_DIR``
+   *  when omitted/null. Required in local mode. */
+  project_folder?: string | null;
   match_date?: string | null;
   club?: string | null;
   match_type?: string | null;
@@ -1195,7 +1206,8 @@ export interface CreateMatchCompetitorPick {
 }
 
 export interface CreateMatchScoreboardBody {
-  project_folder: string;
+  /** Optional in hosted mode (see :type:`CreateMatchManualBody`). */
+  project_folder?: string | null;
   name: string;
   match_id: number;
   content_type: number;
@@ -2016,10 +2028,12 @@ export const api = {
     );
   },
 
-  /** Server-side feature flags (fetched once on app mount). Today this
-   *  surfaces the ``lab`` flag so the SPA can hide the Lab nav entry
-   *  unless ``splitsmith ui --lab`` was passed. */
-  getServerFeatures: () => request<{ lab: boolean }>("/api/server/features"),
+  /** Server-side feature flags (fetched once on app mount). Surfaces:
+   *  - ``lab`` -- hide the Lab nav entry unless ``splitsmith ui --lab``.
+   *  - ``mode`` -- ``"local"`` vs ``"hosted"``; SPA suppresses host
+   *    filesystem pickers / project-folder inputs in hosted mode. */
+  getServerFeatures: () =>
+    request<{ lab: boolean; mode: "local" | "hosted" }>("/api/server/features"),
 
   /** Server health + bind state. The picker route polls this on mount
    *  to decide whether the user landed in unbound mode (boot with no

--- a/src/splitsmith/ui_static/src/lib/features.ts
+++ b/src/splitsmith/ui_static/src/lib/features.ts
@@ -19,13 +19,16 @@ import { useEffect, useState } from "react";
 
 import { api } from "./api";
 
-type Features = { lab: boolean };
+export type DeploymentMode = "local" | "hosted";
+type Features = { lab: boolean; mode: DeploymentMode };
 
 let cached: Promise<Features> | null = null;
 
 function fetchFeatures(): Promise<Features> {
   if (cached === null) {
-    cached = api.getServerFeatures().catch(() => ({ lab: false }) as Features);
+    cached = api
+      .getServerFeatures()
+      .catch(() => ({ lab: false, mode: "local" }) as Features);
   }
   return cached;
 }
@@ -45,4 +48,29 @@ export function useLabEnabled(): boolean {
     };
   }, []);
   return enabled;
+}
+
+/** Returns the deployment mode the server is running in.
+ *
+ * - ``"local"`` -- ``splitsmith ui`` against the host filesystem.
+ *   Folder pickers + project-folder inputs are meaningful.
+ * - ``"hosted"`` -- ``splitsmith serve`` against object storage. The
+ *   container filesystem is ephemeral; folder pickers / host paths
+ *   are suppressed and raw uploads go through the upload endpoint.
+ *
+ * Defaults to ``"local"`` while the initial fetch is in flight or on
+ * failure -- the conservative choice that keeps the local SPA usable
+ * if /api/server/features is temporarily unreachable. */
+export function useDeploymentMode(): DeploymentMode {
+  const [mode, setMode] = useState<DeploymentMode>("local");
+  useEffect(() => {
+    let alive = true;
+    fetchFeatures().then((f) => {
+      if (alive) setMode(f.mode === "hosted" ? "hosted" : "local");
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return mode;
 }

--- a/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
+++ b/src/splitsmith/ui_static/src/pages/CreateMatch.tsx
@@ -45,6 +45,7 @@ import {
   type ScoreboardMatchData,
   type ScoreboardMatchRef,
 } from "@/lib/api";
+import { useDeploymentMode } from "@/lib/features";
 import { slugify } from "@/lib/slugify";
 import { cn } from "@/lib/utils";
 
@@ -236,6 +237,11 @@ function ScoreboardVariant({
   const [parentDir, setParentDir] = useState<string>(DEFAULT_PARENT_DIR);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  // In hosted mode the server picks the project folder
+  // (``users/<user_id>/projects/<slug>/``); the picker UI is suppressed
+  // because there's no useful host filesystem inside the container.
+  const deploymentMode = useDeploymentMode();
+  const hostedMode = deploymentMode === "hosted";
   // Division facet -- ``null`` means "any". Selected division narrows the
   // accordion list to a single group. Squad isn't on the wire today, so
   // division does double duty as both the facet chip row and the
@@ -465,7 +471,7 @@ function ScoreboardVariant({
     !!selected &&
     !!matchData &&
     checked.size > 0 &&
-    parentDir.trim().length > 0 &&
+    (hostedMode || parentDir.trim().length > 0) &&
     slug.trim().length > 0 &&
     slugError == null &&
     !creating;
@@ -490,7 +496,9 @@ function ScoreboardVariant({
     onError(null);
     try {
       const health = await api.createMatchFromScoreboard({
-        project_folder: projectFolder,
+        // Hosted mode: server picks the path; the SPA doesn't have a
+        // useful host filesystem to point at. See #425.
+        project_folder: hostedMode ? null : projectFolder,
         name: selected.name,
         match_id: selected.id,
         content_type: selected.content_type,
@@ -771,31 +779,33 @@ function ScoreboardVariant({
 
           <Section eyebrow="03 Project folder" title="Where to save this match">
             <p className="-mt-1 mb-4 max-w-2xl text-[0.8125rem] text-muted">
-              The match folder will be created as a new directory inside
-              the parent you pick. The leaf defaults to the match name in
-              kebab-case; edit it if you'd like a different folder name.
+              {hostedMode
+                ? "The hosted server picks the storage location for you. The match name still drives the folder slug below; edit it if you'd like a different one."
+                : "The match folder will be created as a new directory inside the parent you pick. The leaf defaults to the match name in kebab-case; edit it if you'd like a different folder name."}
             </p>
 
             <div className="flex flex-col gap-3 rounded-lg border border-rule bg-surface-3 px-4 py-3.5">
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="font-mono text-[0.625rem] uppercase tracking-[0.1em] text-subtle">
-                    Parent folder
+              {!hostedMode && (
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-mono text-[0.625rem] uppercase tracking-[0.1em] text-subtle">
+                      Parent folder
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-[0.8125rem] tabular-nums text-ink-2">
+                      {parentDir}
+                    </div>
                   </div>
-                  <div className="mt-0.5 truncate font-mono text-[0.8125rem] tabular-nums text-ink-2">
-                    {parentDir}
-                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setPickerOpen(true)}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-rule-strong bg-surface-2 px-3 py-1.5 font-display text-[0.6875rem] font-bold uppercase tracking-[0.08em] text-ink-2 hover:border-led-deep hover:bg-led-tint hover:text-led"
+                  >
+                    <FolderOpen className="size-3.5" />
+                    Change...
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setPickerOpen(true)}
-                  className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-rule-strong bg-surface-2 px-3 py-1.5 font-display text-[0.6875rem] font-bold uppercase tracking-[0.08em] text-ink-2 hover:border-led-deep hover:bg-led-tint hover:text-led"
-                >
-                  <FolderOpen className="size-3.5" />
-                  Change...
-                </button>
-              </div>
-              <div className="border-t border-rule pt-3">
+              )}
+              <div className={cn(hostedMode ? "" : "border-t border-rule pt-3")}>
                 <label className="block font-mono text-[0.625rem] uppercase tracking-[0.1em] text-subtle">
                   Folder name
                 </label>
@@ -839,14 +849,16 @@ function ScoreboardVariant({
                   </p>
                 )}
               </div>
-              <div className="border-t border-rule pt-3">
-                <div className="font-mono text-[0.625rem] uppercase tracking-[0.1em] text-subtle">
-                  Will create
+              {!hostedMode && (
+                <div className="border-t border-rule pt-3">
+                  <div className="font-mono text-[0.625rem] uppercase tracking-[0.1em] text-subtle">
+                    Will create
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-[0.8125rem] tabular-nums text-ink">
+                    {projectFolder}/
+                  </div>
                 </div>
-                <div className="mt-0.5 truncate font-mono text-[0.8125rem] tabular-nums text-ink">
-                  {projectFolder}/
-                </div>
-              </div>
+              )}
             </div>
           </Section>
 
@@ -891,7 +903,7 @@ function ScoreboardVariant({
         </div>
       )}
 
-      {pickerOpen && (
+      {pickerOpen && !hostedMode && (
         <DirectoryPickerModal
           initialPath={parentDir.startsWith("~") ? null : parentDir}
           onSelect={(picked) => {
@@ -1148,6 +1160,8 @@ function ManualVariant({
   onError: (e: string | null) => void;
 }) {
   const navigate = useNavigate();
+  const deploymentMode = useDeploymentMode();
+  const hostedMode = deploymentMode === "hosted";
   const today = new Date().toISOString().slice(0, 10);
   const [name, setName] = useState("");
   const [matchDate, setMatchDate] = useState(today);
@@ -1168,7 +1182,10 @@ function ManualVariant({
   const [creating, setCreating] = useState(false);
 
   // Auto-suggest a folder path from the match name once typed.
+  // Hosted mode skips the suggestion -- the server picks the path and
+  // the input isn't rendered.
   useEffect(() => {
+    if (hostedMode) return;
     if (!folder && name.trim()) {
       const slug = name
         .toLowerCase()
@@ -1176,7 +1193,7 @@ function ManualVariant({
         .replace(/^-+|-+$/g, "");
       if (slug) setFolder(`~/Splitsmith/${slug}/`);
     }
-  }, [name, folder]);
+  }, [name, folder, hostedMode]);
 
   const totalExpected = useMemo(
     () =>
@@ -1211,8 +1228,12 @@ function ManualVariant({
   }
 
   async function submit() {
-    if (!name.trim() || !folder.trim() || !shooterName.trim()) {
-      onError("Match name, project folder, and shooter name are required.");
+    if (!name.trim() || !shooterName.trim()) {
+      onError("Match name and shooter name are required.");
+      return;
+    }
+    if (!hostedMode && !folder.trim()) {
+      onError("Project folder is required in local mode.");
       return;
     }
     if (stages.length === 0) {
@@ -1224,7 +1245,8 @@ function ManualVariant({
     try {
       const health = await api.createMatchManual({
         name: name.trim(),
-        project_folder: folder.trim(),
+        // Hosted mode: server picks the path; see #425.
+        project_folder: hostedMode ? null : folder.trim(),
         match_date: matchDate || null,
         club: club.trim() || null,
         match_type: matchType,
@@ -1287,14 +1309,16 @@ function ManualVariant({
               options={DIVISIONS}
             />
           </FormField>
-          <FormField label="Project folder">
-            <TextInput
-              value={folder}
-              onChange={setFolder}
-              placeholder="~/Splitsmith/<slug>/"
-              mono
-            />
-          </FormField>
+          {!hostedMode && (
+            <FormField label="Project folder">
+              <TextInput
+                value={folder}
+                onChange={setFolder}
+                placeholder="~/Splitsmith/<slug>/"
+                mono
+              />
+            </FormField>
+          )}
         </div>
       </Section>
 
@@ -1418,7 +1442,7 @@ function ManualVariant({
             disabled={
               creating ||
               !name.trim() ||
-              !folder.trim() ||
+              (!hostedMode && !folder.trim()) ||
               !shooterName.trim() ||
               stages.length === 0
             }

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type StatusFilter = "all" | "in_progress" | "exported" | "archived";
+type StatusFilter = "all" | "awaiting_footage" | "in_progress" | "exported" | "archived";
 
 /** Build the URL the picker should navigate to after a successful bind.
  *
@@ -119,12 +119,19 @@ export function Pick() {
   }, []);
 
   const counts = useMemo(() => {
-    const c = { all: 0, in_progress: 0, exported: 0, archived: 0 };
+    const c = {
+      all: 0,
+      awaiting_footage: 0,
+      in_progress: 0,
+      exported: 0,
+      archived: 0,
+    };
     if (!recents) return c;
     for (const r of recents) {
       if (r.kind === "missing") continue;
       c.all += 1;
-      if (r.status === "in_progress") c.in_progress += 1;
+      if (r.status === "awaiting_footage") c.awaiting_footage += 1;
+      else if (r.status === "in_progress") c.in_progress += 1;
       else if (r.status === "exported") c.exported += 1;
       else if (r.status === "archived") c.archived += 1;
     }
@@ -434,6 +441,15 @@ export function Pick() {
             >
               All
             </FilterChip>
+            {counts.awaiting_footage > 0 && (
+              <FilterChip
+                active={statusFilter === "awaiting_footage"}
+                count={counts.awaiting_footage}
+                onClick={() => setStatusFilter("awaiting_footage")}
+              >
+                Awaiting footage
+              </FilterChip>
+            )}
             <FilterChip
               active={statusFilter === "in_progress"}
               count={counts.in_progress}
@@ -841,6 +857,8 @@ function MatchRow({
       <div className="flex flex-col gap-1.5">
         {isMissing ? (
           <StatusPill tone="led">Missing</StatusPill>
+        ) : project.status === "awaiting_footage" ? (
+          <StatusPill tone="awaiting">Awaiting Footage</StatusPill>
         ) : project.status === "in_progress" ? (
           <StatusPill tone="in-progress">In Progress</StatusPill>
         ) : project.status === "exported" ? (

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5542,7 +5542,50 @@ def test_recent_projects_detail_enriches_metadata(tmp_path: Path, _user_config_h
     assert by_kind["match"]["name"] == "Fancy Match"
     assert by_kind["match"]["shooter_count"] == 1
     assert by_kind["match"]["stage_count"] == 2
+    # No footage attached -> "awaiting_footage". The picker uses this
+    # to flip from the default red "needs your attention" treatment to
+    # a softer "ready for footage" empty state (#425).
+    assert by_kind["match"]["status"] == "awaiting_footage"
+    assert by_kind["match"]["video_count"] == 0
+
+
+def test_recent_projects_detail_in_progress_once_footage_attached(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    """Once any video lands on the project the status flips from
+    ``awaiting_footage`` to ``in_progress`` (the existing in-flight
+    state). Drives the MatchShell menu treatment per #425."""
+    from splitsmith import match_model, user_config
+    from splitsmith.ui.project import StageEntry, StageVideo
+
+    match_root = tmp_path / "with-footage"
+    match = match_model.Match.init(match_root, name="With Footage")
+    match.stages = [match_model.MatchStageDefinition(stage_number=1, stage_name="One")]
+    match.save(match_root)
+    shooter = match_model.Shooter(slug="ma", name="Mathias")
+    match.add_shooter(match_root, shooter)
+    shooter_root = match_model.Match.shooter_root(match_root, "ma")
+    legacy = MatchProject.init(shooter_root, name="With Footage")
+    # Drop a placeholder video into the registry. ``StageEntry`` accepts
+    # a videos list; a single entry is enough to flip the status.
+    legacy.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=0.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+        )
+    ]
+    legacy.save(shooter_root)
+    user_config.record_project_open(match_root, match.name, kind="match")
+
+    app = create_app()
+    client = _MatchClient(app)
+    resp = client.get("/api/me/recent-projects?detail=true")
+    assert resp.status_code == 200
+    by_kind = {p["kind"]: p for p in resp.json()["projects"]}
     assert by_kind["match"]["status"] == "in_progress"
+    assert by_kind["match"]["video_count"] == 1
 
 
 def test_recent_projects_detail_marks_missing_path(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5610,6 +5653,78 @@ def test_create_match_manual_scaffolds_match_and_binds_shooter(
     detail = client.get("/api/me/recent-projects?detail=true").json()
     kinds = sorted(p["kind"] for p in detail["projects"])
     assert kinds == ["match"]
+
+
+def test_create_match_manual_local_mode_requires_project_folder(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    """Local mode must reject an omitted project_folder -- the SPA's
+    folder picker drives this in local mode and we don't want a missing
+    field to silently write somewhere arbitrary (issue #425)."""
+    app = create_app()
+    client = _MatchClient(app)
+
+    body = {
+        "name": "Bromma",
+        # project_folder omitted on purpose.
+        "stages": [{"stage_number": 1, "stage_name": "One"}],
+        "primary_shooter": {"name": "MA"},
+    }
+    resp = client.post("/api/match/create-manual", json=body)
+    assert resp.status_code == 400
+    assert "project_folder" in resp.text
+
+
+def test_create_match_manual_hosted_mode_synthesizes_path(
+    tmp_path: Path, monkeypatch, _user_config_home: Path
+) -> None:
+    """Hosted mode lets the SPA omit ``project_folder``; the server
+    synthesizes ``<SPLITSMITH_PROJECTS_DIR>/users/<id>/projects/<slug>/``
+    so the create-match flow works without a host filesystem picker
+    (issue #425). The SPA discriminates via ``/api/server/features``
+    (see ``test_server_features_reports_hosted_mode_when_env_set``)."""
+    from splitsmith import match_model
+    from splitsmith.ui import server as server_mod
+
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
+    monkeypatch.setenv("SPLITSMITH_PROJECTS_DIR", str(tmp_path / "hosted-root"))
+
+    # Stub the hosted wiring so the test doesn't need a Postgres URL.
+    # We still need ``state.auth.user_id`` to be set -- that's the
+    # multi-tenant prefix the synthesized path embeds. Use a sentinel
+    # value and verify it appears in the resolved match folder.
+    from splitsmith.auth import User
+
+    class _StubAuth:
+        user_id = "01TESTUSER0000000000000001"
+        _user = User(id=user_id, email="stub@test", display_name="Stub")
+
+        async def authenticate_request(self, request):
+            return self._user
+
+    def _stub_wiring(state):
+        state.auth = _StubAuth()
+
+    monkeypatch.setattr(server_mod, "_apply_hosted_mode_wiring", _stub_wiring)
+
+    app = create_app()
+    client = _MatchClient(app)
+
+    body = {
+        "name": "Bromma Practice",
+        # project_folder omitted on purpose -- server picks the path.
+        "stages": [{"stage_number": 1, "stage_name": "One"}],
+        "primary_shooter": {"name": "MA"},
+    }
+    resp = client.post("/api/match/create-manual", json=body)
+    assert resp.status_code == 200, resp.text
+
+    expected_root = (
+        tmp_path / "hosted-root" / "users" / "01TESTUSER0000000000000001" / "projects" / "bromma-practice"
+    )
+    assert (expected_root / "match.json").exists()
+    match = match_model.Match.load(expected_root)
+    assert match.name == "Bromma Practice"
 
 
 def test_create_match_manual_refuses_existing_match_folder(tmp_path: Path, _user_config_home: Path) -> None:
@@ -5792,6 +5907,41 @@ def test_load_env_files_picks_up_user_config_env(tmp_path: Path, monkeypatch: py
     import os
 
     assert os.environ.get("SPLITSMITH_TEST_TOKEN") == "from-user-config"
+
+
+def test_server_features_reports_local_mode_by_default(tmp_path: Path) -> None:
+    """Without ``SPLITSMITH_MODE=hosted`` the SPA should see local mode
+    so it keeps showing the host filesystem pickers + project-folder
+    input (issue #425)."""
+    app = _match_create_app(project_root=tmp_path / "match", project_name="x")
+    client = _MatchClient(app)
+    resp = client.get("/api/server/features")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "local"
+    assert body["lab"] is False
+
+
+def test_server_features_reports_hosted_mode_when_env_set(tmp_path: Path, monkeypatch) -> None:
+    """``SPLITSMITH_MODE=hosted`` flips the discriminator; SPA reads
+    this on boot to suppress filesystem-picker UX that's meaningless
+    against an ephemeral hosted container (issue #425)."""
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
+    # We test *only* the feature flag projection; the full hosted
+    # wiring (Postgres-backed stores) is exercised in the hosted
+    # integration smoke (``pytest -m docker``). create_app already
+    # checks SPLITSMITH_MODE up front, so we have to monkeypatch the
+    # wiring helper to a no-op for this isolated test.
+    from splitsmith.ui import server as server_mod
+
+    monkeypatch.setattr(server_mod, "_apply_hosted_mode_wiring", lambda _state: None)
+
+    app = _match_create_app(project_root=tmp_path / "match", project_name="x")
+    client = _MatchClient(app)
+    resp = client.get("/api/server/features")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "hosted"
 
 
 def test_promote_against_fixture_endpoint_lab_gated(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #425.

## Summary

- ``GET /api/server/features`` now returns ``mode: "local" | "hosted"``; SPA reads it via a new ``useDeploymentMode()`` hook (same cached features fetch).
- ``CreateMatch`` (scoreboard + manual variants) hides the project-folder input + ``DirectoryPickerModal`` in hosted mode and sends ``project_folder: null``. Server-side, ``CreateMatchManualRequest`` / ``CreateMatchScoreboardRequest`` accept the null; a new ``_resolve_create_target`` helper synthesises ``$SPLITSMITH_PROJECTS_DIR/users/<user_id>/projects/<slug>/`` so the SPA never has to point at a host filesystem. Local mode still requires the field (400 on omission).
- ``RecentProjectDetail`` gains ``video_count`` + a new ``awaiting_footage`` status. Pick.tsx renders a muted "Awaiting Footage" pill + filter chip; ``MatchSidebar`` gates Audit / Coach / Export rows on ``hasFootage`` (cross-shooter rollup) and disables them with an "Attach footage first" tooltip when no shooter has video attached.
- ``AddFootageModal`` renders a curl-only ``HostedModePlaceholder`` in hosted mode so the ``FolderPicker`` no longer hits ``/api/fs/*`` against the ephemeral container filesystem. The full browser upload UX is deferred to the tus migration (doc 05) per the #425 plan.

## Test plan

- [x] ``uv run ruff check src/ tests/``
- [x] ``uv run black --check src/ tests/``
- [x] ``uv run pytest tests/`` (1492 passed)
- [x] ``npm run typecheck`` + ``npm run build`` in ``src/splitsmith/ui_static``
- [ ] Smoke against ``docker compose up --build``: create-match without a project-folder field works; recent-projects pill shows "Awaiting Footage"; Audit / Coach / Export rows are disabled until a video is registered.
- [ ] Local-mode regression check: ``splitsmith ui`` still requires + uses the project-folder input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)