### PR TITLE
feat(saas): raw_videos[] on MatchProject + v2->v3 migration (doc 05)

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -143,7 +143,14 @@ SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard", "probes"
 #        which could alias to a previous primary's audio after a reassignment.
 #        Migration deletes the legacy files so the next access re-extracts
 #        under the new naming.
-SCHEMA_VERSION = 2
+#   3 -- ``raw_videos[]`` added to MatchProject (doc 05). Migration
+#        backfills one RawVideo per unique StageVideo.path across stages
+#        + unassigned, aggregating covers_stages. Legacy entries get
+#        ``sha256=None`` and ``size_bytes`` from disk when accessible (0
+#        when the source is offline). The field is forward-compatible --
+#        a v2-on-disk project loads cleanly into the v3 model with an
+#        empty ``raw_videos``; the migration just populates it.
+SCHEMA_VERSION = 3
 
 
 def _migrate_v1_to_v2(root: Path, project: MatchProject) -> None:
@@ -193,6 +200,73 @@ def _migrate_v1_to_v2(root: Path, project: MatchProject) -> None:
         "schema migration v1->v2 on %s: removed %d legacy audio/trim cache file(s)",
         project.name,
         removed,
+    )
+
+
+def _migrate_v2_to_v3(root: Path, project: MatchProject) -> None:
+    """Backfill ``raw_videos[]`` from existing StageVideo entries.
+
+    Groups every StageVideo (assigned + unassigned) by ``str(path)`` so a
+    single source recording that's been added to multiple stages collapses
+    to one RawVideo entry with ``covers_stages`` aggregated. ``size_bytes``
+    is read from disk when the source is reachable; ``0`` otherwise so the
+    migration is lossless even when the user's external drive is unplugged.
+    ``sha256`` stays ``None`` (we never computed one); a future hosted-mode
+    attach can fill it in via :meth:`MatchProject.attach_raw_video`.
+
+    Idempotent: re-running against an already-populated ``raw_videos`` is a
+    merge (via ``attach_raw_video``) rather than a duplicate-append, so the
+    migration is safe to invoke on partial-v3 projects.
+    """
+    # storage_path -> {filename, covers_stages set, earliest_added_at}
+    aggregated: dict[str, dict[str, Any]] = {}
+
+    def _ingest(video: StageVideo, stage_number: int | None) -> None:
+        key = str(video.path)
+        entry = aggregated.setdefault(
+            key,
+            {
+                "filename": Path(video.path).name,
+                "covers_stages": set(),
+                "earliest_added_at": video.added_at,
+            },
+        )
+        if stage_number is not None:
+            entry["covers_stages"].add(stage_number)
+        if video.added_at < entry["earliest_added_at"]:
+            entry["earliest_added_at"] = video.added_at
+
+    for stage in project.stages:
+        for sv in stage.videos:
+            _ingest(sv, stage.stage_number)
+    for sv in project.unassigned_videos:
+        _ingest(sv, None)
+
+    backfilled = 0
+    for storage_path, info in aggregated.items():
+        size_bytes = 0
+        try:
+            resolved = project.resolve_video_path(root, Path(storage_path))
+            if resolved.exists():
+                size_bytes = resolved.stat().st_size
+        except OSError:
+            # Source offline -- record 0 and let a future re-scan fill it.
+            size_bytes = 0
+        rv = RawVideo(
+            original_filename=info["filename"],
+            size_bytes=size_bytes,
+            sha256=None,
+            uploaded_at=info["earliest_added_at"],
+            storage_path=storage_path,
+            covers_stages=sorted(info["covers_stages"]),
+        )
+        project.attach_raw_video(rv)
+        backfilled += 1
+
+    logger.info(
+        "schema migration v2->v3 on %s: backfilled %d raw_videos entry/entries",
+        project.name,
+        backfilled,
     )
 
 
@@ -579,6 +653,36 @@ class VideoMatchAnalysisEntry(BaseModel):
     stage_numbers: list[int]
 
 
