### PR TITLE
feat(saas): storage-aware resolve_video_path + worker S3 download cache

### DIFF
--- a/src/splitsmith/storage.py
+++ b/src/splitsmith/storage.py
@@ -69,6 +69,20 @@ class Storage(Protocol):
         reads to EOF.
         """
 
+    def open_stream(self, path: str) -> BinaryIO:
+        """Open the object for chunked reads. Symmetric to ``upload_stream``.
+
+        Raises ``FileNotFoundError`` if the object is absent. Returned
+        file-like supports ``read(size)``, ``close()``, and the
+        context-manager protocol -- callers should use ``with`` so the
+        underlying network handle (S3) or file descriptor (local) is
+        released even on partial reads.
+
+        For multi-GB raw footage this is the seam the worker uses to
+        copy the object to a local cache without buffering the full
+        payload into memory the way ``read_bytes`` would.
+        """
+
     def exists(self, path: str) -> bool:
         """Return True iff an object exists at the path."""
 
@@ -168,6 +182,13 @@ class FilesystemStorage:
             raise
         return total
 
+    def open_stream(self, path: str) -> BinaryIO:
+        # ``open`` raises FileNotFoundError natively when the path is
+        # absent, matching the Protocol contract. The returned
+        # ``BufferedReader`` is a real BinaryIO -- already a context
+        # manager -- so no wrapping is needed.
+        return self._resolve(path).open("rb")
+
     def exists(self, path: str) -> bool:
         return self._resolve(path).exists()
 
@@ -216,6 +237,35 @@ class FilesystemStorage:
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+
+class _S3StreamWrapper:
+    """Adapt a botocore ``StreamingBody`` to the ``BinaryIO`` Protocol.
+
+    ``StreamingBody`` exposes ``read()`` and ``close()`` but lacks
+    ``__enter__`` / ``__exit__``, so a ``with storage.open_stream(...)``
+    block against S3 would TypeError without this shim. The wrapper
+    just forwards reads and ties the context-manager exit to
+    ``close()`` so callers can use one idiom across both backends.
+    """
+
+    def __init__(self, body: object) -> None:
+        self._body = body
+
+    def read(self, size: int = -1) -> bytes:
+        # boto3's StreamingBody.read uses ``None`` to mean "read all";
+        # BinaryIO's ``-1`` means the same. Translate so the caller can
+        # pass either convention.
+        return self._body.read(None if size == -1 else size)  # type: ignore[attr-defined]
+
+    def close(self) -> None:
+        self._body.close()  # type: ignore[attr-defined]
+
+    def __enter__(self) -> _S3StreamWrapper:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
 
 
 class _CountingReader:
@@ -332,6 +382,21 @@ class S3Storage:
         counter = _CountingReader(fileobj)
         self._client.upload_fileobj(counter, self._bucket, self._key(path))
         return counter.bytes_read
+
+    def open_stream(self, path: str) -> BinaryIO:
+        from botocore.exceptions import ClientError
+
+        try:
+            response = self._client.get_object(Bucket=self._bucket, Key=self._key(path))
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404"):
+                raise FileNotFoundError(f"no object at {path!r}") from exc
+            raise
+        # ``response["Body"]`` is a botocore StreamingBody backed by the
+        # underlying HTTPS connection; wrap so callers can use it as a
+        # context manager without leaking the socket on a partial read.
+        return _S3StreamWrapper(response["Body"])
 
     def exists(self, path: str) -> bool:
         from botocore.exceptions import ClientError

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -34,11 +34,12 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, PrivateAttr, computed_field
 
 from .. import video_match
 from ..automation import AutomationOverride
 from ..config import BeepCandidate, StageData, StageRounds, VideoMatchConfig
+from ..storage import Storage
 from ..video_match import match_videos_to_stages
 
 logger = logging.getLogger(__name__)
@@ -788,6 +789,22 @@ class MatchProject(BaseModel):
     # projects until first upload/attach; backfilled from existing
     # StageVideos on v2->v3 schema migration.
     raw_videos: list[RawVideo] = Field(default_factory=list)
+
+    # Worker-side ``Storage`` handle, set by ``state.shooter_project``
+    # after load in hosted mode. Not persisted: it's request-scope state,
+    # not project-on-disk state, and a ``MatchProject`` round-tripped
+    # through ``model_dump`` / ``model_validate`` must stay identical.
+    # Local mode leaves this ``None`` and :meth:`resolve_video_path`
+    # falls back to the legacy path-only resolution -- desktop behavior
+    # is unchanged.
+    _storage: Storage | None = PrivateAttr(default=None)
+
+    def bind_storage(self, storage: Storage | None) -> None:
+        """Attach a per-request ``Storage`` so :meth:`resolve_video_path`
+        can mirror hosted-mode raw videos into the project's local
+        cache on first access. Idempotent; ``None`` clears the binding.
+        """
+        self._storage = storage
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -1551,9 +1568,65 @@ class MatchProject(BaseModel):
         return video
 
     def resolve_video_path(self, root: Path, video_path: Path) -> Path:
-        """Resolve a ``StageVideo.path`` (which may be project-relative or
-        absolute) to an absolute filesystem path."""
-        return video_path if video_path.is_absolute() else root / video_path
+        """Resolve a ``StageVideo.path`` to an absolute filesystem path,
+        mirroring from hosted storage on first access when needed.
+
+        Behaviour matrix:
+
+        - **Absolute path** -- returned as-is (legacy local-mode flow:
+          external drive, FCP scratch).
+        - **Relative path, no storage bound** -- returned as
+          ``root / video_path``. Identical to pre-PR-4 behavior; the
+          desktop UI lands here.
+        - **Relative path, storage bound, local mirror exists** -- the
+          cached mirror at ``root / video_path`` wins. Subsequent
+          detection jobs on the same project re-use the same local
+          copy without a second download.
+        - **Relative path, storage bound, no local mirror** -- streams
+          the object from storage into ``root / video_path`` via a
+          temp + atomic-rename, then returns the local path. A
+          missing key is left to surface as a downstream
+          ``FileNotFoundError`` -- callers already handle that for
+          offline-source cases.
+
+        ``storage`` is set by :meth:`bind_storage`, which the hosted
+        boot calls inside ``state.shooter_project`` so every project
+        load that goes through that accessor is automatically wired up.
+        """
+        if video_path.is_absolute():
+            return video_path
+        local = root / video_path
+        if self._storage is not None and not local.exists():
+            self._mirror_from_storage(self._storage, str(video_path), local)
+        return local
+
+    @staticmethod
+    def _mirror_from_storage(storage: Storage, key: str, dest: Path) -> None:
+        """Stream ``key`` from ``storage`` into ``dest`` via temp+rename.
+
+        Best-effort: a missing key is a no-op (the caller's existing
+        ``not source.exists()`` checks already handle that). Network
+        / IO errors propagate so the worker fails the job loudly --
+        a half-downloaded mirror would be worse than a failed detect.
+        """
+        if not storage.exists(key):
+            return
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=dest.name + ".",
+            suffix=".tmp",
+            dir=dest.parent,
+        )
+        try:
+            with storage.open_stream(key) as src, os.fdopen(fd, "wb") as out:
+                shutil.copyfileobj(src, out)
+            Path(tmp_name).replace(dest)
+        except Exception:
+            try:
+                Path(tmp_name).unlink()
+            except FileNotFoundError:
+                pass
+            raise
 
     def find_raw_video(self, storage_path: str) -> RawVideo | None:
         """Return the ``RawVideo`` with this ``storage_path``, or ``None``.

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -143,7 +143,14 @@ SUBDIRS = ("raw", "audio", "trimmed", "audit", "exports", "scoreboard", "probes"
 #        which could alias to a previous primary's audio after a reassignment.
 #        Migration deletes the legacy files so the next access re-extracts
 #        under the new naming.
-SCHEMA_VERSION = 2
+#   3 -- ``raw_videos[]`` added to MatchProject (doc 05). Migration
+#        backfills one RawVideo per unique StageVideo.path across stages
+#        + unassigned, aggregating covers_stages. Legacy entries get
+#        ``sha256=None`` and ``size_bytes`` from disk when accessible (0
+#        when the source is offline). The field is forward-compatible --
+#        a v2-on-disk project loads cleanly into the v3 model with an
+#        empty ``raw_videos``; the migration just populates it.
+SCHEMA_VERSION = 3
 
 
 def _migrate_v1_to_v2(root: Path, project: MatchProject) -> None:
@@ -193,6 +200,73 @@ def _migrate_v1_to_v2(root: Path, project: MatchProject) -> None:
         "schema migration v1->v2 on %s: removed %d legacy audio/trim cache file(s)",
         project.name,
         removed,
+    )
+
+
+def _migrate_v2_to_v3(root: Path, project: MatchProject) -> None:
+    """Backfill ``raw_videos[]`` from existing StageVideo entries.
+
+    Groups every StageVideo (assigned + unassigned) by ``str(path)`` so a
+    single source recording that's been added to multiple stages collapses
+    to one RawVideo entry with ``covers_stages`` aggregated. ``size_bytes``
+    is read from disk when the source is reachable; ``0`` otherwise so the
+    migration is lossless even when the user's external drive is unplugged.
+    ``sha256`` stays ``None`` (we never computed one); a future hosted-mode
+    attach can fill it in via :meth:`MatchProject.attach_raw_video`.
+
+    Idempotent: re-running against an already-populated ``raw_videos`` is a
+    merge (via ``attach_raw_video``) rather than a duplicate-append, so the
+    migration is safe to invoke on partial-v3 projects.
+    """
+    # storage_path -> {filename, covers_stages set, earliest_added_at}
+    aggregated: dict[str, dict[str, Any]] = {}
+
+    def _ingest(video: StageVideo, stage_number: int | None) -> None:
+        key = str(video.path)
+        entry = aggregated.setdefault(
+            key,
+            {
+                "filename": Path(video.path).name,
+                "covers_stages": set(),
+                "earliest_added_at": video.added_at,
+            },
+        )
+        if stage_number is not None:
+            entry["covers_stages"].add(stage_number)
+        if video.added_at < entry["earliest_added_at"]:
+            entry["earliest_added_at"] = video.added_at
+
+    for stage in project.stages:
+        for sv in stage.videos:
+            _ingest(sv, stage.stage_number)
+    for sv in project.unassigned_videos:
+        _ingest(sv, None)
+
+    backfilled = 0
+    for storage_path, info in aggregated.items():
+        size_bytes = 0
+        try:
+            resolved = project.resolve_video_path(root, Path(storage_path))
+            if resolved.exists():
+                size_bytes = resolved.stat().st_size
+        except OSError:
+            # Source offline -- record 0 and let a future re-scan fill it.
+            size_bytes = 0
+        rv = RawVideo(
+            original_filename=info["filename"],
+            size_bytes=size_bytes,
+            sha256=None,
+            uploaded_at=info["earliest_added_at"],
+            storage_path=storage_path,
+            covers_stages=sorted(info["covers_stages"]),
+        )
+        project.attach_raw_video(rv)
+        backfilled += 1
+
+    logger.info(
+        "schema migration v2->v3 on %s: backfilled %d raw_videos entry/entries",
+        project.name,
+        backfilled,
     )
 
 
