### PR TITLE
feat(jobs): kind+args dispatch + out-of-process worker (PR-gamma)

### DIFF
--- a/src/splitsmith/db/job_backend.py
+++ b/src/splitsmith/db/job_backend.py
@@ -1,18 +1,25 @@
 """Postgres-backed :class:`JobBackend` (doc 04, Tier 2 of doc 10).
 
 Hosted-mode counterpart to :class:`splitsmith.ui.jobs.JobRegistry`'s
-in-memory dict + thread pool. The persistence layer is Postgres; the
-dispatch layer is still an in-process :class:`ThreadPoolExecutor`
-inside the API server. Multi-machine workers via Procrastinate / arq
-+ a closure-free ``submit(task_name, args)`` shape land in a follow-up
-PR -- this one just makes job state survive a server restart, which is
-the gate for the docker-compose smoke test.
+in-memory dict + thread pool. Persistence is Postgres (``compute_jobs``);
+dispatch is out-of-process via Procrastinate (PR-gamma). :meth:`submit`
+writes a ``pending`` row and hands the job to the injected
+:data:`JobDeferrer`, which enqueues it on the per-tenant Procrastinate
+queue. A separate ``splitsmith worker`` process pops it and calls
+:meth:`run_job`, which drives the same ``kind`` -> body callable the
+local :class:`JobRegistry` uses (registered via
+``register_job_bodies(state)``) and writes the terminal status back to
+the row the API created. The SPA polls ``/api/jobs/{id}`` against that
+row throughout.
 
-**Restart hygiene:** at construction the backend sweeps any
-``compute_jobs`` rows for this user that were ``pending`` or
-``running`` and flips them to ``failed`` with an explanatory error
-message. The in-process executor that was supposed to drive them is
-gone; the SPA would otherwise see them stuck in ``pending`` forever.
+The body closures only carry JSON-serialisable ``args`` across the
+process boundary -- a closure can't be pickled onto a queue, which is
+why PR-gamma reshaped ``submit(fn=...)`` to ``submit(kind=, args=)``.
+
+**Restart hygiene:** at construction (when ``sweep_on_boot``) the
+backend sweeps this user's ``pending``/``running`` rows to ``failed``.
+This is correct for the API process on restart; the worker passes
+``sweep_on_boot=False`` so it never fails jobs it is about to run.
 
 **Multi-tenant:** every query filters by
 ``ComputeJobRow.user_id == self._user_id`` (see the
@@ -23,16 +30,15 @@ gone; the SPA would otherwise see them stuck in ``pending`` forever.
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import logging
 import subprocess
 import threading
 import uuid
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -47,6 +53,26 @@ from ..ui.jobs import (
 from .models import ComputeJobRow
 
 logger = logging.getLogger(__name__)
+
+# Enqueue side of the split: ``submit`` calls this with a fully
+# JSON-serialisable payload; the implementation (see
+# ``splitsmith.queue.make_deferrer``) defers a ``run_compute_job``
+# Procrastinate task onto ``queue_name_for_user(user_id)``. Injected so
+# the backend stays free of any ``procrastinate`` import and so tests can
+# pass a fake that records or inline-runs the payload.
+JobDeferrer = Callable[..., Awaitable[None]]
+
+
+def _to_wire_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Project ``args`` to a JSON-serialisable dict for the queue.
+
+    Pydantic models (the ``req`` carried by ``export`` / ``match_export``)
+    become ``model_dump(mode="json")`` dicts; the worker rehydrates them
+    to the typed request before calling the body. Everything else
+    (slug, stage_number, flags) is already JSON-native and passes
+    through untouched.
+    """
+    return {k: (v.model_dump(mode="json") if isinstance(v, BaseModel) else v) for k, v in args.items()}
 
 
 _ROW_TO_JOB_FIELDS = (
@@ -76,13 +102,14 @@ def _row_to_job(row: ComputeJobRow) -> Job:
 class PostgresJobBackend:
     """Per-user :class:`JobBackend` backed by ``compute_jobs``.
 
-    Persistence-only for now: ``submit`` writes a PENDING row and
-    schedules the callable on an in-process :class:`ThreadPoolExecutor`
-    the same way :class:`JobRegistry` does. The DB-touching methods on
-    the Protocol (``submit`` / ``get`` / ``list`` / ``cancel`` /
-    ``acknowledge`` / ``acknowledge_all_failures`` / ``find_active``)
-    are async; the lifecycle methods stay sync because they're
-    process-local concepts (a thread pool, a drain flag).
+    The API process constructs one with a ``deferrer`` and uses
+    :meth:`submit` to enqueue. The worker process constructs one with
+    ``sweep_on_boot=False`` and uses :meth:`run_job` to execute. Both
+    share the persistence + :class:`JobHandle` bridge methods; the
+    DB-touching Protocol methods (``submit`` / ``get`` / ``list`` /
+    ``cancel`` / ``acknowledge`` / ``acknowledge_all_failures`` /
+    ``find_active``) are async; the lifecycle methods stay sync because
+    they're process-local concepts (a drain flag, the subprocess map).
     """
 
     def __init__(
@@ -90,7 +117,8 @@ class PostgresJobBackend:
         session_factory: async_sessionmaker,
         *,
         user_id: str,
-        max_concurrent: int = 2,
+        deferrer: JobDeferrer | None = None,
+        sweep_on_boot: bool = True,
     ) -> None:
         # Defence-in-depth: see :class:`PostgresRecentProjectsStore`
         # for the same fail-loud-on-empty-user_id rationale.
@@ -102,29 +130,29 @@ class PostgresJobBackend:
             )
         self._session_factory = session_factory
         self._user_id = user_id
-        # Populated by ``register_job_bodies(state)`` in ``create_app``,
-        # same as the local :class:`JobRegistry`. The hosted worker
-        # process holds its own identically-populated registry.
+        # ``submit`` hands the enqueue to this; ``None`` means the backend
+        # can persist + execute (``run_job``) but not enqueue. Calling
+        # ``submit`` without one is a programming error (surfaced there).
+        self._deferrer = deferrer
+        # Populated by ``register_job_bodies(state)`` in ``create_app``
+        # (API) and the worker bootstrap, same as the local
+        # :class:`JobRegistry`. Each process holds its own copy.
         self.bodies = JobBodyRegistry()
 
-        self._executor = ThreadPoolExecutor(
-            max_workers=max_concurrent,
-            thread_name_prefix="splitsmith-pgjob",
-        )
         self._lock = threading.RLock()
         self._subprocs: dict[str, subprocess.Popen] = {}
         self._shutting_down = False
         self._drained = threading.Event()
-        # In-process count of jobs we're currently driving on the
-        # executor. Does NOT include rows other API processes may be
-        # working on -- this is purely local-process bookkeeping for
-        # the drain primitive.
+        # In-process count of jobs this process is currently driving in
+        # ``run_job``. Zero in the API process (it only enqueues); the
+        # drain primitive is meaningful in the worker.
         self._inflight = 0
 
-        # Restart hygiene: any rows still marked PENDING or RUNNING
-        # for this user belong to a previous server process that's
-        # gone. Mark them FAILED so the SPA doesn't see ghosts.
-        asyncio.run(self._sweep_stuck_jobs_on_boot())
+        # Restart hygiene: any rows still PENDING/RUNNING for this user
+        # belong to a previous API process that's gone. The worker
+        # disables this -- it must not fail jobs queued for it to run.
+        if sweep_on_boot:
+            asyncio.run(self._sweep_stuck_jobs_on_boot())
 
     # ------------------------------------------------------------------
     # Lifecycle (sync) -- match JobRegistry semantics
@@ -173,8 +201,20 @@ class PostgresJobBackend:
     ) -> Job:
         if self._shutting_down:
             raise ShutdownInProgressError("server is shutting down; no new jobs accepted")
-        body = self.bodies.get(kind)
-        call_args = args or {}
+        if self._deferrer is None:
+            raise RuntimeError(
+                "PostgresJobBackend.submit needs a deferrer; this backend was "
+                "built execute-only (worker side). Enqueue from the API process."
+            )
+        # Resolve the body now so an unknown kind fails fast at the
+        # caller -- before a row is written or a job is enqueued.
+        self.bodies.get(kind)
+        # Match identity rides the queue so the worker can re-set the
+        # ``current_match_*`` ContextVars before running the body.
+        # ``model_download`` (submitted at startup) carries no match.
+        from ..ui.server import current_match_id
+
+        match_id = current_match_id.get()
         now = datetime.now(UTC)
         job_id = uuid.uuid4().hex
         row = ComputeJobRow(
@@ -195,18 +235,52 @@ class PostgresJobBackend:
             await session.refresh(row)
             snapshot = _row_to_job(row)
 
-        # Capture ContextVars + dispatch on the executor. Matches
-        # :class:`JobRegistry`'s behaviour so workers that depend on
-        # request-scoped state still see it (Tier 1 step 3 of doc 10).
-        captured_ctx = contextvars.copy_context()
+        await self._deferrer(
+            job_id=job_id,
+            user_id=self._user_id,
+            kind=kind,
+            args=_to_wire_args(args or {}),
+            match_id=match_id,
+        )
+        return snapshot
+
+    async def run_job(
+        self,
+        *,
+        job_id: str,
+        kind: str,
+        args: dict[str, Any] | None = None,
+        before_body: Callable[[], None] | None = None,
+    ) -> None:
+        """Execute a previously-:meth:`submit`-ted job. Worker entry point.
+
+        The worker's Procrastinate task calls this. Looks up the ``kind``
+        -> body callable and drives it through the same persistence path
+        the in-process executor used to. Offloaded to a thread because
+        :meth:`_run` and the :class:`JobHandle` bridge use ``asyncio.run``
+        for their DB writes, which can't run inside the worker's
+        already-running event loop; ``to_thread`` also copies the current
+        context so the ContextVars propagate.
+
+        ``before_body`` runs on the worker thread immediately before the
+        body, *inside* :meth:`_run`'s failure capture. The worker uses it
+        to re-set the ``current_match_*`` ContextVars from the queued
+        ``match_id``; routing it through here (rather than the calling
+        task) means a failure to resolve the match surfaces as a FAILED
+        job row with a legible message instead of an escaped exception
+        that strands the row at PENDING.
+        """
+        body = self.bodies.get(kind)
+        call_args = args or {}
 
         def _ctx_fn(handle: JobHandle) -> None:
-            captured_ctx.run(lambda: body(handle, **call_args))
+            if before_body is not None:
+                before_body()
+            body(handle, **call_args)
 
         with self._lock:
             self._inflight += 1
-        self._executor.submit(self._run, job_id, _ctx_fn)
-        return snapshot
+        await asyncio.to_thread(self._run, job_id, _ctx_fn)
 
     async def get(self, job_id: str) -> Job | None:
         async with self._session_factory() as session:
@@ -394,8 +468,13 @@ class PostgresJobBackend:
             row_snapshot = asyncio.run(self._begin_run(job_id, now))
             if row_snapshot is None:
                 return
-            if row_snapshot.status == JobStatus.CANCELLED.value:
-                # cancel() raced ahead of the worker; nothing to do.
+            if row_snapshot.status in (
+                JobStatus.CANCELLED.value,
+                JobStatus.FAILED.value,
+                JobStatus.SUCCEEDED.value,
+            ):
+                # cancel() (or a duplicate delivery) raced ahead of the
+                # worker; the row is already terminal. Nothing to run.
                 return
 
             handle = JobHandle(self, job_id)  # type: ignore[arg-type]
@@ -426,6 +505,15 @@ class PostgresJobBackend:
             ).scalar_one_or_none()
             if row is None:
                 return None
+            # Already terminal: a ``cancel()`` (or a duplicate delivery)
+            # beat the worker to this row. Don't resurrect it to RUNNING
+            # -- return the snapshot so ``_run`` can skip the body.
+            if row.status in (
+                JobStatus.CANCELLED.value,
+                JobStatus.FAILED.value,
+                JobStatus.SUCCEEDED.value,
+            ):
+                return _row_to_job(row)
             if row.cancel_requested and row.status == JobStatus.PENDING.value:
                 row.status = JobStatus.CANCELLED.value
                 row.finished_at = now

--- a/src/splitsmith/db/job_backend.py
+++ b/src/splitsmith/db/job_backend.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from ..ui.jobs import (
     Job,
+    JobBodyRegistry,
     JobCancelled,
     JobHandle,
     JobStatus,
@@ -101,6 +102,10 @@ class PostgresJobBackend:
             )
         self._session_factory = session_factory
         self._user_id = user_id
+        # Populated by ``register_job_bodies(state)`` in ``create_app``,
+        # same as the local :class:`JobRegistry`. The hosted worker
+        # process holds its own identically-populated registry.
+        self.bodies = JobBodyRegistry()
 
         self._executor = ThreadPoolExecutor(
             max_workers=max_concurrent,
@@ -162,12 +167,14 @@ class PostgresJobBackend:
         self,
         *,
         kind: str,
-        fn: Callable[[JobHandle], None],
+        args: dict[str, Any] | None = None,
         stage_number: int | None = None,
         video_id: str | None = None,
     ) -> Job:
         if self._shutting_down:
             raise ShutdownInProgressError("server is shutting down; no new jobs accepted")
