### PR TITLE
feat(saas): Procrastinate queue foundation (PR-alpha)

### DIFF
--- a/alembic/versions/ba72882f8c1c_apply_procrastinate_schema.py
+++ b/alembic/versions/ba72882f8c1c_apply_procrastinate_schema.py
@@ -1,0 +1,91 @@
+"""apply procrastinate schema
+
+Revision ID: ba72882f8c1c
+Revises: 5f824d1e237f
+Create Date: 2026-05-27
+
+Lands the Procrastinate (Postgres-native job queue) schema -- types,
+tables, indexes, functions, triggers -- alongside our own
+``compute_jobs`` table. ``compute_jobs`` stays the user-facing job
+record; ``procrastinate_jobs`` (and friends) become the dispatch
+layer that pops work to ``splitsmith worker`` processes.
+
+This migration is **Postgres-only**. Procrastinate doesn't support
+SQLite and its schema relies on custom types + PL/pgSQL functions
+that have no SQLite equivalent. The aiosqlite-backed dev/smoke runs
+(see ``pyproject.toml`` comment on the ``hosted`` extra) skip the
+migration body entirely; nothing in those code paths exercises the
+queue.
+
+We embed the schema by calling ``procrastinate.schema.SchemaManager
+.get_schema()`` so the SQL stays in lockstep with whatever
+procrastinate version is installed. Bumping the procrastinate pin in
+``pyproject.toml`` and re-running this migration on a fresh DB yields
+the new schema automatically; for existing deploys, follow
+procrastinate's release notes for any breaking migration steps.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "ba72882f8c1c"
+down_revision: str | Sequence[str] | None = "5f824d1e237f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    from procrastinate.schema import SchemaManager
+
+    op.execute(SchemaManager.get_schema())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    # Drop everything procrastinate owns. The schema only creates
+    # objects prefixed ``procrastinate_*`` so a CASCADE on the public-
+    # schema objects is safe. We list each object class explicitly so
+    # this is auditable without rerunning the upstream schema script.
+    op.execute("""
+        DO $$
+        DECLARE
+            obj record;
+        BEGIN
+            FOR obj IN
+                SELECT n.nspname AS schema, p.proname AS name,
+                       pg_get_function_identity_arguments(p.oid) AS args
+                FROM pg_proc p
+                JOIN pg_namespace n ON n.oid = p.pronamespace
+                WHERE p.proname LIKE 'procrastinate_%'
+            LOOP
+                EXECUTE format(
+                    'DROP FUNCTION IF EXISTS %I.%I(%s) CASCADE',
+                    obj.schema, obj.name, obj.args
+                );
+            END LOOP;
+
+            FOR obj IN
+                SELECT c.relname AS name
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind = 'r' AND c.relname LIKE 'procrastinate_%'
+            LOOP
+                EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', obj.name);
+            END LOOP;
+
+            FOR obj IN
+                SELECT t.typname AS name
+                FROM pg_type t
+                JOIN pg_namespace n ON n.oid = t.typnamespace
+                WHERE t.typname LIKE 'procrastinate_%'
+            LOOP
+                EXECUTE format('DROP TYPE IF EXISTS %I CASCADE', obj.name);
+            END LOOP;
+        END $$;
+        """)

--- a/docs/saas-readiness/00-context-and-principles.md
+++ b/docs/saas-readiness/00-context-and-principles.md
@@ -50,7 +50,7 @@ The bias order is:
    email, Neon for Postgres).
 2. **Library** -- open-source, well-maintained, fits the use case.
    Use it inside our own deploy (fsspec for storage abstraction,
-   SQLAlchemy for ORM, arq for job queue).
+   SQLAlchemy for ORM, Procrastinate for job queue).
 3. **Custom code** -- only when no library or service exists, and
    even then prefer a thin shim around an existing primitive.
 
@@ -69,7 +69,7 @@ is measured, not preemptively.
 | Auth (magic link) | [Clerk](https://clerk.com/) or [WorkOS](https://workos.com/) | Free tier covers <100s of users; pick after a v1 prototype with each |
 | Object storage | [Cloudflare R2](https://www.cloudflare.com/products/r2/) | S3-compatible API, **$0 egress**, ~$0.015/GB stored. Massive cost advantage over S3 for media workloads. |
 | Database hosting | [Neon](https://neon.tech/) (Postgres) or [Turso](https://turso.tech/) (SQLite-as-a-service) | Free tiers for v1; both scale up with usage |
-| Background workers (hosted) | [Inngest](https://www.inngest.com/) or [Trigger.dev](https://trigger.dev/) | Use only if `arq` + small Redis instance turns into too much ops |
+| Background workers (hosted) | [Inngest](https://www.inngest.com/) or [Trigger.dev](https://trigger.dev/) | Use only if in-deploy Procrastinate turns into too much ops |
 | Email (magic links + transactional) | [Resend](https://resend.com/) or [Postmark](https://postmarkapp.com/) | No SMTP self-hosting; generous free tiers |
 | Billing | [Stripe Checkout](https://stripe.com/docs/payments/checkout) + [Stripe webhooks](https://stripe.com/docs/webhooks) | Stripe-hosted checkout page; we never touch card data |
 | Errors / monitoring | [Sentry](https://sentry.io/) | Hosted; free tier covers our scale |
@@ -84,7 +84,7 @@ is measured, not preemptively.
 | Storage abstraction | [`fsspec`](https://filesystem-spec.readthedocs.io/) | One API across filesystem / S3 / R2 / GCS / Azure |
 | Database / migrations | [SQLAlchemy](https://www.sqlalchemy.org/) + [Alembic](https://alembic.sqlalchemy.org/) | Already idiomatic for FastAPI |
 | Auth (self-host fallback) | [Auth.js](https://authjs.dev/) backed by SQLite | If Clerk/WorkOS pricing flips at scale |
-| Job queue (in-deploy) | [arq](https://arq-docs.helpmanual.io/) (Redis-backed) or [Procrastinate](https://procrastinate.readthedocs.io/) (Postgres-backed, no Redis) | Both well-maintained, ~asyncio-native |
+| Job queue (in-deploy) | [Procrastinate](https://procrastinate.readthedocs.io/) (Postgres-backed) | Reuses our Postgres; no Redis dependency. Picked over arq because we already pay the Postgres cost. |
 | ML inference | [ONNX Runtime](https://onnxruntime.ai/) + [Web variant](https://onnxruntime.ai/docs/tutorials/web/) | Same model artifact runs server-side and in-browser |
 | ML export | [`sklearn-onnx`](https://onnx.ai/sklearn-onnx/) for GBDT | CLAP/PANN already PyTorch -> ONNX exportable |
 | Resumable upload | [tus.io](https://tus.io/) protocol; [tus-py-server](https://github.com/tus-project) + [tus-js-client](https://github.com/tus/tus-js-client) | Proven; resumes mid-upload after network drops |
@@ -285,10 +285,15 @@ questions live in the relevant doc.
   region pinning is nice for EU users (the user is in Sweden) and its
   pricing is predictable. Railway's developer experience is the
   smoothest. Decide when implementing 06-api-surface.md.
-- **Job queue: arq vs Procrastinate.** arq needs Redis. Procrastinate
-  needs Postgres (which we have anyway in v2+ but not v1). v1 might
-  ship with arq + a tiny Redis instance because v1 doesn't have
-  Postgres yet.
+- **Job queue: Procrastinate (resolved 2026-05-27).** Picked
+  Procrastinate over arq. The "v1 has no Postgres yet" caveat that
+  made arq + Redis attractive went away once hosted mode landed on
+  Postgres for the rest of the persistence layer (users,
+  recent_projects, compute_jobs). Procrastinate's
+  ``procrastinate_*`` schema lives alongside ours and is applied
+  via the same alembic stream (migration ``ba72882f8c1c``); the
+  worker entrypoint is ``splitsmith worker`` (lands in PR-beta of
+  this chunk).
 - **WASM ML bundle size budget.** GBDT-only stays under 5 MB. If we
   want to add envelope onset (currently pure DSP) as a WASM module
   too, the bundle grows but we lose a server round-trip per detection

--- a/docs/saas-readiness/01-deployment-modes.md
+++ b/docs/saas-readiness/01-deployment-modes.md
@@ -84,8 +84,10 @@ upload by default, premium pricing tier gates access.
   Holds users, projects, project members, billing entitlements,
   upload sessions. **Does NOT hold detection results -- those stay
   in the JSON files in R2** (principle 6 in doc 00).
-- Background jobs run on `arq` workers (or hosted Inngest / Trigger
-  if ops cost flips against us -- see doc 00).
+- Background jobs run on Procrastinate workers (Postgres-native
+  queue; no Redis required), spawned by the `splitsmith worker`
+  CLI. Hosted Inngest / Trigger remains the escape hatch if
+  in-deploy ops cost flips against us -- see doc 00.
 - Stripe Checkout is the paywall. Webhooks update entitlements in
   Postgres. See 08-billing-and-quotas.md.
 - Sentry is on, with PII scrubbing. PostHog optional in v2.

--- a/docs/saas-readiness/04-compute-backends.md
+++ b/docs/saas-readiness/04-compute-backends.md
@@ -175,9 +175,14 @@ spinner.
 
 ## The cloud worker
 
-A FastAPI app + an `arq` worker, deployed together (Fly machines or
-Railway services). The HTTP app receives detection requests, the
-worker processes them.
+A FastAPI app + a Procrastinate worker, deployed together (Fly
+machines or Railway services). The HTTP app receives detection
+requests; the `splitsmith worker` process drains the queue.
+Procrastinate's tables live in the same Postgres the API server
+already uses, so the worker fleet doesn't need a separate broker.
+Per-tenant queues (`user-<id>`) let us pin worker pools to specific
+tenants later -- see [HOSTED-LOCAL.md](HOSTED-LOCAL.md) "Workers"
+for the operational shape.
 
 ### Job shape
 
@@ -234,9 +239,10 @@ known storage paths.
 
 ### Failure handling
 
-- Worker crashes mid-job => `arq` retries up to 3 times with
-  exponential backoff. After 3 fails, the job moves to `failed`
-  with `error_message` set.
+- Worker crashes mid-job => Procrastinate retries up to 3 times
+  with exponential backoff (configured via the task's
+  ``retry`` policy). After 3 fails, the ``compute_jobs`` row
+  moves to ``failed`` with ``error_message`` set.
 - The user sees a "Retry" button. Retry creates a new job ID
   (different ULID) -- the failed job stays in the table for
   debugging.

--- a/docs/saas-readiness/05-uploads-and-streaming.md
+++ b/docs/saas-readiness/05-uploads-and-streaming.md
@@ -63,7 +63,7 @@ Browser                          API server                   R2
   |-- POST /api/v1/jobs ------------>|                          |
   |   { project_id, stage_n,         |                          |
   |     upload_id }                  |                          |
-  |                                  |-- enqueue arq job        |
+  |                                  |-- enqueue queue job      |
   |<-- { job_id } ------------------|                          |
 ```
 

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -137,8 +137,9 @@ later steps are blocked on earlier ones.
 - [ ] Provision R2 bucket + lifecycle rule for incomplete multipart
   uploads.
 - [ ] Provision Postgres (Neon free tier likely).
-- [ ] Provision Redis if going with `arq` (or skip if going with
-  Procrastinate).
+- [x] ~~Provision Redis if going with `arq`~~ -- not needed:
+  Procrastinate (Postgres-native) is the picked job queue
+  (resolved 2026-05-27, doc 00).
 - [ ] Wire Sentry on the API + worker.
 - [ ] Wire Resend (or Postmark) for magic-link email delivery.
 - [ ] Set up the `splitsmith.app` domain + Cloudflare in front.
@@ -215,8 +216,9 @@ later steps are blocked on earlier ones.
 - [ ] ONNX-Web GBDT artifact built + served from `/static/models/`.
 - [ ] `compute_jobs` table.
 - [ ] `RemoteComputeBackend` (server-side wrapper that creates jobs).
-- [ ] `arq` worker that processes Tier 2 jobs (CLAP + PANN
-  inference + features back).
+- [ ] Procrastinate worker (`splitsmith worker` CLI) that processes
+  Tier 2 jobs (CLAP + PANN inference + features back). PR-alpha
+  landed the schema + queue module; PR-beta lands the CLI.
 - [ ] `POST /api/v1/projects/<id>/jobs` (enqueue).
 - [ ] `GET /api/v1/jobs/<id>` (poll status).
 - [ ] SSE stream `GET /api/v1/jobs/stream` for the jobs drawer (per

--- a/docs/saas-readiness/10-singleton-elimination.md
+++ b/docs/saas-readiness/10-singleton-elimination.md
@@ -133,10 +133,13 @@ backend swaps in without touching handlers.
 1. **(done)** Define `JobBackend` Protocol; `JobRegistry`
    satisfies it; `AppState.jobs` widened to the Protocol.
 2. Pick the backing store per doc 04 -- Postgres `compute_jobs`
-   table is the spec. `arq` Redis queue is the runtime.
+   table is the spec. Procrastinate (Postgres-native) is the
+   queue runtime; its schema lives alongside `compute_jobs` in
+   the same DB.
 3. Ship a hosted-mode backend: `submit` inserts into
-   `compute_jobs`, the worker picks up via `arq`, status writes
-   land in Postgres, `list` / `get` / `cancel` read from Postgres.
+   `compute_jobs`, the worker picks up via Procrastinate, status
+   writes land in Postgres, `list` / `get` / `cancel` read from
+   Postgres.
 4. The local-mode backend stays in-memory (no Postgres dep on the
    desktop). A SQLite-backed `PersistentLocalJobBackend` is the
    obvious bridge if the desktop ever needs job persistence too

--- a/docs/saas-readiness/HOSTED-LOCAL.md
+++ b/docs/saas-readiness/HOSTED-LOCAL.md
@@ -240,21 +240,34 @@ On container restart, any `pending` / `running` row is swept to
 `failed` with `error="server restarted before this job finished"`
 -- no other process will resume them.
 
-**What's missing for a real worker fleet** (deferred to a follow-up PR):
+**What PR-alpha (2026-05-27) landed:**
+
+- [Procrastinate](https://procrastinate.readthedocs.io/) is on the
+  dependency list (hosted extra only -- local-mode wheels stay
+  queue-free). Its schema applies via alembic migration
+  `ba72882f8c1c` alongside our own tables.
+- `splitsmith.queue` exposes `build_app(database_url)` and a
+  per-tenant queue-name helper (`user-<id>` -- see "Per-tenant
+  queues" in 04). No tasks registered yet; the App is plumbing
+  only at this stage.
+
+**What's still missing for a real worker fleet** (PR-beta onwards):
 
 - A `splitsmith worker` CLI that boots a long-lived process which
-  pops jobs from a real queue and registers task handlers by name.
-- A Postgres-native queue layer ([Procrastinate](https://procrastinate.readthedocs.io/)
-  is the planned pick -- reuses our existing DB; no Redis
-  dependency). It would land a sibling `procrastinate_jobs` table
-  alongside `compute_jobs`.
+  pops jobs from a Procrastinate queue and registers task
+  handlers by name.
 - A `submit()` shape change from `fn=callable` (closure-passing)
   to `task_name + args` (worker-side registered tasks) -- this
-  cascades through ~30 callsites in `server.py`.
+  cascades through ~18 callsites in `server.py`. The plan is to
+  extract each closure body into a pure `*_body(handle, ...)`
+  function so local mode's `JobRegistry` keeps the closure path
+  (no Postgres / queue dependency on the desktop) while the
+  hosted Procrastinate task rebuilds per-user state from args and
+  calls the same body.
 
-Until then, two splitsmith containers pointed at the same Postgres
-would each only see / dispatch their own submissions; cross-container
-work-stealing doesn't exist.
+Until those land, two splitsmith containers pointed at the same
+Postgres would each only see / dispatch their own submissions;
+cross-container work-stealing doesn't exist.
 
 ### Workflows that touch the local filesystem
 

--- a/docs/saas-readiness/README.md
+++ b/docs/saas-readiness/README.md
@@ -46,8 +46,8 @@ touching.
    The `ComputeBackend` abstraction, the three-tier model
    (Tier 1 local / Tier 2 audio + cloud ML / Tier 3 full cloud), the
    browser-capability bench that drives auto-selection, the cloud
-   worker shape (`arq` + the `compute_jobs` table), and rough cost
-   sizing per tier.
+   worker shape (Procrastinate + the `compute_jobs` table), and rough
+   cost sizing per tier.
 
 6. **[05 -- Uploads and streaming](./05-uploads-and-streaming.md)**
    The tus.io upload protocol, the audio-default flow, opt-in raw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,15 @@ hosted = [
     # ``S3Storage.__init__`` (and ``__init__`` only runs in hosted
     # mode -- see ``_apply_hosted_mode_wiring``).
     "boto3>=1.35.0",
+    # Postgres-native job queue for the worker fleet (doc 04). Pulled
+    # in only via the hosted extra so local-mode wheels stay queue-
+    # free. ``splitsmith.queue`` is lazy-imported behind
+    # ``_hosted_mode_active()``; local entrypoints never reach it.
+    # ``psycopg[binary]`` ships the libpq C bindings procrastinate's
+    # PsycopgConnector needs; procrastinate itself only requires the
+    # pure ``psycopg[pool]`` and leaves the backend choice to us.
+    "procrastinate>=2.0.0",
+    "psycopg[binary]>=3.2.0",
 ]
 
 [build-system]

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -1,0 +1,97 @@
+"""Procrastinate-backed job queue (hosted mode).
+
+The Postgres-native dispatch layer that backs the worker fleet
+(see ``docs/saas-readiness/04-compute-backends.md``). Today's
+``PostgresJobBackend`` persists ``compute_jobs`` rows but drives
+them on an in-process :class:`~concurrent.futures.ThreadPoolExecutor`
+inside ``splitsmith serve``; this module is the queue layer that
+lets the dispatch step move out-of-process so a separate
+``splitsmith worker`` fleet can pop jobs.
+
+PR-alpha (this PR) lands the schema + the configured
+:class:`procrastinate.App` only. No tasks are registered yet -- task
+registration is the PR-gamma migration step where each job kind
+(``shot_detect``, ``beep_detect``, ``trim``, ...) gets split into a
+pure ``*_body`` function and a thin task wrapper that rebuilds per-
+user state from ``user_id`` + project_id alone.
+
+## Local-mode safety
+
+Importing this module pulls in ``procrastinate`` + ``psycopg``,
+which are ``[hosted]``-extra dependencies. Local desktop
+(``splitsmith ui``) must therefore never import this module --
+that's why the import lives behind ``_hosted_mode_active()`` in
+``splitsmith.ui.server._apply_hosted_mode_wiring``, alongside the
+existing lazy imports of ``splitsmith.db.*``.
+
+## Per-tenant queues
+
+Each user's tasks land on a queue named ``user-<id>``. The
+convention exists so future worker pools can be pinned to specific
+tenants (premium-tier worker fleet vs. shared free-tier pool), and
+so per-tenant rate-limiting becomes a queue-level concern instead
+of a per-task one. For now, a single worker can subscribe to all
+``user-*`` queues with one glob -- the cost of the convention
+today is zero.
+"""
+
+from __future__ import annotations
+
+import re
+
+import procrastinate
+
+
+def _to_psycopg_dsn(sqlalchemy_url: str) -> str:
+    """Translate a SQLAlchemy async URL to a psycopg3 DSN.
+
+    Procrastinate's :class:`PsycopgConnector` talks to psycopg3
+    directly, not through SQLAlchemy, so it wants a bare libpq DSN
+    (``postgresql://user:pass@host:5432/db``) -- no ``+asyncpg``
+    dialect suffix. We strip the suffix so callers can keep passing
+    the same ``SPLITSMITH_DATABASE_URL`` they already pass to
+    SQLAlchemy.
+
+    SQLite URLs raise: Procrastinate is Postgres-only, and the
+    alembic migration that lands its schema is a no-op on SQLite.
+    Callers must not construct the App against a SQLite URL.
+    """
+    if sqlalchemy_url.startswith("sqlite"):
+        raise ValueError(
+            "Procrastinate requires Postgres; got a SQLite URL. "
+            "SQLite-backed dev/smoke runs don't exercise the queue."
+        )
+    # ``postgresql+asyncpg://...`` -> ``postgresql://...``
+    return re.sub(r"^postgresql\+\w+://", "postgresql://", sqlalchemy_url)
+
+
+def build_app(database_url: str) -> procrastinate.App:
+    """Build the configured :class:`procrastinate.App`.
+
+    ``database_url`` is the same ``SPLITSMITH_DATABASE_URL`` value
+    consumed by SQLAlchemy elsewhere. The async/asyncpg dialect
+    suffix is stripped here so psycopg3 can parse it.
+
+    The returned App has **no tasks registered**. Task registration
+    happens in PR-gamma when each job kind gets its task wrapper.
+    Until then, callers can still use this App for the dispatch
+    plumbing (open/close connector, run the worker loop with a no-op
+    handler) so PR-beta's ``splitsmith worker`` smoke test is wirable
+    against a real queue.
+    """
+    dsn = _to_psycopg_dsn(database_url)
+    connector = procrastinate.PsycopgConnector(kwargs={"conninfo": dsn})
+    return procrastinate.App(connector=connector)
+
+
+def queue_name_for_user(user_id: str) -> str:
+    """Return the per-tenant queue name for ``user_id``.
+
+    Convention: ``user-<id>``. See module docstring for the
+    rationale. ``user_id`` is the ULID from the ``users`` table;
+    callers should never pass an unsanitised email or any value
+    they didn't read out of the DB.
+    """
+    if not isinstance(user_id, str) or not user_id:
+        raise ValueError(f"queue_name_for_user requires a non-empty user_id; got {user_id!r}")
+    return f"user-{user_id}"

--- a/tests/test_local_mode_no_hosted_imports.py
+++ b/tests/test_local_mode_no_hosted_imports.py
@@ -1,0 +1,124 @@
+"""Pin the lazy-import contract that keeps local desktop free of
+hosted-mode dependencies.
+
+Local-mode entrypoints (``splitsmith ui``, ``splitsmith cli`` --
+any path that doesn't set ``SPLITSMITH_MODE=hosted``) must never
+pull in:
+
+- ``splitsmith.db`` -- the SQLAlchemy stores
+- ``splitsmith.queue`` -- the Procrastinate App + queue helpers
+- ``procrastinate`` / ``psycopg`` -- the queue's transitive deps
+- ``sqlalchemy`` / ``asyncpg`` / ``aiosqlite`` / ``alembic`` -- the
+  DB layer's transitive deps
+- ``boto3`` -- the ``S3Storage`` backend
+- ``ulid`` -- ``python-ulid`` only used by Postgres-backed stores
+
+If any of these slip into the module-level import chain, a slim
+local-mode wheel without the ``[hosted]`` extra would crash on
+``import splitsmith.cli`` before the user types anything. This
+test catches that drift before it ships.
+
+The check runs in a subprocess so it sees a clean ``sys.modules``;
+the in-process test runner already has half the codebase imported.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+# Modules that MUST NOT appear in sys.modules after importing a
+# local-mode entrypoint. We match by exact name OR ``name.``
+# prefix (so ``sqlalchemy.orm`` is caught when checking ``sqlalchemy``).
+FORBIDDEN_PREFIXES = (
+    "splitsmith.db",
+    "splitsmith.queue",
+    "procrastinate",
+    "psycopg",
+    "sqlalchemy",
+    "asyncpg",
+    "aiosqlite",
+    "alembic",
+    "boto3",
+    "botocore",
+    "ulid",
+)
+
+
+def _run_import_probe(entrypoint_import: str) -> set[str]:
+    """Spawn a child python process, run ``entrypoint_import``, return
+    the set of forbidden modules that ended up in sys.modules.
+
+    The child writes the offending module names to stdout, one per
+    line. An empty stdout means the import was clean.
+    """
+    script = textwrap.dedent(f"""
+        import sys, os
+        # Make absolutely sure the child does not think it's in hosted
+        # mode (the parent env may have leaked an override).
+        os.environ.pop("SPLITSMITH_MODE", None)
+        {entrypoint_import}
+        forbidden_prefixes = {FORBIDDEN_PREFIXES!r}
+        bad = sorted(
+            name for name in sys.modules
+            if any(name == p or name.startswith(p + ".") for p in forbidden_prefixes)
+        )
+        for name in bad:
+            print(name)
+        """)
+    env = {**os.environ}
+    # Strip mode override; the parent test runner may have set it for
+    # other tests' fixtures.
+    env.pop("SPLITSMITH_MODE", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return {line for line in result.stdout.splitlines() if line.strip()}
+
+
+def test_importing_splitsmith_cli_does_not_pull_in_hosted_deps() -> None:
+    """``splitsmith.cli`` is the Typer app exposed by the ``splitsmith``
+    console-script. A local user typing ``splitsmith ui`` enters
+    through here; the import must stay free of hosted-only deps."""
+    bad = _run_import_probe("import splitsmith.cli")
+    assert not bad, (
+        "Local-mode entrypoint pulled in hosted-only modules. "
+        f"Found: {sorted(bad)}. Check ``splitsmith.cli`` and any "
+        "module it imports for accidental top-level imports of "
+        "``splitsmith.db`` / ``splitsmith.queue`` / SQLAlchemy / etc. "
+        "Hosted-only code must live behind ``_hosted_mode_active()``."
+    )
+
+
+def test_importing_splitsmith_ui_server_does_not_pull_in_hosted_deps() -> None:
+    """``splitsmith.ui.server`` is what ``cli.ui`` lazy-imports to
+    boot the local-mode FastAPI app. Its module-level imports must
+    stay clean even though ``_apply_hosted_mode_wiring`` (gated by
+    ``_hosted_mode_active``) does pull the hosted layer in."""
+    bad = _run_import_probe("import splitsmith.ui.server")
+    assert not bad, (
+        "Hosted-only modules leaked at server module load time. "
+        f"Found: {sorted(bad)}. The hosted-mode imports inside "
+        "``_apply_hosted_mode_wiring`` must stay inside the function "
+        "body, not move to module scope."
+    )
+
+
+def test_queue_module_is_not_eagerly_imported() -> None:
+    """Direct guard on ``splitsmith.queue`` specifically -- the
+    Procrastinate App is the thing this PR adds, so the regression
+    we care most about is some future refactor accidentally
+    importing it from the local-mode path."""
+    bad = _run_import_probe("import splitsmith")
+    queue_leaked = {m for m in bad if m == "splitsmith.queue" or m.startswith("splitsmith.queue.")}
+    assert not queue_leaked, (
+        "``splitsmith.queue`` leaked into a plain ``import splitsmith``. "
+        "It must only be imported behind ``_hosted_mode_active()`` "
+        "(same lazy-import pattern as ``splitsmith.db``)."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -630,6 +639,18 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -2311,6 +2332,24 @@ wheels = [
 ]
 
 [[package]]
+name = "procrastinate"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "attrs" },
+    { name = "croniter" },
+    { name = "packaging" },
+    { name = "psycopg", extra = ["pool"] },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/cd/cbb88b0f19fa94e8a610af2fd3844e96b70591f4263ef4c36f10e4ebe4e2/procrastinate-3.8.1.tar.gz", hash = "sha256:cf7f11dfd4247daa166e9b61a211f9d5b70512d86eccc2bf4298f6ad182a32fa", size = 85343, upload-time = "2026-04-08T06:24:21.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/ef/05a54e7ef9328d3d91a1a3b84ccf08a578128a48c57cd1117d1fbd8e6f17/procrastinate-3.8.1-py3-none-any.whl", hash = "sha256:67db4e9f0243c45775c02a0090fb3bfc7877d496e6b279d960d9ad4b1fa2f185", size = 148736, upload-time = "2026-04-08T06:24:19.754Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2323,6 +2362,90 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
     { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
     { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -3297,6 +3420,8 @@ hosted = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "boto3" },
+    { name = "procrastinate" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "python-ulid" },
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
@@ -3335,6 +3460,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "onnxruntime", specifier = ">=1.20.0" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "procrastinate", marker = "extra == 'hosted'", specifier = ">=2.0.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'hosted'", specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -3728,6 +3855,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First step of the worker-fleet chunk (doc 04 / [HOSTED-LOCAL.md](../blob/main/docs/saas-readiness/HOSTED-LOCAL.md) "Workers"). Lands the Postgres-native job queue **dependency, schema, and configured App** -- but **no dispatch changes**, so runtime behaviour is identical to `main`. The `submit()` reshape and `splitsmith worker` CLI land in follow-up PRs.

Chosen over arq because hosted mode already runs on Postgres for the rest of the persistence layer; the "v1 has no Postgres yet" caveat that made arq + Redis attractive is gone.

## What's in this PR

- **Dependency**: `procrastinate>=2.0.0` + `psycopg[binary]>=3.2.0` added to the `[hosted]` extra **only**. Local-mode wheels stay queue-free. (procrastinate declares `psycopg[pool]` but leaves the binary backend choice to us.)
- **Migration** `ba72882f8c1c`: applies Procrastinate's bundled schema via `SchemaManager.get_schema()`. **Postgres-only** -- SQLite-backed dev/smoke runs are a no-op (Procrastinate doesn't support SQLite). Up/down round-trip verified on SQLite.
- **`splitsmith.queue`**: `build_app(database_url)` (strips the `+asyncpg` dialect suffix for psycopg3) + `queue_name_for_user(user_id) -> "user-<id>"` for the per-tenant queue convention. Lazy-importable behind `SPLITSMITH_MODE=hosted`; **no tasks registered yet**.
- **`tests/test_local_mode_no_hosted_imports.py`**: 3 subprocess-based tests that pin the lazy-import contract -- importing `splitsmith.cli` / `splitsmith.ui.server` / `splitsmith` must not pull in procrastinate / sqlalchemy / asyncpg / psycopg / boto3 / alembic / ulid. Regression-proofs "local desktop stays queue-free".
- **Docs**: arq -> Procrastinate across the saas-readiness set (00, 01, 04, 05, 09, 10, README); HOSTED-LOCAL "Workers" section now reflects what landed vs. what's deferred.

## Local-mode safety

The whole point of the chunking: local desktop must not regress and must not grow a queue dependency. Enforced by (1) procrastinate living in the hosted extra, (2) `splitsmith.queue` being lazy-imported behind the hosted gate, and (3) the new import-contract test.

## Test plan

- [x] `ruff check` + `black --check` clean on new/changed files
- [x] `pytest` -- 1544 passing, 16 skipped
- [x] New lazy-import tests pass (3/3)
- [x] Migration up/down/up round-trip on SQLite (no-op path)
- [ ] Migration applies on real Postgres -- exercised by the docker smoke (`pytest -m docker`) once the queue is dispatched against in PR-beta
- [ ] Note: `test_sigterm_to_main_exits_clean` fails on this branch **and on clean `main`** (reproduced by stashing this PR's changes). Pre-existing, unrelated to this PR -- tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)