### PR TITLE
fix(queue): PsycopgConnector conninfo collision + worker round-trip smoke

### DIFF
--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -81,7 +81,13 @@ def build_app(database_url: str) -> procrastinate.App:
     each gets a thin task wrapper around a pure ``*_body`` function.
     """
     dsn = _to_psycopg_dsn(database_url)
-    connector = procrastinate.PsycopgConnector(kwargs={"conninfo": dsn})
+    # PsycopgConnector forwards every extra kwarg to its pool factory
+    # (psycopg_pool.AsyncConnectionPool), whose first arg is ``conninfo``.
+    # Passing it directly is correct; wrapping it as ``kwargs={"conninfo":
+    # dsn}`` instead lands in the pool's *per-connection* ``kwargs`` and
+    # collides with the pool's own ``conninfo`` ("got multiple values for
+    # argument 'conninfo'") -- a runtime-only failure the unit tests miss.
+    connector = procrastinate.PsycopgConnector(conninfo=dsn)
     app = procrastinate.App(connector=connector)
     _register_smoke_tasks(app)
     return app

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -221,3 +221,44 @@ def test_migrations_applied_against_postgres(hosted_stack: None) -> None:
             f"WHERE table_schema='public' AND table_name='{table}'"
         )
         assert exists == "1", f"table {table!r} missing after migrations"
+
+
+def test_worker_drains_ping_task(hosted_stack: None) -> None:
+    """PR-beta round-trip proof: defer a ``ping`` from the host onto the
+    queue and assert the separate ``worker`` container pops + runs it to
+    ``succeeded``.
+
+    This is the one test that exercises the actual cross-process
+    dispatch -- the unit tests only inspect the App. The host defers
+    through the same ``build_app`` path the API uses (Postgres exposed
+    on localhost:5432 by compose); the worker container, draining all
+    queues, executes it and writes ``succeeded`` to ``procrastinate_jobs``.
+    """
+    import asyncio
+
+    from splitsmith.queue import build_app
+
+    host_url = "postgresql+asyncpg://splitsmith:splitsmith@localhost:5432/splitsmith"
+
+    async def _defer() -> None:
+        app = build_app(host_url)
+        async with app.open_async():
+            await app.tasks["ping"].defer_async(payload="pong")
+
+    asyncio.run(_defer())
+
+    # Poll the queue table until the worker marks the job done. The
+    # worker's fetch_job_polling_interval defaults to 5s, so allow a
+    # comfortable margin over a couple of poll cycles.
+    deadline = time.time() + 30.0
+    status = ""
+    while time.time() < deadline:
+        status = _psql(
+            "SELECT status FROM procrastinate_jobs " "WHERE task_name = 'ping' ORDER BY id DESC LIMIT 1"
+        )
+        if status == "succeeded":
+            return
+        if status == "failed":
+            pytest.fail("ping job reached 'failed' -- the worker errored running it")
+        time.sleep(1.0)
+    pytest.fail(f"worker did not drain ping within 30s (last status: {status!r})")


### PR DESCRIPTION
## Summary
- **Bug fix:** `build_app` constructed the connector as `PsycopgConnector(kwargs={"conninfo": dsn})`. `PsycopgConnector` forwards extra kwargs to its pool factory, so that landed in the pool's *per-connection* `kwargs` and collided with the pool's own (empty) `conninfo` -> `AsyncConnection.connect() got multiple values for argument 'conninfo'`. The connector never opened a live connection until now, so **both the API's queue-defer path and the `splitsmith worker` container were silently broken** (PR-alpha regression, merged untested against live Postgres). Fix: pass `conninfo=dsn` directly.
- **New test:** `test_worker_drains_ping_task` in the docker smoke defers a `ping` from the host and asserts the separate `worker` container runs it to `succeeded`. First test to exercise the real cross-process dispatch -- the db-free unit tests only inspect the `App`, which is exactly how the connector bug slipped through CI.

This is the verification gap flagged on #443.

## Test plan
- [x] `ruff` + `black --check` clean
- [x] `pytest tests/test_worker_queue.py` (4 passed, db-free)
- [x] `pytest -m docker tests/test_hosted_docker_smoke.py` -- **4 passed**, including the new worker round-trip (defer ping -> worker drains to `succeeded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)