+        body = self.bodies.get(kind)
+        call_args = args or {}
         now = datetime.now(UTC)
         job_id = uuid.uuid4().hex
         row = ComputeJobRow(
@@ -194,7 +201,7 @@ class PostgresJobBackend:
         captured_ctx = contextvars.copy_context()
 
         def _ctx_fn(handle: JobHandle) -> None:
-            captured_ctx.run(fn, handle)
+            captured_ctx.run(lambda: body(handle, **call_args))
 
         with self._lock:
             self._inflight += 1

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -40,9 +40,18 @@ today is zero.
 
 from __future__ import annotations
 
+import asyncio
 import re
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import procrastinate
+
+# Procrastinate task name for the unified compute-job dispatcher. The
+# API enqueues it via :func:`make_deferrer` (``configure_task`` -- no
+# local registration needed); the worker registers the real
+# implementation via :func:`register_compute_task`.
+RUN_COMPUTE_JOB_TASK = "run_compute_job"
 
 
 def _to_psycopg_dsn(sqlalchemy_url: str) -> str:
@@ -112,6 +121,114 @@ def _register_smoke_tasks(app: procrastinate.App) -> None:
         return payload
 
 
+def make_deferrer(database_url: str) -> Callable[..., Awaitable[None]]:
+    """Build the enqueue coroutine injected into :class:`PostgresJobBackend`.
+
+    The returned ``deferrer(job_id, user_id, kind, args, match_id)``
+    enqueues a :data:`RUN_COMPUTE_JOB_TASK` job onto the user's queue.
+    ``configure_task`` defers a task by name without registering its
+    body locally -- the API process only enqueues; the worker owns the
+    implementation. The :class:`procrastinate.App` is built lazily and
+    cached on first defer so merely wiring hosted mode (e.g. against
+    SQLite, where the queue is unused) never touches Postgres; a SQLite
+    URL raises only if a job is actually submitted.
+    """
+    cache: dict[str, procrastinate.App] = {}
+
+    async def _defer(
+        *,
+        job_id: str,
+        user_id: str,
+        kind: str,
+        args: dict[str, Any],
+        match_id: str | None,
+    ) -> None:
+        app = cache.get("app")
+        if app is None:
+            app = build_app(database_url)
+            cache["app"] = app
+        queue = queue_name_for_user(user_id)
+        async with app.open_async():
+            await app.configure_task(name=RUN_COMPUTE_JOB_TASK, queue=queue).defer_async(
+                job_id=job_id,
+                kind=kind,
+                args=args,
+                match_id=match_id,
+            )
+
+    return _defer
+
+
+def register_compute_task(app: procrastinate.App, state: Any) -> None:
+    """Register the worker-side :data:`RUN_COMPUTE_JOB_TASK` on ``app``.
+
+    Bound to a worker ``state`` (built by
+    ``splitsmith.ui.server.build_worker_state``). The task re-sets the
+    ``current_match_*`` ContextVars from the queued ``match_id``,
+    rehydrates any Pydantic ``req`` in ``args``, then drives the shared
+    body via :meth:`PostgresJobBackend.run_job` -- the same ``kind`` ->
+    body mapping the local registry uses. Must be registered before
+    :meth:`procrastinate.App.run_worker_async`.
+    """
+    from .match_registry import MatchNotRegisteredError
+    from .ui.server import current_match_id, current_match_root
+
+    @app.task(name=RUN_COMPUTE_JOB_TASK, queue="default")
+    async def _run_compute_job(
+        *,
+        job_id: str,
+        kind: str,
+        args: dict[str, Any] | None = None,
+        match_id: str | None = None,
+    ) -> None:
+        call_args = _rehydrate_args(kind, args or {})
+
+        def _bind_match() -> None:
+            """Re-set the match ContextVars from the queued ``match_id``.
+
+            Runs on the worker thread inside ``run_job``'s failure
+            capture, so an unresolvable match fails the job cleanly
+            instead of stranding its row at PENDING. The worker resolves
+            a match through its *local* recent-projects list; a separate
+            worker process has none of the API user's matches, so every
+            match-carrying kind fails here today. Only ``model_download``
+            (no ``match_id``) is proven end-to-end on the worker -- making
+            cross-process match metadata reachable is a later chunk.
+            """
+            if match_id is None:
+                return
+            try:
+                root = state.matches.resolve(match_id)
+            except MatchNotRegisteredError as exc:
+                raise RuntimeError(
+                    f"hosted worker cannot resolve match {match_id!r}: its match "
+                    "metadata is not reachable cross-process yet (a later chunk). "
+                    "Only match-less kinds (e.g. model_download) run on the worker today."
+                ) from exc
+            current_match_root.set(root)
+            current_match_id.set(match_id)
+
+        await state.jobs.run_job(job_id=job_id, kind=kind, args=call_args, before_body=_bind_match)
+
+
+def _rehydrate_args(kind: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Rebuild the typed ``req`` Pydantic model dropped to a dict by
+    :func:`splitsmith.db.job_backend._to_wire_args` for the queue.
+
+    Only ``export`` / ``match_export`` carry a ``req``; every other kind
+    passes through. Importing the request models lazily keeps this module
+    free of a server import at load time (it stays lazy-importable behind
+    ``_hosted_mode_active()``)."""
+    if kind not in ("export", "match_export") or "req" not in args:
+        return args
+    from .ui.server import ExportStageRequest, MatchExportRequest
+
+    model = ExportStageRequest if kind == "export" else MatchExportRequest
+    out = dict(args)
+    out["req"] = model.model_validate(args["req"])
+    return out
+
+
 async def run_worker(
     database_url: str,
     *,
@@ -128,15 +245,24 @@ async def run_worker(
 
     A persistent worker is the whole point of the fleet: it loads the
     ensemble models once (the process-wide ``_ENSEMBLE_RUNTIME``
-    singleton, on the first detection task in PR-gamma) and drains
-    many jobs. For PR-beta the only registered task is ``ping``, so
-    the worker stays light.
+    singleton, on the first detection) and drains many jobs. Building
+    the worker ``state`` wires the per-user ``PostgresJobBackend``
+    (execute-only, no boot sweep) + storage + the shared job bodies.
 
     Installs SIGINT/SIGTERM handlers (Procrastinate default) for
     graceful drain; must therefore run on the main thread, which it
     does via ``asyncio.run`` from the ``splitsmith worker`` command.
+
+    ``build_worker_state`` runs its own ``asyncio.run`` calls (the auth
+    bootstrap upserts the user row synchronously), so it can't run inside
+    this coroutine's event loop -- it's offloaded to a worker thread,
+    which has no running loop of its own.
     """
+    from .ui.server import build_worker_state
+
+    state = await asyncio.to_thread(build_worker_state)
     app = build_app(database_url)
+    register_compute_task(app, state)
     async with app.open_async():
         await app.run_worker_async(queues=queues, concurrency=concurrency)
 

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -91,6 +91,56 @@ class _Unset:
 _UNSET = _Unset()
 
 
+# A job body performs one job kind. Signature: ``body(handle, **args)``.
+# ``args`` is whatever the submit callsite passed and MUST be JSON-
+# serialisable so the hosted transport can ship it to a worker process.
+JobBody = Callable[..., None]
+
+
+class UnknownJobKindError(KeyError):
+    """Raised by :meth:`JobBodyRegistry.get` for an unregistered kind.
+
+    This is a programming error (a ``submit(kind=...)`` whose body was
+    never registered in ``register_job_bodies``), not a user-facing
+    condition -- it should surface loudly in development, never in prod.
+    """
+
+
+class JobBodyRegistry:
+    """Maps a job ``kind`` to the callable that performs it.
+
+    The unification point of the worker-fleet dispatch (doc 04): both the
+    local in-process :class:`JobRegistry` and the hosted
+    ``PostgresJobBackend`` resolve the body to run from this same map, so
+    there is one dispatch shape (``kind`` + serialisable ``args``) and no
+    closure-vs-task_name divergence between desktop and hosted.
+
+    ``register_job_bodies(state)`` in ``server.py`` populates one of these
+    against a process's :class:`AppState`; the hosted worker bootstrap
+    populates an identical one against its own hosted state. The bodies
+    close over that ``state`` -- which is why each process registers its
+    own -- but every callsite and the wire format stay state-agnostic.
+    """
+
+    def __init__(self) -> None:
+        self._bodies: dict[str, JobBody] = {}
+
+    def register(self, kind: str, body: JobBody) -> None:
+        self._bodies[kind] = body
+
+    def get(self, kind: str) -> JobBody:
+        try:
+            return self._bodies[kind]
+        except KeyError:
+            raise UnknownJobKindError(
+                f"no body registered for job kind {kind!r}; "
+                "register it in splitsmith.ui.server.register_job_bodies"
+            ) from None
+
+    def __contains__(self, kind: str) -> bool:
+        return kind in self._bodies
+
+
 class JobStatus(StrEnum):
     """Job lifecycle states.
 
@@ -278,6 +328,10 @@ class JobBackend(Protocol):
     in ``server.py`` and ``embedded.py`` untouched.
     """
 
+    # The kind->body map this backend dispatches through. Populated by
+    # ``register_job_bodies(state)`` against this process's AppState.
+    bodies: JobBodyRegistry
+
     @property
     def is_shutting_down(self) -> bool: ...
 
@@ -291,7 +345,7 @@ class JobBackend(Protocol):
         self,
         *,
         kind: str,
-        fn: Callable[[JobHandle], None],
+        args: dict[str, Any] | None = None,
         stage_number: int | None = None,
         video_id: str | None = None,
     ) -> Job: ...
@@ -330,6 +384,7 @@ class JobRegistry:
     """
 
     def __init__(self, *, max_concurrent: int = 2, retain_recent: int = 50) -> None:
+        self.bodies = JobBodyRegistry()
         self._jobs: dict[str, Job] = {}
         self._order: list[str] = []
         self._lock = threading.RLock()
@@ -402,17 +457,19 @@ class JobRegistry:
         self,
         *,
         kind: str,
-        fn: Callable[[JobHandle], None],
+        args: dict[str, Any] | None = None,
         stage_number: int | None = None,
         video_id: str | None = None,
     ) -> Job:
-        """Schedule ``fn`` to run on the thread pool.
+        """Schedule the body registered for ``kind`` to run on the thread
+        pool, called as ``body(handle, **args)``.
 
         Returns the job snapshot (status=PENDING) immediately so the HTTP
         handler can hand the id back to the caller without blocking.
 
         Raises :class:`ShutdownInProgressError` if :meth:`begin_shutdown`
-        has been called -- the HTTP layer maps this to a 503.
+        has been called -- the HTTP layer maps this to a 503. Raises
+        :class:`UnknownJobKindError` if no body is registered for ``kind``.
 
         The submitting HTTP request's ``contextvars`` (notably
         ``current_match_root`` / ``current_match_id`` set by the
@@ -420,10 +477,14 @@ class JobRegistry:
         here and replayed inside the worker thread. Without this the
         ContextVars are unset on the executor thread and any
         ``state.shooter_root(...)`` call inside the worker 409s
-        ``no_project``. See Tier 1 step 3 of doc 10.
+        ``no_project``. See Tier 1 step 3 of doc 10. (The hosted backend
+        instead reconstructs the match context from the ``args`` it ships
+        to the worker process, which has no inherited contextvars.)
         """
         if self._shutting_down:
             raise ShutdownInProgressError("server is shutting down; no new jobs accepted")
+        body = self.bodies.get(kind)
+        call_args = args or {}
         now = datetime.now(UTC)
         job = Job(
             id=uuid.uuid4().hex,
@@ -437,7 +498,7 @@ class JobRegistry:
         captured_ctx = contextvars.copy_context()
 
         def _ctx_fn(handle: JobHandle) -> None:
-            captured_ctx.run(fn, handle)
+            captured_ctx.run(lambda: body(handle, **call_args))
 
         with self._lock:
             self._jobs[job.id] = job

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -899,6 +899,962 @@ async def _maybe_submit_model_download(state: AppState) -> None:
         return
 
 
+def register_job_bodies(state: AppState) -> None:
+    """Register the production job-body closures on ``state.jobs.bodies``.
+
+    Shared by ``create_app`` (local + embedded hosts) and the
+    Procrastinate worker bootstrap so the same ``kind`` -> body mapping
+    backs every transport. The bodies close over ``state``; a hosted
+    worker builds its own ``state`` and calls this against it. Dev-only
+    lab kinds register at their callsites in ``create_app`` since they're
+    never deferred to a hosted worker.
+    """
+    # Cross-cam alignment is accepted as a *suggestion* (beep_source="aligned",
+    # beep_reviewed=False so the SPA forces the user to verify on the waveform
+    # picker) when the peak-to-runner-up ratio of the cross-correlation clears
+    # this threshold. 1.0 means the landmark wasn't distinctive at all.
+    # Empirically calibrated on tallmilan-2026 secondaries: same-stage pairs
+    # where in-stream detection independently succeeded land at 1.23-1.34, and
+    # plausible alignments on the in-stream-failed pairs land at 1.15-1.31.
+    # Same-mic non-overlapping clips sit at ~1.00. 1.10 leaves a slim margin
+    # over the floor while still surfacing real alignments. False positives
+    # are caught by the user in the picker before "Mark reviewed"; false
+    # negatives mean the user starts from the auto-detect-failed state and
+    # places the marker by hand, which is the same UX as before this change.
+    _align_confidence_floor = 1.10
+
+    def _try_align_secondary_to_primary(
+        root: Path,
+        proj: MatchProject,
+        stage: StageEntry,
+        video: StageVideo,
+        handle: JobHandle,
+    ) -> cross_align.CrossAlignResult | None:
+        """Attempt cross-correlation alignment of ``video`` against the stage's
+        primary. Returns the raw result whenever cross-correlation could be
+        computed (so the caller can save ``confidence`` as a diagnostic even
+        below the auto-accept floor); returns ``None`` only when alignment
+        isn't possible at all (no primary, no primary beep_time, audio not
+        cached, landmark window too narrow). Threshold comparison happens at
+        the call site so a low-confidence result can still inform the UI.
+
+        Run only on the secondary soft-fail path -- when in-stream beep
+        detection has already raised ``BeepNotFoundError``. Cheap (envelope
+        cross-correlation at 200 Hz; sub-second on a 60 s clip), but not free,
+        so we skip it on the primary path entirely.
+        """
+        primary = stage.primary()
+        if primary is None or primary.beep_time is None:
+            return None
+        primary_audio_path = audio_helpers.primary_audio_path(root, stage.stage_number, project=proj)
+        secondary_audio_path = audio_helpers.video_audio_path(root, stage.stage_number, video, project=proj)
+        if not primary_audio_path.exists() or not secondary_audio_path.exists():
+            # Either side missing means the user hasn't run beep-detect on
+            # the primary yet, or the secondary's own audio extract failed
+            # before we even got here. Both are dealt with by the existing
+            # soft-fail UX -- alignment can be retried later.
+            return None
+        try:
+            primary_audio, primary_sr = beep_detect.load_audio(primary_audio_path)
+            secondary_audio, secondary_sr = beep_detect.load_audio(secondary_audio_path)
+            handle.update(progress=0.45, message="Aligning to primary...")
+            result = cross_align.align_secondary_to_primary(
+                primary_audio,
+                primary_sr,
+                primary.beep_time,
+                secondary_audio,
+                secondary_sr,
+            )
+        except cross_align.CrossAlignError as exc:
+            logger.info(
+                "cross-align skipped for stage %d video %s: %s",
+                stage.stage_number,
+                video.video_id,
+                exc,
+            )
+            return None
+        return result
+
+    def _run_detect_beep_for_video(handle: JobHandle, slug: str, stage_number: int, video_id: str) -> None:
+        """Worker: detect ``video``'s beep, then auto-chain trim.
+
+        Generic over role:
+          - primary: detect -> trim -> shot_detect (existing pipeline).
+          - secondary: detect -> trim (no shot_detect; the audit timeline
+            is anchored to the primary's beep).
+
+        Trim is treated as a soft failure: the beep is valuable on its
+        own and the SPA can re-trim later.
+        """
+        handle.update(progress=0.05, message="Loading project...")
+        proj = state.shooter_project(slug)
+        stg = proj.stage(stage_number)
+        video = stg.find_video_by_id(video_id)
+        if video is None:
+            raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
+        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
+        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
+        handle.update(
+            progress=0.15,
+            message=f"Extracting audio + detecting beep ({role_label})...",
+        )
+        try:
+            beep = audio_helpers.detect_video_beep(
+                state.shooter_root(slug),
+                stage_number,
+                video,
+                source,
+                project=proj,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
+            )
+        except beep_detect.BeepNotFoundError as exc:
+            # Primary failure is fatal -- the entire downstream pipeline
+            # (trim window, shot timeline) hangs off the primary beep.
+            # Surfacing as a job error gets the user looking at the audio
+            # right away rather than silently falling through to a wrong
+            # alignment. Secondary failure is soft-handled below: many
+            # non-headcam cameras (iPhone tripod, RO position, AGC'd) just
+            # don't capture a sustained 2-5 kHz tone, and aborting the
+            # import on every one of them is the worse UX.
+            if video.role == "primary":
+                raise
+            logger.info(
+                "no beep on secondary stage %d video %s: %s",
+                stage_number,
+                video.video_id,
+                exc,
+            )
+            # Cross-correlation fallback: when the primary already has a
+            # beep, try aligning the secondary's audio against the
+            # primary's landmark window. Same buzzer + first shots in the
+            # same room means the loudness envelopes line up modulo a
+            # constant time offset, even when the secondary's mic missed
+            # the sustained 2-5 kHz tone the in-stream detector wants.
+            aligned = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
+            video.beep_peak_amplitude = None
+            video.beep_duration_ms = None
+            video.beep_candidates = []
+            video.beep_reviewed = False
+            video.processed["beep"] = True
+            # Surface the cross-correlation confidence whenever we got one,
+            # even if we don't promote the suggestion. Lets the UI tell the
+            # difference between "never tried" and "tried, sub-floor result".
+            video.beep_alignment_confidence = aligned.confidence if aligned is not None else None
+            # Delta is only meaningful when both in-stream AND cross-align
+            # produced timestamps. In-stream failed here, so wipe it.
+            video.beep_alignment_delta_ms = None
+            if aligned is not None and aligned.confidence >= _align_confidence_floor:
+                handle.update(
+                    progress=0.55,
+                    message=(f"Aligned to primary (conf {aligned.confidence:.2f}); " "verify on waveform"),
+                )
+                video.beep_time = aligned.secondary_beep_time
+                video.beep_source = "aligned"
+                video.beep_auto_detect_failed = False
+                # Treat as "we have a usable beep_time": fall through to
+                # the trim block below.
+                beep = aligned
+            else:
+                if aligned is not None:
+                    logger.info(
+                        "cross-align below floor for stage %d video %s: conf %.2f < %.2f",
+                        stage_number,
+                        video.video_id,
+                        aligned.confidence,
+                        _align_confidence_floor,
+                    )
+                handle.update(progress=0.55, message="No beep detected; pick on waveform")
+                video.beep_time = None
+                video.beep_source = "auto"
+                video.beep_auto_detect_failed = True
+                video.processed["trim"] = False
+                beep = None
+        else:
+            handle.update(progress=0.55, message="Saving beep...")
+            video.beep_time = beep.time
+            video.beep_source = "auto"
+            video.beep_peak_amplitude = beep.peak_amplitude
+            video.beep_duration_ms = beep.duration_ms
+            video.beep_confidence = beep.confidence
+            video.beep_candidates = list(beep.candidates)
+            video.beep_auto_detect_failed = False
+            video.beep_alignment_confidence = None
+            video.beep_alignment_delta_ms = None
+            video.processed["beep"] = True
+            # Auto-detected beeps need explicit user review (#71) UNLESS
+            # the calibrated confidence (#220 layer 3a) clears the
+            # ``beep_low_confidence_threshold`` automation gate (#219).
+            # Above the threshold we auto-trust: the detector is right
+            # ~95 % of the time in that band, so making the user click
+            # to confirm every high-confidence beep adds friction
+            # without catching real problems. Below it the user has to
+            # review -- the HITL queue (``GET /api/hitl-queue``) lists
+            # exactly these. Resets to False on re-detection so the
+            # prior approval doesn't carry over to a fresh run.
+            resolved_auto = automation_settings.resolve_automation(
+                project_override=proj.automation,
+            )
+            threshold = resolved_auto.settings.beep_low_confidence_threshold
+            video.beep_reviewed = beep.confidence >= threshold
+            # Sanity check: when in-stream succeeded on a secondary, ALSO
+            # run cross-correlation against the primary. If the two
+            # methods disagree by more than ~250 ms it usually means the
+            # in-stream detector locked onto something that wasn't the
+            # buzzer (a steel-strike that resembles a tone, an early
+            # range-officer command, etc.). The delta is surfaced in the
+            # SPA so the user can compare both candidates on the
+            # waveform before marking reviewed. Never overrides the
+            # in-stream result -- in-stream has frequency-domain
+            # information cross-align doesn't, so when they agree we
+            # trust the in-stream answer; when they disagree we let the
+            # user decide.
+            if video.role != "primary":
+                check = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
+                if check is not None and check.confidence >= _align_confidence_floor:
+                    video.beep_alignment_confidence = check.confidence
+                    video.beep_alignment_delta_ms = (beep.time - check.secondary_beep_time) * 1000.0
+
+        trimmed_ok = False
+        if beep is not None and stg.time_seconds > 0:
+            handle.check_cancel()
+            handle.update(progress=0.55, message=f"Trimming audit clip ({role_label})...")
+            try:
+                audio_helpers.ensure_video_audit_trim(
+                    state.shooter_root(slug),
+                    stage_number,
+                    video,
+                    source,
+                    video.beep_time,
+                    stg.time_seconds,
+                    project=proj,
+                    runner=_cancellable_runner(handle),
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
+                )
+                video.processed["trim"] = True
+                trimmed_ok = True
+            except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
+                # Soft failure: beep alone is still useful, especially for
+                # secondaries (audit alignment works without a trim cache).
+                logger.warning(
+                    "auto-trim failed for stage %d video %s: %s",
+                    stage_number,
+                    video.video_id,
+                    exc,
+                )
+                handle.update(message=f"beep saved; trim failed: {exc}")
+        handle.update(progress=0.85, message="Saving project...")
+        # Read-modify-write the project file: extract / detection /
+        # ffmpeg trim can take 30+ s during which the user may have
+        # toggled ``beep_reviewed`` on other stages. Reloading and
+        # copying our targeted fields onto the fresh project preserves
+        # those concurrent edits instead of stomping them with the
+        # snapshot we loaded at job start.
+        fresh = state.shooter_project(slug)
+        try:
+            stg_fresh = fresh.stage(stage_number)
+        except KeyError:
+            stg_fresh = None
+        v_fresh = stg_fresh.find_video_by_id(video_id) if stg_fresh is not None else None
+        if v_fresh is not None:
+            v_fresh.beep_time = video.beep_time
+            v_fresh.beep_source = video.beep_source
+            v_fresh.beep_peak_amplitude = video.beep_peak_amplitude
+            v_fresh.beep_duration_ms = video.beep_duration_ms
+            v_fresh.beep_confidence = video.beep_confidence
+            v_fresh.beep_candidates = list(video.beep_candidates)
+            v_fresh.beep_reviewed = video.beep_reviewed
+            v_fresh.beep_auto_detect_failed = video.beep_auto_detect_failed
+            v_fresh.beep_alignment_confidence = video.beep_alignment_confidence
+            v_fresh.beep_alignment_delta_ms = video.beep_alignment_delta_ms
+            v_fresh.processed["beep"] = True
+            if trimmed_ok:
+                v_fresh.processed["trim"] = True
+            fresh.save(state.shooter_root(slug))
+        if trimmed_ok and video.role == "primary" and video.beep_reviewed:
+            # Shot detection is primary-only AND gated on
+            # ``beep_reviewed`` (#71). That flag is True either because
+            # the user explicitly clicked "Mark reviewed" (which
+            # re-triggers chaining via ``set_beep_reviewed``) or because
+            # the auto-trust gate cleared (#219 layer 3b: confidence at
+            # or above ``beep_low_confidence_threshold``). Saves the
+            # heavy CLAP / GBDT / PANN ensemble work when the beep
+            # timestamp is wrong, since everything downstream of it
+            # would be garbage anyway.
+            #
+            # Layered automation gate (#215): users can disable the
+            # auto-trigger globally or per project. ``cli_override`` is
+            # always None for the server -- the daemon doesn't take
+            # CLI flags at this entry point.
+            resolved = automation_settings.resolve_automation(
+                project_override=fresh.automation,
+            )
+            # Worker callback runs in a ThreadPoolExecutor thread with
+            # no event loop; bridge to the async JobBackend via
+            # ``asyncio.run``.
+            if (
+                resolved.settings.shot_detect_on_beep_verified
+                and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
+            ):
+                asyncio.run(
+                    state.jobs.submit(
+                        kind="shot_detect",
+                        stage_number=stage_number,
+                        args={"slug": slug, "stage_number": stage_number},
+                    )
+                )
+        handle.update(progress=1.0, message="Done")
+
+    def _run_trim(
+        handle: JobHandle,
+        *,
+        slug: str,
+        stage_number: int,
+        video_id: str,
+        chain_shot_detect: bool = True,
+    ) -> None:
+        """Worker for the audit-mode trim of a specific video.
+
+        Resolves the shooter via ``slug`` (so the body is portable to a
+        hosted worker process -- the bulk path used to pass an explicit
+        ``shooter_root`` Path, which can't cross a process boundary).
+
+        Auto-chains shot detection only when the trimmed video is the
+        reviewed primary AND ``chain_shot_detect`` is set; secondaries
+        align to the primary's audit timeline by their own beep, so they
+        do not need their own shot-detection run. The bulk maintenance
+        pass passes ``chain_shot_detect=False`` -- it regenerates derived
+        trim caches without re-running detection over the whole match.
+        """
+        handle.update(progress=0.1, message="Preparing trim...")
+        proj = state.shooter_project(slug)
+        root = state.shooter_root(slug)
+        stg = proj.stage(stage_number)
+        video = stg.find_video_by_id(video_id)
+        if video is None or video.beep_time is None:
+            raise RuntimeError("video or beep disappeared mid-flight")
+        source = proj.resolve_video_path(root, video.path)
+        handle.check_cancel()
+        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
+        handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
+        audio_helpers.ensure_video_audit_trim(
+            root,
+            stage_number,
+            video,
+            source,
+            video.beep_time,
+            stg.time_seconds,
+            project=proj,
+            runner=_cancellable_runner(handle),
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
+        )
+        handle.update(progress=0.85, message="Saving project...")
+        # Read-modify-write to avoid stomping concurrent edits made
+        # while ffmpeg was running (e.g. another stage's beep review).
+        fresh = state.shooter_project(slug)
+        stg_fresh = fresh.stage(stage_number)
+        v_fresh = stg_fresh.find_video_by_id(video_id)
+        if v_fresh is not None:
+            v_fresh.processed["trim"] = True
+            fresh.save(root)
+        # Worker callback runs in a ThreadPoolExecutor thread with no
+        # event loop; bridge to the async JobBackend via ``asyncio.run``.
+        if (
+            chain_shot_detect
+            and video.role == "primary"
+            and video.beep_reviewed
+            and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
+        ):
+            # Same gate as the detect-then-trim path (#71): don't burn
+            # CLAP / GBDT / PANN cycles on a beep the user hasn't
+            # confirmed. Manual entries pre-set ``beep_reviewed`` to True
+            # so this still runs; the auto-detect path waits for the
+            # user's explicit "Mark reviewed" click which re-fires
+            # shot_detect from there.
+            #
+            # Layered automation gate (#215): a global / project
+            # opt-out can suppress this auto-trigger.
+            resolved = automation_settings.resolve_automation(
+                project_override=fresh.automation,
+            )
+            if resolved.settings.shot_detect_on_beep_verified:
+                asyncio.run(
+                    state.jobs.submit(
+                        kind="shot_detect",
+                        stage_number=stage_number,
+                        args={"slug": slug, "stage_number": stage_number},
+                    )
+                )
+        handle.update(progress=1.0, message="Done")
+
+    def _run_shot_detect(handle: JobHandle, slug: str, stage_number: int, reset: bool = False) -> None:
+        """Worker that runs the 4-voter ensemble on the stage's audit clip.
+
+        Reads the trimmed clip's WAV (extracting it on demand if needed),
+        runs ``splitsmith.ensemble.detect_shots_ensemble`` over the
+        ``[beep .. beep+stage]`` window, and writes both the consensus
+        ``shots[]`` and the full voter-A universe into the audit JSON.
+
+        ``_candidates_pending_audit.candidates`` carries every candidate
+        annotated with per-voter signals (vote_a/b/c/d, ensemble_score,
+        score_c, clap_diff, gunshot_prob) so the audit UI can render the
+        decision trail. ``shots[]`` is seeded from the consensus subset
+        unless it is already populated -- the user retains authority. If
+        ``reset`` is True, ``shots[]`` is wiped first so the user can
+        start over after a bad beep / detector pass.
+
+        Adaptive prior: if the audit JSON already carries
+        ``stage_rounds.expected``, voter C switches to its adaptive
+        top-(K+slack) mode and the apriori boost lifts the top-K
+        confidence-ranked candidates over the consensus line.
+        """
+        proj = state.shooter_project(slug)
+        stg = proj.stage(stage_number)
+        prim = stg.primary()
+        if prim is None or prim.beep_time is None:
+            raise RuntimeError(f"stage {stage_number} has no primary or no beep yet")
+        if stg.time_seconds <= 0:
+            raise RuntimeError(
+                f"stage {stage_number} has time_seconds=0; import a "
+                "scoreboard before running shot detection"
+            )
+        source = proj.resolve_video_path(state.shooter_root(slug), prim.path)
+
+        # Re-detect-all on an old project (and the v1->v2 cache migration in
+        # #298) leaves stages with no trimmed MP4 cached. Without that file,
+        # ensure_audit_audio falls back to the full source WAV -- shot
+        # detection still works, but the audit page then streams the raw
+        # source clip into <video>, where long-GOP 4K MOVs wedge in buffering
+        # on first play. Force the trim here so every shot-detect run leaves
+        # the audit cache in the same state the beep-detect path would have.
+        handle.update(progress=0.05, message="Ensuring audit trim...")
+        try:
+            audio_helpers.ensure_video_audit_trim(
+                state.shooter_root(slug),
+                stage_number,
+                prim,
+                source,
+                prim.beep_time,
+                stg.time_seconds,
+                project=proj,
+                runner=_cancellable_runner(handle),
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
+            )
+            trim_fresh = state.shooter_project(slug)
+            try:
+                v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
+            except KeyError:
+                v_fresh = None
+            if v_fresh is not None and not v_fresh.processed.get("trim"):
+                v_fresh.processed["trim"] = True
+                trim_fresh.save(state.shooter_root(slug))
+        except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
+            # Soft failure: detection can still proceed against the source
+            # WAV. ensure_audit_audio's fallback handles the missing trim,
+            # so we log and continue rather than abort the whole job.
+            logger.warning(
+                "shot_detect could not (re)build trim for stage %d: %s",
+                stage_number,
+                exc,
+            )
+
+        handle.update(progress=0.1, message="Preparing audio...")
+        audit = audio_helpers.ensure_audit_audio(
+            state.shooter_root(slug),
+            stage_number,
+            source,
+            prim.beep_time,
+            project=proj,
+            ffmpeg_binary=process_runtime().ffmpeg_binary,
+        )
+        beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else prim.beep_time
+
+        # Read existing audit JSON up-front: we need ``stage_rounds.expected``
+        # before running detection (it changes voter C's mode and the
+        # apriori boost) and we'll merge results back into the same dict.
+        audit_dir = proj.audit_path(state.shooter_root(slug))
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        audit_file = audit_dir / f"stage{stage_number}.json"
+        if audit_file.exists():
+            try:
+                existing_json = json.loads(audit_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                existing_json = {}
+        else:
+            existing_json = {
+                "stage_number": stg.stage_number,
+                "stage_name": stg.stage_name,
+                "stage_time_seconds": stg.time_seconds,
+                "beep_time": round(beep_in_clip, 4),
+                "shots": [],
+            }
+        # Carry stage_rounds (min_rounds + target breakdown) from the
+        # project state into the audit JSON so the ensemble's adaptive
+        # voter C + apriori boost can consume ``stage_rounds.expected``.
+        # Project value wins over a stale audit-JSON copy: re-running
+        # detection after a scoreboard refresh should pick up the new
+        # round count without manual edits.
+        if stg.stage_rounds is not None:
+            existing_json["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
+        expected_rounds: int | None = None
+        sr_block = existing_json.get("stage_rounds")
+        if isinstance(sr_block, dict):
+            raw = sr_block.get("expected")
+            if isinstance(raw, int) and raw > 0:
+                expected_rounds = raw
+
+        handle.update(progress=0.2, message="Loading ensemble models...")
+        handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
+        audio_array, sr = beep_detect.load_audio(audit.audio_path)
+        # Camera-class dispatch (issue #143). When the primary's mount
+        # is set, look up handheld vs. headcam thresholds; otherwise
+        # the ensemble falls back to the default class (headcam).
+        cam_class = ensemble_module.camera_class_from_mount(prim.camera_mount)
+        # Voter E opt-in (issue #183). Off by default for the first
+        # release; flip via env var until corpus growth justifies
+        # default-on. Requires the calibration to ship a probe head
+        # AND the source video to be reachable.
+        enable_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
+        ensemble_cfg = ensemble_module.EnsembleConfig(enable_voter_e=enable_e)
+        result = state.compute.detect_stage(
+            audio=audio_array,
+            sample_rate=sr,
+            beep_time_in_clip=beep_in_clip,
+            stage_time_seconds=stg.time_seconds,
+            expected_rounds=expected_rounds,
+            ensemble_config=ensemble_cfg,
+            camera_class=cam_class,
+            camera_make=prim.camera_make,
+            camera_model=prim.camera_model,
+            video_path=source if enable_e else None,
+            source_beep_time=prim.beep_time if enable_e else None,
+        )
+
+        candidates: list[dict[str, Any]] = []
+        for cand in result.candidates:
+            candidates.append(
+                {
+                    "candidate_number": cand.candidate_number,
+                    "time": cand.time,
+                    "ms_after_beep": cand.ms_after_beep,
+                    "peak_amplitude": cand.peak_amplitude,
+                    "confidence": cand.confidence,
+                    "vote_a": cand.vote_a,
+                    "vote_b": cand.vote_b,
+                    "vote_c": cand.vote_c,
+                    "vote_e": cand.vote_e,
+                    "vote_total": cand.vote_total,
+                    "apriori_boost": cand.apriori_boost,
+                    "ensemble_score": cand.ensemble_score,
+                    "score_c": cand.score_c,
+                    "clap_diff": cand.clap_diff,
+                    "gunshot_prob": cand.gunshot_prob,
+                    "voter_e_signal": cand.voter_e_signal,
+                }
+            )
+
+        handle.update(progress=0.85, message="Saving audit JSON...")
+        existing_json["_candidates_pending_audit"] = {
+            "_note": (
+                "3-voter ensemble (PANN gunshot folded into voter C). "
+                "vote_a/b/c=1 means the voter kept the candidate; "
+                "ensemble_score = vote_total + apriori_boost. shots[] is "
+                "seeded from candidates with ensemble_score >= consensus."
+            ),
+            "consensus": result.consensus,
+            "expected_rounds": result.expected_rounds,
+            "candidates": candidates,
+        }
+        if reset:
+            existing_json["shots"] = []
+        seeded_shots = False
+        if not existing_json.get("shots"):
+            kept = [c for c in result.candidates if c.kept]
+            existing_json["shots"] = [
+                {
+                    "shot_number": i,
+                    "candidate_number": c.candidate_number,
+                    "time": c.time,
+                    "ms_after_beep": c.ms_after_beep,
+                    "source": "detected",
+                    "ensemble_votes": c.vote_total,
+                    "apriori_boost": c.apriori_boost,
+                    "ensemble_score": c.ensemble_score,
+                }
+                for i, c in enumerate(kept, start=1)
+            ]
+            seeded_shots = True
+        events = list(existing_json.get("audit_events") or [])
+        events.append(
+            {
+                "ts": _now_iso(),
+                "kind": "shot_detect_run",
+                "payload": {
+                    "candidate_count": len(candidates),
+                    "kept_count": sum(1 for c in result.candidates if c.kept),
+                    "consensus": result.consensus,
+                    "expected_rounds": result.expected_rounds,
+                    "seeded_shots": seeded_shots,
+                },
+            }
+        )
+        existing_json["audit_events"] = events
+
+        # Atomic write + .bak (mirrors put_stage_audit).
+        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
+        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
+        tmp.write_text(json.dumps(existing_json, indent=2) + "\n", encoding="utf-8")
+        if audit_file.exists():
+            if backup.exists():
+                backup.unlink()
+            audit_file.replace(backup)
+        tmp.replace(audit_file)
+
+        # Read-modify-write the project file: a long-running shot_detect
+        # job must not save the snapshot it loaded at start, because the
+        # user may have toggled ``beep_reviewed`` on other stages in the
+        # interim (the review action kicks shot_detect, so concurrent
+        # bursts are the common case). Reloading from disk and mutating
+        # only the targeted field preserves those concurrent edits.
+        fresh = state.shooter_project(slug)
+        stg_fresh = fresh.stage(stage_number)
+        prim_fresh = stg_fresh.primary()
+        if prim_fresh is not None:
+            prim_fresh.processed["shot_detect"] = True
+            fresh.save(state.shooter_root(slug))
+        handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
+
+    def _run_export_for_stage(
+        handle: JobHandle, slug: str, stage_number: int, req: ExportStageRequest
+    ) -> None:
+        """Worker for /api/stages/{n}/export. Phases mirror the user's
+        mental model so the JobsPanel message is meaningful."""
+        from ..config import StageData as EngineStageData
+
+        handle.update(progress=0.05, message="Loading project...")
+        proj = state.shooter_project(slug)
+        stg = proj.stage(stage_number)
+        prim = stg.primary()
+        if prim is None or prim.beep_time is None:
+            raise RuntimeError("primary or beep disappeared mid-flight")
+
+        audit_file = proj.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
+        exports_dir = proj.exports_path(state.shooter_root(slug))
+        source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
+        engine_stage = EngineStageData(
+            stage_number=stg.stage_number,
+            stage_name=stg.stage_name,
+            time_seconds=stg.time_seconds,
+            scorecard_updated_at=stg.scorecard_updated_at,
+        )
+
+        # Phase progress is approximate; trim dominates wall time when the
+        # source is large, so we hold at 0.4 through the trim phase and
+        # then jump on the small writers.
+        if req.write_trim:
+            handle.update(progress=0.15, message="Trimming source (lossless stream copy)...")
+        elif req.write_fcpxml:
+            handle.update(progress=0.15, message="Reading audit + preparing FCPXML...")
+        else:
+            handle.update(progress=0.15, message="Reading audit JSON...")
+        handle.check_cancel()
+
+        # Multi-cam (issue #54). Each secondary with a known beep ships
+        # alongside the primary so a single Generate click produces the
+        # complete multi-cam timeline. Cams without a beep yet -- e.g.
+        # registered but ingest didn't finish -- are silently skipped; the
+        # SPA's ingest screen flags those rows separately. The Export page
+        # may also pass ``secondary_video_ids`` to restrict the roster to a
+        # subset (None = include every cam with a beep, the legacy default).
+        allowed_ids: set[str] | None = (
+            set(req.secondary_video_ids) if req.secondary_video_ids is not None else None
+        )
+        secondaries: list[export_helpers.SecondaryExport] = []
+        for sv in stg.videos:
+            if sv.role != "secondary":
+                continue
+            if sv.beep_time is None:
+                continue
+            if allowed_ids is not None and sv.video_id not in allowed_ids:
+                continue
+            sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
+            secondaries.append(
+                export_helpers.SecondaryExport(
+                    video_id=sv.video_id,
+                    source_path=sec_source,
+                    beep_time_in_source=sv.beep_time,
+                    label=f"Cam {sv.video_id}",
+                )
+            )
+
+        try:
+            result = export_helpers.export_stage(
+                request=export_helpers.StageExportRequest(
+                    stage_number=stage_number,
+                    write_trim=req.write_trim,
+                    write_csv=req.write_csv,
+                    write_fcpxml=req.write_fcpxml,
+                    write_report=req.write_report,
+                    write_overlay=req.write_overlay,
+                    overlay_codec=req.overlay_codec,
+                    overlay_max_height=req.overlay_max_height,
+                    overlay_max_fps=req.overlay_max_fps,
+                    overlay_theme=req.overlay_theme,
+                ),
+                audit_path=audit_file,
+                exports_dir=exports_dir,
+                source_video_path=source_video if source_video.exists() else None,
+                stage_data=engine_stage,
+                beep_time_in_source=prim.beep_time,
+                pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                post_buffer_seconds=proj.trim_post_buffer_seconds,
+                config=Config(),
+                secondaries=secondaries,
+            )
+        except export_helpers.StageExportError as exc:
+            # Surface as a job failure with the exporter's own message so
+            # the JobsPanel row reads "audit JSON has no shots in shots[]"
+            # rather than a stack trace.
+            raise RuntimeError(str(exc)) from exc
+
+        handle.update(progress=0.95, message="Saving project...")
+        proj.updated_at = datetime.now(UTC)
+        proj.save(state.shooter_root(slug))
+
+        # Final message summarises what shipped + flags any skipped
+        # artefacts (FCPXML without a trim, etc). The full list lives in
+        # the report.txt; the user can Reveal it for details.
+        bits: list[str] = []
+        if result.trimmed_video_path is not None:
+            bits.append("trim")
+        if result.secondary_trimmed_paths:
+            n = len(result.secondary_trimmed_paths)
+            bits.append(f"{n} secondary trim{'s' if n != 1 else ''}")
+        if result.csv_path is not None:
+            bits.append("csv")
+        if result.fcpxml_path is not None:
+            bits.append("fcpxml")
+        if result.report_path is not None:
+            bits.append("report")
+        if result.overlay_path is not None:
+            bits.append("overlay")
+        summary = ", ".join(bits) if bits else "nothing written"
+        if result.anomalies:
+            n = len(result.anomalies)
+            word = "anomaly" if n == 1 else "anomalies"
+            summary += f" ({n} {word} -- see report.txt)"
+        handle.update(progress=1.0, message=f"Done: {summary}")
+
+    def _run_match_export(handle: JobHandle, slug: str, req: MatchExportRequest) -> None:
+        """Worker for the shooter's match-export job. Re-runs the per-stage exporter for
+        any selected stage missing its lossless trim, then composes the
+        match FCPXML.
+        """
+        from ..config import StageData as EngineStageData
+        from . import exports as exports_mod
+
+        handle.update(progress=0.02, message="Loading project...")
+        proj = state.shooter_project(slug)
+        exports_dir = proj.exports_path(state.shooter_root(slug))
+        audit_dir = proj.audit_path(state.shooter_root(slug))
+
+        n = len(req.stage_numbers)
+        # Reserve the last 10% for the match compose step; the rest is
+        # split evenly across per-stage trims (the dominant wall time).
+        # Stages that already have a trim skip ahead within their slice
+        # instead of contributing to the wait.
+        per_stage_share = 0.85 / max(1, n)
+
+        for idx, stage_number in enumerate(req.stage_numbers):
+            handle.check_cancel()
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            if prim is None or prim.beep_time is None:
+                raise RuntimeError(f"stage {stage_number}: primary or beep disappeared mid-flight")
+
+            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
+            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+            overlay_target = exports_dir / f"{base}_overlay.mov"
+
+            # Decide what's missing. The match composer needs the
+            # lossless trim + per-cam trims (when include_secondaries) +
+            # optional overlay. Re-run the per-stage exporter for any
+            # stage where any required artefact isn't on disk.
+            wanted_secondary_ids: set[str] = set()
+            if req.include_secondaries:
+                for sv in stg.videos:
+                    if sv.role == "secondary" and sv.beep_time is not None:
+                        wanted_secondary_ids.add(sv.video_id)
+            secondary_trims_present = all(
+                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
+            )
+            # Treat any non-default overlay format option as "force re-render"
+            # so the dialog's codec / max-height / max-fps choices actually
+            # apply when a stale overlay sits on disk. With all defaults we
+            # keep the legacy "skip if present" behaviour for fast re-stitching.
+            overlay_format_overridden = (
+                req.overlay_codec != "auto"
+                or req.overlay_max_height is not None
+                or req.overlay_max_fps is not None
+                or req.overlay_theme != "splitsmith"
+            )
+            overlay_missing = req.include_overlay and (
+                not overlay_target.exists() or overlay_format_overridden
+            )
+
+            needs_per_stage = not trimmed_path.exists() or not secondary_trims_present or overlay_missing
+            if needs_per_stage:
+                handle.update(
+                    progress=0.02 + idx * per_stage_share,
+                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."),
+                )
+                # Build the secondaries list for the per-stage exporter --
+                # mirrors the single-stage endpoint's logic.
+                secondaries_in: list[export_helpers.SecondaryExport] = []
+                if req.include_secondaries:
+                    for sv in stg.videos:
+                        if sv.role != "secondary" or sv.beep_time is None:
+                            continue
+                        sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
+                        secondaries_in.append(
+                            export_helpers.SecondaryExport(
+                                video_id=sv.video_id,
+                                source_path=sec_source,
+                                beep_time_in_source=sv.beep_time,
+                                label=f"Cam {sv.video_id}",
+                            )
+                        )
+                source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
+                engine_stage = EngineStageData(
+                    stage_number=stg.stage_number,
+                    stage_name=stg.stage_name,
+                    time_seconds=stg.time_seconds,
+                    scorecard_updated_at=stg.scorecard_updated_at,
+                )
+                try:
+                    export_helpers.export_stage(
+                        request=export_helpers.StageExportRequest(
+                            stage_number=stage_number,
+                            write_trim=True,
+                            write_csv=True,
+                            write_fcpxml=True,
+                            write_report=True,
+                            write_overlay=req.include_overlay,
+                            overlay_codec=req.overlay_codec,
+                            overlay_max_height=req.overlay_max_height,
+                            overlay_max_fps=req.overlay_max_fps,
+                            overlay_theme=req.overlay_theme,
+                        ),
+                        audit_path=audit_dir / f"stage{stage_number}.json",
+                        exports_dir=exports_dir,
+                        source_video_path=source_video if source_video.exists() else None,
+                        stage_data=engine_stage,
+                        beep_time_in_source=prim.beep_time,
+                        pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                        post_buffer_seconds=proj.trim_post_buffer_seconds,
+                        config=Config(),
+                        secondaries=secondaries_in,
+                    )
+                except export_helpers.StageExportError as exc:
+                    raise RuntimeError(f"stage {stage_number}: {exc}") from exc
+            else:
+                handle.update(
+                    progress=0.02 + idx * per_stage_share,
+                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "trim already present; skipping"),
+                )
+
+        handle.check_cancel()
+        handle.update(progress=0.92, message="Stitching match FCPXML...")
+
+        # Re-load the project: the per-stage worker writes processed flags
+        # via project.save() side-effects, so a fresh load picks those up.
+        proj = state.shooter_project(slug)
+        stages_input: list[match_export_helpers.MatchStageInput] = []
+        for stage_number in req.stage_numbers:
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            assert prim is not None and prim.beep_time is not None
+            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
+            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+            audit_path = audit_dir / f"stage{stage_number}.json"
+            overlay_path = exports_dir / f"{base}_overlay.mov"
+            secondaries: list[match_export_helpers.MatchSecondaryInput] = []
+            for sv in stg.videos:
+                if sv.role != "secondary" or sv.beep_time is None:
+                    continue
+                sec_clip_beep = min(proj.trim_pre_buffer_seconds, sv.beep_time)
+                secondaries.append(
+                    match_export_helpers.MatchSecondaryInput(
+                        video_id=sv.video_id,
+                        trimmed_path=exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4",
+                        beep_offset_seconds=sec_clip_beep,
+                        label=f"Cam {sv.video_id}",
+                    )
+                )
+            primary_clip_beep = min(proj.trim_pre_buffer_seconds, prim.beep_time)
+            stages_input.append(
+                match_export_helpers.MatchStageInput(
+                    stage_number=stage_number,
+                    stage_name=stg.stage_name,
+                    audit_path=audit_path,
+                    trimmed_path=trimmed_path,
+                    beep_offset_seconds=primary_clip_beep,
+                    secondaries=tuple(secondaries),
+                    overlay_path=overlay_path,
+                )
+            )
+
+        project_name = req.project_name or proj.name or "match"
+        request_data = match_export_helpers.MatchExportRequestData(
+            stage_numbers=tuple(req.stage_numbers),
+            head_pad_seconds=req.head_pad_seconds,
+            tail_pad_seconds=req.tail_pad_seconds,
+            include_secondaries=req.include_secondaries,
+            include_overlay=req.include_overlay,
+            project_name=project_name,
+            pip_layout=req.pip_layout,
+            output_format=req.output_format,
+            transition_kind=req.transition_kind,
+            transition_duration_seconds=req.transition_duration_seconds,
+            title_kind=req.title_kind,
+            title_duration_seconds=req.title_duration_seconds,
+            intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
+            outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
+            youtube_sidecar=req.youtube_sidecar,
+            youtube_preset=req.youtube_preset,
+        )
+        try:
+            result = match_export_helpers.export_match(
+                stages=stages_input,
+                request=request_data,
+                exports_dir=exports_dir,
+                config=Config().output,
+            )
+        except match_export_helpers.MatchExportError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        handle.set_result(
+            {
+                "fcpxml_path": str(result.fcpxml_path),
+                "stage_count": result.stage_count,
+                "duration_seconds": result.duration_seconds,
+                "anomalies": result.anomalies,
+            }
+        )
+        anom_word = "anomaly" if len(result.anomalies) == 1 else "anomalies"
+        anom_suffix = f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
+        handle.update(
+            progress=1.0,
+            message=(f"Done: {result.stage_count} stages, " f"{result.duration_seconds:.1f}s{anom_suffix}"),
+        )
+
+    state.jobs.bodies.register("model_download", _run_model_download_job)
+    state.jobs.bodies.register("detect_beep", _run_detect_beep_for_video)
+    state.jobs.bodies.register("trim", _run_trim)
+    state.jobs.bodies.register("shot_detect", _run_shot_detect)
+    state.jobs.bodies.register("export", _run_export_for_stage)
+    state.jobs.bodies.register("match_export", _run_match_export)
+
+
 class HealthResponse(BaseModel):
     status: str = "ok"
     version: str = splitsmith_version
@@ -2145,7 +3101,7 @@ def _hosted_mode_active() -> bool:
     return os.environ.get(SPLITSMITH_MODE_ENV, "").strip().lower() == "hosted"
 
 
-def _apply_hosted_mode_wiring(state: AppState) -> None:
+def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     """Swap AppState's local-mode defaults for Postgres-backed impls.
 
     Runs only when :func:`_hosted_mode_active` is True. Requires
@@ -2199,8 +3155,38 @@ def _apply_hosted_mode_wiring(state: AppState) -> None:
     state.auth = auth
     state.recent_projects = PostgresRecentProjectsStore(session_factory, user_id=user_id)
     state.scoreboard_identity = PostgresScoreboardIdentityStore(session_factory, user_id=user_id)
-    state.jobs = PostgresJobBackend(session_factory, user_id=user_id)
+    # The API process enqueues via the deferrer; the worker executes and
+    # must not sweep jobs queued for it to run. The worker also enqueues
+    # (job chaining defers a follow-up onto the queue), so it gets a
+    # deferrer too.
+    from ..queue import make_deferrer
+
+    state.jobs = PostgresJobBackend(
+        session_factory,
+        user_id=user_id,
+        deferrer=make_deferrer(url),
+        sweep_on_boot=not worker,
+    )
     state.storage = _build_hosted_storage(user_id)
+
+
+def build_worker_state() -> AppState:
+    """Build the hosted ``AppState`` a ``splitsmith worker`` runs jobs against.
+
+    The headless counterpart to ``create_app``'s state wiring: no FastAPI
+    app and no routes -- just the compute backend (local ensemble, loaded
+    once per process via the ``_ENSEMBLE_RUNTIME`` singleton), the
+    hosted-mode Postgres/S3 wiring (execute-only job backend, no boot
+    sweep), and the shared job-body registry the Procrastinate
+    ``run_compute_job`` task dispatches against. Requires hosted-mode env
+    (``SPLITSMITH_DATABASE_URL``); ``_apply_hosted_mode_wiring`` raises
+    otherwise.
+    """
+    state = AppState()
+    state.compute = LocalComputeBackend(runtime_loader=lambda: _get_ensemble_runtime())
+    _apply_hosted_mode_wiring(state, worker=True)
+    register_job_bodies(state)
+    return state
 
 
 def _build_hosted_storage(user_id: str) -> Storage | None:
@@ -2333,13 +3319,12 @@ def create_app(
     # ``create_app`` runs at boot outside any event loop, so the async
     # JobBackend submission is wrapped in ``asyncio.run`` here.
     #
-    # ``model_download`` is the one kind submitted during create_app
-    # itself (the others fire only from HTTP handlers, after this
-    # function returns), so its body must be registered before the
-    # prefetch submit -- the rest register just before ``return app``.
-    # ``_run_model_download_job`` is module-level; tests monkeypatch it,
-    # and the name resolves to the patched function here.
-    state.jobs.bodies.register("model_download", _run_model_download_job)
+    # All job bodies register here, after any hosted-mode backend swap
+    # above, so ``submit(kind=...)`` resolves against whichever backend is
+    # bound. Must precede the prefetch submit below, which fires
+    # ``model_download`` during create_app itself. ``register_job_bodies``
+    # is shared with the Procrastinate worker bootstrap.
+    register_job_bodies(state)
     asyncio.run(_maybe_submit_model_download(state))
 
     async def get_current_user(request: Request) -> User:
@@ -3913,301 +4898,6 @@ def create_app(
             )
         return project, stage, video
 
-    # Cross-cam alignment is accepted as a *suggestion* (beep_source="aligned",
-    # beep_reviewed=False so the SPA forces the user to verify on the waveform
-    # picker) when the peak-to-runner-up ratio of the cross-correlation clears
-    # this threshold. 1.0 means the landmark wasn't distinctive at all.
-    # Empirically calibrated on tallmilan-2026 secondaries: same-stage pairs
-    # where in-stream detection independently succeeded land at 1.23-1.34, and
-    # plausible alignments on the in-stream-failed pairs land at 1.15-1.31.
-    # Same-mic non-overlapping clips sit at ~1.00. 1.10 leaves a slim margin
-    # over the floor while still surfacing real alignments. False positives
-    # are caught by the user in the picker before "Mark reviewed"; false
-    # negatives mean the user starts from the auto-detect-failed state and
-    # places the marker by hand, which is the same UX as before this change.
-    _align_confidence_floor = 1.10
-
-    def _try_align_secondary_to_primary(
-        root: Path,
-        proj: MatchProject,
-        stage: StageEntry,
-        video: StageVideo,
-        handle: JobHandle,
-    ) -> cross_align.CrossAlignResult | None:
-        """Attempt cross-correlation alignment of ``video`` against the stage's
-        primary. Returns the raw result whenever cross-correlation could be
-        computed (so the caller can save ``confidence`` as a diagnostic even
-        below the auto-accept floor); returns ``None`` only when alignment
-        isn't possible at all (no primary, no primary beep_time, audio not
-        cached, landmark window too narrow). Threshold comparison happens at
-        the call site so a low-confidence result can still inform the UI.
-
-        Run only on the secondary soft-fail path -- when in-stream beep
-        detection has already raised ``BeepNotFoundError``. Cheap (envelope
-        cross-correlation at 200 Hz; sub-second on a 60 s clip), but not free,
-        so we skip it on the primary path entirely.
-        """
-        primary = stage.primary()
-        if primary is None or primary.beep_time is None:
-            return None
-        primary_audio_path = audio_helpers.primary_audio_path(root, stage.stage_number, project=proj)
-        secondary_audio_path = audio_helpers.video_audio_path(root, stage.stage_number, video, project=proj)
-        if not primary_audio_path.exists() or not secondary_audio_path.exists():
-            # Either side missing means the user hasn't run beep-detect on
-            # the primary yet, or the secondary's own audio extract failed
-            # before we even got here. Both are dealt with by the existing
-            # soft-fail UX -- alignment can be retried later.
-            return None
-        try:
-            primary_audio, primary_sr = beep_detect.load_audio(primary_audio_path)
-            secondary_audio, secondary_sr = beep_detect.load_audio(secondary_audio_path)
-            handle.update(progress=0.45, message="Aligning to primary...")
-            result = cross_align.align_secondary_to_primary(
-                primary_audio,
-                primary_sr,
-                primary.beep_time,
-                secondary_audio,
-                secondary_sr,
-            )
-        except cross_align.CrossAlignError as exc:
-            logger.info(
-                "cross-align skipped for stage %d video %s: %s",
-                stage.stage_number,
-                video.video_id,
-                exc,
-            )
-            return None
-        return result
-
-    def _run_detect_beep_for_video(handle: JobHandle, slug: str, stage_number: int, video_id: str) -> None:
-        """Worker: detect ``video``'s beep, then auto-chain trim.
-
-        Generic over role:
-          - primary: detect -> trim -> shot_detect (existing pipeline).
-          - secondary: detect -> trim (no shot_detect; the audit timeline
-            is anchored to the primary's beep).
-
-        Trim is treated as a soft failure: the beep is valuable on its
-        own and the SPA can re-trim later.
-        """
-        handle.update(progress=0.05, message="Loading project...")
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        video = stg.find_video_by_id(video_id)
-        if video is None:
-            raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
-        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
-        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
-        handle.update(
-            progress=0.15,
-            message=f"Extracting audio + detecting beep ({role_label})...",
-        )
-        try:
-            beep = audio_helpers.detect_video_beep(
-                state.shooter_root(slug),
-                stage_number,
-                video,
-                source,
-                project=proj,
-                ffmpeg_binary=process_runtime().ffmpeg_binary,
-            )
-        except beep_detect.BeepNotFoundError as exc:
-            # Primary failure is fatal -- the entire downstream pipeline
-            # (trim window, shot timeline) hangs off the primary beep.
-            # Surfacing as a job error gets the user looking at the audio
-            # right away rather than silently falling through to a wrong
-            # alignment. Secondary failure is soft-handled below: many
-            # non-headcam cameras (iPhone tripod, RO position, AGC'd) just
-            # don't capture a sustained 2-5 kHz tone, and aborting the
-            # import on every one of them is the worse UX.
-            if video.role == "primary":
-                raise
-            logger.info(
-                "no beep on secondary stage %d video %s: %s",
-                stage_number,
-                video.video_id,
-                exc,
-            )
-            # Cross-correlation fallback: when the primary already has a
-            # beep, try aligning the secondary's audio against the
-            # primary's landmark window. Same buzzer + first shots in the
-            # same room means the loudness envelopes line up modulo a
-            # constant time offset, even when the secondary's mic missed
-            # the sustained 2-5 kHz tone the in-stream detector wants.
-            aligned = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
-            video.beep_peak_amplitude = None
-            video.beep_duration_ms = None
-            video.beep_candidates = []
-            video.beep_reviewed = False
-            video.processed["beep"] = True
-            # Surface the cross-correlation confidence whenever we got one,
-            # even if we don't promote the suggestion. Lets the UI tell the
-            # difference between "never tried" and "tried, sub-floor result".
-            video.beep_alignment_confidence = aligned.confidence if aligned is not None else None
-            # Delta is only meaningful when both in-stream AND cross-align
-            # produced timestamps. In-stream failed here, so wipe it.
-            video.beep_alignment_delta_ms = None
-            if aligned is not None and aligned.confidence >= _align_confidence_floor:
-                handle.update(
-                    progress=0.55,
-                    message=(f"Aligned to primary (conf {aligned.confidence:.2f}); " "verify on waveform"),
-                )
-                video.beep_time = aligned.secondary_beep_time
-                video.beep_source = "aligned"
-                video.beep_auto_detect_failed = False
-                # Treat as "we have a usable beep_time": fall through to
-                # the trim block below.
-                beep = aligned
-            else:
-                if aligned is not None:
-                    logger.info(
-                        "cross-align below floor for stage %d video %s: conf %.2f < %.2f",
-                        stage_number,
-                        video.video_id,
-                        aligned.confidence,
-                        _align_confidence_floor,
-                    )
-                handle.update(progress=0.55, message="No beep detected; pick on waveform")
-                video.beep_time = None
-                video.beep_source = "auto"
-                video.beep_auto_detect_failed = True
-                video.processed["trim"] = False
-                beep = None
-        else:
-            handle.update(progress=0.55, message="Saving beep...")
-            video.beep_time = beep.time
-            video.beep_source = "auto"
-            video.beep_peak_amplitude = beep.peak_amplitude
-            video.beep_duration_ms = beep.duration_ms
-            video.beep_confidence = beep.confidence
-            video.beep_candidates = list(beep.candidates)
-            video.beep_auto_detect_failed = False
-            video.beep_alignment_confidence = None
-            video.beep_alignment_delta_ms = None
-            video.processed["beep"] = True
-            # Auto-detected beeps need explicit user review (#71) UNLESS
-            # the calibrated confidence (#220 layer 3a) clears the
-            # ``beep_low_confidence_threshold`` automation gate (#219).
-            # Above the threshold we auto-trust: the detector is right
-            # ~95 % of the time in that band, so making the user click
-            # to confirm every high-confidence beep adds friction
-            # without catching real problems. Below it the user has to
-            # review -- the HITL queue (``GET /api/hitl-queue``) lists
-            # exactly these. Resets to False on re-detection so the
-            # prior approval doesn't carry over to a fresh run.
-            resolved_auto = automation_settings.resolve_automation(
-                project_override=proj.automation,
-            )
-            threshold = resolved_auto.settings.beep_low_confidence_threshold
-            video.beep_reviewed = beep.confidence >= threshold
-            # Sanity check: when in-stream succeeded on a secondary, ALSO
-            # run cross-correlation against the primary. If the two
-            # methods disagree by more than ~250 ms it usually means the
-            # in-stream detector locked onto something that wasn't the
-            # buzzer (a steel-strike that resembles a tone, an early
-            # range-officer command, etc.). The delta is surfaced in the
-            # SPA so the user can compare both candidates on the
-            # waveform before marking reviewed. Never overrides the
-            # in-stream result -- in-stream has frequency-domain
-            # information cross-align doesn't, so when they agree we
-            # trust the in-stream answer; when they disagree we let the
-            # user decide.
-            if video.role != "primary":
-                check = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
-                if check is not None and check.confidence >= _align_confidence_floor:
-                    video.beep_alignment_confidence = check.confidence
-                    video.beep_alignment_delta_ms = (beep.time - check.secondary_beep_time) * 1000.0
-
-        trimmed_ok = False
-        if beep is not None and stg.time_seconds > 0:
-            handle.check_cancel()
-            handle.update(progress=0.55, message=f"Trimming audit clip ({role_label})...")
-            try:
-                audio_helpers.ensure_video_audit_trim(
-                    state.shooter_root(slug),
-                    stage_number,
-                    video,
-                    source,
-                    video.beep_time,
-                    stg.time_seconds,
-                    project=proj,
-                    runner=_cancellable_runner(handle),
-                    ffmpeg_binary=process_runtime().ffmpeg_binary,
-                )
-                video.processed["trim"] = True
-                trimmed_ok = True
-            except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
-                # Soft failure: beep alone is still useful, especially for
-                # secondaries (audit alignment works without a trim cache).
-                logger.warning(
-                    "auto-trim failed for stage %d video %s: %s",
-                    stage_number,
-                    video.video_id,
-                    exc,
-                )
-                handle.update(message=f"beep saved; trim failed: {exc}")
-        handle.update(progress=0.85, message="Saving project...")
-        # Read-modify-write the project file: extract / detection /
-        # ffmpeg trim can take 30+ s during which the user may have
-        # toggled ``beep_reviewed`` on other stages. Reloading and
-        # copying our targeted fields onto the fresh project preserves
-        # those concurrent edits instead of stomping them with the
-        # snapshot we loaded at job start.
-        fresh = state.shooter_project(slug)
-        try:
-            stg_fresh = fresh.stage(stage_number)
-        except KeyError:
-            stg_fresh = None
-        v_fresh = stg_fresh.find_video_by_id(video_id) if stg_fresh is not None else None
-        if v_fresh is not None:
-            v_fresh.beep_time = video.beep_time
-            v_fresh.beep_source = video.beep_source
-            v_fresh.beep_peak_amplitude = video.beep_peak_amplitude
-            v_fresh.beep_duration_ms = video.beep_duration_ms
-            v_fresh.beep_confidence = video.beep_confidence
-            v_fresh.beep_candidates = list(video.beep_candidates)
-            v_fresh.beep_reviewed = video.beep_reviewed
-            v_fresh.beep_auto_detect_failed = video.beep_auto_detect_failed
-            v_fresh.beep_alignment_confidence = video.beep_alignment_confidence
-            v_fresh.beep_alignment_delta_ms = video.beep_alignment_delta_ms
-            v_fresh.processed["beep"] = True
-            if trimmed_ok:
-                v_fresh.processed["trim"] = True
-            fresh.save(state.shooter_root(slug))
-        if trimmed_ok and video.role == "primary" and video.beep_reviewed:
-            # Shot detection is primary-only AND gated on
-            # ``beep_reviewed`` (#71). That flag is True either because
-            # the user explicitly clicked "Mark reviewed" (which
-            # re-triggers chaining via ``set_beep_reviewed``) or because
-            # the auto-trust gate cleared (#219 layer 3b: confidence at
-            # or above ``beep_low_confidence_threshold``). Saves the
-            # heavy CLAP / GBDT / PANN ensemble work when the beep
-            # timestamp is wrong, since everything downstream of it
-            # would be garbage anyway.
-            #
-            # Layered automation gate (#215): users can disable the
-            # auto-trigger globally or per project. ``cli_override`` is
-            # always None for the server -- the daemon doesn't take
-            # CLI flags at this entry point.
-            resolved = automation_settings.resolve_automation(
-                project_override=fresh.automation,
-            )
-            # Worker callback runs in a ThreadPoolExecutor thread with
-            # no event loop; bridge to the async JobBackend via
-            # ``asyncio.run``.
-            if (
-                resolved.settings.shot_detect_on_beep_verified
-                and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
-            ):
-                asyncio.run(
-                    state.jobs.submit(
-                        kind="shot_detect",
-                        stage_number=stage_number,
-                        args={"slug": slug, "stage_number": stage_number},
-                    )
-                )
-        handle.update(progress=1.0, message="Done")
-
     async def _submit_detect_beep(slug: str, stage_number: int, video: StageVideo) -> JSONResponse:
         """Validate + dedupe + queue a detect-beep job for ``video``.
 
@@ -4404,325 +5094,6 @@ def create_app(
         """Submit an audit-mode trim job for ``video_id`` on ``stage_number``."""
         project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         return await _submit_trim(slug, stage_number, stage, video, project)
-
-    def _run_trim(
-        handle: JobHandle,
-        *,
-        slug: str,
-        stage_number: int,
-        video_id: str,
-        chain_shot_detect: bool = True,
-    ) -> None:
-        """Worker for the audit-mode trim of a specific video.
-
-        Resolves the shooter via ``slug`` (so the body is portable to a
-        hosted worker process -- the bulk path used to pass an explicit
-        ``shooter_root`` Path, which can't cross a process boundary).
-
-        Auto-chains shot detection only when the trimmed video is the
-        reviewed primary AND ``chain_shot_detect`` is set; secondaries
-        align to the primary's audit timeline by their own beep, so they
-        do not need their own shot-detection run. The bulk maintenance
-        pass passes ``chain_shot_detect=False`` -- it regenerates derived
-        trim caches without re-running detection over the whole match.
-        """
-        handle.update(progress=0.1, message="Preparing trim...")
-        proj = state.shooter_project(slug)
-        root = state.shooter_root(slug)
-        stg = proj.stage(stage_number)
-        video = stg.find_video_by_id(video_id)
-        if video is None or video.beep_time is None:
-            raise RuntimeError("video or beep disappeared mid-flight")
-        source = proj.resolve_video_path(root, video.path)
-        handle.check_cancel()
-        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
-        handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
-        audio_helpers.ensure_video_audit_trim(
-            root,
-            stage_number,
-            video,
-            source,
-            video.beep_time,
-            stg.time_seconds,
-            project=proj,
-            runner=_cancellable_runner(handle),
-            ffmpeg_binary=process_runtime().ffmpeg_binary,
-        )
-        handle.update(progress=0.85, message="Saving project...")
-        # Read-modify-write to avoid stomping concurrent edits made
-        # while ffmpeg was running (e.g. another stage's beep review).
-        fresh = state.shooter_project(slug)
-        stg_fresh = fresh.stage(stage_number)
-        v_fresh = stg_fresh.find_video_by_id(video_id)
-        if v_fresh is not None:
-            v_fresh.processed["trim"] = True
-            fresh.save(root)
-        # Worker callback runs in a ThreadPoolExecutor thread with no
-        # event loop; bridge to the async JobBackend via ``asyncio.run``.
-        if (
-            chain_shot_detect
-            and video.role == "primary"
-            and video.beep_reviewed
-            and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
-        ):
-            # Same gate as the detect-then-trim path (#71): don't burn
-            # CLAP / GBDT / PANN cycles on a beep the user hasn't
-            # confirmed. Manual entries pre-set ``beep_reviewed`` to True
-            # so this still runs; the auto-detect path waits for the
-            # user's explicit "Mark reviewed" click which re-fires
-            # shot_detect from there.
-            #
-            # Layered automation gate (#215): a global / project
-            # opt-out can suppress this auto-trigger.
-            resolved = automation_settings.resolve_automation(
-                project_override=fresh.automation,
-            )
-            if resolved.settings.shot_detect_on_beep_verified:
-                asyncio.run(
-                    state.jobs.submit(
-                        kind="shot_detect",
-                        stage_number=stage_number,
-                        args={"slug": slug, "stage_number": stage_number},
-                    )
-                )
-        handle.update(progress=1.0, message="Done")
-
-    def _run_shot_detect(handle: JobHandle, slug: str, stage_number: int, reset: bool = False) -> None:
-        """Worker that runs the 4-voter ensemble on the stage's audit clip.
-
-        Reads the trimmed clip's WAV (extracting it on demand if needed),
-        runs ``splitsmith.ensemble.detect_shots_ensemble`` over the
-        ``[beep .. beep+stage]`` window, and writes both the consensus
-        ``shots[]`` and the full voter-A universe into the audit JSON.
-
-        ``_candidates_pending_audit.candidates`` carries every candidate
-        annotated with per-voter signals (vote_a/b/c/d, ensemble_score,
-        score_c, clap_diff, gunshot_prob) so the audit UI can render the
-        decision trail. ``shots[]`` is seeded from the consensus subset
-        unless it is already populated -- the user retains authority. If
-        ``reset`` is True, ``shots[]`` is wiped first so the user can
-        start over after a bad beep / detector pass.
-
-        Adaptive prior: if the audit JSON already carries
-        ``stage_rounds.expected``, voter C switches to its adaptive
-        top-(K+slack) mode and the apriori boost lifts the top-K
-        confidence-ranked candidates over the consensus line.
-        """
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        prim = stg.primary()
-        if prim is None or prim.beep_time is None:
-            raise RuntimeError(f"stage {stage_number} has no primary or no beep yet")
-        if stg.time_seconds <= 0:
-            raise RuntimeError(
-                f"stage {stage_number} has time_seconds=0; import a "
-                "scoreboard before running shot detection"
-            )
-        source = proj.resolve_video_path(state.shooter_root(slug), prim.path)
-
-        # Re-detect-all on an old project (and the v1->v2 cache migration in
-        # #298) leaves stages with no trimmed MP4 cached. Without that file,
-        # ensure_audit_audio falls back to the full source WAV -- shot
-        # detection still works, but the audit page then streams the raw
-        # source clip into <video>, where long-GOP 4K MOVs wedge in buffering
-        # on first play. Force the trim here so every shot-detect run leaves
-        # the audit cache in the same state the beep-detect path would have.
-        handle.update(progress=0.05, message="Ensuring audit trim...")
-        try:
-            audio_helpers.ensure_video_audit_trim(
-                state.shooter_root(slug),
-                stage_number,
-                prim,
-                source,
-                prim.beep_time,
-                stg.time_seconds,
-                project=proj,
-                runner=_cancellable_runner(handle),
-                ffmpeg_binary=process_runtime().ffmpeg_binary,
-            )
-            trim_fresh = state.shooter_project(slug)
-            try:
-                v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
-            except KeyError:
-                v_fresh = None
-            if v_fresh is not None and not v_fresh.processed.get("trim"):
-                v_fresh.processed["trim"] = True
-                trim_fresh.save(state.shooter_root(slug))
-        except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
-            # Soft failure: detection can still proceed against the source
-            # WAV. ensure_audit_audio's fallback handles the missing trim,
-            # so we log and continue rather than abort the whole job.
-            logger.warning(
-                "shot_detect could not (re)build trim for stage %d: %s",
-                stage_number,
-                exc,
-            )
-
-        handle.update(progress=0.1, message="Preparing audio...")
-        audit = audio_helpers.ensure_audit_audio(
-            state.shooter_root(slug),
-            stage_number,
-            source,
-            prim.beep_time,
-            project=proj,
-            ffmpeg_binary=process_runtime().ffmpeg_binary,
-        )
-        beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else prim.beep_time
-
-        # Read existing audit JSON up-front: we need ``stage_rounds.expected``
-        # before running detection (it changes voter C's mode and the
-        # apriori boost) and we'll merge results back into the same dict.
-        audit_dir = proj.audit_path(state.shooter_root(slug))
-        audit_dir.mkdir(parents=True, exist_ok=True)
-        audit_file = audit_dir / f"stage{stage_number}.json"
-        if audit_file.exists():
-            try:
-                existing_json = json.loads(audit_file.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                existing_json = {}
-        else:
-            existing_json = {
-                "stage_number": stg.stage_number,
-                "stage_name": stg.stage_name,
-                "stage_time_seconds": stg.time_seconds,
-                "beep_time": round(beep_in_clip, 4),
-                "shots": [],
-            }
-        # Carry stage_rounds (min_rounds + target breakdown) from the
-        # project state into the audit JSON so the ensemble's adaptive
-        # voter C + apriori boost can consume ``stage_rounds.expected``.
-        # Project value wins over a stale audit-JSON copy: re-running
-        # detection after a scoreboard refresh should pick up the new
-        # round count without manual edits.
-        if stg.stage_rounds is not None:
-            existing_json["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
-        expected_rounds: int | None = None
-        sr_block = existing_json.get("stage_rounds")
-        if isinstance(sr_block, dict):
-            raw = sr_block.get("expected")
-            if isinstance(raw, int) and raw > 0:
-                expected_rounds = raw
-
-        handle.update(progress=0.2, message="Loading ensemble models...")
-        handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
-        audio_array, sr = beep_detect.load_audio(audit.audio_path)
-        # Camera-class dispatch (issue #143). When the primary's mount
-        # is set, look up handheld vs. headcam thresholds; otherwise
-        # the ensemble falls back to the default class (headcam).
-        cam_class = ensemble_module.camera_class_from_mount(prim.camera_mount)
-        # Voter E opt-in (issue #183). Off by default for the first
-        # release; flip via env var until corpus growth justifies
-        # default-on. Requires the calibration to ship a probe head
-        # AND the source video to be reachable.
-        enable_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
-        ensemble_cfg = ensemble_module.EnsembleConfig(enable_voter_e=enable_e)
-        result = state.compute.detect_stage(
-            audio=audio_array,
-            sample_rate=sr,
-            beep_time_in_clip=beep_in_clip,
-            stage_time_seconds=stg.time_seconds,
-            expected_rounds=expected_rounds,
-            ensemble_config=ensemble_cfg,
-            camera_class=cam_class,
-            camera_make=prim.camera_make,
-            camera_model=prim.camera_model,
-            video_path=source if enable_e else None,
-            source_beep_time=prim.beep_time if enable_e else None,
-        )
-
-        candidates: list[dict[str, Any]] = []
-        for cand in result.candidates:
-            candidates.append(
-                {
-                    "candidate_number": cand.candidate_number,
-                    "time": cand.time,
-                    "ms_after_beep": cand.ms_after_beep,
-                    "peak_amplitude": cand.peak_amplitude,
-                    "confidence": cand.confidence,
-                    "vote_a": cand.vote_a,
-                    "vote_b": cand.vote_b,
-                    "vote_c": cand.vote_c,
-                    "vote_e": cand.vote_e,
-                    "vote_total": cand.vote_total,
-                    "apriori_boost": cand.apriori_boost,
-                    "ensemble_score": cand.ensemble_score,
-                    "score_c": cand.score_c,
-                    "clap_diff": cand.clap_diff,
-                    "gunshot_prob": cand.gunshot_prob,
-                    "voter_e_signal": cand.voter_e_signal,
-                }
-            )
-
-        handle.update(progress=0.85, message="Saving audit JSON...")
-        existing_json["_candidates_pending_audit"] = {
-            "_note": (
-                "3-voter ensemble (PANN gunshot folded into voter C). "
-                "vote_a/b/c=1 means the voter kept the candidate; "
-                "ensemble_score = vote_total + apriori_boost. shots[] is "
-                "seeded from candidates with ensemble_score >= consensus."
-            ),
-            "consensus": result.consensus,
-            "expected_rounds": result.expected_rounds,
-            "candidates": candidates,
-        }
-        if reset:
-            existing_json["shots"] = []
-        seeded_shots = False
-        if not existing_json.get("shots"):
-            kept = [c for c in result.candidates if c.kept]
-            existing_json["shots"] = [
-                {
-                    "shot_number": i,
-                    "candidate_number": c.candidate_number,
-                    "time": c.time,
-                    "ms_after_beep": c.ms_after_beep,
-                    "source": "detected",
-                    "ensemble_votes": c.vote_total,
-                    "apriori_boost": c.apriori_boost,
-                    "ensemble_score": c.ensemble_score,
-                }
-                for i, c in enumerate(kept, start=1)
-            ]
-            seeded_shots = True
-        events = list(existing_json.get("audit_events") or [])
-        events.append(
-            {
-                "ts": _now_iso(),
-                "kind": "shot_detect_run",
-                "payload": {
-                    "candidate_count": len(candidates),
-                    "kept_count": sum(1 for c in result.candidates if c.kept),
-                    "consensus": result.consensus,
-                    "expected_rounds": result.expected_rounds,
-                    "seeded_shots": seeded_shots,
-                },
-            }
-        )
-        existing_json["audit_events"] = events
-
-        # Atomic write + .bak (mirrors put_stage_audit).
-        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
-        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
-        tmp.write_text(json.dumps(existing_json, indent=2) + "\n", encoding="utf-8")
-        if audit_file.exists():
-            if backup.exists():
-                backup.unlink()
-            audit_file.replace(backup)
-        tmp.replace(audit_file)
-
-        # Read-modify-write the project file: a long-running shot_detect
-        # job must not save the snapshot it loaded at start, because the
-        # user may have toggled ``beep_reviewed`` on other stages in the
-        # interim (the review action kicks shot_detect, so concurrent
-        # bursts are the common case). Reloading from disk and mutating
-        # only the targeted field preserves those concurrent edits.
-        fresh = state.shooter_project(slug)
-        stg_fresh = fresh.stage(stage_number)
-        prim_fresh = stg_fresh.primary()
-        if prim_fresh is not None:
-            prim_fresh.processed["shot_detect"] = True
-            fresh.save(state.shooter_root(slug))
-        handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
 
     @app.post("/api/shooters/{slug}/stages/shot-detect")
     async def shot_detect_all_endpoint(slug: str, reset: bool = False) -> JSONResponse:
@@ -6634,127 +7005,6 @@ def create_app(
         )
         return JSONResponse(job.model_dump(mode="json"))
 
-    def _run_export_for_stage(
-        handle: JobHandle, slug: str, stage_number: int, req: ExportStageRequest
-    ) -> None:
-        """Worker for /api/stages/{n}/export. Phases mirror the user's
-        mental model so the JobsPanel message is meaningful."""
-        from ..config import StageData as EngineStageData
-
-        handle.update(progress=0.05, message="Loading project...")
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        prim = stg.primary()
-        if prim is None or prim.beep_time is None:
-            raise RuntimeError("primary or beep disappeared mid-flight")
-
-        audit_file = proj.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
-        exports_dir = proj.exports_path(state.shooter_root(slug))
-        source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
-        engine_stage = EngineStageData(
-            stage_number=stg.stage_number,
-            stage_name=stg.stage_name,
-            time_seconds=stg.time_seconds,
-            scorecard_updated_at=stg.scorecard_updated_at,
-        )
-
-        # Phase progress is approximate; trim dominates wall time when the
-        # source is large, so we hold at 0.4 through the trim phase and
-        # then jump on the small writers.
-        if req.write_trim:
-            handle.update(progress=0.15, message="Trimming source (lossless stream copy)...")
-        elif req.write_fcpxml:
-            handle.update(progress=0.15, message="Reading audit + preparing FCPXML...")
-        else:
-            handle.update(progress=0.15, message="Reading audit JSON...")
-        handle.check_cancel()
-
-        # Multi-cam (issue #54). Each secondary with a known beep ships
-        # alongside the primary so a single Generate click produces the
-        # complete multi-cam timeline. Cams without a beep yet -- e.g.
-        # registered but ingest didn't finish -- are silently skipped; the
-        # SPA's ingest screen flags those rows separately. The Export page
-        # may also pass ``secondary_video_ids`` to restrict the roster to a
-        # subset (None = include every cam with a beep, the legacy default).
-        allowed_ids: set[str] | None = (
-            set(req.secondary_video_ids) if req.secondary_video_ids is not None else None
-        )
-        secondaries: list[export_helpers.SecondaryExport] = []
-        for sv in stg.videos:
-            if sv.role != "secondary":
-                continue
-            if sv.beep_time is None:
-                continue
-            if allowed_ids is not None and sv.video_id not in allowed_ids:
-                continue
-            sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
-            secondaries.append(
-                export_helpers.SecondaryExport(
-                    video_id=sv.video_id,
-                    source_path=sec_source,
-                    beep_time_in_source=sv.beep_time,
-                    label=f"Cam {sv.video_id}",
-                )
-            )
-
-        try:
-            result = export_helpers.export_stage(
-                request=export_helpers.StageExportRequest(
-                    stage_number=stage_number,
-                    write_trim=req.write_trim,
-                    write_csv=req.write_csv,
-                    write_fcpxml=req.write_fcpxml,
-                    write_report=req.write_report,
-                    write_overlay=req.write_overlay,
-                    overlay_codec=req.overlay_codec,
-                    overlay_max_height=req.overlay_max_height,
-                    overlay_max_fps=req.overlay_max_fps,
-                    overlay_theme=req.overlay_theme,
-                ),
-                audit_path=audit_file,
-                exports_dir=exports_dir,
-                source_video_path=source_video if source_video.exists() else None,
-                stage_data=engine_stage,
-                beep_time_in_source=prim.beep_time,
-                pre_buffer_seconds=proj.trim_pre_buffer_seconds,
-                post_buffer_seconds=proj.trim_post_buffer_seconds,
-                config=Config(),
-                secondaries=secondaries,
-            )
-        except export_helpers.StageExportError as exc:
-            # Surface as a job failure with the exporter's own message so
-            # the JobsPanel row reads "audit JSON has no shots in shots[]"
-            # rather than a stack trace.
-            raise RuntimeError(str(exc)) from exc
-
-        handle.update(progress=0.95, message="Saving project...")
-        proj.updated_at = datetime.now(UTC)
-        proj.save(state.shooter_root(slug))
-
-        # Final message summarises what shipped + flags any skipped
-        # artefacts (FCPXML without a trim, etc). The full list lives in
-        # the report.txt; the user can Reveal it for details.
-        bits: list[str] = []
-        if result.trimmed_video_path is not None:
-            bits.append("trim")
-        if result.secondary_trimmed_paths:
-            n = len(result.secondary_trimmed_paths)
-            bits.append(f"{n} secondary trim{'s' if n != 1 else ''}")
-        if result.csv_path is not None:
-            bits.append("csv")
-        if result.fcpxml_path is not None:
-            bits.append("fcpxml")
-        if result.report_path is not None:
-            bits.append("report")
-        if result.overlay_path is not None:
-            bits.append("overlay")
-        summary = ", ".join(bits) if bits else "nothing written"
-        if result.anomalies:
-            n = len(result.anomalies)
-            word = "anomaly" if n == 1 else "anomalies"
-            summary += f" ({n} {word} -- see report.txt)"
-        handle.update(progress=1.0, message=f"Done: {summary}")
-
     @app.get("/api/match/templates")
     def list_match_templates() -> JSONResponse:
         """List export templates from built-in + user dirs (issue #198).
@@ -6855,209 +7105,6 @@ def create_app(
             args={"slug": slug, "req": req},
         )
         return JSONResponse(job.model_dump(mode="json"))
-
-    def _run_match_export(handle: JobHandle, slug: str, req: MatchExportRequest) -> None:
-        """Worker for the shooter's match-export job. Re-runs the per-stage exporter for
-        any selected stage missing its lossless trim, then composes the
-        match FCPXML.
-        """
-        from ..config import StageData as EngineStageData
-        from . import exports as exports_mod
-
-        handle.update(progress=0.02, message="Loading project...")
-        proj = state.shooter_project(slug)
-        exports_dir = proj.exports_path(state.shooter_root(slug))
-        audit_dir = proj.audit_path(state.shooter_root(slug))
-
-        n = len(req.stage_numbers)
-        # Reserve the last 10% for the match compose step; the rest is
-        # split evenly across per-stage trims (the dominant wall time).
-        # Stages that already have a trim skip ahead within their slice
-        # instead of contributing to the wait.
-        per_stage_share = 0.85 / max(1, n)
-
-        for idx, stage_number in enumerate(req.stage_numbers):
-            handle.check_cancel()
-            stg = proj.stage(stage_number)
-            prim = stg.primary()
-            if prim is None or prim.beep_time is None:
-                raise RuntimeError(f"stage {stage_number}: primary or beep disappeared mid-flight")
-
-            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
-            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
-            overlay_target = exports_dir / f"{base}_overlay.mov"
-
-            # Decide what's missing. The match composer needs the
-            # lossless trim + per-cam trims (when include_secondaries) +
-            # optional overlay. Re-run the per-stage exporter for any
-            # stage where any required artefact isn't on disk.
-            wanted_secondary_ids: set[str] = set()
-            if req.include_secondaries:
-                for sv in stg.videos:
-                    if sv.role == "secondary" and sv.beep_time is not None:
-                        wanted_secondary_ids.add(sv.video_id)
-            secondary_trims_present = all(
-                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
-            )
-            # Treat any non-default overlay format option as "force re-render"
-            # so the dialog's codec / max-height / max-fps choices actually
-            # apply when a stale overlay sits on disk. With all defaults we
-            # keep the legacy "skip if present" behaviour for fast re-stitching.
-            overlay_format_overridden = (
-                req.overlay_codec != "auto"
-                or req.overlay_max_height is not None
-                or req.overlay_max_fps is not None
-                or req.overlay_theme != "splitsmith"
-            )
-            overlay_missing = req.include_overlay and (
-                not overlay_target.exists() or overlay_format_overridden
-            )
-
-            needs_per_stage = not trimmed_path.exists() or not secondary_trims_present or overlay_missing
-            if needs_per_stage:
-                handle.update(
-                    progress=0.02 + idx * per_stage_share,
-                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."),
-                )
-                # Build the secondaries list for the per-stage exporter --
-                # mirrors the single-stage endpoint's logic.
-                secondaries_in: list[export_helpers.SecondaryExport] = []
-                if req.include_secondaries:
-                    for sv in stg.videos:
-                        if sv.role != "secondary" or sv.beep_time is None:
-                            continue
-                        sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
-                        secondaries_in.append(
-                            export_helpers.SecondaryExport(
-                                video_id=sv.video_id,
-                                source_path=sec_source,
-                                beep_time_in_source=sv.beep_time,
-                                label=f"Cam {sv.video_id}",
-                            )
-                        )
-                source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
-                engine_stage = EngineStageData(
-                    stage_number=stg.stage_number,
-                    stage_name=stg.stage_name,
-                    time_seconds=stg.time_seconds,
-                    scorecard_updated_at=stg.scorecard_updated_at,
-                )
-                try:
-                    export_helpers.export_stage(
-                        request=export_helpers.StageExportRequest(
-                            stage_number=stage_number,
-                            write_trim=True,
-                            write_csv=True,
-                            write_fcpxml=True,
-                            write_report=True,
-                            write_overlay=req.include_overlay,
-                            overlay_codec=req.overlay_codec,
-                            overlay_max_height=req.overlay_max_height,
-                            overlay_max_fps=req.overlay_max_fps,
-                            overlay_theme=req.overlay_theme,
-                        ),
-                        audit_path=audit_dir / f"stage{stage_number}.json",
-                        exports_dir=exports_dir,
-                        source_video_path=source_video if source_video.exists() else None,
-                        stage_data=engine_stage,
-                        beep_time_in_source=prim.beep_time,
-                        pre_buffer_seconds=proj.trim_pre_buffer_seconds,
-                        post_buffer_seconds=proj.trim_post_buffer_seconds,
-                        config=Config(),
-                        secondaries=secondaries_in,
-                    )
-                except export_helpers.StageExportError as exc:
-                    raise RuntimeError(f"stage {stage_number}: {exc}") from exc
-            else:
-                handle.update(
-                    progress=0.02 + idx * per_stage_share,
-                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "trim already present; skipping"),
-                )
-
-        handle.check_cancel()
-        handle.update(progress=0.92, message="Stitching match FCPXML...")
-
-        # Re-load the project: the per-stage worker writes processed flags
-        # via project.save() side-effects, so a fresh load picks those up.
-        proj = state.shooter_project(slug)
-        stages_input: list[match_export_helpers.MatchStageInput] = []
-        for stage_number in req.stage_numbers:
-            stg = proj.stage(stage_number)
-            prim = stg.primary()
-            assert prim is not None and prim.beep_time is not None
-            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
-            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
-            audit_path = audit_dir / f"stage{stage_number}.json"
-            overlay_path = exports_dir / f"{base}_overlay.mov"
-            secondaries: list[match_export_helpers.MatchSecondaryInput] = []
-            for sv in stg.videos:
-                if sv.role != "secondary" or sv.beep_time is None:
-                    continue
-                sec_clip_beep = min(proj.trim_pre_buffer_seconds, sv.beep_time)
-                secondaries.append(
-                    match_export_helpers.MatchSecondaryInput(
-                        video_id=sv.video_id,
-                        trimmed_path=exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4",
-                        beep_offset_seconds=sec_clip_beep,
-                        label=f"Cam {sv.video_id}",
-                    )
-                )
-            primary_clip_beep = min(proj.trim_pre_buffer_seconds, prim.beep_time)
-            stages_input.append(
-                match_export_helpers.MatchStageInput(
-                    stage_number=stage_number,
-                    stage_name=stg.stage_name,
-                    audit_path=audit_path,
-                    trimmed_path=trimmed_path,
-                    beep_offset_seconds=primary_clip_beep,
-                    secondaries=tuple(secondaries),
-                    overlay_path=overlay_path,
-                )
-            )
-
-        project_name = req.project_name or proj.name or "match"
-        request_data = match_export_helpers.MatchExportRequestData(
-            stage_numbers=tuple(req.stage_numbers),
-            head_pad_seconds=req.head_pad_seconds,
-            tail_pad_seconds=req.tail_pad_seconds,
-            include_secondaries=req.include_secondaries,
-            include_overlay=req.include_overlay,
-            project_name=project_name,
-            pip_layout=req.pip_layout,
-            output_format=req.output_format,
-            transition_kind=req.transition_kind,
-            transition_duration_seconds=req.transition_duration_seconds,
-            title_kind=req.title_kind,
-            title_duration_seconds=req.title_duration_seconds,
-            intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
-            outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
-            youtube_sidecar=req.youtube_sidecar,
-            youtube_preset=req.youtube_preset,
-        )
-        try:
-            result = match_export_helpers.export_match(
-                stages=stages_input,
-                request=request_data,
-                exports_dir=exports_dir,
-                config=Config().output,
-            )
-        except match_export_helpers.MatchExportError as exc:
-            raise RuntimeError(str(exc)) from exc
-
-        handle.set_result(
-            {
-                "fcpxml_path": str(result.fcpxml_path),
-                "stage_count": result.stage_count,
-                "duration_seconds": result.duration_seconds,
-                "anomalies": result.anomalies,
-            }
-        )
-        anom_word = "anomaly" if len(result.anomalies) == 1 else "anomalies"
-        anom_suffix = f" ({len(result.anomalies)} {anom_word})" if result.anomalies else ""
-        handle.update(
-            progress=1.0,
-            message=(f"Done: {result.stage_count} stages, " f"{result.duration_seconds:.1f}s{anom_suffix}"),
-        )
 
     def _reveal_in_file_manager(resolved: Path) -> None:
         """Launch the OS file manager for ``resolved``, surfacing failures.
@@ -9435,20 +9482,6 @@ def create_app(
                     ),
                 )
             return FileResponse(index, headers={"Cache-Control": "no-cache"})
-
-    # Register the job bodies the dispatch resolves by ``kind``. Done after
-    # any hosted-mode backend swap (``_apply_hosted_mode_wiring``) so
-    # ``submit(kind=...)`` on whichever backend is bound finds the callable.
-    # The bodies close over this process's ``state``; a hosted worker
-    # registers its own identical set against its own state. See
-    # ``JobBodyRegistry``. ``model_download`` is registered earlier (it's
-    # submitted during create_app); lab-only kinds register inside
-    # ``_setup_lab`` (they're never deferred to a hosted worker).
-    state.jobs.bodies.register("detect_beep", _run_detect_beep_for_video)
-    state.jobs.bodies.register("trim", _run_trim)
-    state.jobs.bodies.register("shot_detect", _run_shot_detect)
-    state.jobs.bodies.register("export", _run_export_for_stage)
-    state.jobs.bodies.register("match_export", _run_match_export)
 
     return app
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -893,7 +893,7 @@ async def _maybe_submit_model_download(state: AppState) -> None:
     if await state.jobs.find_active(kind="model_download") is not None:
         return
     try:
-        await state.jobs.submit(kind="model_download", fn=_run_model_download_job)
+        await state.jobs.submit(kind="model_download")
     except ShutdownInProgressError:
         # Server is already winding down; nothing to do.
         return
@@ -2332,6 +2332,14 @@ def create_app(
     # shot-detect after the user picks a match finds the cache primed.
     # ``create_app`` runs at boot outside any event loop, so the async
     # JobBackend submission is wrapped in ``asyncio.run`` here.
+    #
+    # ``model_download`` is the one kind submitted during create_app
+    # itself (the others fire only from HTTP handlers, after this
+    # function returns), so its body must be registered before the
+    # prefetch submit -- the rest register just before ``return app``.
+    # ``_run_model_download_job`` is module-level; tests monkeypatch it,
+    # and the name resolves to the patched function here.
+    state.jobs.bodies.register("model_download", _run_model_download_job)
     asyncio.run(_maybe_submit_model_download(state))
 
     async def get_current_user(request: Request) -> User:
@@ -4195,7 +4203,7 @@ def create_app(
                     state.jobs.submit(
                         kind="shot_detect",
                         stage_number=stage_number,
-                        fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
+                        args={"slug": slug, "stage_number": stage_number},
                     )
                 )
         handle.update(progress=1.0, message="Done")
@@ -4216,9 +4224,7 @@ def create_app(
             kind="detect_beep",
             stage_number=stage_number,
             video_id=video.video_id,
-            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: (
-                _run_detect_beep_for_video(h, sl, n, vid)
-            ),
+            args={"slug": slug, "stage_number": stage_number, "video_id": video.video_id},
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -4389,7 +4395,7 @@ def create_app(
             kind="trim",
             stage_number=stage_number,
             video_id=video.video_id,
-            fn=lambda h, sl=slug, n=stage_number, vid=video.video_id: (_run_trim_for_video(h, sl, n, vid)),
+            args={"slug": slug, "stage_number": stage_number, "video_id": video.video_id},
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -4399,25 +4405,40 @@ def create_app(
         project, stage, video = _resolve_stage_video(slug, stage_number, video_id)
         return await _submit_trim(slug, stage_number, stage, video, project)
 
-    def _run_trim_for_video(handle: JobHandle, slug: str, stage_number: int, video_id: str) -> None:
+    def _run_trim(
+        handle: JobHandle,
+        *,
+        slug: str,
+        stage_number: int,
+        video_id: str,
+        chain_shot_detect: bool = True,
+    ) -> None:
         """Worker for the audit-mode trim of a specific video.
 
+        Resolves the shooter via ``slug`` (so the body is portable to a
+        hosted worker process -- the bulk path used to pass an explicit
+        ``shooter_root`` Path, which can't cross a process boundary).
+
         Auto-chains shot detection only when the trimmed video is the
-        primary; secondaries align to the primary's audit timeline by
-        their own beep, so they do not need their own shot-detection run.
+        reviewed primary AND ``chain_shot_detect`` is set; secondaries
+        align to the primary's audit timeline by their own beep, so they
+        do not need their own shot-detection run. The bulk maintenance
+        pass passes ``chain_shot_detect=False`` -- it regenerates derived
+        trim caches without re-running detection over the whole match.
         """
         handle.update(progress=0.1, message="Preparing trim...")
         proj = state.shooter_project(slug)
+        root = state.shooter_root(slug)
         stg = proj.stage(stage_number)
         video = stg.find_video_by_id(video_id)
         if video is None or video.beep_time is None:
             raise RuntimeError("video or beep disappeared mid-flight")
-        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
+        source = proj.resolve_video_path(root, video.path)
         handle.check_cancel()
         role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
         handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
         audio_helpers.ensure_video_audit_trim(
-            state.shooter_root(slug),
+            root,
             stage_number,
             video,
             source,
@@ -4435,11 +4456,12 @@ def create_app(
         v_fresh = stg_fresh.find_video_by_id(video_id)
         if v_fresh is not None:
             v_fresh.processed["trim"] = True
-            fresh.save(state.shooter_root(slug))
+            fresh.save(root)
         # Worker callback runs in a ThreadPoolExecutor thread with no
         # event loop; bridge to the async JobBackend via ``asyncio.run``.
         if (
-            video.role == "primary"
+            chain_shot_detect
+            and video.role == "primary"
             and video.beep_reviewed
             and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
         ):
@@ -4460,74 +4482,10 @@ def create_app(
                     state.jobs.submit(
                         kind="shot_detect",
                         stage_number=stage_number,
-                        fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
+                        args={"slug": slug, "stage_number": stage_number},
                     )
                 )
         handle.update(progress=1.0, message="Done")
-
-    def _run_trim_at_root(
-        handle: JobHandle,
-        shooter_root: Path,
-        stage_number: int,
-        video_id: str,
-    ) -> None:
-        """Like :func:`_run_trim_for_video` but scoped to an explicit
-        ``shooter_root`` instead of the server's bound ``state``. Used by
-        the bulk-rebuild endpoint so the operator can regenerate trim
-        caches for a non-active shooter without rebinding (which would
-        force-reload their current Audit / Compare context).
-
-        Unlike the bound variant this never auto-chains shot detection --
-        the operator is doing a maintenance pass on derived data; the
-        original audit + shot results are kept as-is.
-        """
-        handle.update(progress=0.1, message="Preparing trim...")
-        proj = MatchProject.load(shooter_root)
-        stg = proj.stage(stage_number)
-        video = stg.find_video_by_id(video_id)
-        if video is None or video.beep_time is None:
-            raise RuntimeError("video or beep disappeared mid-flight")
-        source = proj.resolve_video_path(shooter_root, video.path)
-        handle.check_cancel()
-        role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
-        handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
-        audio_helpers.ensure_video_audit_trim(
-            shooter_root,
-            stage_number,
-            video,
-            source,
-            video.beep_time,
-            stg.time_seconds,
-            project=proj,
-            runner=_cancellable_runner(handle),
-            ffmpeg_binary=process_runtime().ffmpeg_binary,
-        )
-        handle.update(progress=0.85, message="Saving project...")
-        fresh = MatchProject.load(shooter_root)
-        stg_fresh = fresh.stage(stage_number)
-        v_fresh = stg_fresh.find_video_by_id(video_id)
-        if v_fresh is not None:
-            v_fresh.processed["trim"] = True
-            fresh.save(shooter_root)
-        handle.update(progress=1.0, message="Done")
-
-    def _run_trim_for_stage(handle: JobHandle, slug: str, stage_number: int) -> None:
-        """Backward-compat shim for legacy callers (e.g. beep-override
-        endpoints) that submit a trim by stage_number alone.
-
-        Resolves the stage's primary and forwards to the per-video
-        worker. New callers should pass a ``video_id`` and submit via
-        :func:`_run_trim_for_video` directly.
-        """
-        proj = state.shooter_project(slug)
-        try:
-            stg = proj.stage(stage_number)
-        except KeyError as exc:
-            raise RuntimeError(f"stage {stage_number} disappeared mid-flight: {exc}") from exc
-        primary = stg.primary()
-        if primary is None:
-            raise RuntimeError(f"stage {stage_number} has no primary mid-flight")
-        _run_trim_for_video(handle, slug, stage_number, primary.video_id)
 
     def _run_shot_detect(handle: JobHandle, slug: str, stage_number: int, reset: bool = False) -> None:
         """Worker that runs the 4-voter ensemble on the stage's audit clip.
@@ -4803,7 +4761,7 @@ def create_app(
             job = await state.jobs.submit(
                 kind="shot_detect",
                 stage_number=stage_number,
-                fn=lambda h, sl=slug, n=stage_number, r=reset: _run_shot_detect(h, sl, n, reset=r),
+                args={"slug": slug, "stage_number": stage_number, "reset": reset},
             )
             jobs.append(job.model_dump(mode="json"))
         return JSONResponse({"jobs": jobs, "skipped": skipped})
@@ -4850,7 +4808,7 @@ def create_app(
         job = await state.jobs.submit(
             kind="shot_detect",
             stage_number=stage_number,
-            fn=lambda h, sl=slug, r=reset: _run_shot_detect(h, sl, stage_number, reset=r),
+            args={"slug": slug, "stage_number": stage_number, "reset": reset},
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -4993,9 +4951,11 @@ def create_app(
             kind="trim",
             stage_number=stage.stage_number,
             video_id=video.video_id,
-            fn=lambda h, sl=slug, n=stage.stage_number, vid=video.video_id: (
-                _run_trim_for_video(h, sl, n, vid)
-            ),
+            args={
+                "slug": slug,
+                "stage_number": stage.stage_number,
+                "video_id": video.video_id,
+            },
         )
 
     def _select_candidate_on_video(video: StageVideo, time_value: float) -> None:
@@ -5268,7 +5228,7 @@ def create_app(
             await state.jobs.submit(
                 kind="shot_detect",
                 stage_number=stage_number,
-                fn=lambda h, sl=slug, n=stage_number: _run_shot_detect(h, sl, n),
+                args={"slug": slug, "stage_number": stage_number},
             )
 
         return JSONResponse(project.model_dump(mode="json"))
@@ -6670,7 +6630,7 @@ def create_app(
         job = await state.jobs.submit(
             kind="export",
             stage_number=stage_number,
-            fn=lambda h, sl=slug, n=stage_number, r=req: _run_export_for_stage(h, sl, n, r),
+            args={"slug": slug, "stage_number": stage_number, "req": req},
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -6892,7 +6852,7 @@ def create_app(
             return JSONResponse(existing.model_dump(mode="json"))
         job = await state.jobs.submit(
             kind="match_export",
-            fn=lambda h, sl=slug, r=req: _run_match_export(h, sl, r),
+            args={"slug": slug, "req": req},
         )
         return JSONResponse(job.model_dump(mode="json"))
 
@@ -7832,9 +7792,12 @@ def create_app(
                 kind="trim",
                 stage_number=stage.stage_number,
                 video_id=primary.video_id,
-                fn=lambda h, sr=shooter_root, n=stage.stage_number, vid=primary.video_id: (
-                    _run_trim_at_root(h, sr, n, vid)
-                ),
+                args={
+                    "slug": slug,
+                    "stage_number": stage.stage_number,
+                    "video_id": primary.video_id,
+                    "chain_shot_detect": False,
+                },
             )
             jobs_submitted.append(job.model_dump(mode="json"))
 
@@ -8318,7 +8281,13 @@ def create_app(
                 _lab_universe_cache["last_run"] = run
                 handle.update(progress=1.0, message=f"done ({len(run.universe.fixtures)} fixtures)")
 
-            job = await state.jobs.submit(kind="lab_eval", fn=_run)
+            # Lab kinds are dev-only and never deferred to a hosted worker,
+            # so the body closes over this request's params and is
+            # registered just-in-time. submit() resolves the body
+            # synchronously before any await, so a concurrent lab request
+            # re-registering the same kind can't steal this submission.
+            state.jobs.bodies.register("lab_eval", _run)
+            job = await state.jobs.submit(kind="lab_eval")
             return JSONResponse(job.model_dump(mode="json"))
 
         @app.post("/api/lab/rescore")
@@ -8621,7 +8590,8 @@ def create_app(
                 _lab_runtime_cache.pop("runtime", None)
                 handle.update(progress=1.0, message="calibration rebuilt")
 
-            job = await state.jobs.submit(kind="rebuild_calibration", fn=_run)
+            state.jobs.bodies.register("rebuild_calibration", _run)
+            job = await state.jobs.submit(kind="rebuild_calibration")
             return JSONResponse(job.model_dump(mode="json"))
 
         # ------------------------------------------------------------------
@@ -8746,7 +8716,8 @@ def create_app(
                     ),
                 )
 
-            job = await state.jobs.submit(kind="promote_from_anchor", fn=_run)
+            state.jobs.bodies.register("promote_from_anchor", _run)
+            job = await state.jobs.submit(kind="promote_from_anchor")
             # Return the resolved fixture + anchor paths alongside the job so the
             # SPA can navigate to the review page once the job succeeds without
             # needing a separate result-fetch endpoint.
@@ -9047,7 +9018,8 @@ def create_app(
                     ),
                 )
 
-            job = await state.jobs.submit(kind="promote_from_anchor", fn=_run)
+            state.jobs.bodies.register("promote_from_anchor", _run)
+            job = await state.jobs.submit(kind="promote_from_anchor")
             return JSONResponse(
                 {
                     "job": job.model_dump(mode="json"),
@@ -9253,7 +9225,8 @@ def create_app(
                     ),
                 )
 
-            job = await state.jobs.submit(kind="promote_from_anchor", fn=_run)
+            state.jobs.bodies.register("promote_from_anchor", _run)
+            job = await state.jobs.submit(kind="promote_from_anchor")
             return JSONResponse(
                 {
                     "job": job.model_dump(mode="json"),
@@ -9462,6 +9435,20 @@ def create_app(
                     ),
                 )
             return FileResponse(index, headers={"Cache-Control": "no-cache"})
+
+    # Register the job bodies the dispatch resolves by ``kind``. Done after
+    # any hosted-mode backend swap (``_apply_hosted_mode_wiring``) so
+    # ``submit(kind=...)`` on whichever backend is bound finds the callable.
+    # The bodies close over this process's ``state``; a hosted worker
+    # registers its own identical set against its own state. See
+    # ``JobBodyRegistry``. ``model_download`` is registered earlier (it's
+    # submitted during create_app); lab-only kinds register inside
+    # ``_setup_lab`` (they're never deferred to a hosted worker).
+    state.jobs.bodies.register("detect_beep", _run_detect_beep_for_video)
+    state.jobs.bodies.register("trim", _run_trim)
+    state.jobs.bodies.register("shot_detect", _run_shot_detect)
+    state.jobs.bodies.register("export", _run_export_for_stage)
+    state.jobs.bodies.register("match_export", _run_match_export)
 
     return app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,20 @@ def fixtures_dir() -> Path:
     return FIXTURES_DIR
 
 
+def submit_fn(backend, *, kind: str, fn, **kwargs):
+    """Test shim bridging the pre-gamma ``submit(fn=callable)`` API to the
+    ``kind`` + body-registry dispatch.
+
+    Registers ``fn`` as the body for ``kind`` on ``backend.bodies`` then
+    returns the ``backend.submit(kind=...)`` coroutine, so existing tests
+    can keep writing ``asyncio.run(submit_fn(backend, kind=..., fn=...))``.
+    The body adapter swallows any ``args`` the dispatch would pass, since
+    these test callables take only the handle.
+    """
+    backend.bodies.register(kind, lambda handle, **_args: fn(handle))
+    return backend.submit(kind=kind, **kwargs)
+
+
 def scaffold_match(
     tmp_path: Path,
     *,

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -262,3 +262,63 @@ def test_worker_drains_ping_task(hosted_stack: None) -> None:
             pytest.fail("ping job reached 'failed' -- the worker errored running it")
         time.sleep(1.0)
     pytest.fail(f"worker did not drain ping within 30s (last status: {status!r})")
+
+
+def test_worker_runs_compute_job_end_to_end(hosted_stack: None) -> None:
+    """PR-gamma full-transport proof for a real compute kind.
+
+    Mirror exactly what ``PostgresJobBackend.submit`` does -- write a
+    PENDING ``compute_jobs`` row, then defer a ``run_compute_job`` task
+    onto the user's queue -- and assert the separate worker container
+    pops it, runs the ``model_download`` body, and writes ``succeeded``
+    back to the *same* row the SPA polls. ``model_download`` is the one
+    production kind that carries no per-match state, so it proves the
+    cross-process round-trip end to end. Real detection kinds need match
+    metadata reachable from the worker (a later chunk), so they can't be
+    driven through the queue yet.
+
+    Splitting the row-write from the defer (rather than calling the
+    backend's ``submit``) lets the test own the ``job_id`` it polls; the
+    enqueue uses the same ``make_deferrer`` the API does.
+    """
+    import asyncio
+    import uuid
+
+    from splitsmith.queue import make_deferrer
+
+    host_url = "postgresql+asyncpg://splitsmith:splitsmith@localhost:5432/splitsmith"
+    user_id = _psql("SELECT id FROM users WHERE email = 'loopback@hosted.local'")
+    assert user_id, "loopback user row missing -- auth bootstrap did not run"
+
+    job_id = uuid.uuid4().hex
+    _psql(
+        "INSERT INTO compute_jobs (id, user_id, kind, status, cancel_requested, acknowledged) "
+        f"VALUES ('{job_id}', '{user_id}', 'model_download', 'pending', false, false)"
+    )
+
+    async def _enqueue() -> None:
+        defer = make_deferrer(host_url)
+        await defer(
+            job_id=job_id,
+            user_id=user_id,
+            kind="model_download",
+            args={},
+            match_id=None,
+        )
+
+    asyncio.run(_enqueue())
+
+    # The worker pops from ``user-<id>`` (it drains all queues), runs the
+    # body, and finalises the row. Baked-in slim models make the body a
+    # near-instant no-op, but allow margin over the worker poll interval.
+    deadline = time.time() + 60.0
+    status = ""
+    while time.time() < deadline:
+        status = _psql(f"SELECT status FROM compute_jobs WHERE id = '{job_id}'")
+        if status == "succeeded":
+            return
+        if status == "failed":
+            err = _psql(f"SELECT error FROM compute_jobs WHERE id = '{job_id}'")
+            pytest.fail(f"compute job reached 'failed': {err!r}")
+        time.sleep(1.0)
+    pytest.fail(f"worker did not finish compute job within 60s (last status: {status!r})")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -8,7 +8,14 @@ import time
 
 import pytest
 
-from splitsmith.ui.jobs import JobCancelled, JobRegistry, JobStatus, _priority_for_kind
+from splitsmith.ui.jobs import (
+    JobBodyRegistry,
+    JobCancelled,
+    JobRegistry,
+    JobStatus,
+    UnknownJobKindError,
+    _priority_for_kind,
+)
 
 
 class _Sync:
@@ -42,6 +49,16 @@ class _Sync:
         return self._inner.wait_for_drain(timeout_s)
 
     def submit(self, **kwargs):
+        # The dispatch reshape (worker-fleet gamma) replaced ``fn=callable``
+        # with ``kind`` + a kind->body registry. These tests predate that
+        # and still pass ``fn=`` for terseness; translate by registering the
+        # callable as the body for ``kind`` then submitting by kind. submit()
+        # resolves the body synchronously before any await, so back-to-back
+        # same-kind submits each capture their own callable.
+        fn = kwargs.pop("fn", None)
+        if fn is not None:
+            self._inner.bodies.register(kwargs["kind"], lambda handle, **_a: fn(handle))
+            kwargs.setdefault("args", {})
         return asyncio.run(self._inner.submit(**kwargs))
 
     def get(self, job_id):
@@ -648,3 +665,52 @@ def test_dispatcher_respects_max_concurrent() -> None:
     for j in jobs:
         assert _wait_until(lambda jid=j.id: reg.get(jid).status == JobStatus.SUCCEEDED)
     assert peak == 2
+
+
+# ---------------------------------------------------------------------------
+# Dispatch reshape: kind -> body registry (worker-fleet gamma)
+# ---------------------------------------------------------------------------
+
+
+def test_body_registry_register_and_get() -> None:
+    reg = JobBodyRegistry()
+
+    def body(_handle, **_a):
+        return None
+
+    assert "k" not in reg
+    reg.register("k", body)
+    assert "k" in reg
+    assert reg.get("k") is body
+
+
+def test_body_registry_unknown_kind_raises() -> None:
+    reg = JobBodyRegistry()
+    with pytest.raises(UnknownJobKindError):
+        reg.get("nope")
+
+
+def test_submit_dispatches_registered_body_with_args() -> None:
+    """submit(kind, args) resolves the registered body and calls it as
+    ``body(handle, **args)``."""
+    reg = _Sync(JobRegistry(max_concurrent=1))
+    seen: dict = {}
+    done = threading.Event()
+
+    def body(handle, *, slug, stage_number):
+        seen["slug"] = slug
+        seen["stage_number"] = stage_number
+        seen["handle_id"] = handle.id
+        done.set()
+
+    reg._inner.bodies.register("shot_detect", body)
+    job = reg.submit(kind="shot_detect", args={"slug": "alice", "stage_number": 3})
+    assert done.wait(timeout=2.0)
+    assert _wait_until(lambda: reg.get(job.id).status == JobStatus.SUCCEEDED)
+    assert seen == {"slug": "alice", "stage_number": 3, "handle_id": job.id}
+
+
+def test_submit_unregistered_kind_raises_unknown_job_kind() -> None:
+    reg = _Sync(JobRegistry())
+    with pytest.raises(UnknownJobKindError):
+        reg.submit(kind="never_registered", args={})

--- a/tests/test_models_layer.py
+++ b/tests/test_models_layer.py
@@ -543,7 +543,9 @@ def test_run_model_download_job_aggregates_progress(monkeypatch: pytest.MonkeyPa
     from splitsmith.ui.jobs import JobRegistry
 
     jobs = JobRegistry()
-    submitted = asyncio.run(jobs.submit(kind="model_download", fn=_run_model_download_job))
+    from tests.conftest import submit_fn
+
+    submitted = asyncio.run(submit_fn(jobs, kind="model_download", fn=_run_model_download_job))
     jobs.wait_for_drain(timeout_s=2.0)
     final = asyncio.run(jobs.get(submitted.id))
     assert final is not None

--- a/tests/test_postgres_job_backend.py
+++ b/tests/test_postgres_job_backend.py
@@ -4,11 +4,24 @@ Runs against file-backed SQLite + aiosqlite. The backend is
 engine-agnostic; SQLite suffices to prove the SQL shapes work, the
 per-user filter holds, and the restart-sweep behaviour fires.
 
-Why file-backed and not ``:memory:``: the in-process worker thread
-opens its own event loop via ``asyncio.run`` for each DB call, and
-``sqlite+aiosqlite:///:memory:`` is per-connection in aiosqlite --
-the worker thread would see a fresh empty DB and the row it's
-supposed to update would be invisible. A ``tmp_path``-backed file
+PR-gamma split enqueue from execution: :meth:`submit` writes a PENDING
+row and hands a JSON payload to the injected ``deferrer`` (in
+production, the Procrastinate enqueue); a separate worker process pops
+it and calls :meth:`run_job`. These tests stand in for that worker with
+two fake deferrers:
+
+* an *inline* deferrer that drives :meth:`run_job` immediately, so a
+  ``submit`` runs the body to its terminal state in one call (the common
+  case -- most tests only care about the end state);
+* a *no-op* deferrer that records nothing and runs nothing, leaving the
+  row PENDING so tests can exercise the queued window (cancel-before-pickup,
+  find_active dedupe) and then drive :meth:`run_job` themselves.
+
+Why file-backed and not ``:memory:``: :meth:`run_job` offloads the body
+to a worker thread that opens its own event loop via ``asyncio.run`` for
+each DB call, and ``sqlite+aiosqlite:///:memory:`` is per-connection in
+aiosqlite -- the worker thread would see a fresh empty DB and the row
+it's supposed to update would be invisible. A ``tmp_path``-backed file
 shares state across connections without any extra setup.
 """
 
@@ -30,7 +43,6 @@ from splitsmith.db import (
     sessionmaker,
 )
 from splitsmith.ui.jobs import JobBackend, JobStatus
-from tests.conftest import submit_fn
 
 
 def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0, poll: float = 0.01) -> bool:
@@ -42,12 +54,49 @@ def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0, poll: fl
     return predicate()
 
 
+def _noop_deferrer() -> Callable[..., object]:
+    """A deferrer that records nothing and runs nothing.
+
+    Leaves the submitted row PENDING so tests can exercise the queued
+    window before a worker pops the job.
+    """
+
+    async def _defer(**_payload: object) -> None:
+        return None
+
+    return _defer
+
+
+def _inline_deferrer(box: list[PostgresJobBackend]) -> Callable[..., object]:
+    """A deferrer that runs the job inline via :meth:`run_job`.
+
+    Stands in for the worker round-trip: ``submit`` enqueues, this runs
+    the body to its terminal state before ``submit`` returns. ``box`` is
+    a one-element list holding the backend, populated after construction
+    (the deferrer and the backend reference each other).
+    """
+
+    async def _defer(*, job_id: str, kind: str, args: dict | None = None, **_rest: object) -> None:
+        await box[0].run_job(job_id=job_id, kind=kind, args=args)
+
+    return _defer
+
+
+def _register(backend: PostgresJobBackend, kind: str, fn: Callable[[object], None]) -> None:
+    """Register ``fn`` as the body for ``kind``.
+
+    The adapter swallows any dispatch ``args``; these test callables take
+    only the :class:`JobHandle`.
+    """
+    backend.bodies.register(kind, lambda handle, **_args: fn(handle))
+
+
 def _build_backend_for_new_user(
     tmp_path,
     *,
     email: str = "jobs@thias.se",
-    max_concurrent: int = 2,
     db_name: str = "jobs.sqlite",
+    inline: bool = True,
 ) -> tuple[PostgresJobBackend, sessionmaker, str]:
     db_path = tmp_path / db_name
     engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -64,7 +113,10 @@ def _build_backend_for_new_user(
             return user.id
 
     user_id = asyncio.run(_setup())
-    backend = PostgresJobBackend(session_factory, user_id=user_id, max_concurrent=max_concurrent)
+    box: list[PostgresJobBackend] = []
+    deferrer = _inline_deferrer(box) if inline else _noop_deferrer()
+    backend = PostgresJobBackend(session_factory, user_id=user_id, deferrer=deferrer)
+    box.append(backend)
     return backend, session_factory, user_id
 
 
@@ -85,6 +137,40 @@ def test_construction_rejects_empty_or_non_string_user_id(bad, tmp_path) -> None
         PostgresJobBackend(factory, user_id=bad)  # type: ignore[arg-type]
 
 
+def test_submit_without_deferrer_raises(tmp_path) -> None:
+    """An execute-only backend (worker side, no deferrer) must refuse to
+    enqueue -- enqueuing belongs to the API process."""
+    db_path = tmp_path / "no-deferrer.sqlite"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    session_factory = sessionmaker(engine)
+
+    async def _setup() -> str:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with session_factory() as s:
+            user = User(email="worker@thias.se")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            return user.id
+
+    user_id = asyncio.run(_setup())
+    backend = PostgresJobBackend(session_factory, user_id=user_id, sweep_on_boot=False)
+    _register(backend, "probe", lambda _h: None)
+    with pytest.raises(RuntimeError, match="needs a deferrer"):
+        asyncio.run(backend.submit(kind="probe"))
+
+
+def test_submit_unknown_kind_fails_fast(tmp_path) -> None:
+    """An unknown kind must fail before any row is written or enqueued."""
+    from splitsmith.ui.jobs import UnknownJobKindError
+
+    backend, _, _ = _build_backend_for_new_user(tmp_path)
+    with pytest.raises(UnknownJobKindError):
+        asyncio.run(backend.submit(kind="nope"))
+    assert asyncio.run(backend.list()) == []
+
+
 def test_submit_persists_row_and_runs_to_succeeded(tmp_path) -> None:
     backend, _, _ = _build_backend_for_new_user(tmp_path)
     seen = threading.Event()
@@ -92,7 +178,10 @@ def test_submit_persists_row_and_runs_to_succeeded(tmp_path) -> None:
     def work(_handle):
         seen.set()
 
-    job = asyncio.run(submit_fn(backend, kind="test", fn=work))
+    _register(backend, "test", work)
+    job = asyncio.run(backend.submit(kind="test"))
+    # The returned snapshot reflects the enqueue moment, before the
+    # (inline) worker picks it up.
     assert job.status == JobStatus.PENDING
     assert seen.wait(timeout=2.0)
 
@@ -104,12 +193,13 @@ def test_submit_persists_row_and_runs_to_succeeded(tmp_path) -> None:
 
 
 def test_failed_job_records_error_string(tmp_path) -> None:
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
+    backend, _, _ = _build_backend_for_new_user(tmp_path)
 
     def boom(_handle):
         raise ValueError("oh no")
 
-    job = asyncio.run(submit_fn(backend, kind="test", fn=boom))
+    _register(backend, "test", boom)
+    job = asyncio.run(backend.submit(kind="test"))
     assert _wait_until(lambda: asyncio.run(backend.get(job.id)).status == JobStatus.FAILED)
     final = asyncio.run(backend.get(job.id))
     assert final.error == "oh no"
@@ -135,11 +225,14 @@ def test_list_returns_only_this_users_jobs(tmp_path) -> None:
             return alice.id, bob.id
 
     alice_id, bob_id = asyncio.run(_setup())
-    alice = PostgresJobBackend(session_factory, user_id=alice_id, max_concurrent=2)
-    bob = PostgresJobBackend(session_factory, user_id=bob_id, max_concurrent=2)
+    # No-op deferrers: this test only checks row ownership, not execution.
+    alice = PostgresJobBackend(session_factory, user_id=alice_id, deferrer=_noop_deferrer())
+    bob = PostgresJobBackend(session_factory, user_id=bob_id, deferrer=_noop_deferrer())
+    _register(alice, "probe", lambda _h: None)
+    _register(bob, "probe", lambda _h: None)
 
-    a_job = asyncio.run(submit_fn(alice, kind="probe", fn=lambda _h: None))
-    b_job = asyncio.run(submit_fn(bob, kind="probe", fn=lambda _h: None))
+    a_job = asyncio.run(alice.submit(kind="probe"))
+    b_job = asyncio.run(bob.submit(kind="probe"))
     assert a_job.id != b_job.id
 
     # Each backend sees only its user's row, even though both rows
@@ -156,44 +249,58 @@ def test_list_returns_only_this_users_jobs(tmp_path) -> None:
 
 
 def test_cancel_pending_short_circuits_to_cancelled(tmp_path) -> None:
-    """A cancel that arrives before the worker picks the row up should
-    flip status straight to CANCELLED so the SPA can stop polling."""
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
-    proceed = threading.Event()
-    started = threading.Event()
+    """A cancel that arrives before the worker pops the row should flip
+    status straight to CANCELLED so the SPA can stop polling.
 
-    def hold(_h):
-        started.set()
-        proceed.wait(timeout=2.0)
-
-    # Block the executor with one slow job so a second submission
-    # stays PENDING long enough for cancel() to race in.
-    asyncio.run(submit_fn(backend, kind="hold", fn=hold))
-    assert started.wait(timeout=2.0)
-
+    With out-of-process dispatch the PENDING window is real: the no-op
+    deferrer leaves the row queued, so cancel() races in cleanly without
+    needing to block any executor."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
     ran = threading.Event()
 
     def victim(_h):
         ran.set()
 
-    queued = asyncio.run(submit_fn(backend, kind="victim", fn=victim))
+    _register(backend, "victim", victim)
+    queued = asyncio.run(backend.submit(kind="victim"))
     assert asyncio.run(backend.get(queued.id)).status == JobStatus.PENDING
+
     snapshot = asyncio.run(backend.cancel(queued.id))
     assert snapshot is not None
     assert snapshot.status == JobStatus.CANCELLED
-    proceed.set()
-    # The worker should never have run the victim.
+    # The body never ran.
     assert not ran.is_set()
 
 
+def test_run_job_skips_a_cancelled_row(tmp_path) -> None:
+    """If a worker pops a job that was cancelled while PENDING, the body
+    must not run and the row stays CANCELLED."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
+    ran = threading.Event()
+
+    def victim(_h):
+        ran.set()
+
+    _register(backend, "victim", victim)
+    queued = asyncio.run(backend.submit(kind="victim"))
+    asyncio.run(backend.cancel(queued.id))
+
+    # Worker pops it after the cancel landed.
+    asyncio.run(backend.run_job(job_id=queued.id, kind="victim"))
+    assert not ran.is_set()
+    assert asyncio.run(backend.get(queued.id)).status == JobStatus.CANCELLED
+
+
 def test_acknowledge_and_acknowledge_all_failures(tmp_path) -> None:
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
+    backend, _, _ = _build_backend_for_new_user(tmp_path)
 
     def boom(_h):
         raise ValueError("kaboom")
 
-    a = asyncio.run(submit_fn(backend, kind="a", fn=boom))
-    b = asyncio.run(submit_fn(backend, kind="b", fn=boom))
+    _register(backend, "a", boom)
+    _register(backend, "b", boom)
+    a = asyncio.run(backend.submit(kind="a"))
+    b = asyncio.run(backend.submit(kind="b"))
     assert _wait_until(
         lambda: all(asyncio.run(backend.get(jid)).status == JobStatus.FAILED for jid in (a.id, b.id))
     )
@@ -205,7 +312,8 @@ def test_acknowledge_and_acknowledge_all_failures(tmp_path) -> None:
     assert again == []
 
     # acknowledge on a non-failed job is a no-op snapshot return.
-    succeeded = asyncio.run(submit_fn(backend, kind="ok", fn=lambda _h: None))
+    _register(backend, "ok", lambda _h: None)
+    succeeded = asyncio.run(backend.submit(kind="ok"))
     assert _wait_until(lambda: asyncio.run(backend.get(succeeded.id)).status == JobStatus.SUCCEEDED)
     snap = asyncio.run(backend.acknowledge(succeeded.id))
     assert snap is not None
@@ -213,15 +321,15 @@ def test_acknowledge_and_acknowledge_all_failures(tmp_path) -> None:
 
 
 def test_find_active_dedupe_by_kind_and_stage(tmp_path) -> None:
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
-    proceed = threading.Event()
+    """find_active matches a queued (PENDING) or running job so the SPA
+    can dedupe a resubmission; terminal jobs stop matching."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
+    _register(backend, "trim", lambda _h: None)
 
-    def slow(_h):
-        proceed.wait(timeout=2.0)
+    job = asyncio.run(backend.submit(kind="trim", stage_number=4))
+    assert asyncio.run(backend.get(job.id)).status == JobStatus.PENDING
 
-    job = asyncio.run(submit_fn(backend, kind="trim", stage_number=4, fn=slow))
-    # While running, find_active matches on (kind, stage).
-    assert _wait_until(lambda: asyncio.run(backend.get(job.id)).status == JobStatus.RUNNING)
+    # While queued, find_active matches on (kind, stage).
     found = asyncio.run(backend.find_active(kind="trim", stage_number=4))
     assert found is not None and found.id == job.id
 
@@ -230,9 +338,9 @@ def test_find_active_dedupe_by_kind_and_stage(tmp_path) -> None:
     # Different kind: no match.
     assert asyncio.run(backend.find_active(kind="detect_beep", stage_number=4)) is None
 
-    proceed.set()
-    assert _wait_until(lambda: asyncio.run(backend.get(job.id)).status == JobStatus.SUCCEEDED)
-    # Terminal jobs don't match find_active anymore.
+    # Drive it to completion; terminal jobs don't match find_active.
+    asyncio.run(backend.run_job(job_id=job.id, kind="trim"))
+    assert asyncio.run(backend.get(job.id)).status == JobStatus.SUCCEEDED
     assert asyncio.run(backend.find_active(kind="trim", stage_number=4)) is None
 
 
@@ -286,7 +394,7 @@ def test_restart_sweep_marks_stuck_rows_failed(tmp_path) -> None:
             return uid
 
     user_id = asyncio.run(_setup())
-    backend = PostgresJobBackend(session_factory, user_id=user_id, max_concurrent=1)
+    backend = PostgresJobBackend(session_factory, user_id=user_id)
 
     pending_snap = asyncio.run(backend.get("stuck-pending"))
     running_snap = asyncio.run(backend.get("stuck-running"))
@@ -297,6 +405,40 @@ def test_restart_sweep_marks_stuck_rows_failed(tmp_path) -> None:
     assert running_snap.error == "server restarted before this job finished"
     # Already-terminal rows are untouched.
     assert done_snap.status == JobStatus.SUCCEEDED
+
+
+def test_worker_backend_does_not_sweep_on_boot(tmp_path) -> None:
+    """The worker passes ``sweep_on_boot=False`` so it never fails jobs
+    that were queued for it to run."""
+    engine = create_engine(f"sqlite+aiosqlite:///{tmp_path}/worker-sweep.sqlite")
+    session_factory = sessionmaker(engine)
+
+    async def _setup() -> str:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with session_factory() as s:
+            user = User(email="worker-sweep@thias.se")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            uid = user.id
+            s.add(
+                ComputeJobRow(
+                    id="queued-for-worker",
+                    user_id=uid,
+                    kind="trim",
+                    status=JobStatus.PENDING.value,
+                    cancel_requested=False,
+                    acknowledged=False,
+                )
+            )
+            await s.commit()
+            return uid
+
+    user_id = asyncio.run(_setup())
+    backend = PostgresJobBackend(session_factory, user_id=user_id, sweep_on_boot=False)
+    snap = asyncio.run(backend.get("queued-for-worker"))
+    assert snap.status == JobStatus.PENDING
 
 
 def test_restart_sweep_only_touches_this_users_rows(tmp_path) -> None:
@@ -341,7 +483,7 @@ def test_restart_sweep_only_touches_this_users_rows(tmp_path) -> None:
     alice_id, bob_id = asyncio.run(_setup())
     # Only Alice's backend is constructed; Bob's row should stay
     # untouched.
-    PostgresJobBackend(session_factory, user_id=alice_id, max_concurrent=1)
+    PostgresJobBackend(session_factory, user_id=alice_id)
 
     async def _statuses() -> tuple[str, str]:
         async with session_factory() as s:
@@ -362,25 +504,111 @@ def test_restart_sweep_only_touches_this_users_rows(tmp_path) -> None:
 
 def test_progress_message_round_trip_via_handle(tmp_path) -> None:
     """Worker writes via :class:`JobHandle.update`; the persisted row
-    reflects the latest progress + message."""
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
+    reflects the latest progress + message.
+
+    Drives :meth:`run_job` on a background thread with a body that blocks
+    after its first update, so the main thread can observe the mid-run
+    state before the job finalises."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
     proceed = threading.Event()
 
     def slow(handle):
         handle.update(progress=0.25, message="phase 1")
         proceed.wait(timeout=2.0)
 
-    job = asyncio.run(submit_fn(backend, kind="test", fn=slow))
-    assert _wait_until(lambda: asyncio.run(backend.get(job.id)).message == "phase 1")
-    snap = asyncio.run(backend.get(job.id))
-    assert snap.progress == 0.25
-    proceed.set()
+    _register(backend, "test", slow)
+    job = asyncio.run(backend.submit(kind="test"))
+
+    worker = threading.Thread(target=lambda: asyncio.run(backend.run_job(job_id=job.id, kind="test")))
+    worker.start()
+    try:
+        assert _wait_until(lambda: asyncio.run(backend.get(job.id)).message == "phase 1")
+        snap = asyncio.run(backend.get(job.id))
+        assert snap.progress == 0.25
+    finally:
+        proceed.set()
+        worker.join(timeout=2.0)
 
 
 def test_shutdown_blocks_new_submissions(tmp_path) -> None:
-    backend, _, _ = _build_backend_for_new_user(tmp_path, max_concurrent=1)
+    backend, _, _ = _build_backend_for_new_user(tmp_path)
     backend.begin_shutdown()
     from splitsmith.ui.jobs import ShutdownInProgressError
 
     with pytest.raises(ShutdownInProgressError):
-        asyncio.run(submit_fn(backend, kind="probe", fn=lambda _h: None))
+        asyncio.run(backend.submit(kind="probe"))
+
+
+def test_args_reach_the_body_through_submit(tmp_path) -> None:
+    """A non-empty ``args`` payload survives submit -> deferrer -> run_job
+    and arrives at the body as keyword arguments.
+
+    The other tests register through ``_register``, which swallows
+    dispatch args; this one keeps them so a regression that dropped or
+    mangled ``**call_args`` on the way to the body would fail here.
+    """
+    backend, _, _ = _build_backend_for_new_user(tmp_path)
+    seen: dict[str, object] = {}
+
+    def body(handle, **kwargs):
+        seen.update(kwargs)
+
+    backend.bodies.register("with_args", body)
+    asyncio.run(backend.submit(kind="with_args", args={"slug": "stage-3", "chain": False}))
+
+    assert seen == {"slug": "stage-3", "chain": False}
+
+
+def test_before_body_failure_fails_the_job_not_strands_it(tmp_path) -> None:
+    """A ``before_body`` that raises (e.g. the worker failing to resolve a
+    match cross-process) must mark the row FAILED with the error message,
+    not let the exception escape and strand the row at PENDING.
+
+    This is the worker's match-binding guard: ``register_compute_task``
+    resolves the match inside ``before_body`` precisely so this capture
+    path applies.
+    """
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
+    ran = {"body": False}
+
+    def body(handle, **_kwargs):
+        ran["body"] = True
+
+    backend.bodies.register("needs_match", body)
+    job = asyncio.run(backend.submit(kind="needs_match"))
+
+    def before_body():
+        raise RuntimeError("hosted worker cannot resolve match 'abc123'")
+
+    asyncio.run(backend.run_job(job_id=job.id, kind="needs_match", before_body=before_body))
+
+    snap = asyncio.run(backend.get(job.id))
+    assert snap.status == JobStatus.FAILED.value
+    assert "cannot resolve match 'abc123'" in (snap.error or "")
+    assert ran["body"] is False  # body never ran -- binding failed first
+
+
+def test_wire_and_rehydrate_round_trip_a_pydantic_req() -> None:
+    """``_to_wire_args`` projects the Pydantic ``req`` (carried by
+    ``export`` / ``match_export``) to a JSON-native dict so it can ride
+    the queue, and ``_rehydrate_args`` reconstructs the typed model on
+    the worker side. A closure can't be pickled onto a queue, so this
+    JSON round-trip is the whole reason PR-gamma reshaped dispatch.
+    """
+    from splitsmith.db.job_backend import _to_wire_args
+    from splitsmith.queue import _rehydrate_args
+    from splitsmith.ui.server import ExportStageRequest
+
+    req = ExportStageRequest(write_csv=False, overlay_theme="clean")
+    wire = _to_wire_args({"req": req, "video_id": "v1"})
+
+    # On the wire the model is a plain JSON dict, not a BaseModel.
+    assert isinstance(wire["req"], dict)
+    assert wire["req"]["write_csv"] is False
+    assert wire["video_id"] == "v1"
+
+    rehydrated = _rehydrate_args("export", wire)
+    assert isinstance(rehydrated["req"], ExportStageRequest)
+    assert rehydrated["req"] == req
+    # Pass-through kinds are returned untouched (no ``req`` to rebuild).
+    assert _rehydrate_args("trim", {"video_id": "v1"}) == {"video_id": "v1"}

--- a/tests/test_postgres_job_backend.py
+++ b/tests/test_postgres_job_backend.py
@@ -30,6 +30,7 @@ from splitsmith.db import (
     sessionmaker,
 )
 from splitsmith.ui.jobs import JobBackend, JobStatus
+from tests.conftest import submit_fn
 
 
 def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0, poll: float = 0.01) -> bool:
@@ -91,7 +92,7 @@ def test_submit_persists_row_and_runs_to_succeeded(tmp_path) -> None:
     def work(_handle):
         seen.set()
 
-    job = asyncio.run(backend.submit(kind="test", fn=work))
+    job = asyncio.run(submit_fn(backend, kind="test", fn=work))
     assert job.status == JobStatus.PENDING
     assert seen.wait(timeout=2.0)
 
@@ -108,7 +109,7 @@ def test_failed_job_records_error_string(tmp_path) -> None:
     def boom(_handle):
         raise ValueError("oh no")
 
-    job = asyncio.run(backend.submit(kind="test", fn=boom))
+    job = asyncio.run(submit_fn(backend, kind="test", fn=boom))
     assert _wait_until(lambda: asyncio.run(backend.get(job.id)).status == JobStatus.FAILED)
     final = asyncio.run(backend.get(job.id))
     assert final.error == "oh no"
@@ -137,8 +138,8 @@ def test_list_returns_only_this_users_jobs(tmp_path) -> None:
     alice = PostgresJobBackend(session_factory, user_id=alice_id, max_concurrent=2)
     bob = PostgresJobBackend(session_factory, user_id=bob_id, max_concurrent=2)
 
-    a_job = asyncio.run(alice.submit(kind="probe", fn=lambda _h: None))
-    b_job = asyncio.run(bob.submit(kind="probe", fn=lambda _h: None))
+    a_job = asyncio.run(submit_fn(alice, kind="probe", fn=lambda _h: None))
+    b_job = asyncio.run(submit_fn(bob, kind="probe", fn=lambda _h: None))
     assert a_job.id != b_job.id
 
     # Each backend sees only its user's row, even though both rows
@@ -167,7 +168,7 @@ def test_cancel_pending_short_circuits_to_cancelled(tmp_path) -> None:
 
     # Block the executor with one slow job so a second submission
     # stays PENDING long enough for cancel() to race in.
-    asyncio.run(backend.submit(kind="hold", fn=hold))
+    asyncio.run(submit_fn(backend, kind="hold", fn=hold))
     assert started.wait(timeout=2.0)
 
     ran = threading.Event()
@@ -175,7 +176,7 @@ def test_cancel_pending_short_circuits_to_cancelled(tmp_path) -> None:
     def victim(_h):
         ran.set()
 
-    queued = asyncio.run(backend.submit(kind="victim", fn=victim))
+    queued = asyncio.run(submit_fn(backend, kind="victim", fn=victim))
     assert asyncio.run(backend.get(queued.id)).status == JobStatus.PENDING
     snapshot = asyncio.run(backend.cancel(queued.id))
     assert snapshot is not None
@@ -191,8 +192,8 @@ def test_acknowledge_and_acknowledge_all_failures(tmp_path) -> None:
     def boom(_h):
         raise ValueError("kaboom")
 
-    a = asyncio.run(backend.submit(kind="a", fn=boom))
-    b = asyncio.run(backend.submit(kind="b", fn=boom))
+    a = asyncio.run(submit_fn(backend, kind="a", fn=boom))
+    b = asyncio.run(submit_fn(backend, kind="b", fn=boom))
     assert _wait_until(
         lambda: all(asyncio.run(backend.get(jid)).status == JobStatus.FAILED for jid in (a.id, b.id))
     )
@@ -204,7 +205,7 @@ def test_acknowledge_and_acknowledge_all_failures(tmp_path) -> None:
     assert again == []
 
     # acknowledge on a non-failed job is a no-op snapshot return.
-    succeeded = asyncio.run(backend.submit(kind="ok", fn=lambda _h: None))
+    succeeded = asyncio.run(submit_fn(backend, kind="ok", fn=lambda _h: None))
     assert _wait_until(lambda: asyncio.run(backend.get(succeeded.id)).status == JobStatus.SUCCEEDED)
     snap = asyncio.run(backend.acknowledge(succeeded.id))
     assert snap is not None
@@ -218,7 +219,7 @@ def test_find_active_dedupe_by_kind_and_stage(tmp_path) -> None:
     def slow(_h):
         proceed.wait(timeout=2.0)
 
-    job = asyncio.run(backend.submit(kind="trim", stage_number=4, fn=slow))
+    job = asyncio.run(submit_fn(backend, kind="trim", stage_number=4, fn=slow))
     # While running, find_active matches on (kind, stage).
     assert _wait_until(lambda: asyncio.run(backend.get(job.id)).status == JobStatus.RUNNING)
     found = asyncio.run(backend.find_active(kind="trim", stage_number=4))
@@ -369,7 +370,7 @@ def test_progress_message_round_trip_via_handle(tmp_path) -> None:
         handle.update(progress=0.25, message="phase 1")
         proceed.wait(timeout=2.0)
 
-    job = asyncio.run(backend.submit(kind="test", fn=slow))
+    job = asyncio.run(submit_fn(backend, kind="test", fn=slow))
     assert _wait_until(lambda: asyncio.run(backend.get(job.id)).message == "phase 1")
     snap = asyncio.run(backend.get(job.id))
     assert snap.progress == 0.25
@@ -382,4 +383,4 @@ def test_shutdown_blocks_new_submissions(tmp_path) -> None:
     from splitsmith.ui.jobs import ShutdownInProgressError
 
     with pytest.raises(ShutdownInProgressError):
-        asyncio.run(backend.submit(kind="probe", fn=lambda _h: None))
+        asyncio.run(submit_fn(backend, kind="probe", fn=lambda _h: None))

--- a/tests/test_ui_embedded.py
+++ b/tests/test_ui_embedded.py
@@ -16,6 +16,7 @@ from splitsmith.ui.embedded import (
     READY_PREFIX,
     run_embedded,
 )
+from tests.conftest import submit_fn
 
 
 def test_context_manager_binds_serves_health_and_shuts_down() -> None:
@@ -183,7 +184,7 @@ def _submit_blocking_job(registry, kind: str, started, release):
             if release.wait(0.02):
                 return
 
-    return _await(registry.submit(kind=kind, fn=_block))
+    return _await(submit_fn(registry, kind=kind, fn=_block))
 
 
 def _wait_status(registry, job_id: str, *, deadline_s: float = 3.0):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -39,6 +39,7 @@ def _enable_auto_beep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 from tests.conftest import scaffold_match as _scaffold_match  # noqa: E402
+from tests.conftest import submit_fn  # noqa: E402
 
 _SCOPED_PREFIXES = (
     "/api/shooters/",
@@ -6247,7 +6248,7 @@ def test_cleanup_apply_refuses_while_jobs_active(tmp_path: Path) -> None:
         started.set()
         release.wait(timeout=5.0)
 
-    asyncio.run(state.jobs.submit(kind="test_block", fn=worker))
+    asyncio.run(submit_fn(state.jobs, kind="test_block", fn=worker))
     assert started.wait(timeout=2.0)
 
     try:

--- a/tests/test_ui_shutdown.py
+++ b/tests/test_ui_shutdown.py
@@ -32,7 +32,7 @@ def test_begin_shutdown_blocks_new_submissions() -> None:
     reg = JobRegistry(max_concurrent=1)
     reg.begin_shutdown()
     with pytest.raises(ShutdownInProgressError):
-        asyncio.run(reg.submit(kind="test", fn=lambda _h: None))
+        asyncio.run(submit_fn(reg, kind="test", fn=lambda _h: None))
 
 
 def test_begin_shutdown_is_idempotent() -> None:
@@ -54,7 +54,7 @@ def test_wait_for_drain_waits_for_in_flight_then_returns() -> None:
     def slow(_handle):
         proceed.wait(timeout=2.0)
 
-    job = asyncio.run(reg.submit(kind="test", fn=slow))
+    job = asyncio.run(submit_fn(reg, kind="test", fn=slow))
     assert _wait_until(lambda: asyncio.run(reg.get(job.id)).status == JobStatus.RUNNING)
 
     reg.begin_shutdown()
@@ -74,7 +74,7 @@ def test_wait_for_drain_returns_false_on_timeout() -> None:
     def slow(_handle):
         proceed.wait(timeout=5.0)
 
-    asyncio.run(reg.submit(kind="test", fn=slow))
+    asyncio.run(submit_fn(reg, kind="test", fn=slow))
     assert _wait_until(lambda: reg.active_count() == 1)
 
     reg.begin_shutdown()
@@ -90,7 +90,7 @@ def test_active_count_excludes_terminal_states() -> None:
     def quick(_handle):
         pass
 
-    job = asyncio.run(reg.submit(kind="test", fn=quick))
+    job = asyncio.run(submit_fn(reg, kind="test", fn=quick))
     assert _wait_until(lambda: asyncio.run(reg.get(job.id)).status == JobStatus.SUCCEEDED)
     assert reg.active_count() == 0
 
@@ -100,7 +100,7 @@ def test_active_count_excludes_terminal_states() -> None:
 # ----------------------------------------------------------------------
 
 
-from tests.conftest import scaffold_match  # noqa: E402
+from tests.conftest import scaffold_match, submit_fn  # noqa: E402
 
 
 def _make_client(tmp_path: Path) -> TestClient:
@@ -187,7 +187,7 @@ def test_submit_during_shutdown_raises_at_registry(tmp_path: Path) -> None:
     state = client.app.state.splitsmith_state
     assert state.jobs.is_shutting_down
     with pytest.raises(ShutdownInProgressError):
-        asyncio.run(state.jobs.submit(kind="probe", fn=lambda _h: None))
+        asyncio.run(submit_fn(state.jobs, kind="probe", fn=lambda _h: None))
 
 
 def test_shutdown_calls_handler_after_drain(tmp_path: Path) -> None:
@@ -216,7 +216,7 @@ def test_shutdown_drains_in_flight_job_before_calling_handler(tmp_path: Path) ->
     def slow(_handle):
         proceed.wait(timeout=5.0)
 
-    asyncio.run(state.jobs.submit(kind="test", fn=slow))
+    asyncio.run(submit_fn(state.jobs, kind="test", fn=slow))
     assert _wait_until(lambda: state.jobs.active_count() == 1)
 
     resp = client.post("/api/shutdown")


### PR DESCRIPTION
## PR-gamma: real worker separation

Reshapes job dispatch from `submit(fn=closure)` to `submit(kind=, args=)` so jobs can cross a process boundary, then wires a separate `splitsmith worker` to pop and run them. Completes the worker-fleet chunk's last planned piece (after #437-#444).

A closure can't be pickled onto a queue -- Procrastinate serializes *args*, not captured functions -- so this reshape is the prerequisite for out-of-process workers.

### Two commits

- **`3de8156` -- local half.** `JobBodyRegistry` (`kind -> body`), `register_job_bodies(state)` in `server.py`, all 16 production + lab submit callsites reshaped. The local desktop `JobRegistry` stays an in-process `name -> body` dispatcher on its existing `ThreadPoolExecutor` -- no Procrastinate, no Postgres, still queue-free (option C from the design discussion).
- **`995af63` -- worker half.** `PostgresJobBackend.submit` writes a PENDING row and enqueues a `run_compute_job` Procrastinate task via an injected `JobDeferrer` (`make_deferrer`). A separate worker (`build_worker_state` + `register_compute_task`) pops it and drives `run_job`, which calls the same `kind -> body` mapping. Pydantic `req` args are projected to JSON via `_to_wire_args` and rebuilt via `_rehydrate_args`. The worker constructs its backend with `sweep_on_boot=False` so it never fails jobs queued for it to run. Idempotent terminal-status guards handle duplicate queue delivery.

### Known follow-up (carved out, next chunk)

Only match-**less** kinds (`model_download`) run end-to-end on the worker today. Match-carrying kinds (`shot_detect`/`trim`/`detect_beep`/`export`/`match_export`) submit fine but can't yet run on a separate worker: `MatchRegistry.resolve` reads the local `user_config` recent-projects file (not the Postgres store hosted mode uses), and the worker lacks the match's on-disk files. Until cross-process match metadata is wired, `register_compute_task` binds the match inside a `run_job(before_body=...)` hook so an unresolvable match **fails the job cleanly with a legible message** instead of stranding its `compute_jobs` row at PENDING.

### Validation

- `ruff` clean, `black` clean
- Full suite: **1567 passed**, 16 skipped, 0 failures
- `pytest -m docker`: **5 passed** -- real cross-process worker round-trip through the production `make_deferrer`
- Reviewed by a 4-agent review workflow + adversarial verification: no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)