### PR TITLE
feat(saas): audit-trim MP4 storage write-back (PR-epsilon part 1)

### DIFF
--- a/src/splitsmith/ui/audio.py
+++ b/src/splitsmith/ui/audio.py
@@ -258,6 +258,12 @@ def ensure_audit_audio(
     the result is mtime-cached.
     """
     trimmed_video = trimmed_primary_path(project_root, stage_number, project=project)
+    # Hosted: the trim was cut on a worker, not here. Pull it down so the
+    # audit screen serves the trimmed-window waveform instead of falling
+    # back to the full source WAV (wrong extent + wrong beep position).
+    # No-op in local mode (no storage bound).
+    if not trimmed_video.exists():
+        _try_pull_trim_from_storage(project, trimmed_video)
     # If a prior trim was interrupted, ensure_audit_trim leaves no .partial
     # behind, but be defensive: ignore an obviously-broken trim by checking
     # for a non-empty file. Anything more sophisticated (full ffprobe round
@@ -443,6 +449,138 @@ def invalidate_video_audit_trim(
             pass
 
 
+def _storage_trim_key(project: MatchProject | None, local_mp4: Path) -> str | None:
+    """Compute the storage key for an audit-trim MP4.
+
+    Returns ``None`` in local mode (no storage bound) or when no
+    per-project scope is set -- both cases skip the storage cache.
+    Mirrors :func:`_storage_audio_key`: the key is
+    ``<scope>/trimmed/<basename>`` and the basename already carries the
+    ``video_id``, so two shooters in different matches can't collide.
+    """
+    if project is None or project._storage is None or project._storage_scope is None:
+        return None
+    return f"{project._storage_scope}/trimmed/{local_mp4.name}"
+
+
+def _try_pull_trim_from_storage(project: MatchProject | None, local_mp4: Path) -> bool:
+    """If the audit trim exists in the project's storage cache, download
+    it (and its params sidecar) into place and return True.
+
+    Unlike the WAV cache, the trim's validity is checked against the
+    ``*.params.json`` sidecar in :func:`ensure_video_audit_trim`, so we
+    pull the sidecar alongside the MP4 -- the caller's existing cache_hit
+    check then decides whether the pulled trim is trustworthy or must be
+    re-cut. The sidecar is optional: a torn/legacy cache without one is
+    treated as a miss by the validation and re-cut.
+
+    Best-effort: a storage hiccup falls through to ffmpeg rather than
+    failing the job. On any failure the half-written MP4 is removed so the
+    re-cut path doesn't trip over a torn file.
+    """
+    key = _storage_trim_key(project, local_mp4)
+    if key is None:
+        return False
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        if not storage.exists(key):
+            return False
+    except Exception as exc:
+        logger.info("trim cache: storage.exists(%s) raised %s", key, exc)
+        return False
+    params_local = trim_params_path(local_mp4)
+    params_key = f"{key.rsplit('/', 1)[0]}/{params_local.name}"
+    try:
+        local_mp4.parent.mkdir(parents=True, exist_ok=True)
+        with storage.open_stream(key) as src, local_mp4.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+        # Pull the sidecar when present; its absence just forces a re-cut.
+        try:
+            if storage.exists(params_key):
+                with storage.open_stream(params_key) as src, params_local.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        except Exception as exc:
+            logger.info("trim cache: params pull from %s failed: %s", params_key, exc)
+        return True
+    except Exception as exc:
+        logger.info("trim cache: pull from %s failed: %s", key, exc)
+        for torn in (local_mp4, params_local):
+            try:
+                torn.unlink()
+            except FileNotFoundError:
+                pass
+        return False
+
+
+def _try_push_trim_to_storage(project: MatchProject | None, local_mp4: Path) -> None:
+    """Push a freshly-cut audit trim (+ its params sidecar) to the
+    project's storage cache so the API process can serve the scrub clip
+    and the next worker can skip the ffmpeg re-cut.
+
+    Best-effort: a push failure logs and returns; the local trim is the
+    source of truth for the current job.
+    """
+    key = _storage_trim_key(project, local_mp4)
+    if key is None:
+        return
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        with local_mp4.open("rb") as f:
+            storage.upload_stream(key, f)
+        params_local = trim_params_path(local_mp4)
+        if params_local.exists():
+            params_key = f"{key.rsplit('/', 1)[0]}/{params_local.name}"
+            storage.write_bytes(params_key, params_local.read_bytes())
+    except Exception as exc:
+        logger.info("trim cache: push to %s failed: %s", key, exc)
+
+
+def trim_available(project: MatchProject | None, local_mp4: Path) -> bool:
+    """Whether a usable audit trim exists for ``local_mp4`` -- locally or
+    in the storage cache -- without downloading it.
+
+    Lets metadata callers (the beep-in-clip position) agree with what the
+    byte-serving path (``stream_video?kind=trim``) will produce, paying
+    only a cheap ``storage.exists`` HEAD in hosted mode. In local mode
+    (no storage) this collapses to the plain local non-empty check.
+    """
+    if local_mp4.exists() and local_mp4.stat().st_size > 0:
+        return True
+    key = _storage_trim_key(project, local_mp4)
+    if key is None:
+        return False
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        return storage.exists(key)
+    except Exception as exc:
+        logger.info("trim cache: storage.exists(%s) raised %s", key, exc)
+        return False
+
+
+def pull_trimmed_video(
+    project_root: Path,
+    stage_number: int,
+    video: StageVideo,
+    *,
+    project: MatchProject,
+) -> Path:
+    """Resolve ``video``'s audit-trim path, pulling it from the storage
+    cache first when it isn't already local (hosted mode).
+
+    The API process uses this before serving the scrub clip: a worker
+    cut the trim into its own ephemeral filesystem and pushed it up, so
+    the API has to mirror it down to serve the bytes. Never invokes
+    ffmpeg -- when neither the local copy nor the storage cache has the
+    trim, the returned path simply doesn't exist and the caller falls
+    back to the source clip (or 404s for an explicit ``kind=trim``),
+    exactly as before this seam. No-op in local mode.
+    """
+    output = trimmed_video_path(project_root, stage_number, video, project=project)
+    if not (output.exists() and output.stat().st_size > 0):
+        _try_pull_trim_from_storage(project, output)
+    return output
+
+
 def ensure_video_audit_trim(
     project_root: Path,
     stage_number: int,
@@ -478,6 +616,14 @@ def ensure_video_audit_trim(
     src_resolved = source.resolve()
     if not src_resolved.exists():
         raise FileNotFoundError(f"video missing on disk: {src_resolved}")
+
+    # Storage cache (hosted mode): another worker may have already cut
+    # this trim. Pull the MP4 + params sidecar into place so the cache_hit
+    # check below can validate + reuse it instead of re-running ffmpeg
+    # against the (large) source. Local mode skips this -- the key
+    # resolves to None and the helper returns without touching the network.
+    if not output.exists():
+        _try_pull_trim_from_storage(project, output)
 
     cache_hit = (
         output.exists() and output.stat().st_mtime >= src_resolved.stat().st_mtime and params_file.exists()
@@ -524,6 +670,9 @@ def ensure_video_audit_trim(
 
     partial.replace(output)
     params_file.write_text(json.dumps(current_params, indent=2) + "\n", encoding="utf-8")
+    # Push the freshly-cut trim up so the API can serve the scrub clip and
+    # the next worker can skip the re-cut. Best-effort; local mode no-ops.
+    _try_push_trim_to_storage(project, output)
     return output
 
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -6196,15 +6196,17 @@ def create_app(
         ``min(beep_time, trim_pre_buffer_seconds)`` inside it (the trim
         starts at ``max(0, beep_time - pre_buffer)``). When there's no
         trim we fall through to the source clip and the beep is at
-        ``beep_time`` directly. Pure check: no ffmpeg, no audio
-        extraction -- the file existence + project config is enough.
+        ``beep_time`` directly. No ffmpeg / no audio extraction; in hosted
+        mode this pays only a cheap ``storage.exists`` HEAD so the reported
+        position agrees with the clip ``stream_video`` will actually serve
+        (which pulls the worker-cut trim on demand).
         """
         if video.beep_time is None:
             return None
         trimmed = audio_helpers.trimmed_video_path(
             state.shooter_root(slug), stage_number, video, project=project
         )
-        if trimmed.exists() and trimmed.stat().st_size > 0:
+        if audio_helpers.trim_available(project, trimmed):
             return min(video.beep_time, project.trim_pre_buffer_seconds)
         return video.beep_time
 
@@ -6644,7 +6646,11 @@ def create_app(
             # Per-video short-GOP trim is keyed per role: each angle has
             # its own scrub clip cut around its own beep, so dragging
             # the audit playhead doesn't stall on a 4K MOV from a phone.
-            trimmed = audio_helpers.trimmed_video_path(root, stage.stage_number, video, project=project)
+            # Hosted: a worker cut this trim into its own filesystem and
+            # pushed it to storage; pull it down before serving the bytes.
+            # Never invokes ffmpeg -- a missing trim falls through to the
+            # source clip (kind=auto) or 404s (kind=trim), as before.
+            trimmed = audio_helpers.pull_trimmed_video(root, stage.stage_number, video, project=project)
             if trimmed.exists():
                 served_path = trimmed.resolve()
         if served_path is None:
@@ -7680,7 +7686,7 @@ def create_app(
             except Exception:  # noqa: BLE001 -- defensive
                 continue
             cache = audio_helpers.trimmed_video_path(shooter_root, s.stage_number, prim, project=legacy)
-            if not cache.exists():
+            if not audio_helpers.trim_available(legacy, cache):
                 stages_missing_trim += 1
         # Camera grouping: ``(make, model, mount)`` -> [(role, count, stages)].
         groups: dict[tuple[str | None, str | None, str | None], dict[str, Any]] = {}
@@ -7973,7 +7979,7 @@ def create_app(
                 skipped.append({"stage": stage.stage_number, "reason": "source_missing"})
                 continue
             cache = audio_helpers.trimmed_video_path(shooter_root, stage.stage_number, primary, project=proj)
-            if cache.exists():
+            if audio_helpers.trim_available(proj, cache):
                 skipped.append({"stage": stage.stage_number, "reason": "already_cached"})
                 continue
             # video_id is a hash of the source path so it's unique across

--- a/tests/test_trim_storage_cache.py
+++ b/tests/test_trim_storage_cache.py
@@ -1,0 +1,334 @@
+"""Tests for the hosted-mode audit-trim cache push/pull.
+
+The audit-trim MP4 (``trimmed/stage<N>_cam_<video_id>_trimmed.mp4``) is
+the short-GOP scrub clip the audit screen streams. On a worker fleet it
+is cut out-of-process, so it has to round-trip through storage the same
+way the audio WAV already does (see ``test_audio_storage_cache.py``):
+worker cuts it once and pushes it up; the API pulls it down to serve the
+``<video>`` bytes, and a second worker pulls it to skip the ffmpeg re-cut.
+
+These tests stub the ffmpeg-backed ``splitsmith.trim`` calls so they
+don't depend on a real binary, and use ``FilesystemStorage`` against
+``tmp_path`` (Protocol-equivalent to ``S3Storage`` per
+``test_s3_storage.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from splitsmith.storage import FilesystemStorage
+from splitsmith.ui import audio as audio_helpers
+from splitsmith.ui.audio import ensure_video_audit_trim, trimmed_video_path
+from splitsmith.ui.project import MatchProject, StageEntry, StageVideo
+
+STAGE = 1
+STAGE_TIME = 10.0
+BEEP_TIME = 3.5
+SCOPE = "matches/m1/shooters/me"
+
+
+@pytest.fixture
+def fake_trim(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Replace the ffmpeg-backed trim with a fake that writes the output.
+
+    ``ensure_video_audit_trim`` calls ``splitsmith.trim.select_audit_encoder``
+    then ``splitsmith.trim.trim_video(output_path=<partial>, ...)``. The
+    fake records each ``trim_video`` call's kwargs and writes a sentinel
+    byte to the partial so the rest of the pipeline sees a real (tiny)
+    MP4. Returns the list of recorded calls so tests can assert "trim ran"
+    or "trim did NOT run".
+    """
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "splitsmith.trim.select_audit_encoder",
+        lambda *a, **k: "libx264",
+    )
+
+    def fake_trim_video(**kwargs: object) -> None:
+        calls.append(dict(kwargs))
+        dest = Path(kwargs["output_path"])  # type: ignore[arg-type]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"MP4DATA")
+
+    monkeypatch.setattr("splitsmith.trim.trim_video", fake_trim_video)
+    return calls
+
+
+def _project_with_stage_video(root: Path, video_path: Path) -> tuple[MatchProject, StageVideo]:
+    project = MatchProject.init(root, name="trim-test")
+    video = StageVideo(path=video_path, role="primary")
+    project.stages = [
+        StageEntry(
+            stage_number=STAGE,
+            stage_name="One",
+            time_seconds=STAGE_TIME,
+            videos=[video],
+        )
+    ]
+    project.save(root)
+    return project, video
+
+
+def _cut(root: Path, project: MatchProject, video: StageVideo, source: Path) -> Path:
+    return ensure_video_audit_trim(
+        root,
+        STAGE,
+        video,
+        source,
+        BEEP_TIME,
+        STAGE_TIME,
+        project=project,
+    )
+
+
+def _make_source(tmp_path: Path) -> Path:
+    source = tmp_path / "raw" / "v.mp4"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"video bytes")
+    return source
+
+
+def _current_params(project: MatchProject) -> dict[str, float]:
+    return {
+        "beep_time": round(BEEP_TIME, 4),
+        "stage_time_seconds": round(STAGE_TIME, 4),
+        "pre_buffer_seconds": float(project.trim_pre_buffer_seconds),
+        "post_buffer_seconds": float(project.trim_post_buffer_seconds),
+    }
+
+
+def _trim_keys(project: MatchProject, video: StageVideo, root: Path) -> tuple[str, str]:
+    output = trimmed_video_path(root, STAGE, video, project=project)
+    mp4_key = f"{SCOPE}/trimmed/{output.name}"
+    params_key = f"{SCOPE}/trimmed/{output.stem}.params.json"
+    return mp4_key, params_key
+
+
+def test_local_mode_no_storage_runs_trim_and_never_touches_storage(
+    tmp_path: Path, fake_trim: list[dict[str, object]]
+) -> None:
+    """Desktop / CLI mode: with no storage bound the cache helpers are
+    no-ops and the existing ffmpeg trim path runs unchanged."""
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+
+    assert project._storage is None
+    output = _cut(root, project, video, source)
+
+    assert output.exists()
+    assert output.read_bytes() == b"MP4DATA"
+    assert len(fake_trim) == 1
+
+
+def test_storage_cache_hit_skips_trim(tmp_path: Path, fake_trim: list[dict[str, object]]) -> None:
+    """A trim already in the storage cache (MP4 + matching params) is
+    pulled and reused -- a cold worker skips the ffmpeg re-cut."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    mp4_key, params_key = _trim_keys(project, video, root)
+    storage.write_bytes(mp4_key, b"PRECUT")
+    storage.write_bytes(params_key, (json.dumps(_current_params(project)) + "\n").encode("utf-8"))
+
+    output = _cut(root, project, video, source)
+
+    assert output.read_bytes() == b"PRECUT"
+    assert len(fake_trim) == 0  # never re-cut
+
+
+def test_cold_cut_pushes_mp4_and_params_to_storage(
+    tmp_path: Path, fake_trim: list[dict[str, object]]
+) -> None:
+    """Neither local nor storage has the trim: ffmpeg runs and both the
+    MP4 and its params sidecar are pushed up for the next worker / API."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    output = _cut(root, project, video, source)
+
+    assert output.read_bytes() == b"MP4DATA"
+    assert len(fake_trim) == 1
+    mp4_key, params_key = _trim_keys(project, video, root)
+    assert storage.exists(mp4_key)
+    assert storage.read_bytes(mp4_key) == b"MP4DATA"
+    assert storage.exists(params_key)
+    assert json.loads(storage.read_bytes(params_key)) == _current_params(project)
+
+
+def test_local_cache_hit_skips_storage_and_trim(tmp_path: Path, fake_trim: list[dict[str, object]]) -> None:
+    """A fresh local trim + matching params short-circuits before storage
+    or ffmpeg are consulted -- repeated runs on one worker stay cheap."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    first = _cut(root, project, video, source)
+    assert len(fake_trim) == 1
+
+    second = _cut(root, project, video, source)
+    assert second == first
+    assert len(fake_trim) == 1  # unchanged
+
+
+def test_storage_params_mismatch_recuts(tmp_path: Path, fake_trim: list[dict[str, object]]) -> None:
+    """A storage trim cut for different params (stale beep / stage time)
+    is pulled but rejected by the params check, so it is re-cut. This is
+    the trim-specific case the WAV cache can't have (WAVs are name-keyed
+    and trusted)."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    mp4_key, params_key = _trim_keys(project, video, root)
+    storage.write_bytes(mp4_key, b"STALECUT")
+    stale = _current_params(project) | {"beep_time": 99.0}
+    storage.write_bytes(params_key, (json.dumps(stale) + "\n").encode("utf-8"))
+
+    output = _cut(root, project, video, source)
+
+    assert len(fake_trim) == 1  # re-cut because params didn't match
+    assert output.read_bytes() == b"MP4DATA"
+
+
+def test_storage_push_failure_does_not_break_cut(
+    tmp_path: Path,
+    fake_trim: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A push outage must not fail the trim job -- the local MP4 is the
+    source of truth for the current job; the cache push is best-effort."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+
+    def boom(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("simulated R2 outage")
+
+    monkeypatch.setattr(storage, "upload_stream", boom)
+
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    output = _cut(root, project, video, source)
+    assert output.read_bytes() == b"MP4DATA"
+
+
+def test_storage_pull_torn_file_falls_through_to_trim(
+    tmp_path: Path,
+    fake_trim: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If open_stream raises mid-copy the helper cleans up the torn MP4
+    and lets ffmpeg run, rather than leaving a half-downloaded clip the
+    next call would happily serve."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+    mp4_key, params_key = _trim_keys(project, video, root)
+    storage.write_bytes(mp4_key, b"PRECUT")
+    storage.write_bytes(params_key, (json.dumps(_current_params(project)) + "\n").encode("utf-8"))
+
+    def boom(path: str) -> object:
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(storage, "open_stream", boom)
+
+    output = _cut(root, project, video, source)
+
+    assert output.read_bytes() == b"MP4DATA"
+    assert len(fake_trim) == 1
+
+
+def test_bind_storage_without_scope_disables_trim_cache(
+    tmp_path: Path, fake_trim: list[dict[str, object]]
+) -> None:
+    """Storage bound but scope None (non-match request path): the trim
+    cache stays off, just like the audio cache."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=None)
+
+    _cut(root, project, video, source)
+
+    assert len(fake_trim) == 1
+    assert list(storage.list("")) == []
+
+
+def test_trim_available_reports_storage_without_download(
+    tmp_path: Path, fake_trim: list[dict[str, object]]
+) -> None:
+    """``trim_available`` sees a worker-pushed trim via a cheap exists()
+    probe (no local copy, no download) so the beep-position metadata
+    agrees with what the byte-serving path will produce."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+
+    output = trimmed_video_path(root, STAGE, video, project=project)
+    assert not output.exists()
+    assert audio_helpers.trim_available(project, output) is False
+
+    mp4_key, _ = _trim_keys(project, video, root)
+    storage.write_bytes(mp4_key, b"PRECUT")
+
+    # Still no local copy, but storage has it -> available, no download.
+    assert audio_helpers.trim_available(project, output) is True
+    assert not output.exists()
+
+
+def test_pull_trimmed_video_mirrors_from_storage(tmp_path: Path, fake_trim: list[dict[str, object]]) -> None:
+    """The API serving path pulls a worker-pushed trim into the local
+    cache and never invokes ffmpeg."""
+    backing = tmp_path / "tenant"
+    backing.mkdir()
+    storage = FilesystemStorage(backing)
+    root = tmp_path / "p"
+    source = _make_source(tmp_path)
+    project, video = _project_with_stage_video(root, source)
+    project.bind_storage(storage, scope=SCOPE)
+    mp4_key, _ = _trim_keys(project, video, root)
+    storage.write_bytes(mp4_key, b"PRECUT")
+
+    pulled = audio_helpers.pull_trimmed_video(root, STAGE, video, project=project)
+
+    assert pulled.exists()
+    assert pulled.read_bytes() == b"PRECUT"
+    assert len(fake_trim) == 0

--- a/tests/test_worker_storage_seam.py
+++ b/tests/test_worker_storage_seam.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from splitsmith.match_model import Match
 from splitsmith.storage import FilesystemStorage
+from splitsmith.ui import audio as audio_helpers
 from splitsmith.ui import server as srv
-from splitsmith.ui.project import PROJECT_FILE, MatchProject
+from splitsmith.ui.project import PROJECT_FILE, MatchProject, StageEntry, StageVideo
 from splitsmith.ui.server import AppState, current_match_id, current_match_root
 
 
@@ -133,6 +136,57 @@ def test_audit_json_round_trips(tmp_path: Path) -> None:
         state.pull_audit("alpha", 1)
         api_audit = Match.shooter_root(api_root, "alpha") / "audit" / "stage1.json"
         assert json.loads(api_audit.read_text())["shots"] == [0.21, 0.55]
+
+
+def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The heavy binary seam: a worker cuts the audit-trim MP4 and pushes
+    it to storage; the API mirrors it down to serve the scrub clip. Proves
+    the scope wiring (``state.shooter_project`` bind) produces matching
+    push/pull keys across two working roots."""
+    # Fake the ffmpeg-backed trim so the test has no binary dependency.
+    monkeypatch.setattr("splitsmith.trim.select_audit_encoder", lambda *a, **k: "libx264")
+
+    def fake_trim_video(**kwargs: object) -> None:
+        dest = Path(kwargs["output_path"])  # type: ignore[arg-type]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"MP4DATA")
+
+    monkeypatch.setattr("splitsmith.trim.trim_video", fake_trim_video)
+
+    storage = FilesystemStorage(tmp_path / "s3")
+    state = AppState()
+    state.storage = storage
+
+    api_root = tmp_path / "api"
+    match_id = _scaffold_match(api_root)
+    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
+
+    # Worker: fresh root pointed at the same storage. Add a stage with a
+    # primary video (round-trips via project.json), then cut the trim ->
+    # pushes the MP4 to storage.
+    worker_root = tmp_path / "worker"
+    worker_root.mkdir()
+    with _BoundMatch(worker_root, match_id):
+        wproj = state.shooter_project("alpha")
+        video = StageVideo(path=Path("raw/v.mp4"), role="primary", beep_time=3.5)
+        wproj.stages = [StageEntry(stage_number=1, stage_name="One", time_seconds=10.0, videos=[video])]
+        wshooter = state.shooter_root("alpha")
+        wproj.save(wshooter)
+        source = wshooter / "raw" / "v.mp4"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(b"video bytes")
+        audio_helpers.ensure_video_audit_trim(wshooter, 1, video, source, 3.5, 10.0, project=wproj)
+
+    # API: pulls project.json (sees the stage), then mirrors the trim down.
+    with _BoundMatch(api_root, match_id):
+        aproj = state.shooter_project("alpha")
+        prim = aproj.stage(1).primary()
+        assert prim is not None
+        ashooter = state.shooter_root("alpha")
+        assert not audio_helpers.trimmed_video_path(ashooter, 1, prim, project=aproj).exists()
+        pulled = audio_helpers.pull_trimmed_video(ashooter, 1, prim, project=aproj)
+        assert pulled.exists()
+        assert pulled.read_bytes() == b"MP4DATA"
 
 
 def test_seam_is_noop_without_storage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Context

The worker fleet now runs `detect_beep` / `shot_detect` end-to-end out of
process (#445, #446). Small JSON state round-trips through S3 (PR-delta),
and the **audit WAV** already round-trips through a storage cache. But the
**audit-trim MP4** the worker cuts (`trimmed/stage<N>_cam_<id>_trimmed.mp4`,
via `ensure_video_audit_trim`) landed only on the worker's ephemeral
filesystem. The API process -- a separate container -- couldn't serve it,
so on a hosted worker the audit screen's scrub `<video>` (kind=trim) 404'd
and the waveform fell back to the full-source WAV (wrong window, wrong beep
position).

This gives the trim MP4 the same push-on-produce / pull-on-access storage
cache the WAV already has. Scope is **trim cache only**; the `exports/`
deliverables (FCPXML / lossless trim / overlay) are a separate follow-up
(part 2).

## Approach

Mirror the proven WAV storage-cache pattern (`_try_pull/push_audio_to_storage`).
Storage is bound onto the `MatchProject` by `state.shooter_project`;
artifacts key at `<scope>/trimmed/<basename>`. All helpers no-op in local
mode (`_storage is None` -> key resolves to `None`), so desktop is
unchanged.

The trim differs from the WAV in one way: its cache validity is checked
against a `*.params.json` sidecar (beep_time / stage_time / buffers). So
the helpers move the **MP4 and its sidecar together**, letting the existing
`cache_hit` validation in `ensure_video_audit_trim` decide whether a pulled
trim is trustworthy or must be re-cut.

## Changes

- **`ui/audio.py`**: `_storage_trim_key`, `_try_pull_trim_from_storage`
  (pulls MP4 + sidecar; cleans the torn MP4 on failure),
  `_try_push_trim_to_storage`, cheap `trim_available()` (local-or-storage
  existence via a `storage.exists` HEAD, no download), and public
  `pull_trimmed_video()` for the API serving path. Pull-if-missing +
  push-after-cut wired into `ensure_video_audit_trim`; pull-if-missing into
  `ensure_audit_audio` so `/stages/{n}/audio` + `/peaks` serve the
  trimmed-window waveform instead of the full-source fallback.
- **`ui/server.py`**: `stream_video` pulls via `pull_trimmed_video`;
  `_beep_in_clip_for_video` and the two "is trim cached?" checks
  (missing-trim status count + bulk-trim submit) use `trim_available` so the
  hosted API agrees with what it serves and doesn't re-submit redundant trim
  jobs. Compare-export trim ref left alone (depends on export media, part 2).

## Tests

- New `tests/test_trim_storage_cache.py` (10 cases, helper-level, incl. the
  params-mismatch-recut case the name-keyed WAV cache can't have).
- `tests/test_worker_storage_seam.py` gains a cross-root worker->API MP4
  round-trip through the `state.shooter_project` scope wiring.
- Both use `FilesystemStorage` (Protocol-equivalent to `S3Storage`) and mock
  `splitsmith.trim.trim_video`.

## Gates

- ruff + black clean across `src/` + `tests/`.
- Full suite: **1594 passed, 16 skipped** locally.
- No connector/migration/db touched, so `pytest -m docker` isn't required
  for this part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)