### PR TITLE
feat(saas): splitsmith worker CLI + compose worker service (PR-beta)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,9 @@ ENV PATH="/app/.venv/bin:${PATH}" \
 
 EXPOSE 5174
 
-# ``serve`` sets SPLITSMITH_MODE=hosted itself; the compose file layers in
-# SPLITSMITH_DATABASE_URL + S3 credentials.
-ENTRYPOINT ["splitsmith", "serve"]
-CMD ["--host", "0.0.0.0", "--port", "5174"]
+# ENTRYPOINT is just the CLI so the same image runs both roles: the API
+# (default CMD = ``serve ...``) and the worker fleet (compose overrides
+# ``command: ["worker"]``). Both subcommands set SPLITSMITH_MODE=hosted
+# themselves; the compose file layers in SPLITSMITH_DATABASE_URL + S3 creds.
+ENTRYPOINT ["splitsmith"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "5174"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,35 @@ services:
       retries: 20
       start_period: 30s
 
+  worker:
+    # Same image as the API; ENTRYPOINT is the bare ``splitsmith`` CLI so
+    # ``command: worker`` runs the long-lived queue drainer instead of
+    # ``serve``. The worker pops jobs the API enqueues onto ``user-*``
+    # queues (PR-beta: only the ``ping`` smoke task is registered).
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["worker"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      # Wait for the API to be healthy, not just Postgres: ``serve`` runs
+      # ``alembic upgrade head`` on boot, which creates the Procrastinate
+      # schema the worker connects to. Starting the worker first would
+      # race the migration.
+      splitsmith:
+        condition: service_healthy
+    environment:
+      SPLITSMITH_DATABASE_URL: postgresql+asyncpg://splitsmith:splitsmith@postgres:5432/splitsmith
+      SPLITSMITH_MODE: hosted
+      SPLITSMITH_S3_ENDPOINT_URL: http://minio:9000
+      SPLITSMITH_S3_ACCESS_KEY_ID: splitsmith
+      SPLITSMITH_S3_SECRET_ACCESS_KEY: splitsmithsplitsmith
+      SPLITSMITH_S3_BUCKET: splitsmith-uploads
+      SPLITSMITH_S3_REGION: us-east-1
+
 volumes:
   postgres-data:
   minio-data:

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -594,6 +594,52 @@ def serve(
         console.print("\n[yellow]Stopped.[/]")
 
 
+@app.command()
+def worker(
+    concurrency: int = typer.Option(1, "--concurrency", "-c", help="Max jobs this worker runs in parallel."),
+) -> None:
+    """Run a long-lived hosted-mode worker that drains the job queue.
+
+    The other half of the worker fleet (doc 04): ``splitsmith serve``
+    enqueues jobs onto per-tenant ``user-<id>`` queues; this process
+    pops and runs them. Loads the ensemble models once and stays warm
+    across many jobs -- the reason the fleet isn't serverless.
+
+    Subscribes to **all** queues (Procrastinate has no queue-glob), so
+    a single worker covers every tenant. Run several for more
+    throughput; pin specific queues later for premium tiers.
+
+    Required env vars:
+
+    - ``SPLITSMITH_DATABASE_URL`` -- the same Postgres URL ``serve``
+      uses. The Procrastinate schema must already be migrated
+      (``serve`` runs ``alembic upgrade head`` on boot); start the
+      worker after the API, not before.
+    """
+    import asyncio as _asyncio
+    import os as _os
+
+    from .queue import run_worker as _run_worker
+
+    _os.environ.setdefault("SPLITSMITH_MODE", "hosted")
+    db_url = _os.environ.get("SPLITSMITH_DATABASE_URL")
+    if not db_url:
+        console.print(
+            "[red]SPLITSMITH_DATABASE_URL is not set.[/] "
+            "The worker needs the same Postgres URL as `splitsmith serve` "
+            "(e.g. postgresql+asyncpg://user:pass@host/db)."
+        )
+        raise typer.Exit(2)
+
+    console.print(
+        f"[green]splitsmith worker[/]: draining all queues (concurrency={concurrency})   (Ctrl+C to stop)"
+    )
+    try:
+        _asyncio.run(_run_worker(db_url, concurrency=concurrency))
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Stopped.[/]")
+
+
 @app.command("audit-prep")
 def audit_prep(
     video: Path = typer.Option(..., "--video", help="Source video file (mp4/mov)."),

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -8,12 +8,15 @@ inside ``splitsmith serve``; this module is the queue layer that
 lets the dispatch step move out-of-process so a separate
 ``splitsmith worker`` fleet can pop jobs.
 
-PR-alpha (this PR) lands the schema + the configured
-:class:`procrastinate.App` only. No tasks are registered yet -- task
-registration is the PR-gamma migration step where each job kind
-(``shot_detect``, ``beep_detect``, ``trim``, ...) gets split into a
-pure ``*_body`` function and a thin task wrapper that rebuilds per-
-user state from ``user_id`` + project_id alone.
+PR-alpha landed the schema + the configured :class:`procrastinate.App`.
+PR-beta (this change) adds the long-lived worker entrypoint
+(:func:`run_worker`, exposed as ``splitsmith worker``) plus a single
+state-free ``ping`` task whose only job is to prove the round-trip:
+enqueue from the API process, dispatch + execute in a separate worker
+process. The real job-kind tasks (``shot_detect``, ``beep_detect``,
+``trim``, ...) land in PR-gamma, where each job kind gets split into a
+pure ``*_body`` function and a thin task wrapper that rebuilds per-user
+state from ``user_id`` + project_id alone.
 
 ## Local-mode safety
 
@@ -72,16 +75,64 @@ def build_app(database_url: str) -> procrastinate.App:
     consumed by SQLAlchemy elsewhere. The async/asyncpg dialect
     suffix is stripped here so psycopg3 can parse it.
 
-    The returned App has **no tasks registered**. Task registration
-    happens in PR-gamma when each job kind gets its task wrapper.
-    Until then, callers can still use this App for the dispatch
-    plumbing (open/close connector, run the worker loop with a no-op
-    handler) so PR-beta's ``splitsmith worker`` smoke test is wirable
-    against a real queue.
+    The returned App has the ``ping`` smoke task registered (see
+    :func:`_register_smoke_tasks`). The real job-kind tasks
+    (``shot_detect`` / ``beep_detect`` / ``trim``) are still PR-gamma:
+    each gets a thin task wrapper around a pure ``*_body`` function.
     """
     dsn = _to_psycopg_dsn(database_url)
     connector = procrastinate.PsycopgConnector(kwargs={"conninfo": dsn})
-    return procrastinate.App(connector=connector)
+    app = procrastinate.App(connector=connector)
+    _register_smoke_tasks(app)
+    return app
+
+
+def _register_smoke_tasks(app: procrastinate.App) -> None:
+    """Register the worker-fleet smoke task(s) on ``app``.
+
+    ``ping`` carries no per-user state and touches no project files.
+    Its sole purpose is the PR-beta round-trip proof: the API process
+    defers ``ping`` onto a queue, and a separate ``splitsmith worker``
+    process pops + runs it. Real job kinds arrive in PR-gamma.
+
+    Tasks must be registered on the App instance before
+    :meth:`procrastinate.App.run_worker_async`, so this runs inside
+    :func:`build_app` rather than at import time (the module must stay
+    lazy-importable behind ``_hosted_mode_active()``).
+    """
+
+    @app.task(name="ping", queue="default")
+    async def _ping(*, payload: str = "ping") -> str:
+        return payload
+
+
+async def run_worker(
+    database_url: str,
+    *,
+    concurrency: int = 1,
+    queues: list[str] | None = None,
+) -> None:
+    """Run a long-lived worker that drains the job queue until killed.
+
+    ``queues=None`` (the default) subscribes to **every** queue --
+    Procrastinate has no queue-glob, so one worker covers all
+    ``user-*`` queues this way. Per-tenant pinning means passing an
+    explicit ``queues=[...]`` list; that's a future concern, not
+    wired here.
+
+    A persistent worker is the whole point of the fleet: it loads the
+    ensemble models once (the process-wide ``_ENSEMBLE_RUNTIME``
+    singleton, on the first detection task in PR-gamma) and drains
+    many jobs. For PR-beta the only registered task is ``ping``, so
+    the worker stays light.
+
+    Installs SIGINT/SIGTERM handlers (Procrastinate default) for
+    graceful drain; must therefore run on the main thread, which it
+    does via ``asyncio.run`` from the ``splitsmith worker`` command.
+    """
+    app = build_app(database_url)
+    async with app.open_async():
+        await app.run_worker_async(queues=queues, concurrency=concurrency)
 
 
 def queue_name_for_user(user_id: str) -> str:

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -1,0 +1,50 @@
+"""PR-beta: the ``splitsmith worker`` CLI + queue smoke task.
+
+These are db-free unit tests -- they build the Procrastinate App and
+inspect it, but never open a connector or touch Postgres. The live
+round-trip (API defers ``ping`` -> worker process runs it) is exercised
+by the ``pytest -m docker`` smoke, not here.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from typer.testing import CliRunner
+
+from splitsmith.cli import app
+from splitsmith.queue import build_app, run_worker
+
+_FAKE_PG_URL = "postgresql+asyncpg://u:p@localhost:5432/db"
+
+
+def test_build_app_registers_ping_task() -> None:
+    """A worker built from :func:`build_app` must have ``ping`` ready to
+    run; without it the PR-beta round-trip has nothing to dispatch."""
+    queue_app = build_app(_FAKE_PG_URL)
+    assert "ping" in queue_app.tasks
+
+
+def test_build_app_rejects_sqlite() -> None:
+    """Procrastinate is Postgres-only; a SQLite URL must fail loudly at
+    build time rather than dying deep in the connector."""
+    with pytest.raises(ValueError, match="Postgres"):
+        build_app("sqlite+aiosqlite:///x.db")
+
+
+def test_run_worker_is_async() -> None:
+    assert inspect.iscoroutinefunction(run_worker)
+
+
+def test_worker_command_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing ``SPLITSMITH_DATABASE_URL`` exits 2 with a clear message,
+    before any attempt to connect."""
+    monkeypatch.delenv("SPLITSMITH_DATABASE_URL", raising=False)
+    # Tracked by monkeypatch so the command's ``setdefault`` is undone.
+    monkeypatch.delenv("SPLITSMITH_MODE", raising=False)
+
+    result = CliRunner().invoke(app, ["worker"])
+
+    assert result.exit_code == 2
+    assert "SPLITSMITH_DATABASE_URL is not set" in result.stdout


### PR DESCRIPTION
## Summary
- Adds `splitsmith worker` -- a long-lived process that drains the Procrastinate queue (`run_worker()` in `queue.py`), the worker half of the fleet (doc 04). `serve` enqueues; this pops + runs.
- Registers a state-free `ping` smoke task in `build_app` to prove the enqueue -> dispatch -> execute round-trip across processes. Real job-kind tasks (shot_detect/beep_detect/trim) remain PR-gamma.
- `Dockerfile` ENTRYPOINT generalized to `["splitsmith"]` (serve moved to CMD) so one image runs both roles; compose `worker` service overrides `command: ["worker"]`, gated on the API being healthy so the Procrastinate schema is migrated before the worker connects.
- The `worker` command lazy-imports `splitsmith.queue` inside the body, keeping the local-mode no-hosted-deps import contract intact (pinned by the existing test).

`queues=None` drains all queues -- Procrastinate has no queue-glob, so one worker covers every `user-*` queue. Per-tenant pinning is future.

## Test plan
- [x] `ruff` + `black --check` clean on changed files
- [x] `pytest tests/test_worker_queue.py tests/test_local_mode_no_hosted_imports.py` (7 passed) -- task registration, sqlite rejection, missing-`DATABASE_URL` exit, lazy-import contract
- [x] `docker compose config` resolves postgres/minio/splitsmith/worker
- [ ] Live round-trip (defer `ping` -> worker runs it) via `pytest -m docker` -- not yet automated; follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)