### PR TITLE
feat(saas): storage-aware resolve_video_path + worker S3 download cache

### DIFF
--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -34,11 +34,12 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, PrivateAttr, computed_field
 
 from .. import video_match
 from ..automation import AutomationOverride
 from ..config import BeepCandidate, StageData, StageRounds, VideoMatchConfig
+from ..storage import Storage
 from ..video_match import match_videos_to_stages
 
 logger = logging.getLogger(__name__)
@@ -788,6 +789,22 @@ class MatchProject(BaseModel):
     # projects until first upload/attach; backfilled from existing
     # StageVideos on v2->v3 schema migration.
     raw_videos: list[RawVideo] = Field(default_factory=list)
+
+    # Worker-side ``Storage`` handle, set by ``state.shooter_project``
+    # after load in hosted mode. Not persisted: it's request-scope state,
+    # not project-on-disk state, and a ``MatchProject`` round-tripped
+    # through ``model_dump`` / ``model_validate`` must stay identical.
+    # Local mode leaves this ``None`` and :meth:`resolve_video_path`
+    # falls back to the legacy path-only resolution -- desktop behavior
+    # is unchanged.
+    _storage: Storage | None = PrivateAttr(default=None)
+
+    def bind_storage(self, storage: Storage | None) -> None:
+        """Attach a per-request ``Storage`` so :meth:`resolve_video_path`
+        can mirror hosted-mode raw videos into the project's local
+        cache on first access. Idempotent; ``None`` clears the binding.
+        """
+        self._storage = storage
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -1551,9 +1568,65 @@ class MatchProject(BaseModel):
         return video
 
     def resolve_video_path(self, root: Path, video_path: Path) -> Path:
