### PR TITLE
fix(db): apply procrastinate schema statement-by-statement (asyncpg)

### DIFF
--- a/alembic/versions/ba72882f8c1c_apply_procrastinate_schema.py
+++ b/alembic/versions/ba72882f8c1c_apply_procrastinate_schema.py
@@ -25,6 +25,7 @@ the new schema automatically; for existing deploys, follow
 procrastinate's release notes for any breaking migration steps.
 """
 
+import re
 from collections.abc import Sequence
 
 from alembic import op
@@ -34,6 +35,70 @@ down_revision: str | Sequence[str] | None = "5f824d1e237f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Matches an opening/closing dollar-quote tag: ``$$`` or ``$name$``.
+_DOLLAR_TAG_RE = re.compile(r"\$[A-Za-z0-9_]*\$")
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a multi-statement SQL script into individual statements.
+
+    asyncpg (our production driver) rejects multiple commands in a
+    single ``execute`` -- "cannot insert multiple commands into a
+    prepared statement". Procrastinate ships its schema as one ~40-
+    statement script, so we split on top-level ``;`` and run each
+    statement on its own.
+
+    The split is dollar-quote aware: Procrastinate's PL/pgSQL function
+    bodies are wrapped in ``$$ ... $$`` (or ``$tag$ ... $tag$``) and
+    contain their own semicolons that must NOT split the statement.
+    ``--`` line comments are skipped so a semicolon inside a comment
+    can't break a statement boundary.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(sql)
+    dollar_tag: str | None = None
+    while i < n:
+        if dollar_tag is None:
+            # Line comment: skip to end of line.
+            if sql.startswith("--", i):
+                eol = sql.find("\n", i)
+                if eol == -1:
+                    break
+                buf.append(sql[i:eol])
+                i = eol
+                continue
+            # Opening dollar quote ($tag$).
+            m = _DOLLAR_TAG_RE.match(sql, i)
+            if m:
+                dollar_tag = m.group(0)
+                buf.append(dollar_tag)
+                i = m.end()
+                continue
+            if sql[i] == ";":
+                stmt = "".join(buf).strip()
+                if stmt:
+                    statements.append(stmt)
+                buf = []
+                i += 1
+                continue
+            buf.append(sql[i])
+            i += 1
+        else:
+            # Inside a dollar-quoted body: only the matching tag closes it.
+            if sql.startswith(dollar_tag, i):
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                dollar_tag = None
+                continue
+            buf.append(sql[i])
+            i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
 
 def upgrade() -> None:
     bind = op.get_bind()
@@ -41,7 +106,8 @@ def upgrade() -> None:
         return
     from procrastinate.schema import SchemaManager
 
-    op.execute(SchemaManager.get_schema())
+    for statement in _split_sql_statements(SchemaManager.get_schema()):
+        op.execute(statement)
 
 
 def downgrade() -> None:

--- a/tests/test_procrastinate_migration.py
+++ b/tests/test_procrastinate_migration.py
@@ -1,0 +1,114 @@
+"""Guards for the procrastinate-schema migration's SQL splitter.
+
+Regression coverage for the asyncpg "cannot insert multiple commands
+into a prepared statement" failure: Procrastinate ships its schema as
+one ~40-statement script, and ``op.execute`` of the whole blob blows
+up under asyncpg (our production driver). The migration splits the
+script into individual statements; these tests pin the splitter so a
+future edit can't silently reintroduce the multi-command execute or
+break dollar-quote handling.
+
+The split-correctness logic is driver-agnostic and needs no database,
+so it runs in the normal (non-docker) CI lane -- which is the whole
+point: the bug shipped because the only Postgres coverage was the
+``-m docker`` smoke that CI skips. A real end-to-end apply is covered
+by ``scripts/smoke_hosted.sh`` / ``pytest -m docker``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "alembic"
+    / "versions"
+    / "ba72882f8c1c_apply_procrastinate_schema.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("_proc_migration", _MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _is_comment_only(stmt: str) -> bool:
+    return all((not ln.strip()) or ln.strip().startswith("--") for ln in stmt.splitlines())
+
+
+def test_splits_plain_statements() -> None:
+    split = _load_migration()._split_sql_statements
+    out = split("CREATE TABLE a (id int); CREATE TABLE b (id int);")
+    assert out == ["CREATE TABLE a (id int)", "CREATE TABLE b (id int)"]
+
+
+def test_dollar_quoted_body_semicolons_do_not_split() -> None:
+    """A PL/pgSQL function body holds its own ``;`` -- the split must
+    treat the whole ``$$ ... $$`` block as one statement."""
+    split = _load_migration()._split_sql_statements
+    sql = (
+        "CREATE FUNCTION f() RETURNS void AS $$\n"
+        "BEGIN\n"
+        "  PERFORM 1;\n"
+        "  PERFORM 2;\n"
+        "END;\n"
+        "$$ LANGUAGE plpgsql;\n"
+        "CREATE TABLE t (id int);"
+    )
+    out = split(sql)
+    assert len(out) == 2
+    assert out[0].startswith("CREATE FUNCTION f()")
+    assert "PERFORM 1;" in out[0] and "PERFORM 2;" in out[0]
+    assert out[1] == "CREATE TABLE t (id int)"
+
+
+def test_tagged_dollar_quote() -> None:
+    split = _load_migration()._split_sql_statements
+    sql = (
+        "CREATE FUNCTION g() RETURNS void AS $body$ BEGIN PERFORM 1; END; $body$ "
+        "LANGUAGE plpgsql; SELECT 1;"
+    )
+    out = split(sql)
+    assert len(out) == 2
+    assert "$body$" in out[0] and "PERFORM 1;" in out[0]
+    assert out[1] == "SELECT 1"
+
+
+def test_semicolon_in_line_comment_does_not_split() -> None:
+    split = _load_migration()._split_sql_statements
+    sql = "CREATE TABLE a (id int); -- trailing; comment with; semicolons\nCREATE TABLE b (id int);"
+    out = split(sql)
+    assert len(out) == 2
+    assert out[0] == "CREATE TABLE a (id int)"
+    assert out[1].endswith("CREATE TABLE b (id int)")
+
+
+def test_trailing_statement_without_semicolon_kept() -> None:
+    split = _load_migration()._split_sql_statements
+    assert split("SELECT 1; SELECT 2") == ["SELECT 1", "SELECT 2"]
+
+
+def test_real_procrastinate_schema_splits_cleanly() -> None:
+    """The actual shipped schema must split into many individual
+    statements, none empty, none comment-only, with balanced ``$$`` in
+    every function body. This is the exact blob that broke on asyncpg."""
+    pytest.importorskip("procrastinate")
+    from procrastinate.schema import SchemaManager
+
+    split = _load_migration()._split_sql_statements
+    out = split(SchemaManager.get_schema())
+
+    assert len(out) > 1, "schema must split into multiple statements"
+    assert all(s.strip() for s in out), "no empty statements"
+    assert not any(_is_comment_only(s) for s in out), "no comment-only statements (asyncpg rejects them)"
+
+    fns = [s for s in out if "FUNCTION" in s.upper()]
+    assert fns, "expected function definitions in the schema"
+    for fn in fns:
+        assert fn.count("$$") % 2 == 0, f"unbalanced $$ in function body: {fn[:60]!r}"