@@ -579,6 +653,36 @@ class VideoMatchAnalysisEntry(BaseModel):
     stage_numbers: list[int]
 
 
+class RawVideo(BaseModel):
+    """One uploaded raw video file attached to a match (doc 05).
+
+    A raw video is the original camera recording the user uploaded once;
+    a single 30-minute head-cam clip typically ``covers_stages = [1, 2, 3, 4]``.
+    ``StageVideo`` entries are the per-stage references that point at this
+    raw via ``storage_path`` -- the relationship is N:1 (many StageVideos
+    can resolve to the same RawVideo when one source covers multiple
+    stages).
+
+    ``storage_path`` is the canonical key. In hosted mode it is a
+    storage-relative path under the user's tenant prefix (e.g.
+    ``raw/GH010023.mp4``); in local mode it is the project-relative or
+    absolute path on disk -- either way it round-trips through the active
+    ``Storage`` backend.
+
+    ``sha256`` is optional on legacy backfilled entries (we never computed
+    one) and populated on hosted uploads via ``X-Content-SHA256``. Future
+    content-addressable dedup keys off this field; for now ``storage_path``
+    is the primary identity.
+    """
+
+    original_filename: str
+    size_bytes: int = 0
+    sha256: str | None = None
+    uploaded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    storage_path: str
+    covers_stages: list[int] = Field(default_factory=list)
+
+
 class MatchAnalysis(BaseModel):
     """Project-level match analysis exposed at GET /api/project/match-analysis.
 
@@ -677,6 +781,13 @@ class MatchProject(BaseModel):
     # decides re-emission, the project just remembers what was
     # dismissed.
     nudges_dismissed_stages: list[int] = Field(default_factory=list)
+    # Uploaded raw videos for this match (doc 05). One entry per source
+    # recording -- a single head-cam clip that covers stages 1-4 is one
+    # entry with ``covers_stages = [1, 2, 3, 4]``. StageVideo entries
+    # reference these by ``storage_path``. Empty on legacy and local-mode
+    # projects until first upload/attach; backfilled from existing
+    # StageVideos on v2->v3 schema migration.
+    raw_videos: list[RawVideo] = Field(default_factory=list)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -728,7 +839,10 @@ class MatchProject(BaseModel):
         project = cls.model_validate(data)
         if on_disk_version < 2:
             _migrate_v1_to_v2(root, project)
-            project.schema_version = 2
+        if on_disk_version < 3:
+            _migrate_v2_to_v3(root, project)
+        if on_disk_version < SCHEMA_VERSION:
+            project.schema_version = SCHEMA_VERSION
             project.save(root)
         return project
 
@@ -1440,6 +1554,47 @@ class MatchProject(BaseModel):
         """Resolve a ``StageVideo.path`` (which may be project-relative or
         absolute) to an absolute filesystem path."""
         return video_path if video_path.is_absolute() else root / video_path
+
+    def find_raw_video(self, storage_path: str) -> RawVideo | None:
+        """Return the ``RawVideo`` with this ``storage_path``, or ``None``.
+
+        ``storage_path`` is the canonical identity key -- see RawVideo's
+        docstring for the local-vs-hosted semantics.
+        """
+        for rv in self.raw_videos:
+            if rv.storage_path == storage_path:
+                return rv
+        return None
+
+    def attach_raw_video(self, rv: RawVideo) -> RawVideo:
+        """Register a raw video on this project, merging into an existing
+        entry when one shares the same ``storage_path``.
+
+        Merge rules when an entry already exists:
+
+        - ``covers_stages`` -- union of existing + new (stable insertion
+          order; sorted ascending so the SPA renders deterministically).
+        - ``size_bytes`` -- adopt the new value when the existing one is 0
+          (legacy backfill placeholder).
+        - ``sha256`` -- adopt the new value when the existing one is
+          ``None`` (legacy backfill).
+        - ``original_filename`` / ``uploaded_at`` -- existing wins (we don't
+          rewrite the historical record once it's set).
+
+        Returns the canonical entry on the project (either the merged
+        existing one or the newly appended ``rv``).
+        """
+        existing = self.find_raw_video(rv.storage_path)
+        if existing is None:
+            self.raw_videos.append(rv)
+            return rv
+        merged = sorted(set(existing.covers_stages) | set(rv.covers_stages))
+        existing.covers_stages = merged
+        if existing.size_bytes == 0 and rv.size_bytes:
+            existing.size_bytes = rv.size_bytes
+        if existing.sha256 is None and rv.sha256:
+            existing.sha256 = rv.sha256
+        return existing
 
     def assign_video(
         self,

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -687,8 +687,17 @@ class AppState:
 
     def shooter_project(self, slug: str) -> MatchProject:
         """Load the per-shooter ``MatchProject`` (each shooter slot
-        inside a Match folder owns its own ``project.json``)."""
-        return MatchProject.load(self.shooter_root(slug))
+        inside a Match folder owns its own ``project.json``).
+
+        Binds :attr:`storage` onto the project so
+        :meth:`MatchProject.resolve_video_path` can mirror hosted-mode
+        raw videos into the local cache on first access. Local mode
+        leaves ``storage`` at ``None``; the bind is a no-op and the
+        legacy disk-only resolver wins.
+        """
+        project = MatchProject.load(self.shooter_root(slug))
+        project.bind_storage(self.storage)
+        return project
 
     def register_match(self, root: Path) -> str | None:
         """Load the match at ``root`` and pin its ``match_id`` into

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -146,6 +146,7 @@ from .jobs import Job, JobBackend, JobCancelled, JobHandle, JobRegistry, Shutdow
 from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
+    RawVideo,
     ScoreboardImportConflictError,
     StageEntry,
     StageVideo,
@@ -1318,6 +1319,23 @@ class ForgetRecentProjectRequest(BaseModel):
     """Body for POST /api/user/recent-projects/forget (#75)."""
 
     path: str
+
+
+class AttachRawVideoRequest(BaseModel):
+    """Body for POST /api/shooters/{slug}/raw-videos/attach (doc 05).
+
+    The SPA passes back the shape ``POST /api/me/raw/upload`` returned
+    plus an optional ``covers_stages``. ``filename`` round-trips through
+    ``_sanitize_raw_filename`` so a malicious request body can't escape
+    the user's ``raw/`` prefix. ``covers_stages`` is optional -- callers
+    can leave it null and run auto-match later, or pre-declare it when
+    they already know which stages the recording spans.
+    """
+
+    filename: str
+    sha256: str | None = None
+    size_bytes: int | None = None
+    covers_stages: list[int] | None = None
 
 
 class ScoreboardIdentityRequest(BaseModel):
@@ -2847,6 +2865,109 @@ def create_app(
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"delete failed: {exc}") from exc
         return JSONResponse({"ok": True, "path": key})
+
+    @app.post("/api/shooters/{slug}/raw-videos/attach")
+    def attach_raw_video(
+        slug: str,
+        body: AttachRawVideoRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Register an uploaded raw video against a shooter's project (doc 05).
+
+        Hosted-only -- 503 when ``state.storage`` is unwired. The
+        upload itself must already be in object storage (the SPA calls
+        ``POST /api/me/raw/upload`` first); this endpoint validates that
+        and records the manifest entry on ``match.json``.
+
+        Body shape: ``{filename, sha256?, size_bytes?, covers_stages?}``.
+        The trailing fields default to whatever the upload endpoint
+        echoed back; size + sha256 fill in the legacy backfill
+        placeholders if the project's migration left them empty. When
+        ``covers_stages`` is provided, the endpoint also creates
+        ``StageVideo`` entries on those stages (path =
+        ``raw/<filename>``, role auto-promoted to primary when the
+        stage has no primary yet -- same rule as
+        :meth:`MatchProject.assign_video`).
+
+        Returns the canonical ``RawVideo`` (either the freshly attached
+        entry or the merged-into existing one).
+
+        Error contract:
+
+        - 503 -- no hosted storage wired (local mode).
+        - 400 -- filename failed ``_sanitize_raw_filename`` (path
+          separators, ``..``, empty).
+        - 404 -- no object at ``raw/<filename>`` in storage.
+        - 422 -- ``covers_stages`` references a stage_number the
+          project doesn't have.
+        """
+        storage = state.storage
+        if storage is None:
+            raise HTTPException(
+                status_code=503,
+                detail="raw video attach is hosted-mode only",
+            )
+
+        name = _sanitize_raw_filename(body.filename)
+        storage_path = f"raw/{name}"
+        stat = storage.stat(storage_path)
+        if stat is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"no upload at {storage_path!r}; upload first via POST /api/me/raw/upload",
+            )
+
+        project = state.shooter_project(slug)
+        root = state.shooter_root(slug)
+
+        covers = sorted(set(body.covers_stages or []))
+        if covers:
+            # Verify every claimed stage exists before mutating anything;
+            # an unknown stage_number is a 422 (client bug) rather than a
+            # silent skip that leaves the manifest in a half-populated state.
+            known = {s.stage_number for s in project.stages}
+            unknown = [n for n in covers if n not in known]
+            if unknown:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "unknown_stage_numbers",
+                        "stage_numbers": unknown,
+                    },
+                )
+
+        # Trust the upload endpoint's sha256 verification: it already
+        # rolled the object back on mismatch (see the X-Content-SHA256
+        # path in upload_raw_video). The size on the body is informational;
+        # we always defer to S3's reported ContentLength when available
+        # so the manifest matches the object the worker will download.
+        rv = RawVideo(
+            original_filename=name,
+            size_bytes=int(stat.size if stat.size else (body.size_bytes or 0)),
+            sha256=body.sha256,
+            storage_path=storage_path,
+            covers_stages=covers,
+        )
+        canonical = project.attach_raw_video(rv)
+
+        # When the caller pre-declared coverage, also wire up the
+        # per-stage StageVideo entries so the worker has something to
+        # detect against. Each stage gets its own StageVideo with the
+        # same ``path`` (one raw -> N stage rows is the doc-05 model);
+        # if the stage already references this path we skip rather than
+        # double-register. Role auto-promotes to primary when the stage
+        # has no primary yet -- same convention as ``assign_video``.
+        video_path = Path(storage_path)
+        for stage_number in covers:
+            stage = project.stage(stage_number)
+            if any(str(v.path) == storage_path for v in stage.videos):
+                continue
+            role: VideoRole = "secondary" if stage.primary() is not None else "primary"
+            stage.videos.append(StageVideo(path=video_path, role=role))
+
+        project.save(root)
+
+        return JSONResponse(canonical.model_dump(mode="json"))
 
     @app.get("/api/shooters/{slug}/automation")
     def get_automation(slug: str) -> JSONResponse:

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -33,6 +33,7 @@ from moto import mock_aws  # noqa: E402
 
 from splitsmith.db import Base, create_engine  # noqa: E402
 from splitsmith.storage import S3Storage  # noqa: E402
+from splitsmith.ui.project import MatchProject  # noqa: E402
 
 BUCKET = "splitsmith-uploads-test"
 
@@ -358,3 +359,244 @@ def test_delete_rejects_path_traversal(hosted_client) -> None:
     # _sanitize_raw_filename raises a 400; both that and the storage
     # guard fail closed.
     assert resp.status_code in (400, 404)
+
+
+# --- POST /api/shooters/{slug}/raw-videos/attach -----------------------
+#
+# The attach endpoint is the bridge from "file lives in S3" to
+# "project knows the file exists". It populates ``raw_videos[]`` on
+# match.json per doc 05 and optionally creates StageVideo entries on
+# the stages the recording covers, so the next step (PR 4) can run
+# detection against an S3-backed source.
+
+
+@pytest.fixture
+def hosted_client_with_match(hosted_client, tmp_path: Path) -> Iterator[tuple[TestClient, S3Storage, str]]:
+    """Extend ``hosted_client`` with a scaffolded Match + one shooter
+    so attach-endpoint tests have something to attach raw videos to.
+
+    Yields ``(client, storage, match_id)``. The match has two stages
+    so tests can exercise the multi-stage ``covers_stages`` path.
+    """
+    from splitsmith import match_model
+    from splitsmith.ui.project import StageEntry
+
+    client, storage = hosted_client
+
+    match_root = tmp_path / "matches" / "attach-test"
+    match = match_model.Match.init(match_root, name="Attach Test")
+    match.stages = [
+        match_model.MatchStageDefinition(stage_number=1, stage_name="One"),
+        match_model.MatchStageDefinition(stage_number=2, stage_name="Two"),
+    ]
+    match.save(match_root)
+    match.add_shooter(match_root, match_model.Shooter(slug="me", name="Me"))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.init(sroot, name="Attach Test")
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="One", time_seconds=10.0),
+        StageEntry(stage_number=2, stage_name="Two", time_seconds=15.0),
+    ]
+    project.save(sroot)
+
+    resp = client.post(
+        "/api/me/recent-projects/bind",
+        json={"path": str(match_root.resolve())},
+    )
+    assert resp.status_code == 200, resp.text
+
+    ids = client.app.state.splitsmith_state.matches.known_ids()
+    assert len(ids) == 1
+    yield client, storage, ids[0]
+
+
+def _attach_url(match_id: str, slug: str = "me") -> str:
+    # The alias middleware rewrites ``/api/matches/{id}/<rest>`` to
+    # ``/api/<rest>`` -- so the prefix here is ``shooters/...``, not
+    # ``api/shooters/...``. Matches the _MatchClient rewrite pattern.
+    return f"/api/matches/{match_id}/shooters/{slug}/raw-videos/attach"
+
+
+def _seed_upload(client: TestClient, filename: str, payload: bytes) -> dict:
+    """Push a file through the upload endpoint so the attach test
+    can reference a real key. Returns the JSON the SPA would echo
+    back into the attach request body."""
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": (filename, io.BytesIO(payload), "video/mp4")},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_attach_registers_raw_video_on_project(hosted_client_with_match) -> None:
+    """An upload + attach round-trip lands a RawVideo entry on the
+    project's ``raw_videos[]`` with the storage_path the SPA can
+    reference back to."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "GH010023.mp4", b"video bytes " * 1024)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "size_bytes": upload["size"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["original_filename"] == "GH010023.mp4"
+    assert body["storage_path"] == "raw/GH010023.mp4"
+    assert body["sha256"] == upload["sha256"]
+    assert body["size_bytes"] == upload["size"]
+    assert body["covers_stages"] == []
+
+    # Persisted to the project on disk.
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].storage_path == "raw/GH010023.mp4"
+
+
+def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match) -> None:
+    """``covers_stages`` pre-declares the per-stage references so the
+    worker has something to detect against without a separate
+    auto-match call. The first stage gets primary; subsequent get
+    secondary (since they already have a primary on the shared raw)."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "headcam.mp4", b"shared " * 4096)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "size_bytes": upload["size"],
+            "covers_stages": [1, 2],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["covers_stages"] == [1, 2]
+
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    stage_one = project.stage(1)
+    stage_two = project.stage(2)
+    assert len(stage_one.videos) == 1
+    assert len(stage_two.videos) == 1
+    assert str(stage_one.videos[0].path) == "raw/headcam.mp4"
+    assert str(stage_two.videos[0].path) == "raw/headcam.mp4"
+    assert stage_one.videos[0].role == "primary"
+    assert stage_two.videos[0].role == "primary"
+
+
+def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> None:
+    """Repeat attaches with the same storage_path merge covers_stages
+    rather than appending duplicate raw_videos entries (the same
+    contract ``MatchProject.attach_raw_video`` enforces in unit
+    tests)."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "shared.mp4", b"x" * 1024)
+
+    client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "covers_stages": [1],
+        },
+    )
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "covers_stages": [2],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["covers_stages"] == [1, 2]
+
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    assert len(project.raw_videos) == 1
+    # Stage 2 was added by the second attach without disturbing
+    # stage 1's existing StageVideo.
+    assert len(project.stage(1).videos) == 1
+    assert len(project.stage(2).videos) == 1
+
+
+def test_attach_404_when_upload_missing(hosted_client_with_match) -> None:
+    """Attach must refuse to register a key the storage backend
+    doesn't actually have -- otherwise the manifest would point at
+    a non-existent object and the worker would 500 on first
+    detection."""
+    client, _, match_id = hosted_client_with_match
+    resp = client.post(
+        _attach_url(match_id),
+        json={"filename": "never-uploaded.mp4"},
+    )
+    assert resp.status_code == 404
+    assert "no upload" in resp.json()["detail"]
+
+
+def test_attach_422_when_covers_stages_unknown(hosted_client_with_match) -> None:
+    """An unknown stage_number in ``covers_stages`` is a client bug --
+    fail loudly rather than silently dropping the bogus number and
+    leaving the manifest claiming coverage that doesn't exist."""
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "clip.mp4", b"x" * 8)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "covers_stages": [1, 99],
+        },
+    )
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "unknown_stage_numbers"
+    assert detail["stage_numbers"] == [99]
+
+
+def test_attach_400_on_unsafe_filename(hosted_client_with_match) -> None:
+    """``_sanitize_raw_filename`` runs at the route layer so a
+    traversal attempt 400s before the storage backend's own guard
+    sees it."""
+    client, _, match_id = hosted_client_with_match
+    resp = client.post(
+        _attach_url(match_id),
+        json={"filename": "../escape.mp4"},
+    )
+    assert resp.status_code == 400
+
+
+def test_attach_503_when_storage_unwired(
+    hosted_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same hosted-only contract as the upload endpoint -- a desktop
+    install with no storage backend refuses cleanly."""
+    monkeypatch.delenv("SPLITSMITH_S3_BUCKET", raising=False)
+
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/matches/anything/shooters/me/raw-videos/attach",
+            json={"filename": "clip.mp4"},
+        )
+    assert resp.status_code in (503, 404)
+    # 503 is the storage-off contract; 404 is the alias middleware
+    # rejecting an unknown match_id. Either is "fails closed".

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -66,6 +66,61 @@ def test_upload_stream_rejects_traversal(s3_client) -> None:
         storage.upload_stream("../escape.bin", io.BytesIO(b"x"))
 
 
+def test_open_stream_yields_full_bytes(s3_client) -> None:
+    """The streaming-read counterpart to ``upload_stream`` must land the
+    same bytes as ``read_bytes`` so the worker-side download cache (PR 4)
+    can pick either path without observable difference.
+    """
+    storage = _storage(s3_client)
+    payload = b"Z" * 17 + b"tail"
+    storage.write_bytes("raw/clip.bin", payload)
+
+    with storage.open_stream("raw/clip.bin") as src:
+        streamed = src.read()
+    assert streamed == payload
+    assert streamed == storage.read_bytes("raw/clip.bin")
+
+
+def test_open_stream_raises_file_not_found(s3_client) -> None:
+    storage = _storage(s3_client)
+    with pytest.raises(FileNotFoundError):
+        storage.open_stream("raw/missing.bin")
+
+
+def test_open_stream_supports_copyfileobj(s3_client, tmp_path) -> None:
+    """The PR 4 worker resolver pattern: stream an S3 object into a
+    local file via ``shutil.copyfileobj`` so a 500 MB raw video doesn't
+    have to buffer fully into memory.
+    """
+    import shutil
+
+    storage = _storage(s3_client)
+    storage.write_bytes("raw/clip.bin", b"copy me" * 4096)
+    dest = tmp_path / "worker-cache.bin"
+
+    with storage.open_stream("raw/clip.bin") as src, dest.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+
+    assert dest.read_bytes() == b"copy me" * 4096
+
+
+def test_open_stream_closes_underlying_body(s3_client) -> None:
+    """Exiting the ``with`` block must close the StreamingBody so the
+    HTTPS connection returns to the pool instead of leaking.
+    """
+    storage = _storage(s3_client)
+    storage.write_bytes("raw/clip.bin", b"payload")
+
+    stream = storage.open_stream("raw/clip.bin")
+    with stream as src:
+        assert src.read() == b"payload"
+    # After the context exits, the wrapped body is closed -- further
+    # reads raise. botocore raises ValueError("I/O operation on closed
+    # file") for a closed StreamingBody.
+    with pytest.raises(ValueError):
+        stream.read()
+
+
 def test_write_overwrites_existing(s3_client) -> None:
     storage = _storage(s3_client)
     storage.write_bytes("k", b"v1")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -39,6 +39,49 @@ def test_upload_stream_rejects_traversal(tmp_path: Path) -> None:
         storage.upload_stream("../escape.bin", io.BytesIO(b"x"))
 
 
+def test_open_stream_yields_full_bytes(tmp_path: Path) -> None:
+    """The streaming-read counterpart to ``upload_stream`` must land the
+    same bytes as ``read_bytes`` for the same key.
+    """
+    storage = FilesystemStorage(tmp_path)
+    payload = b"Y" * (2 << 20) + b"tail"  # 2 MiB + sentinel
+    storage.write_bytes("raw/clip.bin", payload)
+
+    with storage.open_stream("raw/clip.bin") as src:
+        streamed = src.read()
+    assert streamed == payload
+    assert streamed == storage.read_bytes("raw/clip.bin")
+
+
+def test_open_stream_raises_file_not_found(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        storage.open_stream("raw/missing.bin")
+
+
+def test_open_stream_supports_copyfileobj(tmp_path: Path) -> None:
+    """The worker-side resolver (PR 4) copies via ``shutil.copyfileobj``.
+    Prove the open_stream return value works as the source argument so
+    the worker doesn't have to special-case the backend.
+    """
+    import shutil
+
+    storage = FilesystemStorage(tmp_path)
+    storage.write_bytes("raw/clip.bin", b"copy me" * 4096)
+    dest = tmp_path / "local-cache.bin"
+
+    with storage.open_stream("raw/clip.bin") as src, dest.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+
+    assert dest.read_bytes() == b"copy me" * 4096
+
+
+def test_open_stream_rejects_traversal(tmp_path: Path) -> None:
+    storage = FilesystemStorage(tmp_path)
+    with pytest.raises(ValueError, match="must be relative"):
+        storage.open_stream("../escape.bin")
+
+
 def test_write_creates_parent_directories(tmp_path: Path) -> None:
     """Callers should not have to mkdir themselves -- a project's
     on-disk layout has many nested folders and forcing every writer

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -23,6 +23,7 @@ from splitsmith.ui.project import (
     SUBDIRS,
     VIDEO_EXTENSIONS,
     MatchProject,
+    RawVideo,
     StageEntry,
     StageStatus,
     StageVideo,
@@ -102,7 +103,8 @@ def test_load_migrates_v1_caches_to_v2(tmp_path: Path) -> None:
 
     reloaded = MatchProject.load(root)
 
-    assert reloaded.schema_version == 2
+    # v1 chains through v2 + v3 to the current SCHEMA_VERSION.
+    assert reloaded.schema_version == SCHEMA_VERSION
     assert not legacy_full.exists()
     assert not legacy_audit.exists()
     assert not legacy_peaks.exists()
@@ -111,7 +113,168 @@ def test_load_migrates_v1_caches_to_v2(tmp_path: Path) -> None:
     assert survivor.exists()
     # And the version bump is persisted, so a second load is a no-op.
     persisted = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
-    assert persisted["schema_version"] == 2
+    assert persisted["schema_version"] == SCHEMA_VERSION
+
+
+def test_load_backfills_raw_videos_from_existing_stagevideos(tmp_path: Path) -> None:
+    """A v2 project on disk lands on v3 with ``raw_videos[]`` populated from
+    its StageVideo entries -- one RawVideo per unique source path, with
+    ``covers_stages`` aggregated across stages.
+    """
+    root = tmp_path / "v2-project"
+    project = MatchProject.init(root, name="V2 Project")
+    # One source covering stages 1-3 + a second source on stage 1 only +
+    # an unassigned video. The migration should collapse the multi-stage
+    # source into a single RawVideo with covers_stages=[1, 2, 3].
+    shared = Path("raw/headcam.mp4")
+    side = Path("raw/sidecam.mp4")
+    unassigned = Path("raw/leftover.mp4")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[
+                StageVideo(path=shared, role="primary"),
+                StageVideo(path=side, role="secondary"),
+            ],
+        ),
+        StageEntry(
+            stage_number=2,
+            stage_name="Two",
+            time_seconds=15.0,
+            videos=[StageVideo(path=shared, role="primary")],
+        ),
+        StageEntry(
+            stage_number=3,
+            stage_name="Three",
+            time_seconds=20.0,
+            videos=[StageVideo(path=shared, role="primary")],
+        ),
+    ]
+    project.unassigned_videos = [StageVideo(path=unassigned)]
+    project.save(root)
+
+    # Materialize one of the sources on disk so the migration can read
+    # its size; leave the others offline to confirm we tolerate that.
+    (root / "raw").mkdir(exist_ok=True)
+    (root / "raw" / "headcam.mp4").write_bytes(b"x" * 4096)
+
+    # Force the on-disk version back to 2 so load() runs the v2->v3 path.
+    data = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    data["schema_version"] = 2
+    data.pop("raw_videos", None)
+    (root / PROJECT_FILE).write_text(json.dumps(data), encoding="utf-8")
+
+    reloaded = MatchProject.load(root)
+
+    assert reloaded.schema_version == SCHEMA_VERSION
+    by_path = {rv.storage_path: rv for rv in reloaded.raw_videos}
+    assert set(by_path) == {"raw/headcam.mp4", "raw/sidecam.mp4", "raw/leftover.mp4"}
+    assert by_path["raw/headcam.mp4"].covers_stages == [1, 2, 3]
+    assert by_path["raw/sidecam.mp4"].covers_stages == [1]
+    # Unassigned videos have no covers_stages -- they exist but aren't on
+    # any stage yet. Empty list, not missing.
+    assert by_path["raw/leftover.mp4"].covers_stages == []
+    # Source-on-disk has its size populated; offline sources stay at 0.
+    assert by_path["raw/headcam.mp4"].size_bytes == 4096
+    assert by_path["raw/sidecam.mp4"].size_bytes == 0
+    # sha256 is None on legacy backfill -- we never had one to record.
+    assert by_path["raw/headcam.mp4"].sha256 is None
+    # original_filename is the basename for SPA display.
+    assert by_path["raw/headcam.mp4"].original_filename == "headcam.mp4"
+
+
+def test_v2_to_v3_migration_is_idempotent(tmp_path: Path) -> None:
+    """Re-loading a project doesn't duplicate raw_videos[] entries.
+
+    The migration runs once on the first v2 load; subsequent loads see
+    schema_version == 3 on disk and skip the backfill entirely.
+    """
+    root = tmp_path / "idempotent"
+    project = MatchProject.init(root, name="Idempotent")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[StageVideo(path=Path("raw/v.mp4"), role="primary")],
+        )
+    ]
+    project.save(root)
+    data = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    data["schema_version"] = 2
+    data.pop("raw_videos", None)
+    (root / PROJECT_FILE).write_text(json.dumps(data), encoding="utf-8")
+
+    first = MatchProject.load(root)
+    second = MatchProject.load(root)
+
+    assert len(first.raw_videos) == 1
+    assert len(second.raw_videos) == 1
+    assert second.raw_videos[0].covers_stages == [1]
+
+
+def test_attach_raw_video_merges_covers_stages(tmp_path: Path) -> None:
+    """Calling ``attach_raw_video`` twice with the same storage_path unions
+    the covers_stages list rather than appending a duplicate entry.
+    """
+    root = tmp_path / "attach"
+    project = MatchProject.init(root, name="Attach")
+
+    first = project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=1024,
+            storage_path="raw/clip.mp4",
+            covers_stages=[1, 2],
+        )
+    )
+    second = project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=1024,
+            storage_path="raw/clip.mp4",
+            covers_stages=[2, 3],
+        )
+    )
+
+    assert first is second
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].covers_stages == [1, 2, 3]
+
+
+def test_attach_raw_video_fills_in_missing_size_and_sha256(tmp_path: Path) -> None:
+    """A legacy backfill entry (size=0, sha256=None) gets upgraded when a
+    real upload lands -- preserves history while filling in the gaps.
+    """
+    root = tmp_path / "upgrade"
+    project = MatchProject.init(root, name="Upgrade")
+    project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=0,
+            sha256=None,
+            storage_path="raw/clip.mp4",
+        )
+    )
+    project.attach_raw_video(
+        RawVideo(
+            original_filename="clip.mp4",
+            size_bytes=2048,
+            sha256="deadbeef",
+            storage_path="raw/clip.mp4",
+        )
+    )
+
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].size_bytes == 2048
+    assert project.raw_videos[0].sha256 == "deadbeef"
+
+
+def test_find_raw_video_returns_none_when_absent(tmp_path: Path) -> None:
+    project = MatchProject.init(tmp_path / "find", name="Find")
+    assert project.find_raw_video("raw/missing.mp4") is None
 
 
 def test_init_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -1619,3 +1619,172 @@ def test_match_analysis_handles_missing_timestamp(tmp_path: Path) -> None:
     analysis = project.match_analysis()
     assert analysis.videos[0].classification == "no_timestamp"
     assert analysis.videos[0].stage_numbers == []