-        """Resolve a ``StageVideo.path`` (which may be project-relative or
-        absolute) to an absolute filesystem path."""
-        return video_path if video_path.is_absolute() else root / video_path
+        """Resolve a ``StageVideo.path`` to an absolute filesystem path,
+        mirroring from hosted storage on first access when needed.
+
+        Behaviour matrix:
+
+        - **Absolute path** -- returned as-is (legacy local-mode flow:
+          external drive, FCP scratch).
+        - **Relative path, no storage bound** -- returned as
+          ``root / video_path``. Identical to pre-PR-4 behavior; the
+          desktop UI lands here.
+        - **Relative path, storage bound, local mirror exists** -- the
+          cached mirror at ``root / video_path`` wins. Subsequent
+          detection jobs on the same project re-use the same local
+          copy without a second download.
+        - **Relative path, storage bound, no local mirror** -- streams
+          the object from storage into ``root / video_path`` via a
+          temp + atomic-rename, then returns the local path. A
+          missing key is left to surface as a downstream
+          ``FileNotFoundError`` -- callers already handle that for
+          offline-source cases.
+
+        ``storage`` is set by :meth:`bind_storage`, which the hosted
+        boot calls inside ``state.shooter_project`` so every project
+        load that goes through that accessor is automatically wired up.
+        """
+        if video_path.is_absolute():
+            return video_path
+        local = root / video_path
+        if self._storage is not None and not local.exists():
+            self._mirror_from_storage(self._storage, str(video_path), local)
+        return local
+
+    @staticmethod
+    def _mirror_from_storage(storage: Storage, key: str, dest: Path) -> None:
+        """Stream ``key`` from ``storage`` into ``dest`` via temp+rename.
+
+        Best-effort: a missing key is a no-op (the caller's existing
+        ``not source.exists()`` checks already handle that). Network
+        / IO errors propagate so the worker fails the job loudly --
+        a half-downloaded mirror would be worse than a failed detect.
+        """
+        if not storage.exists(key):
+            return
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=dest.name + ".",
+            suffix=".tmp",
+            dir=dest.parent,
+        )
+        try:
+            with storage.open_stream(key) as src, os.fdopen(fd, "wb") as out:
+                shutil.copyfileobj(src, out)
+            Path(tmp_name).replace(dest)
+        except Exception:
+            try:
+                Path(tmp_name).unlink()
+            except FileNotFoundError:
+                pass
+            raise
 
     def find_raw_video(self, storage_path: str) -> RawVideo | None:
         """Return the ``RawVideo`` with this ``storage_path``, or ``None``.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -687,8 +687,17 @@ class AppState:
 
     def shooter_project(self, slug: str) -> MatchProject:
         """Load the per-shooter ``MatchProject`` (each shooter slot
-        inside a Match folder owns its own ``project.json``)."""
-        return MatchProject.load(self.shooter_root(slug))
+        inside a Match folder owns its own ``project.json``).
+
+        Binds :attr:`storage` onto the project so
+        :meth:`MatchProject.resolve_video_path` can mirror hosted-mode
+        raw videos into the local cache on first access. Local mode
+        leaves ``storage`` at ``None``; the bind is a no-op and the
+        legacy disk-only resolver wins.
+        """
+        project = MatchProject.load(self.shooter_root(slug))
+        project.bind_storage(self.storage)
+        return project
 
     def register_match(self, root: Path) -> str | None:
         """Load the match at ``root`` and pin its ``match_id`` into

--- a/tests/test_ui_project.py
+++ b/tests/test_ui_project.py
@@ -1619,3 +1619,172 @@ def test_match_analysis_handles_missing_timestamp(tmp_path: Path) -> None:
     analysis = project.match_analysis()
     assert analysis.videos[0].classification == "no_timestamp"
     assert analysis.videos[0].stage_numbers == []
+
+
+# --- resolve_video_path: storage-aware worker resolver ----------------
+#
+# PR 4 of the attach-to-project chunk. resolve_video_path stays the
+# single chokepoint every detection / ffmpeg callsite goes through;
+# hosted mode binds a Storage so the first resolve mirrors the raw
+# video into the project's local cache. Local mode leaves the
+# binding at None and gets the legacy behaviour for free.
+
+
+def test_resolve_local_mode_absolute_path_unchanged(tmp_path: Path) -> None:
+    """Local mode (no storage bound) -- an absolute path is returned
+    as-is. This is the external-drive / FCP-scratch case."""
+    project = MatchProject.init(tmp_path / "m", name="m")
+    abs_path = tmp_path / "elsewhere" / "raw" / "v.mp4"
+    abs_path.parent.mkdir(parents=True)
+    abs_path.write_bytes(b"x")
+
+    resolved = project.resolve_video_path(tmp_path / "m", abs_path)
+    assert resolved == abs_path
+
+
+def test_resolve_local_mode_relative_path_joins_root(tmp_path: Path) -> None:
+    """Local mode -- relative ``raw/v.mp4`` resolves to ``root/raw/v.mp4``
+    even if the file doesn't exist yet (the caller's existence check
+    surfaces missing sources)."""
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+
+    resolved = project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert resolved == root / "raw" / "v.mp4"
+
+
+def test_resolve_hosted_mode_downloads_on_first_access(tmp_path: Path) -> None:
+    """A storage-bound project with no local mirror streams the object
+    from storage into ``<root>/<path>`` on first resolve so the
+    worker's downstream ``open()`` / ffprobe sees real bytes."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    payload = b"raw bytes " * 4096  # 40 KB; enough to exercise copyfileobj chunks
+    (backing / "raw").mkdir()
+    (backing / "raw" / "headcam.mp4").write_bytes(payload)
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    local = root / "raw" / "headcam.mp4"
+    assert not local.exists()
+    resolved = project.resolve_video_path(root, Path("raw/headcam.mp4"))
+    assert resolved == local
+    assert local.read_bytes() == payload
+
+
+def test_resolve_hosted_mode_caches_after_first_download(tmp_path: Path) -> None:
+    """Second resolve must NOT re-stream from storage -- the local
+    mirror is the source of truth once written. Multiple detection
+    jobs on the same project share one download per file."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    (backing / "raw").mkdir()
+    (backing / "raw" / "v.mp4").write_bytes(b"original")
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    local = root / "raw" / "v.mp4"
+
+    # Mutate the backing object to a different value; if a second
+    # resolve re-downloaded, the local mirror would change with it.
+    (backing / "raw" / "v.mp4").write_bytes(b"DIFFERENT")
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert local.read_bytes() == b"original"
+
+
+def test_resolve_hosted_mode_absolute_path_bypasses_storage(tmp_path: Path) -> None:
+    """An absolute ``StageVideo.path`` is always a local-disk reference
+    (external drive, FCP scratch) and must NOT trigger a storage
+    download. Belt-and-braces: hosted-mode projects with mixed
+    sources don't accidentally try to fetch ``/Volumes/...`` from S3."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    external = tmp_path / "external" / "v.mp4"
+    external.parent.mkdir()
+    external.write_bytes(b"on the drive")
+    resolved = project.resolve_video_path(root, external)
+    assert resolved == external
+
+
+def test_resolve_hosted_mode_missing_key_leaves_no_local_file(tmp_path: Path) -> None:
+    """When the storage object is missing, resolve_video_path is a
+    no-op (no download, no half-written mirror). The caller's
+    existing ``not source.exists()`` checks then surface the missing
+    source -- same shape as offline-drive local-mode failure."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+
+    resolved = project.resolve_video_path(root, Path("raw/missing.mp4"))
+    assert resolved == root / "raw" / "missing.mp4"
+    assert not resolved.exists()
+
+
+def test_bind_storage_none_disables_mirror(tmp_path: Path) -> None:
+    """``bind_storage(None)`` reverts a project to local-mode behaviour
+    -- a relative path resolves to root/path without consulting any
+    backend even if one was previously bound."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    (backing / "raw").mkdir()
+    (backing / "raw" / "v.mp4").write_bytes(b"x")
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+    project.bind_storage(None)
+
+    local = root / "raw" / "v.mp4"
+    project.resolve_video_path(root, Path("raw/v.mp4"))
+    assert not local.exists()
+
+
+def test_storage_binding_not_persisted_in_project_json(tmp_path: Path) -> None:
+    """The Storage handle is request-scope state, not project-on-disk
+    state -- it must never round-trip through ``project.json``. A
+    bound-then-saved-then-loaded project comes back with no
+    binding (the caller re-binds at load time)."""
+    from splitsmith.storage import FilesystemStorage
+
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    root = tmp_path / "m"
+    project = MatchProject.init(root, name="m")
+    project.bind_storage(storage)
+    project.save(root)
+
+    reloaded = MatchProject.load(root)
+    assert reloaded._storage is None
+    dumped = json.loads((root / PROJECT_FILE).read_text(encoding="utf-8"))
+    assert "_storage" not in dumped
+    assert "storage" not in dumped


