### PR TITLE
fix(ui): don't block graceful shutdown on the model prefetch

### DIFF
--- a/src/splitsmith/ui/embedded.py
+++ b/src/splitsmith/ui/embedded.py
@@ -204,6 +204,14 @@ def run_embedded(
         # /api/shutdown or SIGTERM already kicked the drain, this is a
         # no-op past the first transition.
         splitsmith_state.jobs.begin_shutdown()
+        # The boot-time model prefetch is a best-effort, resumable
+        # background download (~150 MB on a cold cache). Draining it
+        # would block shutdown for up to the full timeout while the
+        # download finishes; cancel it so the drain only waits on
+        # user-initiated work (shot-detect / trim / export), whose loss
+        # mid-flight would actually matter. The prefetch resumes on the
+        # next boot.
+        _cancel_resumable_jobs(splitsmith_state.jobs)
         splitsmith_state.jobs.wait_for_drain(shutdown_timeout)
         server.should_exit = True
         thread.join(timeout=shutdown_timeout)
@@ -214,6 +222,33 @@ def run_embedded(
             )
             server.force_exit = True
             thread.join(timeout=5.0)
+
+
+# Job kinds that are safe to abandon on shutdown -- background work
+# that re-runs cleanly on the next boot, so we cancel rather than
+# drain them. Keep this narrow: user-initiated jobs (shot-detect,
+# trim, export) must NOT be listed; their loss mid-flight matters.
+_RESUMABLE_JOB_KINDS = ("model_download",)
+
+
+def _cancel_resumable_jobs(jobs: Any) -> None:
+    """Cancel best-effort background jobs so the drain doesn't wait on them.
+
+    The :class:`JobBackend` API is async; ``run_embedded``'s teardown
+    runs on a plain (non-async) thread, so each call is bridged through
+    ``asyncio.run``. Best-effort: any failure here is logged and
+    swallowed -- a stuck cancel must not block the shutdown path it's
+    meant to speed up.
+    """
+    import asyncio
+
+    for kind in _RESUMABLE_JOB_KINDS:
+        try:
+            job = asyncio.run(jobs.find_active(kind=kind))
+            if job is not None:
+                asyncio.run(jobs.cancel(job.id))
+        except Exception:  # noqa: BLE001 -- shutdown path must never raise
+            logger.warning("failed to cancel resumable job kind %r on shutdown", kind, exc_info=True)
 
 
 def _env_int(name: str, default: int) -> int:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -840,6 +840,13 @@ def _run_model_download_job(handle: JobHandle) -> None:
             base: int = completed_bytes,
             cap: int = slug_bytes,
         ) -> None:
+            # Fires once per ~1 MB chunk (see models.download). Checking
+            # cancel here lets an in-flight artifact abort within a chunk
+            # instead of only at artifact boundaries -- the difference
+            # between a sub-second shutdown and waiting out a ~150 MB
+            # download. The prefetch is resumable on next boot, so
+            # abandoning it mid-stream loses nothing.
+            handle.check_cancel()
             if total_bytes:
                 handle.update(progress=(base + min(seen, cap)) / total_bytes)
 

--- a/tests/test_ui_embedded.py
+++ b/tests/test_ui_embedded.py
@@ -156,3 +156,89 @@ def _read_banner(proc: subprocess.Popen[str], *, deadline_s: float) -> str:
         if line.startswith(READY_PREFIX + " "):
             return line.rstrip("\n")
     raise TimeoutError("never saw SPLITSMITH_READY banner")
