### PR TITLE
feat(saas): POST /api/shooters/{slug}/raw-videos/attach endpoint

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -146,6 +146,7 @@ from .jobs import Job, JobBackend, JobCancelled, JobHandle, JobRegistry, Shutdow
 from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
+    RawVideo,
     ScoreboardImportConflictError,
     StageEntry,
     StageVideo,
@@ -1318,6 +1319,23 @@ class ForgetRecentProjectRequest(BaseModel):
     """Body for POST /api/user/recent-projects/forget (#75)."""
 
     path: str
+
+
+class AttachRawVideoRequest(BaseModel):
+    """Body for POST /api/shooters/{slug}/raw-videos/attach (doc 05).
+
+    The SPA passes back the shape ``POST /api/me/raw/upload`` returned
+    plus an optional ``covers_stages``. ``filename`` round-trips through
+    ``_sanitize_raw_filename`` so a malicious request body can't escape
+    the user's ``raw/`` prefix. ``covers_stages`` is optional -- callers
+    can leave it null and run auto-match later, or pre-declare it when
+    they already know which stages the recording spans.
+    """
+
+    filename: str
+    sha256: str | None = None
+    size_bytes: int | None = None
+    covers_stages: list[int] | None = None
 
 
 class ScoreboardIdentityRequest(BaseModel):
@@ -2847,6 +2865,109 @@ def create_app(
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"delete failed: {exc}") from exc
         return JSONResponse({"ok": True, "path": key})
