### PR TITLE
feat(saas): export media storage write-back (PR-epsilon part 2)

### DIFF
--- a/src/splitsmith/ui/export_storage.py
+++ b/src/splitsmith/ui/export_storage.py
@@ -1,0 +1,121 @@
+"""Storage round-trip for export deliverables (worker fleet).
+
+The ``export`` / ``match_export`` job bodies write their deliverables --
+lossless ``exports/*_trimmed.mp4``, ``*.fcpxml``, ``*_splits.csv``,
+``*_report.txt``, ``*_overlay.mov``, per-cam trims, and the stitched
+``<project>-match.fcpxml`` -- to the job's local ``exports/`` dir. On a
+hosted worker that filesystem is ephemeral and invisible to the API
+container, so the artifacts have to push to object storage on produce and
+pull back on download.
+
+This mirrors the audit-trim cache in :mod:`splitsmith.ui.audio`
+(``_storage_trim_key`` / ``_try_pull_trim_from_storage`` /
+``_try_push_trim_to_storage``). The key scheme is ``<scope>/exports/<name>``,
+mirroring the on-disk ``exports/`` subdir, consistent with the ``trimmed/``
+scheme. The exporters themselves (:mod:`splitsmith.ui.exports` /
+:mod:`splitsmith.ui.match_exports`) stay pure ``Path`` I/O with no storage
+seam -- the push happens here, after they return.
+
+Every helper is a no-op in local mode (no storage bound or no per-project
+scope) so desktop behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .project import MatchProject
+
+if TYPE_CHECKING:
+    from .exports import StageExportResult
+
+logger = logging.getLogger(__name__)
+
+# Suffixes pushed/pulled as streams (large binaries) rather than buffered
+# whole into memory via read_bytes/write_bytes. Everything else (FCPXML,
+# CSV, report, SRT, YouTube JSON) is small text.
+_BINARY_SUFFIXES = {".mp4", ".mov"}
+
+
+def _storage_export_key(project: MatchProject | None, local_file: Path) -> str | None:
+    """Storage key for an export deliverable, or ``None`` in local mode.
+
+    Key is ``<scope>/exports/<basename>``. Basenames already carry the
+    stage number + slug (+ ``video_id`` for per-cam trims), so two shooters
+    in different matches can't collide -- the same guarantee the
+    ``trimmed/`` cache relies on.
+    """
+    if project is None or project._storage is None or project._storage_scope is None:
+        return None
+    return f"{project._storage_scope}/exports/{local_file.name}"
+
+
+def pull_export_file(project: MatchProject | None, local_file: Path) -> bool:
+    """Mirror an export deliverable down from storage when it isn't local.
+
+    Returns True when the file is present locally afterwards (already there,
+    or pulled). Best-effort: a storage hiccup logs and returns False rather
+    than raising, so the caller (re-cut path or a 404) behaves as in local
+    mode. No-op + False when storage/scope is unbound.
+    """
+    if local_file.exists() and local_file.stat().st_size > 0:
+        return True
+    key = _storage_export_key(project, local_file)
+    if key is None:
+        return False
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        # _mirror_from_storage HEADs the key (no-op if absent) and does a
+        # temp+rename so a torn pull never lands as a complete file.
+        MatchProject._mirror_from_storage(storage, key, local_file)
+    except Exception as exc:
+        logger.info("export cache: pull from %s failed: %s", key, exc)
+        return False
+    return local_file.exists() and local_file.stat().st_size > 0
+
+
+def push_export_file(project: MatchProject | None, local_file: Path) -> None:
+    """Push one export deliverable to storage.
+
+    Binaries (``.mp4`` / ``.mov``) stream via ``upload_stream`` (multipart,
+    never buffered whole -- overlays can be multi-GB); small text goes via
+    ``write_bytes``. Best-effort: a push failure logs at INFO and returns;
+    the local file is the source of truth for the current job.
+    """
+    key = _storage_export_key(project, local_file)
+    if key is None:
+        return
+    if not (local_file.exists() and local_file.stat().st_size > 0):
+        return
+    storage = project._storage  # type: ignore[union-attr]
+    try:
+        if local_file.suffix.lower() in _BINARY_SUFFIXES:
+            with local_file.open("rb") as f:
+                storage.upload_stream(key, f)
+        else:
+            storage.write_bytes(key, local_file.read_bytes())
+    except Exception as exc:
+        logger.info("export cache: push to %s failed: %s", key, exc)
+
+
+def push_stage_export_outputs(project: MatchProject | None, result: StageExportResult) -> None:
+    """Push every artifact a :func:`exports.export_stage` run produced.
+
+    Iterates the populated single-file paths plus each per-cam secondary
+    trim. ``None`` entries (a skipped artifact) are ignored.
+    """
+    paths: list[Path] = []
+    for p in (
+        result.trimmed_video_path,
+        result.csv_path,
+        result.fcpxml_path,
+        result.report_path,
+        result.overlay_path,
+    ):
+        if p is not None:
+            paths.append(p)
+    paths.extend(result.secondary_trimmed_paths.values())
+    for p in paths:
+        push_export_file(project, p)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -145,6 +145,7 @@ from ..match_registry import MatchRegistry
 from ..runtime import runtime as process_runtime
 from ..storage import Storage
 from . import audio as audio_helpers
+from . import export_storage
 from . import exports as export_helpers
 from . import match_exports as match_export_helpers
 from .jobs import Job, JobBackend, JobCancelled, JobHandle, JobRegistry, ShutdownInProgressError
@@ -1612,6 +1613,11 @@ def register_job_bodies(state: AppState) -> None:
         if prim is None or prim.beep_time is None:
             raise RuntimeError("primary or beep disappeared mid-flight")
 
+        # Hosted: the audit JSON was written by the detect/audit job on
+        # another worker and lives in storage, not this container's FS. Pull
+        # it before the exporter reads it (no-op in local mode). Without this
+        # a cross-process export reads a stale or absent audit file.
+        state.pull_audit(slug, stage_number)
         audit_file = proj.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
         exports_dir = proj.exports_path(state.shooter_root(slug))
         source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
@@ -1695,6 +1701,10 @@ def register_job_bodies(state: AppState) -> None:
         proj.updated_at = datetime.now(UTC)
         proj.save(state.shooter_root(slug))
 
+        # Hosted: push every produced deliverable to storage so the API
+        # container can serve the download. No-op in local mode.
+        export_storage.push_stage_export_outputs(proj, result)
+
         # Final message summarises what shipped + flags any skipped
         # artefacts (FCPXML without a trim, etc). The full list lives in
         # the report.txt; the user can Reveal it for details.
@@ -1750,6 +1760,14 @@ def register_job_bodies(state: AppState) -> None:
             trimmed_path = exports_dir / f"{base}_trimmed.mp4"
             overlay_target = exports_dir / f"{base}_overlay.mov"
 
+            # Hosted: per-stage artifacts (audit JSON + trims + overlay) may
+            # have been produced + pushed by an earlier `export` job on a
+            # different worker. Pull them so the existence checks below reuse
+            # the cached work instead of re-cutting, and so the composer can
+            # read the audit JSON. No-op in local mode.
+            state.pull_audit(slug, stage_number)
+            export_storage.pull_export_file(proj, trimmed_path)
+
             # Decide what's missing. The match composer needs the
             # lossless trim + per-cam trims (when include_secondaries) +
             # optional overlay. Re-run the per-stage exporter for any
@@ -1759,6 +1777,8 @@ def register_job_bodies(state: AppState) -> None:
                 for sv in stg.videos:
                     if sv.role == "secondary" and sv.beep_time is not None:
                         wanted_secondary_ids.add(sv.video_id)
+            for vid in wanted_secondary_ids:
+                export_storage.pull_export_file(proj, exports_dir / f"{base}_cam_{vid}_trimmed.mp4")
             secondary_trims_present = all(
                 (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
             )
@@ -1772,6 +1792,10 @@ def register_job_bodies(state: AppState) -> None:
                 or req.overlay_max_fps is not None
                 or req.overlay_theme != "splitsmith"
             )
+            # Pull a cached overlay only when we'd actually reuse it -- a
+            # format override forces a re-render, so don't waste the download.
+            if req.include_overlay and not overlay_format_overridden:
+                export_storage.pull_export_file(proj, overlay_target)
             overlay_missing = req.include_overlay and (
                 not overlay_target.exists() or overlay_format_overridden
             )
@@ -1806,7 +1830,7 @@ def register_job_bodies(state: AppState) -> None:
                     scorecard_updated_at=stg.scorecard_updated_at,
                 )
                 try:
-                    export_helpers.export_stage(
+                    recut = export_helpers.export_stage(
                         request=export_helpers.StageExportRequest(
                             stage_number=stage_number,
                             write_trim=True,
@@ -1831,6 +1855,10 @@ def register_job_bodies(state: AppState) -> None:
                     )
                 except export_helpers.StageExportError as exc:
                     raise RuntimeError(f"stage {stage_number}: {exc}") from exc
+                # Hosted: a re-cut here produced the per-stage trims/overlay
+                # on this worker -- push them so other workers + the API
+                # download path see them. No-op in local mode.
+                export_storage.push_stage_export_outputs(proj, recut)
             else:
                 handle.update(
                     progress=0.02 + idx * per_stage_share,
@@ -1906,6 +1934,13 @@ def register_job_bodies(state: AppState) -> None:
             )
         except match_export_helpers.MatchExportError as exc:
             raise RuntimeError(str(exc)) from exc
+
+        # Hosted: push the stitched match deliverable (+ optional YouTube
+        # sidecars, when youtube_sidecar wrote them) so the API can serve the
+        # download. push_export_file skips any that don't exist. No-op local.
+        export_storage.push_export_file(proj, result.fcpxml_path)
+        export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".srt"))
+        export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".json"))
 
         handle.set_result(
             {
@@ -7095,6 +7130,46 @@ def create_app(
         project = state.shooter_project(slug)
         rows = project.export_overview(state.shooter_root(slug))
         return JSONResponse({"stages": [r.model_dump(mode="json") for r in rows]})
+
+    @app.get("/api/shooters/{slug}/exports/file/{filename:path}")
+    def download_export_file(slug: str, filename: str) -> FileResponse:
+        """Serve an export deliverable for download.
+
+        Local mode reads the file straight off the project's ``exports/``
+        dir. Hosted mode pulls it from object storage first: the worker that
+        produced it ran in a separate container, so the bytes only exist in
+        S3 until this seam mirrors them down (the export analogue of
+        ``stream_video``'s ``pull_trimmed_video``). The SPA uses this in
+        place of "Reveal in Finder", which is meaningless across containers.
+
+        ``filename`` is confined to the ``exports/`` dir: the resolved path
+        must stay inside it, so ``..`` traversal is a 400.
+        """
+        project = state.shooter_project(slug)
+        exports_dir = project.exports_path(state.shooter_root(slug)).resolve()
+        target = (exports_dir / filename).resolve()
+        try:
+            target.relative_to(exports_dir)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="download path must be inside the exports folder"
+            ) from exc
+        if not (target.exists() and target.is_file()):
+            export_storage.pull_export_file(project, target)
+        if not (target.exists() and target.is_file()):
+            raise HTTPException(status_code=404, detail=f"export not found: {filename}")
+        media_types = {
+            ".mp4": "video/mp4",
+            ".mov": "video/quicktime",
+            ".fcpxml": "application/xml",
+            ".xml": "application/xml",
+            ".csv": "text/csv",
+            ".txt": "text/plain",
+            ".srt": "application/x-subrip",
+            ".json": "application/json",
+        }
+        media_type = media_types.get(target.suffix.lower(), "application/octet-stream")
+        return FileResponse(target, media_type=media_type, filename=target.name)
 
     @app.post("/api/shooters/{slug}/stages/{stage_number}/export")
     async def export_stage(slug: str, stage_number: int, req: ExportStageRequest) -> JSONResponse:

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -2429,6 +2429,16 @@ export const api = {
   ) =>
     `/api/shooters/${encodeURIComponent(slug)}/videos/stream?path=${encodeURIComponent(videoPath)}&kind=${kind}`,
 
+  /** Build a download URL for one finished export deliverable (#447 part 2).
+   *  ``filename`` is the basename under the project's ``exports/`` dir.
+   *  Hosted mode pulls the file from object storage before serving; local
+   *  mode reads it off disk. Used in place of "Reveal in Finder" in hosted
+   *  mode, where the worker that produced the file ran in a separate
+   *  container. Mirrors ``videoStreamUrl``: a bare path consumed as an
+   *  ``<a href download>``, not a fetch. */
+  exportFileUrl: (slug: string, filename: string) =>
+    `/api/shooters/${encodeURIComponent(slug)}/exports/file/${encodeURIComponent(filename)}`,
+
   getStagePeaks: (slug: string, stageNumber: number, bins = 1200) =>
     request<PeaksResult>(
       `/api/shooters/${encodeURIComponent(slug)}/stages/${stageNumber}/peaks?bins=${bins}`,

--- a/src/splitsmith/ui_static/src/pages/Export.tsx
+++ b/src/splitsmith/ui_static/src/pages/Export.tsx
@@ -25,6 +25,7 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
+  Download,
   ExternalLink,
   FileBarChart,
   FileText,
@@ -52,6 +53,7 @@ import {
   type OverlayCodec,
   type StageExportStatus,
 } from "@/lib/api";
+import { useDeploymentMode } from "@/lib/features";
 import { cn } from "@/lib/utils";
 
 type OutputMode = "single" | "compare";
@@ -125,6 +127,7 @@ export function Export() {
 }
 
 function ExportInner({ slug }: { slug: string }) {
+  const deploymentMode = useDeploymentMode();
   const [project, setProject] = useState<MatchProject | null>(null);
   const [overview, setOverview] = useState<ExportOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -239,6 +242,45 @@ function ExportInner({ slug }: { slug: string }) {
     () => stages.map((s) => s.stage_number).filter((n) => selection.has(n)),
     [stages, selection],
   );
+
+  // Hosted mode has no "Reveal in Finder": the worker that produced the
+  // bundle ran in a separate container. Surface the finished match FCPXML
+  // plus the per-stage media it references (trims + overlays + per-cam
+  // trims) as individual download links. Filenames are basenames under the
+  // project's exports/ dir; the download endpoint pulls them from object
+  // storage. Empty until a match export finishes (``result`` set).
+  const hostedDownloads = useMemo(() => {
+    if (deploymentMode !== "hosted" || result === null) return [];
+    const basename = (p: string) => p.split("/").pop() ?? p;
+    const sel = new Set(orderedSelection);
+    const out: { label: string; filename: string }[] = [
+      { label: "Match FCPXML", filename: basename(result.fcpxml_path) },
+    ];
+    for (const s of stages) {
+      if (!sel.has(s.stage_number)) continue;
+      if (s.lossless_trim_present && s.trimmed_video_path) {
+        out.push({
+          label: `Stage ${s.stage_number} trim`,
+          filename: basename(s.trimmed_video_path),
+        });
+      }
+      if (s.overlay_path) {
+        out.push({
+          label: `Stage ${s.stage_number} overlay`,
+          filename: basename(s.overlay_path),
+        });
+      }
+      for (const sec of s.secondaries) {
+        if (sec.trim_present && sec.trim_path) {
+          out.push({
+            label: `Stage ${s.stage_number} ${sec.label}`,
+            filename: basename(sec.trim_path),
+          });
+        }
+      }
+    }
+    return out;
+  }, [deploymentMode, result, stages, orderedSelection]);
 
   // Custom preset auto-sync.
   function selectPreset(next: PaddingPreset) {
@@ -603,7 +645,7 @@ function ExportInner({ slug }: { slug: string }) {
                 <code className="flex-1 truncate rounded-md border border-rule bg-surface-3 px-3 py-2 font-mono text-xs text-ink-2">
                   {project?.exports_dir ?? `${project?.name ?? ""}/exports/`}
                 </code>
-                {project?.exports_dir && (
+                {project?.exports_dir && deploymentMode !== "hosted" && (
                   <button
                     type="button"
                     onClick={() => void reveal(project.exports_dir!)}
@@ -703,7 +745,15 @@ function ExportInner({ slug }: { slug: string }) {
                 </div>
               )}
               {result && (
-                <ResultPanel result={result} onReveal={reveal} />
+                <ResultPanel
+                  result={result}
+                  onReveal={reveal}
+                  hosted={deploymentMode === "hosted"}
+                  downloads={hostedDownloads}
+                  exportFileUrl={(filename) =>
+                    slug ? api.exportFileUrl(slug, filename) : "#"
+                  }
+                />
               )}
             </div>
           </div>
@@ -720,9 +770,15 @@ function ExportInner({ slug }: { slug: string }) {
 function ResultPanel({
   result,
   onReveal,
+  hosted,
+  downloads,
+  exportFileUrl,
 }: {
   result: MatchExportResult;
   onReveal: (path: string) => void;
+  hosted: boolean;
+  downloads: { label: string; filename: string }[];
+  exportFileUrl: (filename: string) => string;
 }) {
   return (
     <div className="mt-3 rounded-lg border border-done/40 bg-done/10 px-3 py-2.5 text-[0.8125rem] text-ink-2">
@@ -736,13 +792,31 @@ function ResultPanel({
           <> &middot; {result.anomalies.length} warnings</>
         )}
       </div>
-      <button
-        type="button"
-        onClick={() => onReveal(result.fcpxml_path)}
-        className="mt-2 inline-flex items-center gap-1.5 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.1em] text-led hover:text-led-soft"
-      >
-        Reveal bundle <ExternalLink className="size-3" />
-      </button>
+      {hosted ? (
+        // Hosted: the bundle lives in object storage, not on a local disk to
+        // reveal. Download each file (FCPXML + the media it references) so
+        // the operator can pull them down and open the timeline in FCP.
+        <div className="mt-2 flex flex-col gap-1">
+          {downloads.map((d) => (
+            <a
+              key={d.filename}
+              href={exportFileUrl(d.filename)}
+              download={d.filename}
+              className="inline-flex items-center gap-1.5 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.1em] text-led hover:text-led-soft"
+            >
+              <Download className="size-3" /> {d.label}
+            </a>
+          ))}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => onReveal(result.fcpxml_path)}
+          className="mt-2 inline-flex items-center gap-1.5 font-display text-[0.6875rem] font-semibold uppercase tracking-[0.1em] text-led hover:text-led-soft"
+        >
+          Reveal bundle <ExternalLink className="size-3" />
+        </button>
+      )}
     </div>
   );
 }

--- a/tests/test_export_storage_cache.py
+++ b/tests/test_export_storage_cache.py
@@ -1,0 +1,212 @@
+"""Tests for the hosted-mode export-deliverable cache push/pull (PR-epsilon
+part 2).
+
+The ``export`` / ``match_export`` job bodies write their deliverables
+(lossless ``exports/*_trimmed.mp4``, FCPXML, CSV, report, overlay, per-cam
+trims, the stitched match FCPXML) to a local ``exports/`` dir. On a worker
+fleet those are produced out-of-process, so they round-trip through storage
+the same way the audit trim already does: push on produce, pull on download.
+
+These tests build a :class:`StageExportResult` directly and use
+``FilesystemStorage`` against ``tmp_path`` (Protocol-equivalent to
+``S3Storage`` per ``test_s3_storage.py``) -- no ffmpeg, no real exporter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from splitsmith.storage import FilesystemStorage
+from splitsmith.ui import export_storage
+from splitsmith.ui.exports import StageExportResult
+from splitsmith.ui.project import MatchProject
+
+SCOPE = "matches/m1/shooters/me"
+
+
+def _project(tmp_path: Path, *, scope: str | None = SCOPE, with_storage: bool = True) -> MatchProject:
+    root = tmp_path / "p"
+    project = MatchProject.init(root, name="export-test")
+    if with_storage:
+        backing = tmp_path / "tenant"
+        backing.mkdir(exist_ok=True)
+        project.bind_storage(FilesystemStorage(backing), scope=scope)
+    return project
+
+
+def _exports_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "p" / "exports"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write(path: Path, data: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def test_storage_export_key_is_none_in_local_mode(tmp_path: Path) -> None:
+    project = _project(tmp_path, with_storage=False)
+    assert export_storage._storage_export_key(project, Path("a_trimmed.mp4")) is None
+    assert export_storage._storage_export_key(None, Path("a.fcpxml")) is None
+
+
+def test_storage_export_key_uses_scope_and_basename(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    key = export_storage._storage_export_key(project, tmp_path / "p" / "exports" / "stage1_x.fcpxml")
+    assert key == f"{SCOPE}/exports/stage1_x.fcpxml"
+
+
+def test_local_mode_push_is_noop(tmp_path: Path) -> None:
+    """No storage bound: push writes nothing, raises nothing."""
+    project = _project(tmp_path, with_storage=False)
+    f = _write(_exports_dir(tmp_path) / "stage1_x.fcpxml")
+    export_storage.push_export_file(project, f)  # no-op, no error
+
+
+def test_scope_none_disables_cache(tmp_path: Path) -> None:
+    """Storage bound but scope None (non-match request): cache stays off."""
+    project = _project(tmp_path, scope=None)
+    f = _write(_exports_dir(tmp_path) / "stage1_x.fcpxml")
+    export_storage.push_export_file(project, f)
+    assert list(project._storage.list("")) == []  # type: ignore[union-attr]
+
+
+def test_push_text_uses_write_bytes_not_upload_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    storage = project._storage
+    calls: list[str] = []
+    monkeypatch.setattr(storage, "upload_stream", lambda *a, **k: calls.append("stream") or 0)
+    monkeypatch.setattr(storage, "write_bytes", lambda *a, **k: calls.append("bytes"))
+
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1.fcpxml"))
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1_splits.csv"))
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1_report.txt"))
+    assert calls == ["bytes", "bytes", "bytes"]
+
+
+def test_push_binary_uses_upload_stream_not_write_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multi-GB overlays / trims must stream, never buffer whole via
+    write_bytes."""
+    project = _project(tmp_path)
+    storage = project._storage
+    calls: list[str] = []
+    monkeypatch.setattr(storage, "upload_stream", lambda *a, **k: calls.append("stream") or 0)
+    monkeypatch.setattr(storage, "write_bytes", lambda *a, **k: calls.append("bytes"))
+
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1_trimmed.mp4"))
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1_overlay.mov"))
+    assert calls == ["stream", "stream"]
+
+
+def test_push_missing_or_empty_file_is_skipped(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    storage = project._storage
+    # Missing file
+    export_storage.push_export_file(project, _exports_dir(tmp_path) / "gone.fcpxml")
+    # Empty file
+    empty = _write(_exports_dir(tmp_path) / "empty.csv", b"")
+    export_storage.push_export_file(project, empty)
+    assert list(storage.list("")) == []  # type: ignore[union-attr]
+
+
+def test_push_failure_is_best_effort(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A push outage must not raise -- the local file is the source of
+    truth for the current job."""
+    project = _project(tmp_path)
+    monkeypatch.setattr(
+        project._storage,
+        "upload_stream",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("simulated R2 outage")),
+    )
+    export_storage.push_export_file(project, _write(_exports_dir(tmp_path) / "s1_trimmed.mp4"))
+
+
+def test_push_stage_outputs_pushes_every_artifact(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    storage = project._storage
+    ed = _exports_dir(tmp_path)
+    result = StageExportResult(
+        stage_number=1,
+        trimmed_video_path=_write(ed / "s1_trimmed.mp4", b"TRIM"),
+        csv_path=_write(ed / "s1_splits.csv", b"CSV"),
+        fcpxml_path=_write(ed / "s1.fcpxml", b"<xml/>"),
+        report_path=_write(ed / "s1_report.txt", b"REPORT"),
+        overlay_path=_write(ed / "s1_overlay.mov", b"OVL"),
+        shots_written=2,
+        anomalies=[],
+        secondary_trimmed_paths={"cam2": _write(ed / "s1_cam_cam2_trimmed.mp4", b"SEC")},
+    )
+
+    export_storage.push_stage_export_outputs(project, result)
+
+    for name, data in [
+        ("s1_trimmed.mp4", b"TRIM"),
+        ("s1_splits.csv", b"CSV"),
+        ("s1.fcpxml", b"<xml/>"),
+        ("s1_report.txt", b"REPORT"),
+        ("s1_overlay.mov", b"OVL"),
+        ("s1_cam_cam2_trimmed.mp4", b"SEC"),
+    ]:
+        assert storage.read_bytes(f"{SCOPE}/exports/{name}") == data  # type: ignore[union-attr]
+
+
+def test_push_stage_outputs_skips_none_artifacts(tmp_path: Path) -> None:
+    """CSV/report-only export (no trim/fcpxml/overlay) pushes just the
+    populated paths."""
+    project = _project(tmp_path)
+    storage = project._storage
+    ed = _exports_dir(tmp_path)
+    result = StageExportResult(
+        stage_number=1,
+        trimmed_video_path=None,
+        csv_path=_write(ed / "s1_splits.csv", b"CSV"),
+        fcpxml_path=None,
+        report_path=_write(ed / "s1_report.txt", b"REPORT"),
+        overlay_path=None,
+        shots_written=2,
+        anomalies=[],
+    )
+
+    export_storage.push_stage_export_outputs(project, result)
+
+    keys = sorted(o.path for o in storage.list(f"{SCOPE}/exports/"))  # type: ignore[union-attr]
+    assert keys == [f"{SCOPE}/exports/s1_report.txt", f"{SCOPE}/exports/s1_splits.csv"]
+
+
+def test_pull_returns_true_when_already_local(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    f = _write(_exports_dir(tmp_path) / "s1.fcpxml", b"local")
+    assert export_storage.pull_export_file(project, f) is True
+
+
+def test_pull_mirrors_from_storage(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    storage = project._storage
+    target = _exports_dir(tmp_path) / "s1_trimmed.mp4"
+    target.unlink(missing_ok=True)
+    storage.write_bytes(f"{SCOPE}/exports/s1_trimmed.mp4", b"PUSHED")  # type: ignore[union-attr]
+
+    assert not target.exists()
+    assert export_storage.pull_export_file(project, target) is True
+    assert target.read_bytes() == b"PUSHED"
+
+
+def test_pull_returns_false_on_absent_key(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    target = _exports_dir(tmp_path) / "never_made.fcpxml"
+    assert export_storage.pull_export_file(project, target) is False
+    assert not target.exists()
+
+
+def test_pull_is_false_in_local_mode(tmp_path: Path) -> None:
+    project = _project(tmp_path, with_storage=False)
+    target = _exports_dir(tmp_path) / "s1.fcpxml"
+    assert export_storage.pull_export_file(project, target) is False

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -6956,3 +6956,28 @@ def test_match_id_alias_missing_segment_returns_400(tmp_path: Path, _user_config
     resp = client.get("/api/matches/")
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "match_id_required"
+
+
+def test_download_export_file_serves_local_and_guards_traversal(tmp_path: Path) -> None:
+    """The export download endpoint serves a deliverable off the local
+    exports dir, 404s an absent file, and refuses a path that escapes the
+    exports folder (encoded ``../``)."""
+    from splitsmith import match_model
+
+    root = tmp_path / "match"
+    app = _match_create_app(project_root=root, project_name="x")
+    client = _MatchClient(app)
+
+    exports = match_model.Match.shooter_root(root, "me") / "exports"
+    exports.mkdir(parents=True, exist_ok=True)
+    (exports / "stage1_one.fcpxml").write_bytes(b"<fcpxml/>")
+
+    resp = client.get("/api/shooters/me/exports/file/stage1_one.fcpxml")
+    assert resp.status_code == 200
+    assert resp.content == b"<fcpxml/>"
+    assert resp.headers["content-type"].startswith("application/xml")
+
+    assert client.get("/api/shooters/me/exports/file/missing.csv").status_code == 404
+
+    resp = client.get("/api/shooters/me/exports/file/%2e%2e%2f%2e%2e%2fmatch.json")
+    assert resp.status_code == 400

--- a/tests/test_worker_storage_seam.py
+++ b/tests/test_worker_storage_seam.py
@@ -189,6 +189,60 @@ def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: p
         assert pulled.read_bytes() == b"MP4DATA"
 
 
+def test_export_media_round_trips_worker_to_api(tmp_path: Path) -> None:
+    """PR-epsilon part 2: a worker produces export deliverables and pushes
+    them to storage; the API mirrors them down via ``pull_export_file``.
+    Proves the scope wiring (``state.shooter_project`` bind) gives matching
+    push/pull keys across two working roots, the same seam the download
+    endpoint serves through."""
+    from splitsmith.ui import export_storage
+    from splitsmith.ui.exports import StageExportResult
+
+    storage = FilesystemStorage(tmp_path / "s3")
+    state = AppState()
+    state.storage = storage
+
+    api_root = tmp_path / "api"
+    match_id = _scaffold_match(api_root)
+    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
+
+    # Worker: produce a stage export bundle on a fresh root and push it.
+    worker_root = tmp_path / "worker"
+    worker_root.mkdir()
+    with _BoundMatch(worker_root, match_id):
+        wproj = state.shooter_project("alpha")
+        ed = wproj.exports_path(state.shooter_root("alpha"))
+        ed.mkdir(parents=True, exist_ok=True)
+        (ed / "stage1_one_trimmed.mp4").write_bytes(b"TRIM")
+        (ed / "stage1_one.fcpxml").write_bytes(b"<fcpxml/>")
+        (ed / "stage1_one_report.txt").write_bytes(b"REPORT")
+        result = StageExportResult(
+            stage_number=1,
+            trimmed_video_path=ed / "stage1_one_trimmed.mp4",
+            csv_path=None,
+            fcpxml_path=ed / "stage1_one.fcpxml",
+            report_path=ed / "stage1_one_report.txt",
+            overlay_path=None,
+            shots_written=2,
+            anomalies=[],
+        )
+        export_storage.push_stage_export_outputs(wproj, result)
+
+    # API: mirrors each deliverable down (the download endpoint's pull seam).
+    with _BoundMatch(api_root, match_id):
+        aproj = state.shooter_project("alpha")
+        aed = aproj.exports_path(state.shooter_root("alpha"))
+        for name, data in [
+            ("stage1_one_trimmed.mp4", b"TRIM"),
+            ("stage1_one.fcpxml", b"<fcpxml/>"),
+            ("stage1_one_report.txt", b"REPORT"),
+        ]:
+            target = aed / name
+            assert not target.exists()
+            assert export_storage.pull_export_file(aproj, target) is True
+            assert target.read_bytes() == data
+
+
 def test_seam_is_noop_without_storage(tmp_path: Path) -> None:
     """Local mode (storage None): pull/push audit + sync are no-ops, no error."""
     state = AppState()  # storage stays None


### PR DESCRIPTION
## What

Completes the worker fleet for detection **and** export: `export` and `match_export` now round-trip out-of-process. PR-delta did the small JSON (match.json / project.json / audit); part 1 (#447) did the audit-trim MP4; this does the export deliverables — lossless `exports/*_trimmed.mp4`, FCPXML, CSV, report.txt, overlay.mov, per-cam trims, and the stitched `<project>-match.fcpxml`.

## Why

On a hosted worker the `exports/` dir is ephemeral and invisible to the API container, so export outputs stranded there. Three gaps:
1. **Outputs** never reached storage.
2. **Inputs** — `_run_export_for_stage` read the audit JSON directly and never called `pull_audit` (only the trim/shot-detect bodies did), so cross-process export read a stale/absent audit.
3. **No download path existed** — exports were *reveal-only* (`/api/files/reveal` → Finder), meaningless across containers.

## Approach

Per-artifact push/pull (approach A), mirroring the part-1 trim cache.

- **`ui/export_storage.py`** (new) — `push_export_file` / `pull_export_file` / `push_stage_export_outputs` / `_storage_export_key` (`<scope>/exports/<basename>`). Binaries (`.mp4`/`.mov`) stream via `upload_stream`; small text via `write_bytes`. No-op in local mode. Storage stays out of the pure exporters.
- **`_run_export_for_stage`** — `pull_audit` before reading the audit, `push_stage_export_outputs` after save.
- **`_run_match_export`** — per-stage `pull_audit` + `pull_export_file` (reuse cross-worker trims/overlay instead of re-cutting); re-cut branch pushes its outputs; composite FCPXML + YouTube `.srt`/`.json` sidecars pushed after compose.
- **`GET /api/shooters/{slug}/exports/file/{filename:path}`** (new) — traversal-guarded, pull-from-storage-if-missing then `FileResponse`. The export analogue of `stream_video`'s pull seam.
- **SPA** — `api.exportFileUrl` + per-file Download links in the export result panel in hosted mode (match FCPXML + the media it references); Reveal-in-Finder stays in local mode. Gated on `useDeploymentMode()`.

## Tests / gates

- `tests/test_export_storage_cache.py` (new, 14) — helper-level, incl. binary-vs-text routing spy, `scope=None` disables, best-effort failure, pull mirror/absent.
- `test_worker_storage_seam.py` +1 — cross-root worker→API export round-trip.
- `test_ui_server.py` +1 — download endpoint: local serve + 404 + encoded-`..` traversal → 400.
- ruff + black clean; **1610 pytest passed** (16 new); SPA typecheck + production build clean.
- No connector / migration / new table touched, so `pytest -m docker` is not required (same call as part 1); can run before merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)