### PR DESCRIPTION
## Summary

Recreated from #431 (auto-closed when its stacked base merged). Diff is now against ``main``.

Fourth chunk of the attach-to-project + worker S3 cache work. This is the seam that lights up hosted detect+export end-to-end: when a worker resolves a StageVideo whose ``path`` is a storage-relative key, the project streams the object from storage into its local ``raw/`` cache (atomic temp + rename) before the resolved ``Path`` is returned. Detection, ffprobe, ffmpeg, and thumbs all hit the local copy without any callsite changes.

## Design

- Pydantic v2 ``PrivateAttr _storage`` on ``MatchProject``; ``state.shooter_project`` binds ``state.storage`` onto every load.
- None of the ~18 ``resolve_video_path`` callsites change.
- Cache lives under existing ``raw/`` directory (project lifetime = cache lifetime).

## Behaviour matrix

| `video_path`            | `_storage`     | Result                                  |
| ----------------------- | -------------- | --------------------------------------- |
| absolute (`/Volumes/X`) | any            | returned as-is                          |
| relative                | `None`         | `root / video_path` (legacy local mode) |
| relative                | bound, cached  | `root / video_path` (cache hit)         |
| relative                | bound, missing | mirror from storage, then return local  |

Local desktop mode is bit-identical -- ``state.storage`` is None, bind is a no-op.

## Test plan

- [x] 8 new resolver tests pass; full suite green (1534)
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)