+
+
+# --- resolve_video_path: storage-aware worker resolver ----------------
+#
+# PR 4 of the attach-to-project chunk. resolve_video_path stays the
+# single chokepoint every detection / ffmpeg callsite goes through;
+# hosted mode binds a Storage so the first resolve mirrors the raw
+# video into the project's local cache. Local mode leaves the
+# binding at None and gets the legacy behaviour for free.
+
+
+def test_resolve_local_mode_absolute_path_unchanged(tmp_path: Path) -> None:
+    """Local mode (no storage bound) -- an absolute path is returned
+    as-is. This is the external-drive / FCP-scratch case."""
+    project = MatchProject.init(tmp_path / "m", name="m")
+    abs_path = tmp_path / "elsewhere" / "raw" / "v.mp4"
+    abs_path.parent.mkdir(parents=True)
+    abs_path.write_bytes(b"x")
+
+    resolved = project.resolve_video_path(tmp_path / "m", abs_path)
+    assert resolved == abs_path
+
+
+def test_resolve_local_mode_relative_path_joins_root(tmp_path: Path) -> None:
+    """Local mode -- relative ``raw/v.mp4`` resolves to ``root/raw/v.mp4``
+    even if the file doesn't exist yet (the caller's existence check
+    surfaces missing sources)."""
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+
+    resolved = project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert resolved == root / "raw" / "v.mp4"
+
+
+def test_resolve_hosted_mode_downloads_on_first_access(tmp_path: Path) -> None:
+    """A storage-bound project with no local mirror streams the object
+    from storage into ``<root>/<path>`` on first resolve so the
+    worker's downstream ``open()`` / ffprobe sees real bytes."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    payload = b"raw bytes " * 4096  # 40 KB; enough to exercise copyfileobj chunks
+    (backing / "raw").mkdir()
+    (backing / "raw" / "headcam.mp4").write_bytes(payload)
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    local = root / "raw" / "headcam.mp4"
+    assert not local.exists()
+    resolved = project.resolve_video_path(root, Path("raw/headcam.mp4"))
+    assert resolved == local
+    assert local.read_bytes() == payload
+
+
+def test_resolve_hosted_mode_caches_after_first_download(tmp_path: Path) -> None:
+    """Second resolve must NOT re-stream from storage -- the local
+    mirror is the source of truth once written. Multiple detection
+    jobs on the same project share one download per file."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    (backing / "raw").mkdir()
+    (backing / "raw" / "v.mp4").write_bytes(b"original")
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    local = root / "raw" / "v.mp4"
+
+    # Mutate the backing object to a different value; if a second
+    # resolve re-downloaded, the local mirror would change with it.
+    (backing / "raw" / "v.mp4").write_bytes(b"DIFFERENT")
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert local.read_bytes() == b"original"
+
+
+def test_resolve_hosted_mode_absolute_path_bypasses_storage(tmp_path: Path) -> None:
+    """An absolute ``StageVideo.path`` is always a local-disk reference
+    (external drive, FCP scratch) and must NOT trigger a storage
+    download. Belt-and-braces: hosted-mode projects with mixed
+    sources don't accidentally try to fetch ``/Volumes/...`` from S3."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    external = tmp_path / "external" / "v.mp4"
+    external.parent.mkdir()
+    external.write_bytes(b"on the drive")
+    resolved = project.resolve_video_path(root, external)
+    assert resolved == external
+
+
+def test_resolve_hosted_mode_missing_key_leaves_no_local_file(tmp_path: Path) -> None:
+    """When the storage object is missing, resolve_video_path is a
+    no-op (no download, no half-written mirror). The caller's
+    existing ``not source.exists()`` checks then surface the missing
+    source -- same shape as offline-drive local-mode failure."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    resolved = project.resolve_video_path(root, Path("raw/missing.mp4"))
+    assert resolved == root / "raw" / "missing.mp4"
+    assert not resolved.exists()
+
+
+def test_bind_storage_none_disables_mirror(tmp_path: Path) -> None:
+    """``bind_storage(None)`` reverts a project to local-mode behaviour
+    -- a relative path resolves to root/path without consulting any
+    backend even if one was previously bound."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    (backing / "raw").mkdir()
+    (backing / "raw" / "v.mp4").write_bytes(b"x")
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+    project.bind_storage(None)
+
+    local = root / "raw" / "v.mp4"
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert not local.exists()
+
+
+def test_storage_binding_not_persisted_in_project_json(tmp_path: Path) -> None:
+    """The Storage handle is request-scope state, not project-on-disk
+    state -- it must never round-trip through ``project.json``. A
+    bound-then-saved-then-loaded project comes back with no
+    binding (the caller re-binds at load time)."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+    project.save(root)
+
+    reloaded = MatchProject.load(root)
+    assert reloaded._storage is None
+    dumped = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    assert "_storage" not in dumped
+    assert "storage" not in dumped


