### PR TITLE
feat(saas): worker pushes extracted audio to S3 (Phase 1)

### DIFF
--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -23,6 +23,7 @@ open so the next access re-extracts under the new naming.
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -31,6 +32,8 @@ from pathlib import Path
 from .. import beep_detect
 from ..config import BeepDetectConfig, BeepDetection
 from .project import MatchProject, StageVideo
+
+logger = logging.getLogger(__name__)
 
 # Standard trim buffer (config.OutputConfig.trim_buffer_seconds default).
 # Used to derive the beep's position inside a trimmed clip when no trim
@@ -149,6 +152,14 @@ def ensure_video_audio(
     if audio_path.exists() and audio_path.stat().st_mtime >= src_resolved.stat().st_mtime:
         return audio_path
 
+    # Storage cache (hosted mode): another worker may have already
+    # extracted this WAV. Pulling 5 MB from S3 beats running ffmpeg
+    # against a 500 MB raw video. Local mode skips this -- ``project``
+    # has no storage bound, so the key resolves to ``None`` and the
+    # helper returns False without touching the network.
+    if _try_pull_audio_from_storage(project, audio_path):
+        return audio_path
+
     if not shutil.which(ffmpeg_binary):
         raise AudioExtractionError(f"ffmpeg binary not found: {ffmpeg_binary}")
 
@@ -173,6 +184,10 @@ def ensure_video_audio(
         raise AudioExtractionError(
             f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
         ) from exc
+    # Push the freshly-extracted WAV up to the storage cache so the
+    # next worker that touches this project can skip ffmpeg. Best-
+    # effort: a network blip during push doesn't fail the job.
+    _try_push_audio_to_storage(project, audio_path)
     return audio_path
 
 
@@ -251,7 +266,13 @@ def ensure_audit_audio(
         audio_path = audit_audio_path(project_root, stage_number, project=project)
         audio_path.parent.mkdir(parents=True, exist_ok=True)
         if not audio_path.exists() or audio_path.stat().st_mtime < trimmed_video.stat().st_mtime:
-            _extract_audio(trimmed_video, audio_path, sample_rate, ffmpeg_binary)
+            # Try the storage cache before invoking ffmpeg. The audit
+            # WAV is derived from the trimmed MP4, but its content is
+            # determined by the trim params; a worker that already
+            # produced this exact WAV pushed it under the same key.
+            if not _try_pull_audio_from_storage(project, audio_path):
+                _extract_audio(trimmed_video, audio_path, sample_rate, ffmpeg_binary)
+                _try_push_audio_to_storage(project, audio_path)
         # Beep position inside the trimmed clip = beep_in_source minus
         # trim_start. trim_start = max(0, beep - pre_buffer); so:
         #   beep_in_clip = min(beep_in_source, pre_buffer)
@@ -305,6 +326,75 @@ def _extract_audio(
         raise AudioExtractionError(
             f"ffmpeg failed (exit {exc.returncode}): {exc.stderr or exc.stdout!r}"
         ) from exc
+
+
+def _storage_audio_key(project: MatchProject | None, local_wav: Path) -> str | None:
+    """Compute the storage key for an extracted audio WAV.
+
+    Returns ``None`` in local mode (no storage bound) or when no
+    per-project scope is set -- both cases skip the storage cache.
+    The key mirrors the local layout under the project's scope:
+    ``<scope>/audio/<basename>``. The basename already includes the
+    ``video_id``, so collisions across shooters in different matches
+    are prevented by ``<scope>``.
+    """
+    if project is None or project._storage is None or project._storage_scope is None:
+        return None
+    return f"{project._storage_scope}/audio/{local_wav.name}"
+
+
+def _try_pull_audio_from_storage(project: MatchProject | None, local_wav: Path) -> bool:
+    """If the WAV exists in the project's storage cache, download it
+    into ``local_wav`` and return True. Returns False when no
+    storage is bound, the key is absent, or the download fails.
+
+    Best-effort by design: a storage hiccup falls through to ffmpeg
+    rather than failing the detection job. Logs at INFO so the
+    operator can spot a misbehaving backend without it being noisy.
+    """
+    key = _storage_audio_key(project, local_wav)
+    if key is None:
+        return False
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        if not storage.exists(key):
+            return False
+    except Exception as exc:
+        logger.info("audio cache: storage.exists(%s) raised %s", key, exc)
+        return False
+    try:
+        local_wav.parent.mkdir(parents=True, exist_ok=True)
+        with storage.open_stream(key) as src, local_wav.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return True
+    except Exception as exc:
+        logger.info("audio cache: pull from %s failed: %s", key, exc)
+        # Leave nothing half-written behind so the ffmpeg fallback
+        # doesn't trip over a torn file.
+        try:
+            local_wav.unlink()
+        except FileNotFoundError:
+            pass
+        return False
+
+
+def _try_push_audio_to_storage(project: MatchProject | None, local_wav: Path) -> None:
+    """Push a freshly-extracted WAV to the project's storage cache.
+
+    Best-effort: a push failure logs and returns; the worker still
+    has the local WAV and can serve the current job. The next
+    worker on this project will re-extract -- annoying but not
+    incorrect.
+    """
+    key = _storage_audio_key(project, local_wav)
+    if key is None:
+        return
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        with local_wav.open("rb") as f:
+            storage.upload_stream(key, f)
+    except Exception as exc:
+        logger.info("audio cache: push to %s failed: %s", key, exc)
 
 
 def trim_params_path(output: Path) -> Path:

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -798,13 +798,30 @@ class MatchProject(BaseModel):
     # falls back to the legacy path-only resolution -- desktop behavior
     # is unchanged.
     _storage: Storage | None = PrivateAttr(default=None)
+    # Per-project scope under the user's storage prefix. Used to key
+    # derived artifact caches (audio WAVs today; trim outputs in the
+    # future) so two shooters in different matches can't collide on
+    # the same ``video_id``. Typical value:
+    # ``matches/<match_id>/shooters/<slug>``. ``None`` when storage
+    # is unbound (local mode) or when there's no match scope yet.
+    _storage_scope: str | None = PrivateAttr(default=None)
 
-    def bind_storage(self, storage: Storage | None) -> None:
-        """Attach a per-request ``Storage`` so :meth:`resolve_video_path`
-        can mirror hosted-mode raw videos into the project's local
-        cache on first access. Idempotent; ``None`` clears the binding.
+    def bind_storage(self, storage: Storage | None, *, scope: str | None = None) -> None:
+        """Attach a per-request ``Storage`` so resolvers can mirror
+        hosted-mode artifacts into the project's local cache on first
+        access.
+
+        ``scope`` -- per-project prefix for derived-artifact caches
+        (audio, trims) so two shooters in different matches can't
+        collide on the same ``video_id``. ``None`` disables derived
+        caching even when ``storage`` is bound; the raw-video
+        resolver still works because it keys off the
+        user-prefix-relative ``StageVideo.path`` directly.
+
+        Idempotent; ``None``/``None`` clears the binding.
         """
         self._storage = storage
+        self._storage_scope = scope
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -691,12 +691,18 @@ class AppState:
 
         Binds :attr:`storage` onto the project so
         :meth:`MatchProject.resolve_video_path` can mirror hosted-mode
-        raw videos into the local cache on first access. Local mode
-        leaves ``storage`` at ``None``; the bind is a no-op and the
-        legacy disk-only resolver wins.
+        raw videos into the local cache on first access. The bound
+        ``scope`` is ``matches/<match_id>/shooters/<slug>`` -- used as
+        the prefix for derived-artifact caches (audio WAVs today,
+        trim outputs later) so two shooters in different matches
+        can't collide on the same ``video_id``. Local mode leaves
+        ``storage`` at ``None``; the bind is a no-op and the legacy
+        disk-only resolvers win.
         """
         project = MatchProject.load(self.shooter_root(slug))
-        project.bind_storage(self.storage)
+        match_id = current_match_id.get()
+        scope = f"matches/{match_id}/shooters/{slug}" if match_id is not None else None
+        project.bind_storage(self.storage, scope=scope)
         return project
 
     def register_match(self, root: Path) -> str | None:

--- a/tests/test_audio_storage_cache.py
+++ b/tests/test_audio_storage_cache.py
@@ -1,0 +1,268 @@
+"""Tests for the hosted-mode audio cache push/pull.
+
+The audio cache (Phase 1) is the seam that makes stateless detection
+workers viable: worker A extracts ``stage<N>_cam_<video_id>.wav``
+once, pushes it to S3, and worker B's next detection on the same
+file pulls the 5 MB WAV instead of downloading the 500 MB raw to
+re-extract.
+
+These tests stub ffmpeg via a ``subprocess.run`` monkeypatch so they
+don't depend on a real binary, and use ``FilesystemStorage`` against
+``tmp_path`` as the storage backend -- the Protocol shape is the
+same as ``S3Storage`` (proven by ``test_s3_storage.py``), so behaviour
+parity carries over.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from splitsmith.storage import FilesystemStorage
+from splitsmith.ui.audio import ensure_video_audio
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+
+@pytest.fixture
+def fake_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Replace ``subprocess.run`` so ffmpeg invocations land in a list.
+
+    Whatever ``-i <src>`` / ``<dest>`` ffmpeg would have produced, the
+    fake writes a sentinel byte to the dest path so the rest of the
+    pipeline sees a real (if tiny) WAV. Returns the list of invoked
+    arg-vectors so tests can assert "ffmpeg ran" or "ffmpeg did NOT
+    run" without inspecting subprocess internals.
+    """
+    invocations: list[list[str]] = []
+    real_which = __import__("shutil").which
+
+    def fake_which(binary: str) -> str | None:
+        # Pretend ffmpeg is installed so the early ``shutil.which``
+        # guard doesn't bail. Other binaries fall through to real.
+        if binary == "ffmpeg":
+            return "/usr/bin/ffmpeg"
+        return real_which(binary)
+
+    monkeypatch.setattr("splitsmith.ui.audio.shutil.which", fake_which)
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        invocations.append(list(cmd))
+        # The dest is the last arg in the ffmpeg invocation built by
+        # ensure_video_audio (-vn <dest>).
+        dest = Path(cmd[-1])
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"WAVDATA")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("splitsmith.ui.audio.subprocess.run", fake_run)
+    return invocations
+
+
+def _project_with_stage_video(root: Path, video_path: Path) -> tuple[MatchProject, StageVideo]:
+    project = MatchProject.init(root, name="audio-test")
+    video = StageVideo(path=video_path, role="primary")
+    project.stages = [
+        StageEntry(
+            stage_number=1,
+            stage_name="One",
+            time_seconds=10.0,
+            videos=[video],
+        )
+    ]
+    project.save(root)
+    return project, video
+
+
+def test_local_mode_no_storage_runs_ffmpeg_and_never_touches_storage(
+    tmp_path: Path, fake_ffmpeg: list[list[str]]
+) -> None:
+    """Regression guard for desktop / CLI mode: with no storage bound
+    the cache helpers are no-ops and the existing ffmpeg path runs
+    unchanged. No method on a Storage object is invoked because no
+    Storage is present.
+    """
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+
+    # Local mode == bind never called == project._storage is None.
+    assert project._storage is None
+    result = ensure_video_audio(root, 1, video, source, project=project)
+
+    assert result.exists()
+    assert result.read_bytes() == b"WAVDATA"
+    assert len(fake_ffmpeg) == 1  # ffmpeg ran exactly once
+
+
+def test_storage_cache_hit_skips_ffmpeg(tmp_path: Path, fake_ffmpeg: list[list[str]]) -> None:
+    """A WAV already present in the storage cache must be downloaded
+    instead of re-extracted. This is the cold-worker path: a fresh
+    container picks up a detection job for a previously-processed
+    video and saves the ffmpeg cost.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope="matches/m1/shooters/me")
+
+    # Pre-populate the storage cache with the WAV another worker
+    # would have produced.
+    audio_basename = f"stage1_cam_{video.video_id}.wav"
+    cached_key = f"matches/m1/shooters/me/audio/{audio_basename}"
+    storage.write_bytes(cached_key, b"PRECACHED")
+
+    result = ensure_video_audio(root, 1, video, source, project=project)
+
+    assert result.read_bytes() == b"PRECACHED"
+    assert len(fake_ffmpeg) == 0  # ffmpeg never ran
+
+
+def test_extraction_pushes_to_storage_when_cold(tmp_path: Path, fake_ffmpeg: list[list[str]]) -> None:
+    """When neither the local nor storage cache has the WAV, ffmpeg
+    runs and the result is pushed up so the next worker hits the
+    cache. This is the warm-up path that primes the cache.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope="matches/m1/shooters/me")
+
+    result = ensure_video_audio(root, 1, video, source, project=project)
+
+    assert result.read_bytes() == b"WAVDATA"
+    assert len(fake_ffmpeg) == 1
+    # The freshly-extracted WAV landed in the storage cache.
+    cached_key = f"matches/m1/shooters/me/audio/stage1_cam_{video.video_id}.wav"
+    assert storage.exists(cached_key)
+    assert storage.read_bytes(cached_key) == b"WAVDATA"
+
+
+def test_local_cache_hit_skips_storage_and_ffmpeg(tmp_path: Path, fake_ffmpeg: list[list[str]]) -> None:
+    """When the local WAV already exists and is newer than the source,
+    neither storage nor ffmpeg is consulted. The cheapest path stays
+    cheap -- repeated detection on the same worker reuses the local
+    WAV exactly as it did pre-PR.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope="matches/m1/shooters/me")
+
+    # First call extracts + pushes.
+    first = ensure_video_audio(root, 1, video, source, project=project)
+    assert len(fake_ffmpeg) == 1
+
+    # Second call must find the local WAV and short-circuit.
+    second = ensure_video_audio(root, 1, video, source, project=project)
+    assert second == first
+    assert len(fake_ffmpeg) == 1  # unchanged
+
+
+def test_storage_push_failure_does_not_break_extraction(
+    tmp_path: Path,
+    fake_ffmpeg: list[list[str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network blip during the post-extraction push must NOT fail
+    the detection job. The local WAV is the source of truth for the
+    current job; the cache push is best-effort.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    # Make upload_stream raise so the push fails. The local
+    # extraction must still succeed.
+    def boom(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("simulated R2 outage")
+
+    monkeypatch.setattr(storage, "upload_stream", boom)
+
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope="matches/m1/shooters/me")
+
+    result = ensure_video_audio(root, 1, video, source, project=project)
+    assert result.read_bytes() == b"WAVDATA"
+
+
+def test_storage_pull_torn_file_falls_through_to_ffmpeg(
+    tmp_path: Path,
+    fake_ffmpeg: list[list[str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If open_stream raises mid-copy, the helper must clean up the
+    torn local file and let ffmpeg run. Otherwise the next call
+    would happily serve a half-downloaded WAV.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope="matches/m1/shooters/me")
+    audio_basename = f"stage1_cam_{video.video_id}.wav"
+    cached_key = f"matches/m1/shooters/me/audio/{audio_basename}"
+    storage.write_bytes(cached_key, b"PRECACHED")
+
+    # Sabotage the pull: open_stream raises after exists() says True.
+    def boom(path: str) -> object:
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(storage, "open_stream", boom)
+
+    result = ensure_video_audio(root, 1, video, source, project=project)
+
+    # ffmpeg ran because the pull failed, and the local file is the
+    # ffmpeg output, not a half-downloaded PRECACHED.
+    assert result.read_bytes() == b"WAVDATA"
+    assert len(fake_ffmpeg) == 1
+
+
+def test_bind_storage_without_scope_disables_audio_cache(
+    tmp_path: Path, fake_ffmpeg: list[list[str]]
+) -> None:
+    """When storage is bound but scope is None (e.g. a non-match
+    request path), the audio cache stays off. The raw-video resolver
+    still works (it doesn't need scope); only derived artifacts do.
+    """
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=None)
+
+    ensure_video_audio(root, 1, video, source, project=project)
+
+    # ffmpeg ran; nothing landed in storage (no scope -> no key).
+    assert len(fake_ffmpeg) == 1
+    assert list(storage.list("")) == []


### PR DESCRIPTION
## Summary

The seam that makes **stateless detection workers viable**. Today every worker that picks up a detection job on a hosted-mode project must download the 500 MB raw video to extract audio. After this PR the worker that runs first does the extraction, pushes the ~5 MB WAV to S3, and every subsequent worker (including cold stateless ones) pulls the WAV instead.

**Bandwidth**: 100x reduction per detection job after first.
**Disk**: detection workers can run on 1 GB ephemeral disk instead of 60 GB persistent volume.
**Architecture**: stateless functions / shared-fleet workers become realistic infra targets without a queue rewrite.

## Storage layout

Inside the existing per-user prefix (``users/<user_id>/``):

```
raw/<filename>                                    -- uploads (unchanged)
matches/<match_id>/shooters/<slug>/audio/<wav>    -- NEW: derived cache
```

Per-(match, shooter) scope prevents two shooters' audio for the same source from colliding on ``video_id``.

## Worker decision tree

In ``ensure_video_audio`` / ``ensure_audit_audio``:

1. **Local cache hit** (mtime newer than source) -> reuse, done. (existing behavior)
2. **Storage cache hit** -> stream WAV down, skip ffmpeg. (NEW)
3. **Cold** -> ffmpeg extract, push WAV to storage, return. (NEW push)

## Local desktop mode

Bit-identical to today:

- ``state.storage`` is None
- ``MatchProject._storage`` stays None after ``bind_storage(None)``
- ``_storage_scope`` stays None
- Cache helpers short-circuit on ``project._storage is None`` before any network call
- Existing ffmpeg path runs unchanged

Verified by a dedicated regression test (``test_local_mode_no_storage_runs_ffmpeg_and_never_touches_storage``).

## What this does NOT do (Phase 2 work)

- **Async pre-extraction at upload time** -- needs a real out-of-process queue (Procrastinate, doc 04). Without that, the API container can't extract a 30-min clip without hanging the request.
- **Trim/export caching** -- trim outputs are stage-specific + change with beep_time / pre-buffer tweaks. Separate invalidation policy needed.
- **Audio invalidation API** -- if a user re-uploads the same filename with different content, the cache might serve stale audio. Manual ``storage.delete(key)`` works as a workaround.
- **Audio.wav lifecycle** -- nothing GCs the audio cache yet. Audio is ~5 MB per (stage, video) so this isn't urgent.

## Test plan

- [x] ``uv run pytest`` -- 1541 passed, 16 skipped, 3 deselected (sigterm pre-existing flake)
- [x] ``uv run ruff check`` -- clean
- [x] ``uv run black --check`` -- clean
- [x] 7 new tests cover:
  - [x] Local mode (no storage): existing ffmpeg path, storage never touched
  - [x] Storage cache hit: ffmpeg never invoked
  - [x] Cold start: ffmpeg + push to storage
  - [x] Local cache hit: storage + ffmpeg both skipped
  - [x] Storage push failure: extraction still succeeds, local WAV intact
  - [x] Storage pull torn file: cleaned up, ffmpeg fallback runs
  - [x] Storage bound without scope: cache disabled (raw-video resolver still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)