### PR TITLE
feat(docker): multi-stage slim image + hosted smoke script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Keep the Docker build context tight. The image build only needs the
+# package source (incl. the built SPA at src/splitsmith/ui_static/dist),
+# the dependency manifests, and the alembic migrations. Everything below
+# is either dev-only, regenerable, or huge (node_modules) -- excluding it
+# speeds the context upload and keeps junk out of the builder stage.
+
+.git
+.github
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+**/__pycache__
+**/*.pyc
+**/*.pyo
+
+# SPA build *inputs* -- only the built dist/ ships. node_modules alone is
+# ~280 MB and never needed at runtime; the TS source + tooling configs are
+# build-time only. Mirrors the wheel's hatch excludes.
+src/splitsmith/ui_static/node_modules
+src/splitsmith/ui_static/src
+src/splitsmith/ui_static/package.json
+src/splitsmith/ui_static/package-lock.json
+src/splitsmith/ui_static/pnpm-lock.yaml
+src/splitsmith/ui_static/vite.config.ts
+src/splitsmith/ui_static/tsconfig*.json
+src/splitsmith/ui_static/index.html
+src/splitsmith/ui_static/*.config.js
+**/*.map
+
+# Dev-only trees nothing in the image reads.
+tests
+docs
+examples
+build
+scripts
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,32 @@ COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /uvx /usr/local/bin/
 ENV UV_PYTHON_DOWNLOADS=never \
     UV_LINK_MODE=copy
 