+class RawVideo(BaseModel):
+    """One uploaded raw video file attached to a match (doc 05).
+
+    A raw video is the original camera recording the user uploaded once;
+    a single 30-minute head-cam clip typically ``covers_stages = [1, 2, 3, 4]``.
+    ``StageVideo`` entries are the per-stage references that point at this
+    raw via ``storage_path`` -- the relationship is N:1 (many StageVideos
+    can resolve to the same RawVideo when one source covers multiple
+    stages).
+
+    ``storage_path`` is the canonical key. In hosted mode it is a
+    storage-relative path under the user's tenant prefix (e.g.
+    ``raw/GH010023.mp4``); in local mode it is the project-relative or
+    absolute path on disk -- either way it round-trips through the active
+    ``Storage`` backend.
+
+    ``sha256`` is optional on legacy backfilled entries (we never computed
+    one) and populated on hosted uploads via ``X-Content-SHA256``. Future
+    content-addressable dedup keys off this field; for now ``storage_path``
+    is the primary identity.
+    """
+
+    original_filename: str
+    size_bytes: int = 0
+    sha256: str | None = None
+    uploaded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    storage_path: str
+    covers_stages: list[int] = Field(default_factory=list)
+
+
 class MatchAnalysis(BaseModel):
     """Project-level match analysis exposed at GET /api/project/match-analysis.
 
@@ -677,6 +781,13 @@ class MatchProject(BaseModel):
     # decides re-emission, the project just remembers what was
     # dismissed.
     nudges_dismissed_stages: list[int] = Field(default_factory=list)
+    # Uploaded raw videos for this match (doc 05). One entry per source
+    # recording -- a single head-cam clip that covers stages 1-4 is one
+    # entry with ``covers_stages = [1, 2, 3, 4]``. StageVideo entries
+    # reference these by ``storage_path``. Empty on legacy and local-mode
+    # projects until first upload/attach; backfilled from existing
+    # StageVideos on v2->v3 schema migration.
+    raw_videos: list[RawVideo] = Field(default_factory=list)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -728,7 +839,10 @@ class MatchProject(BaseModel):
         project = cls.model_validate(data)
         if on_disk_version < 2:
             _migrate_v1_to_v2(root, project)
-            project.schema_version = 2
+        if on_disk_version < 3:
+            _migrate_v2_to_v3(root, project)
+        if on_disk_version < SCHEMA_VERSION:
+            project.schema_version = SCHEMA_VERSION
             project.save(root)
         return project
 
@@ -1440,6 +1554,47 @@ class MatchProject(BaseModel):
         """Resolve a ``StageVideo.path`` (which may be project-relative or
         absolute) to an absolute filesystem path."""
         return video_path if video_path.is_absolute() else root / video_path
+
+    def find_raw_video(self, storage_path: str) -> RawVideo | None:
+        """Return the ``RawVideo`` with this ``storage_path``, or ``None``.
+
+        ``storage_path`` is the canonical identity key -- see RawVideo's
+        docstring for the local-vs-hosted semantics.
+        """
+        for rv in self.raw_videos:
+            if rv.storage_path == storage_path:
+                return rv
+        return None
+
+    def attach_raw_video(self, rv: RawVideo) -> RawVideo:
+        """Register a raw video on this project, merging into an existing
+        entry when one shares the same ``storage_path``.
+
+        Merge rules when an entry already exists:
+
+        - ``covers_stages`` -- union of existing + new (stable insertion
+          order; sorted ascending so the SPA renders deterministically).
+        - ``size_bytes`` -- adopt the new value when the existing one is 0
+          (legacy backfill placeholder).
+        - ``sha256`` -- adopt the new value when the existing one is
+          ``None`` (legacy backfill).
+        - ``original_filename`` / ``uploaded_at`` -- existing wins (we don't
+          rewrite the historical record once it's set).
+
+        Returns the canonical entry on the project (either the merged
+        existing one or the newly appended ``rv``).
+        """
+        existing = self.find_raw_video(rv.storage_path)
+        if existing is None:
+            self.raw_videos.append(rv)
+            return rv
+        merged = sorted(set(existing.covers_stages) | set(rv.covers_stages))
+        existing.covers_stages = merged
+        if existing.size_bytes == 0 and rv.size_bytes:
+            existing.size_bytes = rv.size_bytes
+        if existing.sha256 is None and rv.sha256:
+            existing.sha256 = rv.sha256
+        return existing
 
     def assign_video(
         self,

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -23,6 +23,7 @@ from splitsmith.ui.project import (
     SUBDIRS,
     VIDEO_EXTENSIONS,
     MatchProject,
+    RawVideo,
     StageEntry,
     StageStatus,
     StageVideo,
@@ -102,7 +103,8 @@ def test_load_migrates_v1_caches_to_v2(tmp_path: Path) -> None:
 
     reloaded = MatchProject.load(root)
 
-    assert reloaded.schema_version == 2
+    # v1 chains through v2 + v3 to the current SCHEMA_VERSION.
+    assert reloaded.schema_version == SCHEMA_VERSION
     assert not legacy_full.exists()
     assert not legacy_audit.exists()
     assert not legacy_peaks.exists()
@@ -111,7 +113,168 @@ def test_load_migrates_v1_caches_to_v2(tmp_path: Path) -> None:
     assert survivor.exists()
     # And the version bump is persisted, so a second load is a no-op.
     persisted = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
-    assert persisted["schema_version"] == 2
+    assert persisted["schema_version"] == SCHEMA_VERSION
+
+
+def test_load_backfills_raw_videos_from_existing_stagevideos(tmp_path: Path) -> None:
+    """A v2 project on disk lands on v3 with ``raw_videos[]`` populated from
+    its StageVideo entries -- one RawVideo per unique source path, with
+    ``covers_stages`` aggregated across stages.
+    """
+    root = tmp_path / "v2-project"
+    project = MatchProject.init(root, name="V2 Project")
+    # One source covering stages 1-3 + a second source on stage 1 only +
+    # an unassigned video. The migration should collapse the multi-stage
+    # source into a single RawVideo with covers_stages=[1, 2, 3].
+    shared = Path("raw/headcam.mp4")
+    side = Path("raw/sidecam.mp4")
+    unassigned = Path("raw/leftover.mp4")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[
+                StageVideo(path=shared, role="primary"),
+                StageVideo(path=side, role="secondary"),
+            ],
+        ),
+        StageEntry(
+            stage_number=2,
+            stage_name="Two",
+            time_seconds=15.0,
+            videos=[StageVideo(path=shared, role="primary")],
+        ),
+        StageEntry(
+            stage_number=3,
+            stage_name="Three",
+            time_seconds=20.0,
+            videos=[StageVideo(path=shared, role="primary")],
+        ),
+    ]
+    project.unassigned_videos = [StageVideo(path=unassigned)]
+    project.save(root)
+
+    # Materialize one of the sources on disk so the migration can read
+    # its size; leave the others offline to confirm we tolerate that.
+    (root / "raw").mkdir(exist_ok=True)
+    (root / "raw" / "headcam.mp4").write_bytes(b"x" * 4096)
+
+    # Force the on-disk version back to 2 so load() runs the v2->v3 path.
+    data = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    data["schema_version"] = 2
+    data.pop("raw_videos", None)
+    (root / PROJECT_FILE).write_text(json.dumps(data), encoding="utf-8")
+
+    reloaded = MatchProject.load(root)
+
+    assert reloaded.schema_version == SCHEMA_VERSION
+    by_path = {rv.storage_path: rv for rv in reloaded.raw_videos}
+    assert set(by_path) == {"raw/headcam.mp4", "raw/sidecam.mp4", "raw/leftover.mp4"}
+    assert by_path["raw/headcam.mp4"].covers_stages == [1, 2, 3]
+    assert by_path["raw/sidecam.mp4"].covers_stages == [1]
+    # Unassigned videos have no covers_stages -- they exist but aren't on
+    # any stage yet. Empty list, not missing.
+    assert by_path["raw/leftover.mp4"].covers_stages == []
+    # Source-on-disk has its size populated; offline sources stay at 0.
+    assert by_path["raw/headcam.mp4"].size_bytes == 4096
+    assert by_path["raw/sidecam.mp4"].size_bytes == 0
+    # sha256 is None on legacy backfill -- we never had one to record.
+    assert by_path["raw/headcam.mp4"].sha256 is None
+    # original_filename is the basename for SPA display.
+    assert by_path["raw/headcam.mp4"].original_filename == "headcam.mp4"
+
+
+def test_v2_to_v3_migration_is_idempotent(tmp_path: Path) -> None:
+    """Re-loading a project doesn't duplicate raw_videos[] entries.
+
+    The migration runs once on the first v2 load; subsequent loads see
+    schema_version == 3 on disk and skip the backfill entirely.
+    """
+    root = tmp_path / "idempotent"
+    project = MatchProject.init(root, name="Idempotent")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+        )
+    ]
+    project.save(root)
+    data = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    data["schema_version"] = 2
+    data.pop("raw_videos", None)
+    (root / PROJECT_FILE).write_text(json.dumps(data), encoding="utf-8")
+
+    first = MatchProject.load(root)
+    second = MatchProject.load(root)
+
+    assert len(first.raw_videos) == 1
+    assert len(second.raw_videos) == 1
+    assert second.raw_videos[0].covers_stages == [1]
+
+
+def test_attach_raw_video_merges_covers_stages(tmp_path: Path) -> None:
+    """Calling ``attach_raw_video`` twice with the same storage_path unions
+    the covers_stages list rather than appending a duplicate entry.
+    """
+    root = tmp_path / "attach"
+    project = MatchProject.init(root, name="Attach")
+
+    first = project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=1024,
+            storage_path="raw/clip.mp4",
+            covers_stages=[1, 2],
+        )
+    )
+    second = project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=1024,
+            storage_path="raw/clip.mp4",
+            covers_stages=[2, 3],
+        )
+    )
+
+    assert first is second
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].covers_stages == [1, 2, 3]
+
+
+def test_attach_raw_video_fills_in_missing_size_and_sha256(tmp_path: Path) -> None:
+    """A legacy backfill entry (size=0, sha256=None) gets upgraded when a
+    real upload lands -- preserves history while filling in the gaps.
+    """
+    root = tmp_path / "upgrade"
+    project = MatchProject.init(root, name="Upgrade")
+    project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=0,
+            sha256=None,
+            storage_path="raw/clip.mp4",
+        )
+    )
+    project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=2048,
+            sha256="deadbeef",
+            storage_path="raw/clip.mp4",
+        )
+    )
+
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].size_bytes == 2048
+    assert project.raw_videos[0].sha256 == "deadbeef"
+
+
+def test_find_raw_video_returns_none_when_absent(tmp_path: Path) -> None:
+    project = MatchProject.init(tmp_path / "find", name="Find")
+    assert project.find_raw_video("raw/missing.mp4") is None
 
 
 def test_init_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

First chunk of the **"attach uploaded file to project + worker S3 download cache"** work (per [next-saas-action-local-docker](https://github.com/mandakan/splitsmith/blob/main/docs/saas-readiness/05-uploads-and-streaming.md)). Establishes the on-disk shape doc 05 specifies; the next PRs wire upload-attach endpoints and worker-side downloads through it.

- New ``RawVideo`` Pydantic model with the exact fields from doc 05: ``original_filename``, ``size_bytes``, ``sha256``, ``uploaded_at``, ``storage_path``, ``covers_stages``. ``storage_path`` is the canonical identity -- local-mode = disk path, hosted-mode = storage-relative key under the user's tenant prefix.
- ``MatchProject.raw_videos: list[RawVideo]`` with ``find_raw_video`` / ``attach_raw_video`` helpers. Attach is dedup-merge: same ``storage_path`` unions ``covers_stages`` and fills in ``size_bytes`` / ``sha256`` when the existing entry has the legacy backfill placeholders.
- ``SCHEMA_VERSION = 3`` + ``_migrate_v2_to_v3``: backfills one entry per unique ``StageVideo.path`` across stages + unassigned, aggregating ``covers_stages``. Reads ``size_bytes`` from disk when the source is reachable; tolerates offline drives (``size_bytes=0``). ``sha256`` stays ``None`` on legacy; a future hosted attach fills it via the dedup-merge path.
- The migration chain in ``MatchProject.load`` now applies v1->v2 and v2->v3 in order so a v1-on-disk project lands on the current ``SCHEMA_VERSION`` in a single load. Persists once at the end instead of save-per-step.

## Test plan

- [x] ``uv run pytest`` -- 1512 passed, 16 skipped (pre-existing), 2 deselected
- [x] ``uv run ruff check src tests`` -- clean
- [x] ``uv run black --check`` -- clean
- [x] New tests cover:
  - [x] v2->v3 backfill aggregates ``covers_stages`` across stages, populates ``size_bytes`` for on-disk sources, leaves offline sources at 0, surfaces unassigned videos with empty ``covers_stages``
  - [x] Migration is idempotent (re-load doesn't duplicate entries)
  - [x] ``attach_raw_video`` merges ``covers_stages`` and fills in legacy-backfill ``size_bytes=0`` / ``sha256=None`` when a real upload lands
  - [x] ``find_raw_video`` returns ``None`` on miss
- [x] Updated the existing v1->v2 migration test to expect ``SCHEMA_VERSION`` (now 3) since the chain runs to completion

## What's next

This PR is intentionally schema-only -- no endpoints or worker changes. Subsequent PRs in the sequence:

1. **(this PR)** ``raw_videos[]`` schema + v2->v3 migration
2. ``Storage.open_stream()`` for chunked reads
3. ``POST /api/shooters/{slug}/raw-videos/attach`` endpoint
4. Storage-aware ``resolve_video_path`` + worker download cache (the seam that makes hosted-mode detection actually run)
5. SPA "attach to project" UX on ``HostedUploadSurface``

🤖 Generated with [Claude Code](https://claude.com/claude-code)