### PR DESCRIPTION
## Summary

**main is broken on Postgres.** The procrastinate-schema migration from #437 ran `op.execute()` on Procrastinate's entire ~40-statement schema blob. That no-ops on SQLite (the only Postgres-free path, which is all CI runs), but on real Postgres via **asyncpg** it dies with:

> asyncpg.exceptions.PostgresSyntaxError: cannot insert multiple commands into a prepared statement

So every `SPLITSMITH_MODE=hosted` boot fails at `alembic upgrade head`. Found while bringing the docker-compose stack up.

## Why CI missed it

The only Postgres coverage is `tests/test_hosted_docker_smoke.py`, marked `@pytest.mark.docker` and **excluded from the default pytest run** -- CI never executes it. The SQLite lane no-ops the migration (`if bind.dialect.name != "postgresql": return`), so it passed green.

## Fix

- Split the schema on top-level `;`, **dollar-quote aware** (`$$` / `$tag$` PL/pgSQL bodies keep their internal semicolons) and skipping `--` line comments, then `op.execute` each statement individually.
- Add `tests/test_procrastinate_migration.py` -- fast, **db-free** unit coverage of the splitter (plain statements, dollar-quoted bodies with internal `;`, tagged `$body$` quotes, `;` inside comments, trailing statement without `;`, and the real shipped schema: many statements, none empty/comment-only, balanced `$$`). This runs in the normal CI lane, closing the gap.

Editing the already-merged migration in place is safe: it never applied successfully on any Postgres, so no deployed DB holds the old form.

## Test plan

- [x] `pytest tests/test_procrastinate_migration.py` -- 6 passed
- [x] ruff + black clean
- [x] **Verified end-to-end**: `docker compose up` now boots healthy; `alembic upgrade head` reaches `ba72882f8c1c`; Postgres has all 4 `procrastinate_*` tables + 18 functions. (A repeatable smoke script lands in the follow-up Dockerfile-slimming PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)