### PR DESCRIPTION
## Summary

Fourth chunk of the attach-to-project + worker S3 cache work. **Stacked on #430** (which is stacked on #428); also merges in #429's ``open_stream`` API. Base auto-rebases when the predecessors land.

This is the seam that lights up hosted detect+export end-to-end: when a worker resolves a StageVideo whose ``path`` is a storage-relative key, the project streams the object from storage into its local ``raw/`` cache (atomic temp + rename) before the resolved ``Path`` is returned. Detection, ffprobe, ffmpeg, and thumbs all hit the local copy without any callsite changes.

## Design notes

**Plumbing**: A Pydantic v2 ``PrivateAttr _storage`` lives on ``MatchProject``; ``state.shooter_project`` binds ``state.storage`` onto every load. None of the ~18 ``resolve_video_path`` callsites needed to change. Confirmed with the user that this beats wide explicit ``storage=`` plumbing -- ``PrivateAttr`` is the Pydantic-native way to carry request-scope state without polluting the schema, and a non-bound project (local mode) is bit-identical to today.

**Caching**: First resolve streams from storage into ``<project_root>/<path>``; subsequent resolves see the local mirror and short-circuit. Multiple detection jobs on the same file share one download. Cache lives under the existing ``raw/`` directory the project layout already owns -- no new top-level cache directory, no eviction policy needed (project lifetime = cache lifetime).

