### PR TITLE
feat(saas): SPA "attach to project" action in HostedUploadSurface

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -2959,20 +2959,26 @@ def create_app(
         )
         canonical = project.attach_raw_video(rv)
 
-        # When the caller pre-declared coverage, also wire up the
-        # per-stage StageVideo entries so the worker has something to
-        # detect against. Each stage gets its own StageVideo with the
-        # same ``path`` (one raw -> N stage rows is the doc-05 model);
-        # if the stage already references this path we skip rather than
-        # double-register. Role auto-promotes to primary when the stage
-        # has no primary yet -- same convention as ``assign_video``.
+        # Decide where the per-stage StageVideo entries land:
+        #   - covers_stages given -> one StageVideo per named stage
+        #     (the doc-05 "one raw covers N stages" shape).
+        #   - covers_stages empty -> a single entry in unassigned_videos
+        #     so the ingest tray UI picks it up the same way local-mode
+        #     scan does. The user then drags to stages or runs
+        #     auto-match. Without this, attach + no coverage would
+        #     leave the project's raw_videos manifest populated but
+        #     nothing for the worker to detect against.
         video_path = Path(storage_path)
-        for stage_number in covers:
-            stage = project.stage(stage_number)
-            if any(str(v.path) == storage_path for v in stage.videos):
-                continue
-            role: VideoRole = "secondary" if stage.primary() is not None else "primary"
-            stage.videos.append(StageVideo(path=video_path, role=role))
+        already_registered = project.find_video(video_path) is not None
+        if covers:
+            for stage_number in covers:
+                stage = project.stage(stage_number)
+                if any(str(v.path) == storage_path for v in stage.videos):
+                    continue
+                role: VideoRole = "secondary" if stage.primary() is not None else "primary"
+                stage.videos.append(StageVideo(path=video_path, role=role))
+        elif not already_registered:
+            project.unassigned_videos.append(StageVideo(path=video_path))
 
         project.save(root)
 