+
+
+def _await(coro):
+    """Run an async JobBackend coroutine from a sync test body."""
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _submit_blocking_job(registry, kind: str, started, release):
+    """Submit a job that blocks until cancelled or ``release`` is set.
+
+    ``started`` is set once the worker is actually running so the test
+    can cancel a RUNNING (not just PENDING) job. The worker raises
+    ``JobCancelled`` when cancel is requested -- the cooperative
+    contract real workers follow.
+    """
+    from splitsmith.ui.jobs import JobCancelled
+
+    def _block(handle) -> None:
+        started.set()
+        while True:
+            if handle.is_cancel_requested():
+                raise JobCancelled()
+            if release.wait(0.02):
+                return
+
+    return _await(registry.submit(kind=kind, fn=_block))
+
+
+def _wait_status(registry, job_id: str, *, deadline_s: float = 3.0):
+    """Poll the registry until ``job_id`` reaches a terminal status."""
+    from splitsmith.ui.jobs import JobStatus
+
+    terminal = {JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED}
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        job = _await(registry.get(job_id))
+        if job is not None and job.status in terminal:
+            return job
+        time.sleep(0.02)
+    return _await(registry.get(job_id))
+
+
+def test_cancel_resumable_jobs_cancels_model_download_only() -> None:
+    """Shutdown abandons the resumable model prefetch but lets
+    user-initiated work keep draining.
+
+    Regression guard for the SIGTERM-hang fix: the boot-time
+    ``model_download`` prefetch used to block graceful shutdown for the
+    full drain timeout while a ~150 MB download finished.
+    ``_cancel_resumable_jobs`` must cancel it (and nothing else)."""
+    import threading
+
+    from splitsmith.ui.embedded import _cancel_resumable_jobs
+    from splitsmith.ui.jobs import JobRegistry, JobStatus
+
+    registry = JobRegistry(max_concurrent=2)
+    try:
+        dl_started = threading.Event()
+        dl_release = threading.Event()
+        user_started = threading.Event()
+        user_release = threading.Event()
+
+        dl_job = _submit_blocking_job(registry, "model_download", dl_started, dl_release)
+        user_job = _submit_blocking_job(registry, "shot_detect", user_started, user_release)
+
+        assert dl_started.wait(3.0), "model_download worker never started"
+        assert user_started.wait(3.0), "shot_detect worker never started"
+
+        _cancel_resumable_jobs(registry)
+
+        cancelled = _wait_status(registry, dl_job.id)
+        assert cancelled is not None and cancelled.status == JobStatus.CANCELLED
+
+        # The user-initiated job must be untouched -- still running.
+        user_now = _await(registry.get(user_job.id))
+        assert user_now is not None and user_now.status == JobStatus.RUNNING
+
+        # Let the user job finish so the registry drains cleanly.
+        user_release.set()
+        done = _wait_status(registry, user_job.id)
+        assert done is not None and done.status == JobStatus.SUCCEEDED
+    finally:
+        registry.begin_shutdown()
+        registry.wait_for_drain(2.0)


### PR DESCRIPTION
## Summary

`test_sigterm_to_main_exits_clean` fails on `main` (reproducible by stashing any unrelated change). Root cause: on boot the embedded server fires a `model_download` job that fetches ~150 MB of ONNX artifacts over the network (~33s on a cold cache). While it runs, `JobRegistry.active_count() > 0`, so the shutdown path's `wait_for_drain(30)` blocks the full 30s timeout on SIGTERM -- and the test's 35s wait loses the race.

The prefetch is **best-effort and resumable on next boot**, so it should be *abandoned*, not *drained*, on shutdown.

## Changes

- `run_embedded` teardown cancels resumable background jobs (`_RESUMABLE_JOB_KINDS = ("model_download",)`) before `wait_for_drain`, so the drain only blocks on user-initiated work (shot-detect / trim / export) whose mid-flight loss actually matters.
- `_run_model_download_job` checks cancel inside the per-chunk progress callback (~1 MB cadence, see `models.download`) so an in-flight artifact aborts within a chunk instead of only at artifact boundaries.

Shutdown during an active prefetch: **~33s -> ~0.7s**.

## Why this is the right fix (not just a test tweak)

This is a real production wart: a user pressing Ctrl+C during first-boot model download waited up to 30s. The fix makes shutdown snappy while preserving drain-on-shutdown for jobs that represent real user work. The `model_download` kind is narrow on purpose -- user-initiated kinds are explicitly NOT abandoned.

Note: on hosted mode with models baked into the image (planned, doc 04), `_maybe_submit_model_download` no-ops entirely (`status() == present`), so this path is primarily the local-desktop cold-cache story. The fix is correct there regardless.

## Test plan

- [x] New `test_cancel_resumable_jobs_cancels_model_download_only` -- network-free; asserts the prefetch is cancelled while a concurrent `shot_detect` job keeps draining to SUCCEEDED.
- [x] `test_sigterm_to_main_exits_clean` now passes (file: 7 passed in ~5s, was 37s for the one failing test).
- [x] 179 job/model/shutdown-related tests pass.
- [x] ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)