**Behaviour matrix:**

| `video_path`            | `_storage`     | Result                                     |
| ----------------------- | -------------- | ------------------------------------------ |
| absolute (`/Volumes/X`) | any            | returned as-is                             |
| relative                | `None`         | `root / video_path` (legacy local mode)    |
| relative                | bound, cached  | `root / video_path` (cache hit)            |
| relative                | bound, missing | mirror from storage, then return local     |

## What this enables

After this lands, the existing detection pipeline -- beep_detect, shot_detect, trim, ffprobe, thumbs -- runs against hosted-mode uploads without any per-callsite awareness of S3. The worker codepath was already path-based; the resolver hides the storage round-trip from it.

## Test plan

- [x] ``uv run pytest`` -- 1534 passed, 16 skipped, 3 deselected (sigterm pre-existing flake)
- [x] ``uv run ruff check`` -- clean
- [x] ``uv run black --check`` -- clean
- [x] New tests (8) cover:
  - [x] Local mode: absolute path returned as-is
  - [x] Local mode: relative path joins root (unchanged)
  - [x] Hosted mode: first resolve downloads + writes the local mirror
  - [x] Hosted mode: second resolve uses the cache (changing the backing object doesn't change the local mirror)
  - [x] Hosted mode: absolute paths bypass storage even when bound
  - [x] Hosted mode: missing key is a no-op (downstream missing-source path handles it, same as offline drives)
  - [x] ``bind_storage(None)`` reverts to local-mode behaviour
  - [x] PrivateAttr never round-trips through ``project.json``

Local desktop mode is bit-identical to today -- ``state.storage`` is None, the bind is a no-op, and the resolver hits the unchanged ``root / video_path`` branch.

## What's next

PR 5: SPA ``HostedUploadSurface`` per-file "attach to project" action that posts to PR 3's endpoint. After that, the user can upload a raw video in the browser, attach it to a project, and run detection on a hosted worker -- the full flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)