--- a/src/splitsmith/ui_static/src/components/AddFootageModal.tsx
+++ b/src/splitsmith/ui_static/src/components/AddFootageModal.tsx
@@ -209,7 +209,13 @@ export function AddFootageModal({
   }
 
   if (hostedMode) {
-    return <HostedUploadSurface onClose={onClose} />;
+    return (
+      <HostedUploadSurface
+        slug={slug}
+        onClose={onClose}
+        onImported={onImported}
+      />
+    );
   }
 
   return (
@@ -732,8 +738,18 @@ function StatusIcon({ state }: { state: ScanState }) {
  *  path. Today the upload terminates at object storage -- attaching
  *  to a project happens once the worker pipeline can read from S3
  *  (separate chunk per the saas-readiness roadmap). */
-function HostedUploadSurface({ onClose }: { onClose: () => void }) {
-  return <HostedUploadBody onClose={onClose} />;
+function HostedUploadSurface({
+  slug,
+  onClose,
+  onImported,
+}: {
+  slug: string;
+  onClose: () => void;
+  onImported: (imported: number) => void;
+}) {
+  return (
+    <HostedUploadBody slug={slug} onClose={onClose} onImported={onImported} />
+  );
 }
 
 interface PendingUpload {
@@ -753,11 +769,32 @@ interface PendingUpload {
   controller?: AbortController;
 }
 
-function HostedUploadBody({ onClose }: { onClose: () => void }) {
+function HostedUploadBody({
+  slug,
+  onClose,
+  onImported,
+}: {
+  slug: string;
+  onClose: () => void;
+  onImported: (imported: number) => void;
+}) {
   const [uploads, setUploads] = useState<PendingUpload[]>([]);
   const [existing, setExisting] = useState<RawUploadEntry[] | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Track which uploaded filenames the operator has attached to the
+  // current shooter's project this session, plus any inflight / error
+  // state. Persistent attachment lives on match.json (raw_videos[]);
+  // this state is just the UI flash so the operator sees the action
+  // succeed before closing the modal.
+  const [attachState, setAttachState] = useState<
+    Record<
+      string,
+      | { status: "attaching" }
+      | { status: "attached" }
+      | { status: "error"; message: string }
+    >
+  >({});
 
   // Initial list -- so the surface opens with a real "you've already
   // uploaded X" view instead of looking empty until the operator
@@ -903,6 +940,37 @@ function HostedUploadBody({ onClose }: { onClose: () => void }) {
     }
   };
 
+  const attachToProject = useCallback(
+    async (entry: RawUploadEntry) => {
+      setAttachState((prev) => ({
+        ...prev,
+        [entry.filename]: { status: "attaching" },
+      }));
+      try {
+        await api.attachRawVideo(slug, {
+          filename: entry.filename,
+          sha256: entry.etag,
+          size_bytes: entry.size,
+        });
+        setAttachState((prev) => ({
+          ...prev,
+          [entry.filename]: { status: "attached" },
+        }));
+        // The video now lives in unassigned_videos on the project; tell
+        // the parent so the ingest page refreshes and the operator sees
+        // the new row in the tray when they close the modal.
+        onImported(1);
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.detail : String(err);
+        setAttachState((prev) => ({
+          ...prev,
+          [entry.filename]: { status: "error", message: msg },
+        }));
+      }
+    },
+    [slug, onImported],
+  );
+
   const inFlight = uploads.some(
     (u) => u.status === "queued" || u.status === "hashing" || u.status === "uploading",
   );
@@ -925,8 +993,8 @@ function HostedUploadBody({ onClose }: { onClose: () => void }) {
               Upload raw footage
             </h2>
             <p className="mt-0.5 font-mono text-[0.6875rem] uppercase tracking-[0.06em] text-muted">
-              Files land in your hosted object storage. Attaching to a
-              project is a separate step.
+              Files land in your hosted storage. Attach to this project
+              to drop them into the unassigned tray.
             </p>
           </div>
           {!inFlight && (
@@ -1015,7 +1083,9 @@ function HostedUploadBody({ onClose }: { onClose: () => void }) {
                   <ExistingRow
                     key={e.path}
                     entry={e}
+                    attachState={attachState[e.filename]}
                     onDelete={() => removeUploaded(e.filename)}
+                    onAttach={() => attachToProject(e)}
                   />
                 ))}
               </ul>
@@ -1104,27 +1174,64 @@ function UploadRow({
 
 function ExistingRow({
   entry,
+  attachState,
   onDelete,
+  onAttach,
 }: {
   entry: RawUploadEntry;
+  attachState:
+    | { status: "attaching" }
+    | { status: "attached" }
+    | { status: "error"; message: string }
+    | undefined;
   onDelete: () => void;
+  onAttach: () => void;
 }) {
+  const isAttaching = attachState?.status === "attaching";
+  const isAttached = attachState?.status === "attached";
+  const attachError =
+    attachState?.status === "error" ? attachState.message : null;
   return (
     <li className="flex items-center justify-between gap-3 rounded-md border border-rule bg-surface-2 px-3 py-2">
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="truncate font-mono text-[0.75rem] text-ink">
           {entry.filename}
         </div>
         <div className="font-mono text-[0.625rem] uppercase tracking-[0.06em] text-muted">
           {formatBytes(entry.size)}
           {entry.last_modified && ` . ${formatRelative(entry.last_modified)}`}
+          {isAttached && (
+            <span className="text-done"> . attached to project</span>
+          )}
+          {attachError && (
+            <span className="text-led-text"> . {attachError}</span>
+          )}
         </div>
       </div>
+      {isAttached ? (
+        <span
+          aria-hidden
+          className="inline-flex size-5 items-center justify-center rounded-full bg-done text-bg"
+        >
+          <Check className="size-3" strokeWidth={3} />
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onAttach}
+          disabled={isAttaching}
+          aria-label={`Attach ${entry.filename} to project`}
+          className="rounded-md border border-rule-strong bg-surface px-2.5 py-1 font-mono text-[0.625rem] font-bold uppercase tracking-[0.08em] text-ink-2 hover:border-led-deep hover:bg-led-tint hover:text-led disabled:opacity-50"
+        >
+          {isAttaching ? "Attaching..." : "Attach"}
+        </button>
+      )}
       <button
         type="button"
         onClick={onDelete}
+        disabled={isAttaching}
         aria-label={`Delete ${entry.filename}`}
-        className="rounded-md p-1 text-subtle hover:bg-led-tint hover:text-led-text"
+        className="rounded-md p-1 text-subtle hover:bg-led-tint hover:text-led-text disabled:opacity-50"
       >
         <Trash2 className="size-3.5" />
       </button>

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1267,6 +1267,21 @@ export interface RawUploadEntry {
   etag: string | null;
 }
 
+/** One ``raw_videos[]`` manifest entry on ``match.json`` (doc 05).
+ *  Returned by ``POST /api/shooters/{slug}/raw-videos/attach`` after
+ *  the server merges into any existing entry with the same
+ *  ``storage_path``. The SPA reads this back to confirm the canonical
+ *  ``covers_stages`` post-merge (which may differ from what the
+ *  caller posted when an earlier attach already declared coverage). */
+export interface RawVideoManifestEntry {
+  original_filename: string;
+  size_bytes: number;
+  sha256: string | null;
+  uploaded_at: string;
+  storage_path: string;
+  covers_stages: number[];
+}
+
 /** One shot point on a shooter's timeline in /compare (#328). */
 export interface CompareShotPoint {
   shot_number: number;
@@ -2146,6 +2161,32 @@ export const api = {
         }
         xhr.send(form);
       },
+    ),
+
+  /** Hosted-mode only -- register an uploaded raw video on the
+   *  shooter's project (``POST /api/shooters/{slug}/raw-videos/attach``).
+   *
+   *  Body shape mirrors what ``uploadRawFile`` echoed back:
+   *  ``filename`` is required; ``sha256`` / ``size_bytes`` are
+   *  optional (the server defers to S3's ContentLength either way).
+   *  ``covers_stages`` is optional -- omit it for the
+   *  attach-into-unassigned-tray flow, pass an explicit array when
+   *  the caller already knows which stages the recording spans.
+   *
+   *  Returns the canonical ``RawVideo`` after dedup-merge: a re-attach
+   *  with a different covers_stages set unions them server-side. */
+  attachRawVideo: (
+    slug: string,
+    body: {
+      filename: string;
+      sha256?: string | null;
+      size_bytes?: number | null;
+      covers_stages?: number[] | null;
+    },
+  ) =>
+    request<RawVideoManifestEntry>(
+      `/api/shooters/${encodeURIComponent(slug)}/raw-videos/attach`,
+      { method: "POST", json: body },
     ),
 
   /** Server health + bind state. The picker route polls this on mount

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -460,6 +460,10 @@ def test_attach_registers_raw_video_on_project(hosted_client_with_match) -> None
     project = MatchProject.load(sroot)
     assert len(project.raw_videos) == 1
     assert project.raw_videos[0].storage_path == "raw/GH010023.mp4"
+    # Without covers_stages, the file lands in unassigned_videos so the
+    # ingest tray UI surfaces it -- same shape as local-mode scan.
+    assert len(project.unassigned_videos) == 1
+    assert str(project.unassigned_videos[0].path) == "raw/GH010023.mp4"
 
 
 def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match) -> None:


### PR DESCRIPTION
## Summary

Recreated from #432 (auto-closed when its stacked base merged). Diff is now against ``main``.

Final chunk of the attach-to-project + worker S3 cache work. With this the hosted-mode flow lands end-to-end: browser uploads to S3 -> Attach in modal -> raw_videos[] manifest entry + file in unassigned_videos -> worker streams from S3 on first detection -> existing pipeline runs unchanged.

## Changes

- Backend: attach endpoint puts file in ``unassigned_videos`` when no ``covers_stages``. Mirrors local-mode scan -> tray UX.
- SPA: ``api.attachRawVideo`` client + ``RawVideoManifestEntry`` type.
- SPA: HostedUploadSurface gets ``slug`` + ``onImported`` props; each row in ""already in storage"" gets an Attach button (attaching / attached / error states). Success calls ``onImported(1)`` so parent ingest page refreshes.

## Test plan

- [x] Backend pytest -- 1534 passed
- [x] Backend ruff + black clean
- [x] SPA tsc + vite build clean
- [ ] Manual smoke against hosted docker-compose stack (user owns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)