+# Static ffmpeg + ffprobe (John Van Sickle release builds -- fully
+# statically linked, no runtime shared libs). Replaces the Debian
+# ``ffmpeg`` package, which drags ~300 MB of codec/dev libraries into
+# the runtime image; the static binaries are ~80 MB and self-contained.
+# ``TARGETARCH`` is provided automatically by buildx (amd64 / arm64).
+# The release URL tracks the latest stable ffmpeg; it isn't strictly
+# version-pinned, which is acceptable for a CLI we only shell out to.
+ARG TARGETARCH
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl xz-utils; \
+    rm -rf /var/lib/apt/lists/*; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) ff_arch=amd64 ;; \
+        arm64) ff_arch=arm64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${ff_arch}-static.tar.xz" \
+        -o /tmp/ffmpeg.tar.xz; \
+    mkdir -p /tmp/ffmpeg; \
+    tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1; \
+    install -m0755 /tmp/ffmpeg/ffmpeg /tmp/ffmpeg/ffprobe /usr/local/bin/; \
+    rm -rf /tmp/ffmpeg /tmp/ffmpeg.tar.xz; \
+    /usr/local/bin/ffmpeg -version | head -1; \
+    /usr/local/bin/ffprobe -version | head -1
+
 WORKDIR /app
 
 # Dependency layer first so it caches across source-only edits. Metadata
@@ -71,6 +97,15 @@ COPY src ./src
 RUN test -f src/splitsmith/ui_static/dist/index.html \
     || (echo "ERROR: src/splitsmith/ui_static/dist/index.html missing -- build the SPA before docker build" && exit 1)
 RUN uv sync --frozen --no-dev --extra hosted
+
+# Slim the venv before it's copied to the runtime stage: drop bundled
+# test suites + __pycache__. NOTE: do NOT ``strip`` the native .so files
+# -- the prebuilt scientific wheels (numpy/scipy OpenBLAS) carry an ELF
+# layout that strip corrupts ("load command not page-aligned"), breaking
+# numpy import. The big libs (llvmlite, openblas) stay as shipped.
+RUN find /app/.venv -type d -name '__pycache__' -prune -exec rm -rf {} + ; \
+    find /app/.venv -type d -name 'tests' -prune -exec rm -rf {} + ; \
+    find /app/.venv -type d -name 'test' -prune -exec rm -rf {} +
 
 # Bake the slim ONNX model artifacts into a staging dir we copy into the
 # runtime stage. ``SPLITSMITH_CONFIG_DIR`` drives the cache location
@@ -90,14 +125,17 @@ RUN if [ "$BAKE_MODELS" = "1" ]; then \
 # --------------------------------------------------------------------------
 FROM ${PYTHON_IMAGE} AS runtime
 
-# Runtime system deps only: ffmpeg for trim / probe, curl for the
-# healthcheck. No build tools.
+# Runtime system deps only: ca-certificates for outbound TLS, curl for
+# the compose healthcheck. ffmpeg/ffprobe come as static binaries from
+# the builder (below) -- no apt ffmpeg package, no codec libs.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        ffmpeg \
  && rm -rf /var/lib/apt/lists/*
+
+# Static ffmpeg + ffprobe from the builder (self-contained, no lib deps).
+COPY --from=builder /usr/local/bin/ffmpeg /usr/local/bin/ffprobe /usr/local/bin/
 
 # Non-root user; --create-home so the baked model cache + any runtime
 # writes (logs) land in a writable home.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,97 @@
 # syntax=docker/dockerfile:1.7
 #
-# Docker image for `splitsmith serve` (hosted mode).
+# Multi-stage image for `splitsmith serve` (hosted mode).
 #
-# Single-stage on purpose: the slim runtime (everything outside
-# ``[dev]``) is already small enough that a multi-stage split mostly
-# adds complexity. If the image grows past a few hundred MB it's
-# worth revisiting with a uv build cache + a slim distroless final
-# stage; for now the priority is a single-file ``docker compose up``
-# experience for contributors.
+# Why multi-stage: the single-stage build shipped uv + a 951 MB
+# `chown -R /app` dup layer + ~280 MB of ui_static/node_modules, all of
+# which the runtime never touches. Splitting builder from runtime keeps
+# the final image to {venv + ffmpeg + baked models + base} only.
 #
-# What ships:
+# Layout:
+# - builder: installs the venv (deps + the splitsmith package, editable)
+#   and bakes the slim ONNX models.
+# - runtime: a clean base + ffmpeg, with the venv, the (slim) source tree,
+#   alembic migrations, and baked models copied in. No uv, no SPA build
+#   inputs, no chown dup layer.
+#
+# Why editable (not a built wheel): ``splitsmith serve`` resolves the
+# alembic config dir as ``Path(cli.__file__).parent.parent.parent`` -- the
+# repo root in the ``src/splitsmith/...`` layout. A non-editable install
+# moves the package into site-packages and breaks that path math (alembic
+# then runs with no script_location). Editable keeps cli.py at
+# /app/src/splitsmith/cli.py so the repo-root assumption holds. The
+# ``.dockerignore`` strips ui_static/node_modules + the TS source so the
+# copied tree stays small; only ui_static/dist (the built SPA) ships.
+#
+# CRITICAL invariant: both stages use the SAME base image so the venv's
+# interpreter path (pyvenv.cfg -> /usr/local/bin/python3.11) stays valid
+# after the copy. ``UV_PYTHON_DOWNLOADS=never`` forces uv to build the venv
+# against that base-image Python rather than a uv-managed one that would
+# not exist in the runtime stage.
+#
+# What ships at runtime:
 # - Python 3.11 (matches the wheel's ``requires-python``).
-# - uv for dependency install (faster + lockfile-aware).
-# - ``[project]`` deps + ``[project.optional-dependencies].hosted``:
-#   the core local-mode set plus the runtime hosted-mode deps
-#   (SQLAlchemy + alembic + asyncpg + aiosqlite + python-ulid +
-#   boto3). The dev group (torch / transformers / panns / mypy / ruff
-#   / moto / etc.) stays out -- the slim ONNX runtime + scikit-learn
-#   cover voter B + C inference paths.
-# - ffmpeg + ffprobe via the OS package manager so trim / shot-detect
-#   workers can still execute when a real shooter / match is uploaded.
+# - ``[project]`` deps + ``[project.optional-dependencies].hosted`` (the
+#   slim ONNX runtime + scikit-learn + SQLAlchemy/alembic/asyncpg/boto3/
+#   procrastinate). The dev group (torch / transformers / panns / mypy /
+#   ruff / moto) stays out.
+# - ffmpeg + ffprobe for trim / probe.
+# - Baked CLAP + PANN + text-embedding artifacts (~450 MB) so neither the
+#   API nor a worker downloads models at runtime (doc 04).
 
-FROM python:3.11-slim-bookworm
+ARG PYTHON_IMAGE=python:3.11-slim-bookworm
 
-# System deps: ffmpeg for trim / probe (workers still need it once
-# real jobs run); curl for healthchecks. ``--no-install-recommends``
-# keeps the image tight. Build tools intentionally omitted -- every
-# wheel in the slim runtime ships a manylinux artifact.
+# --------------------------------------------------------------------------
+# Builder
+# --------------------------------------------------------------------------
+FROM ${PYTHON_IMAGE} AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /uvx /usr/local/bin/
+
+# Use the base-image Python; never let uv fetch a managed interpreter (it
+# would bake an interpreter path the runtime stage can't satisfy). Copy
+# link mode so the venv holds real files, not hardlinks into uv's cache
+# (hardlinks don't survive the cross-stage COPY).
+ENV UV_PYTHON_DOWNLOADS=never \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Dependency layer first so it caches across source-only edits. Metadata
+# only -- ``--no-install-project`` skips the splitsmith package itself.
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --extra hosted --no-install-project
+
+# Now the source + the editable project install.
+COPY src ./src
+# Fail fast if the SPA wasn't built before docker build: dist/ is not
+# committed, so a build from a clean checkout would otherwise ship an
+# image that serves no UI. Run ``npm --prefix src/splitsmith/ui_static run
+# build`` first (or copy a prebuilt dist into the context).
+RUN test -f src/splitsmith/ui_static/dist/index.html \
+    || (echo "ERROR: src/splitsmith/ui_static/dist/index.html missing -- build the SPA before docker build" && exit 1)
+RUN uv sync --frozen --no-dev --extra hosted
+
+# Bake the slim ONNX model artifacts into a staging dir we copy into the
+# runtime stage. ``SPLITSMITH_CONFIG_DIR`` drives the cache location
+# (<config_dir>/models). Gated behind BAKE_MODELS so offline / network-
+# restricted builds opt out with ``--build-arg BAKE_MODELS=0``.
+ENV SPLITSMITH_CONFIG_DIR=/opt/splitsmith
+ARG BAKE_MODELS=1
+RUN if [ "$BAKE_MODELS" = "1" ]; then \
+        /app/.venv/bin/splitsmith fetch-models; \
+    else \
+        echo "BAKE_MODELS=0 -- skipping model bake; runtime will download on first detection"; \
+        mkdir -p /opt/splitsmith/models; \
+    fi
+
+# --------------------------------------------------------------------------
+# Runtime
+# --------------------------------------------------------------------------
+FROM ${PYTHON_IMAGE} AS runtime
+
+# Runtime system deps only: ffmpeg for trim / probe, curl for the
+# healthcheck. No build tools.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -34,73 +99,38 @@ RUN apt-get update \
         ffmpeg \
  && rm -rf /var/lib/apt/lists/*
 
-# Install uv -- pinned to the same version range the dev environment uses.
-COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /uvx /usr/local/bin/
-
-# Non-root user. Avoids container processes running as root, and
-# keeps any future volume mounts owned correctly without a chown.
+# Non-root user; --create-home so the baked model cache + any runtime
+# writes (logs) land in a writable home.
 RUN groupadd --system splitsmith \
  && useradd --system --gid splitsmith --home-dir /home/splitsmith --create-home splitsmith
 
 WORKDIR /app
 
-# Copy lock + project metadata first so the dependency install
-# layer caches across source-only changes.
-COPY pyproject.toml uv.lock README.md ./
-COPY alembic.ini ./
-COPY alembic ./alembic
+# The venv carries all deps + the editable link to /app/src. Copy both to
+# the SAME paths they were built at: the venv so interpreter shebangs +
+# the editable .pth resolve, and the source tree the .pth points at.
+COPY --from=builder --chown=splitsmith:splitsmith /app/.venv /app/.venv
+COPY --from=builder --chown=splitsmith:splitsmith /app/src /app/src
 
-# Install dependencies only. ``--no-install-project`` skips the
-# splitsmith package itself, so this layer is invalidated only when
-# ``pyproject.toml`` / ``uv.lock`` change -- a source-only edit reuses
-# the wheel install on the next build. ``--extra hosted`` pulls the
-# hosted-mode runtime deps (alembic + sqlalchemy + asyncpg + boto3 +
-# ...). Without it the container would boot with the local-mode wheel
-# only and ``splitsmith serve`` would crash on the first alembic call.
-RUN uv sync --frozen --no-dev --extra hosted --no-install-project
+# Alembic migrations: ``splitsmith serve`` runs ``alembic upgrade head`` on
+# boot (unless --skip-migrations) with cwd=/app (the repo root in the
+# editable layout), so alembic.ini + the versions tree must live at /app.
+COPY --chown=splitsmith:splitsmith alembic.ini ./
+COPY --chown=splitsmith:splitsmith alembic ./alembic
 
-# Now bring in the source and install the package itself into the
-# already-warm venv. ``--frozen`` ensures the build still fails if
-# the lockfile and pyproject have drifted.
-COPY src ./src
-RUN uv sync --frozen --no-dev --extra hosted
+# Baked models -> the runtime config dir's models/ cache.
+COPY --from=builder --chown=splitsmith:splitsmith /opt/splitsmith /home/splitsmith/.splitsmith
 
-# Hand the working directory to the non-root user so anything the
-# server writes (logs, the optional ``~/.splitsmith`` config) lands
-# in a writable home.
-RUN chown -R splitsmith:splitsmith /app
 USER splitsmith
 
-# Pin the config dir so the model cache (``<config_dir>/models``) lands
-# at a fixed, baked-in path that the build step below and the runtime
-# both agree on -- independent of the platform default, which differs
-# between the build user and any future runtime user/home.
 ENV PATH="/app/.venv/bin:${PATH}" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     SPLITSMITH_CONFIG_DIR=/home/splitsmith/.splitsmith
 
-# Bake the slim ONNX model artifacts (~450 MB: CLAP + PANN + text
-# embeddings) into the image. This is the whole point of running a
-# persistent worker fleet: a cold worker loads models from local disk
-# instead of paying a ~450 MB download on first detection (doc 04 --
-# "model artifacts live in a baked-in Docker layer"). With models
-# present, ``_maybe_submit_model_download`` no-ops at boot, so neither
-# the API nor a worker ever fetches at runtime.
-#
-# Gated behind ``BAKE_MODELS`` so offline / network-restricted builds
-# (e.g. some CI) can opt out with ``--build-arg BAKE_MODELS=0`` and
-# fall back to the runtime-download path. Default on.
-ARG BAKE_MODELS=1
-RUN if [ "$BAKE_MODELS" = "1" ]; then \
-        splitsmith fetch-models; \
-    else \
-        echo "BAKE_MODELS=0 -- skipping model bake; runtime will download on first detection"; \
-    fi
-
 EXPOSE 5174
 
-# ``serve`` sets SPLITSMITH_MODE=hosted itself; the compose file
-# layers in SPLITSMITH_DATABASE_URL + S3 credentials.
+# ``serve`` sets SPLITSMITH_MODE=hosted itself; the compose file layers in
+# SPLITSMITH_DATABASE_URL + S3 credentials.
 ENTRYPOINT ["splitsmith", "serve"]
 CMD ["--host", "0.0.0.0", "--port", "5174"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,10 @@ RUN uv sync --frozen --no-dev --extra hosted
 # numpy import. The big libs (llvmlite, openblas) stay as shipped.
 RUN find /app/.venv -type d -name '__pycache__' -prune -exec rm -rf {} + ; \
     find /app/.venv -type d -name 'tests' -prune -exec rm -rf {} + ; \
-    find /app/.venv -type d -name 'test' -prune -exec rm -rf {} +
+    find /app/.venv -type d -name 'test' -prune -exec rm -rf {} + ; \
+    SP="$(/app/.venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    rm -rf "${SP}/sklearn/datasets/data" "${SP}/sklearn/datasets/descr" \
+           "${SP}/sklearn/datasets/images"
 
 # Bake the slim ONNX model artifacts into a staging dir we copy into the
 # runtime stage. ``SPLITSMITH_CONFIG_DIR`` drives the cache location

--- a/scripts/smoke_hosted.sh
+++ b/scripts/smoke_hosted.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Local hosted-mode smoke test.
+#
+# Builds the hosted image, boots the docker-compose stack (Postgres +
+# MinIO + the splitsmith API), and asserts the things the normal pytest
+# suite CANNOT catch because CI has no Postgres:
+#
+#   - the container boots and /api/health returns 200
+#   - `alembic upgrade head` actually ran (the API is unhealthy otherwise)
+#   - the procrastinate schema landed its tables + functions  <-- the
+#     asyncpg multi-statement migration bug that shipped in #437
+#   - our tenant tables (users / recent_projects / compute_jobs) exist
+#
+# This exists because that migration bug passed CI green: the only
+# Postgres coverage is `pytest -m docker`, which CI skips, and the
+# SQLite lane no-ops the Postgres-only migration.
+#
+# Usage:
+#   scripts/smoke_hosted.sh           # fast: skips the ~450 MB model bake
+#   SMOKE_BAKE=1 scripts/smoke_hosted.sh   # also bake + assert models present
+#
+# ALWAYS tears the stack down and prunes what it built on exit (success
+# OR failure) -- a sparse colima/Lima disk doesn't shrink on its own, so
+# leaving images + volumes around is how the host fills up.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.yml"
+API_BASE="http://localhost:5174"
+HEALTH_TIMEOUT_S="${HEALTH_TIMEOUT_S:-120}"
+BAKE="${SMOKE_BAKE:-0}"
+
+cd "${REPO_ROOT}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info()  { printf '\033[36m==> %s\033[0m\n' "$*"; }
+
+cleanup() {
+    local rc=$?
+    info "tearing down stack + reclaiming build artifacts"
+    # --rmi local drops the image compose built here; -v drops the
+    # Postgres/MinIO volumes so the next run starts clean.
+    docker compose -f "${COMPOSE_FILE}" down -v --rmi local >/dev/null 2>&1 || true
+    # Build cache from this run only -- safe, regenerable.
+    docker builder prune -f >/dev/null 2>&1 || true
+    if [ "${rc}" -eq 0 ]; then
+        green "SMOKE PASSED"
+    else
+        red "SMOKE FAILED (exit ${rc})"
+    fi
+    exit "${rc}"
+}
+trap cleanup EXIT
+
+psql_q() {
+    docker compose -f "${COMPOSE_FILE}" exec -T postgres \
+        psql -U splitsmith -d splitsmith -At -c "$1"
+}
+
+assert() {
+    # assert <description> <actual> <expected>
+    if [ "$2" != "$3" ]; then
+        red "FAIL: $1 (got '$2', expected '$3')"
+        exit 1
+    fi
+    green "ok: $1"
+}
+
+assert_ge() {
+    # assert_ge <description> <actual> <min>
+    if [ "$2" -lt "$3" ]; then
+        red "FAIL: $1 (got '$2', expected >= '$3')"
+        exit 1
+    fi
+    green "ok: $1 ($2)"
+}
+
+info "building hosted image (BAKE_MODELS=${BAKE})"
+docker build --build-arg "BAKE_MODELS=${BAKE}" -t splitsmith-splitsmith "${REPO_ROOT}"
+
+info "starting compose stack"
+docker compose -f "${COMPOSE_FILE}" up -d --no-build
+
+info "waiting for /api/health (timeout ${HEALTH_TIMEOUT_S}s)"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT_S ))
+healthy=0
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+    if curl -fsS "${API_BASE}/api/health" >/dev/null 2>&1; then
+        healthy=1
+        break
+    fi
+    sleep 2
+done
+if [ "${healthy}" -ne 1 ]; then
+    red "API never became healthy -- recent logs:"
+    docker compose -f "${COMPOSE_FILE}" logs --tail 40 splitsmith || true
+    exit 1
+fi
+green "ok: /api/health responding"
+
+info "asserting migrations applied"
+# The procrastinate schema (the asyncpg multi-statement bug) -- 4 tables + funcs.
+proc_tables=$(psql_q "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE 'procrastinate_%'")
+assert_ge "procrastinate_* tables present" "${proc_tables}" 4
+proc_funcs=$(psql_q "SELECT count(*) FROM pg_proc WHERE proname LIKE 'procrastinate_%'")
+assert_ge "procrastinate functions present" "${proc_funcs}" 1
+# Our tenant tables from the earlier migrations.
+for t in users recent_projects compute_jobs; do
+    exists=$(psql_q "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='${t}'")
+    assert "table ${t} exists" "${exists}" 1
+done
+
+info "asserting a Postgres-backed endpoint round-trips"
+recent=$(curl -fsS "${API_BASE}/api/me/recent-projects")
+assert "recent-projects empty list" "${recent}" '{"projects":[]}'
+
+if [ "${BAKE}" = "1" ]; then
+    info "asserting baked models present"
+    missing=$(docker compose -f "${COMPOSE_FILE}" exec -T splitsmith \
+        splitsmith fetch-models --list 2>/dev/null | grep -c missing || true)
+    assert "no missing model artifacts" "${missing}" 0
+fi

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -165,3 +165,59 @@ def test_hosted_user_row_persists_in_postgres(hosted_stack: None) -> None:
     )
     assert out.returncode == 0, out.stderr
     assert out.stdout.strip() == "1"
+
+
+def _psql(query: str) -> str:
+    """Run ``query`` in the compose Postgres and return trimmed stdout."""
+    out = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(COMPOSE_FILE),
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-U",
+            "splitsmith",
+            "-d",
+            "splitsmith",
+            "-At",
+            "-c",
+            query,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
+
+
+def test_migrations_applied_against_postgres(hosted_stack: None) -> None:
+    """Regression guard for the asyncpg multi-statement migration bug.
+
+    The stack only reaches ``healthy`` if ``alembic upgrade head``
+    succeeded, so reaching this assertion already proves the chain ran.
+    We additionally assert the procrastinate schema (the migration that
+    broke on asyncpg) actually landed its objects -- a green health
+    check alone wouldn't notice a migration that silently created
+    nothing."""
+    # Every shipped migration's objects must exist. The procrastinate
+    # schema is the one that broke: 4 tables + a pile of PL/pgSQL funcs.
+    proc_tables = _psql(
+        "SELECT count(*) FROM information_schema.tables "
+        "WHERE table_schema='public' AND table_name LIKE 'procrastinate_%'"
+    )
+    assert int(proc_tables) >= 4, f"expected >=4 procrastinate_* tables, got {proc_tables}"
+
+    proc_funcs = _psql("SELECT count(*) FROM pg_proc WHERE proname LIKE 'procrastinate_%'")
+    assert int(proc_funcs) > 0, "procrastinate PL/pgSQL functions missing"
+
+    # Our own tenant tables from the earlier migrations.
+    for table in ("users", "recent_projects", "compute_jobs"):
+        exists = _psql(
+            "SELECT count(*) FROM information_schema.tables "
+            f"WHERE table_schema='public' AND table_name='{table}'"
+        )
+        assert exists == "1", f"table {table!r} missing after migrations"


### PR DESCRIPTION
## Summary

Two related improvements to the hosted docker stack, both prompted by today's debugging:

1. **Multi-stage build -- 4.1 GB -> 2.53 GB** (with models baked; ~2 GB without).
2. **A repeatable local smoke script** that catches the class of bug (migrations / boot) the normal test suite can't, because CI has no Postgres.

### Image slimming

The single-stage image shipped 1.2 GB of pure waste:
- a **951 MB `chown -R /app`** layer (rewrites the whole venv+src into a new layer),
- **~280 MB of `ui_static/node_modules`** dragged in by `COPY src` (runtime only needs the built `dist/`),
- uv + build cruft in the runtime image.

Fix:
- **Builder stage** installs the venv (editable) + bakes models; **runtime stage** is a clean base + ffmpeg with only the venv, source tree, alembic, and baked models copied in. No uv, no chown dup.
- **`.dockerignore`** keeps `node_modules` + the TS source / tooling out of the build context (only `ui_static/dist` ships).
- Both stages share the same base image and `UV_PYTHON_DOWNLOADS=never` so the copied venv's interpreter path stays valid.
- **Editable install kept on purpose**: `splitsmith serve` derives the alembic config dir from `cli.__file__`'s repo-root layout; a non-editable (site-packages) install breaks that path math (alembic runs with no `script_location`). Comment in the Dockerfile explains it.
- Build **fails fast if `ui_static/dist` is missing** (it's not committed -- build the SPA first).

### Smoke script (`scripts/smoke_hosted.sh`)

The asyncpg migration bug (fixed in #440) shipped because CI has no Postgres lane. This script is the standing guard:
- builds the image, boots the compose stack, asserts **health + the procrastinate schema tables/functions + tenant tables (users/recent_projects/compute_jobs) + a Postgres-backed endpoint round-trip**;
- `SMOKE_BAKE=1` additionally asserts baked models are present;
- **always tears down + prunes on exit** (success or failure) -- a sparse colima/Lima disk doesn't shrink on its own, so leftovers fill the host (learned the hard way today).

Also enhances the `pytest -m docker` smoke with `test_migrations_applied_against_postgres` so a migration that silently creates nothing fails even when `/api/health` is green.

## Test plan

- [x] `scripts/smoke_hosted.sh` -- **SMOKE PASSED** end-to-end (health, 4 procrastinate tables + 18 functions, users/recent_projects/compute_jobs, recent-projects round-trip), auto-cleaned to 0 volumes / 18 GB host free.
- [x] Multi-stage image builds at 2.53 GB (bake) and boots healthy via compose.
- [x] venv interpreter, baked models (`fetch-models --list` all present), `STATIC_DIR` resolves, `db.models` imports -- all verified inside the image.
- [x] Depends on #440 (merged) for the migration to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)