+
+    @app.post("/api/shooters/{slug}/raw-videos/attach")
+    def attach_raw_video(
+        slug: str,
+        body: AttachRawVideoRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Register an uploaded raw video against a shooter's project (doc 05).
+
+        Hosted-only -- 503 when ``state.storage`` is unwired. The
+        upload itself must already be in object storage (the SPA calls
+        ``POST /api/me/raw/upload`` first); this endpoint validates that
+        and records the manifest entry on ``match.json``.
+
+        Body shape: ``{filename, sha256?, size_bytes?, covers_stages?}``.
+        The trailing fields default to whatever the upload endpoint
+        echoed back; size + sha256 fill in the legacy backfill
+        placeholders if the project's migration left them empty. When
+        ``covers_stages`` is provided, the endpoint also creates
+        ``StageVideo`` entries on those stages (path =
+        ``raw/<filename>``, role auto-promoted to primary when the
+        stage has no primary yet -- same rule as
+        :meth:`MatchProject.assign_video`).
+
+        Returns the canonical ``RawVideo`` (either the freshly attached
+        entry or the merged-into existing one).
+
+        Error contract:
+
+        - 503 -- no hosted storage wired (local mode).
+        - 400 -- filename failed ``_sanitize_raw_filename`` (path
+          separators, ``..``, empty).
+        - 404 -- no object at ``raw/<filename>`` in storage.
+        - 422 -- ``covers_stages`` references a stage_number the
+          project doesn't have.
+        """
+        storage = state.storage
+        if storage is None:
+            raise HTTPException(
+                status_code=503,
+                detail="raw video attach is hosted-mode only",
+            )
+
+        name = _sanitize_raw_filename(body.filename)
+        storage_path = f"raw/{name}"
+        stat = storage.stat(storage_path)
+        if stat is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"no upload at {storage_path!r}; upload first via POST /api/me/raw/upload",
+            )
+
+        project = state.shooter_project(slug)
+        root = state.shooter_root(slug)
+
+        covers = sorted(set(body.covers_stages or []))
+        if covers:
+            # Verify every claimed stage exists before mutating anything;
+            # an unknown stage_number is a 422 (client bug) rather than a
+            # silent skip that leaves the manifest in a half-populated state.
+            known = {s.stage_number for s in project.stages}
+            unknown = [n for n in covers if n not in known]
+            if unknown:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "unknown_stage_numbers",
+                        "stage_numbers": unknown,
+                    },
+                )
+
+        # Trust the upload endpoint's sha256 verification: it already
+        # rolled the object back on mismatch (see the X-Content-SHA256
+        # path in upload_raw_video). The size on the body is informational;
+        # we always defer to S3's reported ContentLength when available
+        # so the manifest matches the object the worker will download.
+        rv = RawVideo(
+            original_filename=name,
+            size_bytes=int(stat.size if stat.size else (body.size_bytes or 0)),
+            sha256=body.sha256,
+            storage_path=storage_path,
+            covers_stages=covers,
+        )
+        canonical = project.attach_raw_video(rv)
+
+        # When the caller pre-declared coverage, also wire up the
+        # per-stage StageVideo entries so the worker has something to
+        # detect against. Each stage gets its own StageVideo with the
+        # same ``path`` (one raw -> N stage rows is the doc-05 model);
+        # if the stage already references this path we skip rather than
+        # double-register. Role auto-promotes to primary when the stage
+        # has no primary yet -- same convention as ``assign_video``.
+        video_path = Path(storage_path)
+        for stage_number in covers:
+            stage = project.stage(stage_number)
+            if any(str(v.path) == storage_path for v in stage.videos):
+                continue
+            role: VideoRole = "secondary" if stage.primary() is not None else "primary"
+            stage.videos.append(StageVideo(path=video_path, role=role))
+
+        project.save(root)
+
+        return JSONResponse(canonical.model_dump(mode="json"))
 
     @app.get("/api/shooters/{slug}/automation")
     def get_automation(slug: str) -> JSONResponse:

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -33,6 +33,7 @@ from moto import mock_aws  # noqa: E402
 
 from splitsmith.db import Base, create_engine  # noqa: E402
 from splitsmith.storage import S3Storage  # noqa: E402
+from splitsmith.ui.project import MatchProject  # noqa: E402
 
 BUCKET = "splitsmith-uploads-test"
 
@@ -358,3 +359,244 @@ def test_delete_rejects_path_traversal(hosted_client) -> None:
     # _sanitize_raw_filename raises a 400; both that and the storage
     # guard fail closed.
     assert resp.status_code in (400, 404)
+
+
+# --- POST /api/shooters/{slug}/raw-videos/attach -----------------------
+#
+# The attach endpoint is the bridge from "file lives in S3" to
+# "project knows the file exists". It populates ``raw_videos[]`` on
+# match.json per doc 05 and optionally creates StageVideo entries on
+# the stages the recording covers, so the next step (PR 4) can run
+# detection against an S3-backed source.
+
+
+@pytest.fixture
+def hosted_client_with_match(hosted_client, tmp_path: Path) -> Iterator[tuple[TestClient, S3Storage, str]]:
+    """Extend ``hosted_client`` with a scaffolded Match + one shooter
+    so attach-endpoint tests have something to attach raw videos to.
+
+    Yields ``(client, storage, match_id)``. The match has two stages
+    so tests can exercise the multi-stage ``covers_stages`` path.
+    """
+    from splitsmith import match_model
+    from splitsmith.ui.project import StageEntry
+
+    client, storage = hosted_client
+
+    match_root = tmp_path / "matches" / "attach-test"
+    match = match_model.Match.init(match_root, name="Attach Test")
+    match.stages = [
+        match_model.MatchStageDefinition(stage_number=1, stage_name="One"),
+        match_model.MatchStageDefinition(stage_number=2, stage_name="Two"),
+    ]
+    match.save(match_root)
+    match.add_shooter(match_root, match_model.Shooter(slug="me", name="Me"))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.init(sroot, name="Attach Test")
+    project.stages = [
+        StageEntry(stage_number=1, stage_name="One", time_seconds=10.0),
+        StageEntry(stage_number=2, stage_name="Two", time_seconds=15.0),
+    ]
+    project.save(sroot)
+
+    resp = client.post(
+        "/api/me/recent-projects/bind",
+        json={"path": str(match_root.resolve())},
+    )
+    assert resp.status_code == 200, resp.text
+
+    ids = client.app.state.splitsmith_state.matches.known_ids()
+    assert len(ids) == 1
+    yield client, storage, ids[0]
+
+
+def _attach_url(match_id: str, slug: str = "me") -> str:
+    # The alias middleware rewrites ``/api/matches/{id}/<rest>`` to
+    # ``/api/<rest>`` -- so the prefix here is ``shooters/...``, not
+    # ``api/shooters/...``. Matches the _MatchClient rewrite pattern.
+    return f"/api/matches/{match_id}/shooters/{slug}/raw-videos/attach"
+
+
+def _seed_upload(client: TestClient, filename: str, payload: bytes) -> dict:
+    """Push a file through the upload endpoint so the attach test
+    can reference a real key. Returns the JSON the SPA would echo
+    back into the attach request body."""
+    resp = client.post(
+        "/api/me/raw/upload",
+        files={"file": (filename, io.BytesIO(payload), "video/mp4")},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_attach_registers_raw_video_on_project(hosted_client_with_match) -> None:
+    """An upload + attach round-trip lands a RawVideo entry on the
+    project's ``raw_videos[]`` with the storage_path the SPA can
+    reference back to."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "GH010023.mp4", b"video bytes " * 1024)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "size_bytes": upload["size"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["original_filename"] == "GH010023.mp4"
+    assert body["storage_path"] == "raw/GH010023.mp4"
+    assert body["sha256"] == upload["sha256"]
+    assert body["size_bytes"] == upload["size"]
+    assert body["covers_stages"] == []
+
+    # Persisted to the project on disk.
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    assert len(project.raw_videos) == 1
+    assert project.raw_videos[0].storage_path == "raw/GH010023.mp4"
+
+
+def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match) -> None:
+    """``covers_stages`` pre-declares the per-stage references so the
+    worker has something to detect against without a separate
+    auto-match call. The first stage gets primary; subsequent get
+    secondary (since they already have a primary on the shared raw)."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "headcam.mp4", b"shared " * 4096)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "size_bytes": upload["size"],
+            "covers_stages": [1, 2],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["covers_stages"] == [1, 2]
+
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    stage_one = project.stage(1)
+    stage_two = project.stage(2)
+    assert len(stage_one.videos) == 1
+    assert len(stage_two.videos) == 1
+    assert str(stage_one.videos[0].path) == "raw/headcam.mp4"
+    assert str(stage_two.videos[0].path) == "raw/headcam.mp4"
+    assert stage_one.videos[0].role == "primary"
+    assert stage_two.videos[0].role == "primary"
+
+
+def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> None:
+    """Repeat attaches with the same storage_path merge covers_stages
+    rather than appending duplicate raw_videos entries (the same
+    contract ``MatchProject.attach_raw_video`` enforces in unit
+    tests)."""
+    from splitsmith import match_model
+
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "shared.mp4", b"x" * 1024)
+
+    client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "covers_stages": [1],
+        },
+    )
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "sha256": upload["sha256"],
+            "covers_stages": [2],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["covers_stages"] == [1, 2]
+
+    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
+    sroot = match_model.Match.shooter_root(match_root, "me")
+    project = MatchProject.load(sroot)
+    assert len(project.raw_videos) == 1
+    # Stage 2 was added by the second attach without disturbing
+    # stage 1's existing StageVideo.
+    assert len(project.stage(1).videos) == 1
+    assert len(project.stage(2).videos) == 1
+
+
+def test_attach_404_when_upload_missing(hosted_client_with_match) -> None:
+    """Attach must refuse to register a key the storage backend
+    doesn't actually have -- otherwise the manifest would point at
+    a non-existent object and the worker would 500 on first
+    detection."""
+    client, _, match_id = hosted_client_with_match
+    resp = client.post(
+        _attach_url(match_id),
+        json={"filename": "never-uploaded.mp4"},
+    )
+    assert resp.status_code == 404
+    assert "no upload" in resp.json()["detail"]
+
+
+def test_attach_422_when_covers_stages_unknown(hosted_client_with_match) -> None:
+    """An unknown stage_number in ``covers_stages`` is a client bug --
+    fail loudly rather than silently dropping the bogus number and
+    leaving the manifest claiming coverage that doesn't exist."""
+    client, _, match_id = hosted_client_with_match
+    upload = _seed_upload(client, "clip.mp4", b"x" * 8)
+
+    resp = client.post(
+        _attach_url(match_id),
+        json={
+            "filename": upload["filename"],
+            "covers_stages": [1, 99],
+        },
+    )
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "unknown_stage_numbers"
+    assert detail["stage_numbers"] == [99]
+
+
+def test_attach_400_on_unsafe_filename(hosted_client_with_match) -> None:
+    """``_sanitize_raw_filename`` runs at the route layer so a
+    traversal attempt 400s before the storage backend's own guard
+    sees it."""
+    client, _, match_id = hosted_client_with_match
+    resp = client.post(
+        _attach_url(match_id),
+        json={"filename": "../escape.mp4"},
+    )
+    assert resp.status_code == 400
+
+
+def test_attach_503_when_storage_unwired(
+    hosted_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same hosted-only contract as the upload endpoint -- a desktop
+    install with no storage backend refuses cleanly."""
+    monkeypatch.delenv("SPLITSMITH_S3_BUCKET", raising=False)
+
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/matches/anything/shooters/me/raw-videos/attach",
+            json={"filename": "clip.mp4"},
+        )
+    assert resp.status_code in (503, 404)
+    # 503 is the storage-off contract; 404 is the alias middleware
+    # rejecting an unknown match_id. Either is "fails closed".


### PR DESCRIPTION
## Summary

Recreated from #430 (auto-closed when its stacked base merged). The diff is now against ``main`` directly.

Third chunk of the attach-to-project + worker S3 cache work. Builds on #428's ``raw_videos[]`` schema.

- ``AttachRawVideoRequest`` body: ``{filename, sha256?, size_bytes?, covers_stages?}`` -- mirrors what ``POST /api/me/raw/upload`` echoes back.
- Endpoint validates storage wired (503), upload exists (404), filename safe (400), stage_numbers valid (422).
- ``project.attach_raw_video`` dedup-merges by storage_path.
- When ``covers_stages`` provided, per-stage ``StageVideo`` entries auto-promote (primary if stage has none, secondary otherwise).

## Test plan

- [x] 7 new endpoint tests pass; full suite green
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)