### PR TITLE
feat(docker): bake slim ONNX models into the hosted image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,32 @@ RUN uv sync --frozen --no-dev --extra hosted
 RUN chown -R splitsmith:splitsmith /app
 USER splitsmith
 
+# Pin the config dir so the model cache (``<config_dir>/models``) lands
+# at a fixed, baked-in path that the build step below and the runtime
+# both agree on -- independent of the platform default, which differs
+# between the build user and any future runtime user/home.
 ENV PATH="/app/.venv/bin:${PATH}" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    SPLITSMITH_CONFIG_DIR=/home/splitsmith/.splitsmith
+
+# Bake the slim ONNX model artifacts (~450 MB: CLAP + PANN + text
+# embeddings) into the image. This is the whole point of running a
+# persistent worker fleet: a cold worker loads models from local disk
+# instead of paying a ~450 MB download on first detection (doc 04 --
+# "model artifacts live in a baked-in Docker layer"). With models
+# present, ``_maybe_submit_model_download`` no-ops at boot, so neither
+# the API nor a worker ever fetches at runtime.
+#
+# Gated behind ``BAKE_MODELS`` so offline / network-restricted builds
+# (e.g. some CI) can opt out with ``--build-arg BAKE_MODELS=0`` and
+# fall back to the runtime-download path. Default on.
+ARG BAKE_MODELS=1
+RUN if [ "$BAKE_MODELS" = "1" ]; then \
+        splitsmith fetch-models; \
+    else \
+        echo "BAKE_MODELS=0 -- skipping model bake; runtime will download on first detection"; \
+    fi
 
 EXPOSE 5174
 


### PR DESCRIPTION
## Summary

Prerequisite for the persistent worker fleet (doc 04). A worker only pays off if a cold start loads models from local disk instead of downloading ~450 MB (CLAP + PANN + text embeddings) on its first detection. This bakes the artifacts into the image so **neither the API nor any worker fetches at runtime** -- with the cache populated, `_maybe_submit_model_download` no-ops at boot.

## Changes (Dockerfile only)

- Pin `SPLITSMITH_CONFIG_DIR=/home/splitsmith/.splitsmith` so the build-time fetch and the runtime agree on the cache location (`<config_dir>/models`), independent of the platform default.
- Run `splitsmith fetch-models` after the package install, as the non-root `splitsmith` user so the cache is owned correctly.
- Gate behind `ARG BAKE_MODELS=1` (default on); offline / network-restricted builds opt out with `--build-arg BAKE_MODELS=0` and fall back to the runtime-download path.

## Why now

This is the "dynamic management" enabler discussed for worker separation: persistent workers + baked models means the per-job model cost is zero (process singleton `_ENSEMBLE_RUNTIME`) and the per-worker-start cost is a RAM load, not a network download. Image grows by ~450 MB -- the intended tradeoff.

## Test plan

- [ ] `docker build` succeeds with the bake step (local build in progress)
- [ ] `splitsmith fetch-models` populates `/home/splitsmith/.splitsmith/models` in the image
- [ ] Boot the container; confirm no `model_download` job fires (artifacts present)
- [ ] `--build-arg BAKE_MODELS=0` still builds and falls back to runtime download

🤖 Generated with [Claude Code](https://claude.com/claude-code)