### PR TITLE
feat(saas): database-enforced tenant isolation via Postgres RLS

### DIFF
--- a/alembic/versions/a7c4e9d21b06_enable_rls_on_tenant_tables.py
+++ b/alembic/versions/a7c4e9d21b06_enable_rls_on_tenant_tables.py
@@ -1,0 +1,77 @@
+"""enable row-level security on tenant tables
+
+Adds database-enforced tenant isolation on the three per-user tables
+(``recent_projects``, ``matches``, ``compute_jobs``). Each gets ENABLE +
+FORCE ROW LEVEL SECURITY and a single ``tenant_isolation`` policy keyed on
+the ``app.user_id`` session GUC the app sets per connection (see
+``splitsmith.db.engine.tenant_session_factory``).
+
+This is the backstop for the application-layer ``WHERE user_id = ...``
+filters every store already writes: even a future raw-SQL helper that
+forgets that clause sees only the current tenant's rows.
+
+- ``FORCE`` is required because the app role owns these tables, and the
+  owner bypasses RLS without it.
+- ``current_setting('app.user_id', true)`` (missing_ok) returns NULL when
+  the GUC is unset, so the predicate is false and the query is fail-closed
+  (0 rows / rejected writes) rather than leaking.
+- ``WITH CHECK`` blocks inserting or updating a row into another tenant.
+
+Postgres-only: SQLite (the unit-test engine) has no RLS, so the body is
+dialect-guarded and no-ops there. The proof lives in the ``pytest -m
+docker`` isolation test.
+
+``users`` is deliberately excluded: auth must resolve identity (look up by
+email) before any ``app.user_id`` exists, so an RLS'd ``users`` would break
+login. The ``procrastinate_*`` queue tables are infra, not tenant tables.
+
+Revision ID: a7c4e9d21b06
+Revises: b74c9ab3ed2f
+Create Date: 2026-05-29 13:10:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c4e9d21b06"
+down_revision: str | Sequence[str] | None = "b74c9ab3ed2f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The per-user tables that hold a ``user_id`` column. Keep in sync with the
+# multi-tenant store classes in ``splitsmith.db``.
+TENANT_TABLES = ("recent_projects", "matches", "compute_jobs")
+
+_POLICY = "tenant_isolation"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if op.get_bind().dialect.name != "postgresql":
+        # SQLite (unit tests) has no RLS. No-op so the suite still runs the
+        # migration chain end to end.
+        return
+    for table in TENANT_TABLES:
+        # Each statement issued separately: asyncpg cannot run multiple
+        # commands in one prepared statement (see the #440 hotfix).
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
+        op.execute(
+            f"CREATE POLICY {_POLICY} ON {table} "
+            f"FOR ALL "
+            f"USING (user_id = current_setting('app.user_id', true)) "
+            f"WITH CHECK (user_id = current_setting('app.user_id', true))"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table in TENANT_TABLES:
+        op.execute(f"DROP POLICY IF EXISTS {_POLICY} ON {table}")
+        op.execute(f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      # Creates the non-superuser ``splitsmith_app`` role the API/worker
+      # connect as, so RLS policies actually apply (a superuser bypasses
+      # RLS). Runs once on first init; recreate the volume to re-run.
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U splitsmith -d splitsmith"]
       interval: 2s
@@ -84,7 +88,10 @@ services:
     environment:
       # asyncpg dialect so SQLAlchemy's async engine + Alembic align
       # with the production engine choice.
-      SPLITSMITH_DATABASE_URL: postgresql+asyncpg://splitsmith:splitsmith@postgres:5432/splitsmith
+      # Connect as the NON-superuser app role so RLS is enforced (the
+      # ``splitsmith`` superuser bypasses RLS). Alembic-on-boot runs as
+      # this role too, so it owns every table it creates.
+      SPLITSMITH_DATABASE_URL: postgresql+asyncpg://splitsmith_app:splitsmith_app@postgres:5432/splitsmith
       SPLITSMITH_MODE: hosted
       # S3Storage credentials -- wired once a hosted-mode codepath
       # actually constructs an S3Storage instance. Left in the compose
@@ -127,7 +134,10 @@ services:
       splitsmith:
         condition: service_healthy
     environment:
-      SPLITSMITH_DATABASE_URL: postgresql+asyncpg://splitsmith:splitsmith@postgres:5432/splitsmith
+      # Connect as the NON-superuser app role so RLS is enforced (the
+      # ``splitsmith`` superuser bypasses RLS). Alembic-on-boot runs as
+      # this role too, so it owns every table it creates.
+      SPLITSMITH_DATABASE_URL: postgresql+asyncpg://splitsmith_app:splitsmith_app@postgres:5432/splitsmith
       SPLITSMITH_MODE: hosted
       SPLITSMITH_S3_ENDPOINT_URL: http://minio:9000
       SPLITSMITH_S3_ACCESS_KEY_ID: splitsmith

--- a/docker/postgres-init/10-app-role.sql
+++ b/docker/postgres-init/10-app-role.sql
@@ -1,0 +1,24 @@
+-- Least-privilege application role for Row-Level Security.
+--
+-- The API, the worker, and Alembic-on-boot all connect as this
+-- NON-superuser role. This is load-bearing for RLS: PostgreSQL
+-- superusers bypass RLS unconditionally, and the table owner bypasses
+-- it too unless the table is set FORCE ROW LEVEL SECURITY. By running
+-- everything (including migrations) as `splitsmith_app`, every table is
+-- owned by it, and the RLS migration's `FORCE ROW LEVEL SECURITY` makes
+-- the owner-applies case explicit. This mirrors Neon production, where
+-- the default role is a non-superuser owner.
+--
+-- The POSTGRES_USER superuser (`splitsmith`) stays available for
+-- bootstrap, seeding, and debugging. Tests seed cross-tenant rows
+-- through it precisely because a superuser bypasses RLS.
+--
+-- This script runs once, on first DB init (empty data dir). After
+-- changing it, recreate the volume: `docker compose down -v`.
+CREATE ROLE splitsmith_app LOGIN PASSWORD 'splitsmith_app' NOSUPERUSER NOBYPASSRLS;
+
+-- CREATE lets the role create its own tables (Alembic runs as it, so it
+-- owns the app + procrastinate schema); USAGE lets it reference objects
+-- in the schema. On PG15+ the public schema no longer grants CREATE to
+-- PUBLIC, so this grant is required.
+GRANT CREATE, USAGE ON SCHEMA public TO splitsmith_app;

--- a/docs/saas-readiness/02-tenancy-and-identity.md
+++ b/docs/saas-readiness/02-tenancy-and-identity.md
@@ -205,6 +205,54 @@ asserts membership before doing anything else. There is **no
 "current project" implicit context** in the request -- always
 explicit, always checked.
 
+## Database-enforced isolation (Row-Level Security)
+
+App-layer `WHERE user_id = ...` filters in every store class are the
+first line of defence, but they only protect code that goes through
+those stores. Postgres Row-Level Security is the backstop that survives
+a future raw-SQL helper forgetting the clause. As of the RLS-hardening
+PR it is **enabled and FORCED** on the three per-user tenant tables
+(`recent_projects`, `matches`, `compute_jobs`) with one policy each:
+
+```sql
+ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;
+ALTER TABLE <t> FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON <t>
+  FOR ALL
+  USING      (user_id = current_setting('app.user_id', true))
+  WITH CHECK (user_id = current_setting('app.user_id', true));
+```
+
+Two hard requirements make this real rather than decorative:
+
+- **The app's DB role must be a non-superuser without `BYPASSRLS`.**
+  Postgres superusers bypass RLS unconditionally, and the table owner
+  bypasses it unless `FORCE` is set. The API, worker, and Alembic all
+  connect as a least-privilege role (`splitsmith_app` locally; on Neon
+  the project's default role, which is already a non-superuser owner) so
+  the policies apply -- `FORCE` then covers the owner-applies case. The
+  `postgres`/`splitsmith` superuser stays for bootstrap and seeding only.
+- **Every session sets `app.user_id`.** The per-user store sessions run
+  through `tenant_session_factory`, which pins the GUC per transaction
+  (`set_config(..., true)`, the `SET LOCAL` form) via an `after_begin`
+  listener -- re-set on each transaction because the `NullPool` engine
+  hands each transaction a fresh connection. With the GUC unset the
+  policy is fail-closed (zero rows / rejected writes).
+
+`users` is deliberately **not** under RLS: auth must resolve a user by
+email before any `app.user_id` exists, so an RLS'd `users` would break
+login. Its `scoreboard_identity` JSON column stays guarded by the
+app-layer `User.id == user_id` filter; moving it to its own RLS'd table
+is a possible follow-up. The `procrastinate_*` queue tables are infra,
+not tenant data, and are excluded.
+
+Sharing does not change any of this: the per-user tables stay strictly
+owner-scoped. When the `project_members` ACL above lands, the shareable
+tables gain a *second* policy clause that ORs in
+`EXISTS (SELECT 1 FROM project_members WHERE user_id = current_setting('app.user_id', true) ...)`.
+The GUC substrate is already in place. Tracked in the sharing data-model
+issue.
+
 ## Project ID -- what it represents
 
 A `project_id` corresponds to one **single-shooter MatchProject** --

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -22,7 +22,7 @@ this DB layer internally without leaking SQL into handler code.
 """
 
 from .auth import HOSTED_LOOPBACK_EMAIL, HostedLoopbackAuth
-from .engine import create_engine, sessionmaker
+from .engine import create_engine, sessionmaker, tenant_session_factory
 from .job_backend import PostgresJobBackend
 from .matches import PostgresMatchStore
 from .models import Base, ComputeJobRow, MatchRow, RecentProjectRow, User, new_ulid
@@ -44,4 +44,5 @@ __all__ = [
     "create_engine",
     "new_ulid",
     "sessionmaker",
+    "tenant_session_factory",
 ]

--- a/src/splitsmith/db/engine.py
+++ b/src/splitsmith/db/engine.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
+from sqlalchemy import event, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.orm import Session, SessionTransaction
 from sqlalchemy.pool import NullPool
 
 
@@ -52,3 +57,66 @@ def sessionmaker(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     serialised from ORM objects).
     """
     return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+def _tenant_guc_after_begin(user_id: str) -> Callable[[Session, SessionTransaction, Connection], None]:
+    """Build an ``after_begin`` listener that pins ``app.user_id`` for the
+    transaction that just began.
+
+    Uses ``set_config(..., true)`` -- the function form of ``SET LOCAL``,
+    so the value is scoped to the current transaction and cleared at its
+    end. This is set *per transaction* rather than once per session on
+    purpose: under :class:`NullPool` (the hosted engine), a
+    :class:`~sqlalchemy.orm.Session` releases its connection on every
+    commit/rollback and acquires a *fresh* one for the next transaction,
+    so a session-level ``SET`` would be lost the moment a store method
+    runs a second query after a commit (e.g. ``PostgresMatchStore.upsert``'s
+    IntegrityError retry). Re-setting on each ``after_begin`` guarantees
+    every connection a query lands on carries the GUC.
+
+    No-op on non-PostgreSQL backends (SQLite has no ``set_config`` / RLS),
+    so the unit-test engine is untouched; RLS itself is proven by the
+    ``pytest -m docker`` isolation test.
+    """
+
+    def _after_begin(
+        session: Session,
+        transaction: SessionTransaction,
+        connection: Connection,
+    ) -> None:
+        if connection.dialect.name != "postgresql":
+            return
+        connection.execute(
+            text("SELECT set_config('app.user_id', :uid, true)"),
+            {"uid": user_id},
+        )
+
+    return _after_begin
+
+
+def tenant_session_factory(
+    base_factory: async_sessionmaker[AsyncSession],
+    user_id: str,
+) -> Callable[[], AsyncSession]:
+    """Wrap ``base_factory`` so every session it opens sets the
+    ``app.user_id`` GUC the Row-Level Security policies key on, on each
+    transaction.
+
+    Returns a callable with the same ``async with factory() as session``
+    shape as :func:`sessionmaker`'s result, so the per-user store classes
+    consume it unchanged -- the GUC is set transparently (via an
+    ``after_begin`` listener, see :func:`_tenant_guc_after_begin`) before
+    they run a single statement, and re-set on every subsequent
+    transaction within the session.
+    """
+    listener = _tenant_guc_after_begin(user_id)
+
+    def _open() -> AsyncSession:
+        session = base_factory()
+        # Attach to this session instance only; the listener is collected
+        # with the session, so distinct per-user factories never share or
+        # accumulate listeners.
+        event.listen(session.sync_session, "after_begin", listener)
+        return session
+
+    return _open

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3272,6 +3272,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
         PostgresScoreboardIdentityStore,
         create_engine,
         sessionmaker,
+        tenant_session_factory,
     )
 
     url = os.environ.get(SPLITSMITH_DATABASE_URL_ENV)
@@ -3296,9 +3297,17 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     auth = HostedLoopbackAuth(session_factory)
     user_id = auth.user_id
 
+    # Every per-user store opens its sessions through a tenant-scoped
+    # factory that sets the ``app.user_id`` GUC the RLS policies key on
+    # (no-op on SQLite). The auth backend keeps the raw ``session_factory``
+    # because it resolves identity from ``users`` -- which has no RLS --
+    # before any GUC exists. ``build_worker_state`` reaches this same seam,
+    # so the worker's stores get the GUC too.
+    tenant_factory = tenant_session_factory(session_factory, user_id)
+
     state.auth = auth
-    state.recent_projects = PostgresRecentProjectsStore(session_factory, user_id=user_id)
-    state.scoreboard_identity = PostgresScoreboardIdentityStore(session_factory, user_id=user_id)
+    state.recent_projects = PostgresRecentProjectsStore(tenant_factory, user_id=user_id)
+    state.scoreboard_identity = PostgresScoreboardIdentityStore(tenant_factory, user_id=user_id)
     # The API process enqueues via the deferrer; the worker executes and
     # must not sweep jobs queued for it to run. The worker also enqueues
     # (job chaining defers a follow-up onto the queue), so it gets a
@@ -3306,7 +3315,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     from ..queue import make_deferrer
 
     state.jobs = PostgresJobBackend(
-        session_factory,
+        tenant_factory,
         user_id=user_id,
         deferrer=make_deferrer(url),
         sweep_on_boot=not worker,
@@ -3316,7 +3325,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     # Per-user ``matches`` table. The API upserts a row when a match is
     # opened (see the open path); the worker resolves a queued ``match_id``
     # through it (it never opened the match locally).
-    match_store = PostgresMatchStore(session_factory, user_id=user_id)
+    match_store = PostgresMatchStore(tenant_factory, user_id=user_id)
     state.matches_store = match_store
     if worker:
         worker_root = Path(

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -167,9 +167,16 @@ def test_hosted_user_row_persists_in_postgres(hosted_stack: None) -> None:
     assert out.stdout.strip() == "1"
 
 
-def _psql(query: str) -> str:
-    """Run ``query`` in the compose Postgres and return trimmed stdout."""
-    out = subprocess.run(
+def _psql_run(query: str, *, user: str = "splitsmith") -> subprocess.CompletedProcess[str]:
+    """Run ``query`` in the compose Postgres as ``user`` and return the
+    completed process (no return-code assertion).
+
+    ``user`` defaults to the ``splitsmith`` superuser, which **bypasses
+    RLS** -- correct for seeding cross-tenant rows and for inspecting the
+    raw table state. Pass ``user="splitsmith_app"`` (the non-superuser app
+    role) to exercise the RLS policies the app actually runs under.
+    """
+    return subprocess.run(
         [
             "docker",
             "compose",
@@ -180,16 +187,24 @@ def _psql(query: str) -> str:
             "postgres",
             "psql",
             "-U",
-            "splitsmith",
+            user,
             "-d",
             "splitsmith",
-            "-At",
+            # ``-q`` suppresses command tags ("SET", "INSERT 0 1") so a
+            # multi-statement ``SET ...; SELECT ...`` returns only the row
+            # data; SELECT output and errors are unaffected.
+            "-qAt",
             "-c",
             query,
         ],
         capture_output=True,
         text=True,
     )
+
+
+def _psql(query: str, *, user: str = "splitsmith") -> str:
+    """Run ``query`` (asserting success) and return trimmed stdout."""
+    out = _psql_run(query, user=user)
     assert out.returncode == 0, out.stderr
     return out.stdout.strip()
 
@@ -426,3 +441,108 @@ def test_worker_resolves_match_cross_process(hosted_stack: None) -> None:
     assert (
         "resolve match" not in err and "matchnotregistered" not in err
     ), f"worker failed to resolve the match cross-process: {err!r}"
+
+
+# The three per-user tenant tables RLS protects. Keep in sync with the
+# migration's TENANT_TABLES and the multi-tenant store classes.
+_RLS_TABLES = ("recent_projects", "matches", "compute_jobs")
+
+
+def _seed_two_tenants() -> tuple[str, str]:
+    """Seed users A and B with one row each in every tenant table.
+
+    Runs as the ``splitsmith`` superuser, which bypasses RLS -- that is
+    the only way to write rows owned by two different tenants in one
+    pass. Returns the two user ids."""
+    uid_a, uid_b = "user-a-rls", "user-b-rls"
+    _psql(
+        "INSERT INTO users (id, email, entitlement) VALUES "
+        f"('{uid_a}', 'a-rls@hosted.local', 'free'), "
+        f"('{uid_b}', 'b-rls@hosted.local', 'free') "
+        "ON CONFLICT (id) DO NOTHING"
+    )
+    _psql(
+        "INSERT INTO recent_projects (id, user_id, path, name) VALUES "
+        f"('rp-a', '{uid_a}', '/a', 'A proj'), ('rp-b', '{uid_b}', '/b', 'B proj') "
+        "ON CONFLICT (id) DO NOTHING"
+    )
+    _psql(
+        "INSERT INTO matches (id, user_id, match_id, name, storage_prefix) VALUES "
+        f"('m-a', '{uid_a}', 'mid-a', 'A match', 'matches/mid-a'), "
+        f"('m-b', '{uid_b}', 'mid-b', 'B match', 'matches/mid-b') "
+        "ON CONFLICT (id) DO NOTHING"
+    )
+    _psql(
+        "INSERT INTO compute_jobs (id, user_id, kind, status, cancel_requested, acknowledged) "
+        f"VALUES ('j-a', '{uid_a}', 'model_download', 'pending', false, false), "
+        f"('j-b', '{uid_b}', 'model_download', 'pending', false, false) "
+        "ON CONFLICT (id) DO NOTHING"
+    )
+    return uid_a, uid_b
+
+
+def test_rls_blocks_cross_tenant_reads_and_writes(hosted_stack: None) -> None:
+    """The real RLS proof: as the non-superuser app role, a query with no
+    ``user_id`` filter at all returns only the current tenant's rows.
+
+    This is the failure mode the per-query app-layer filters can't catch
+    -- a future raw-SQL helper that forgets the ``WHERE user_id = ...``
+    clause. With RLS it sees only the tenant whose id is in the
+    ``app.user_id`` GUC; without the GUC it sees nothing (fail-closed).
+    """
+    uid_a, uid_b = _seed_two_tenants()
+    seeded = f"('{uid_a}', '{uid_b}')"
+
+    # Guard: the whole test is meaningless if the app role can bypass RLS.
+    assert _psql("SELECT rolsuper FROM pg_roles WHERE rolname='splitsmith_app'") == "f"
+    assert _psql("SELECT rolbypassrls FROM pg_roles WHERE rolname='splitsmith_app'") == "f"
+
+    # The migration enabled + FORCED RLS and created the policy on all three.
+    assert (
+        _psql(
+            "SELECT count(*) FROM pg_policies WHERE policyname='tenant_isolation' "
+            "AND tablename IN ('recent_projects','matches','compute_jobs')"
+        )
+        == "3"
+    )
+    assert (
+        _psql(
+            "SELECT count(*) FROM pg_class WHERE relforcerowsecurity "
+            "AND relname IN ('recent_projects','matches','compute_jobs')"
+        )
+        == "3"
+    )
+
+    for table in _RLS_TABLES:
+        # GUC = A: the deliberately-unfiltered SELECT returns only A's row.
+        visible_a = _psql(
+            f"SET app.user_id = '{uid_a}'; "
+            f"SELECT user_id FROM {table} WHERE user_id IN {seeded} ORDER BY user_id",
+            user="splitsmith_app",
+        )
+        assert visible_a == uid_a, f"{table}: tenant A saw {visible_a!r}, expected only {uid_a!r}"
+
+        # GUC = B: only B's row.
+        visible_b = _psql(
+            f"SET app.user_id = '{uid_b}'; "
+            f"SELECT user_id FROM {table} WHERE user_id IN {seeded} ORDER BY user_id",
+            user="splitsmith_app",
+        )
+        assert visible_b == uid_b, f"{table}: tenant B saw {visible_b!r}, expected only {uid_b!r}"
+
+        # No GUC set: fail-closed, zero rows (current_setting -> NULL).
+        unset = _psql(
+            f"SELECT count(*) FROM {table} WHERE user_id IN {seeded}",
+            user="splitsmith_app",
+        )
+        assert unset == "0", f"{table}: GUC-unset query leaked {unset} rows (should be 0)"
+
+    # WITH CHECK: as tenant A, inserting a row owned by B must be rejected.
+    bad_insert = _psql_run(
+        f"SET app.user_id = '{uid_a}'; "
+        "INSERT INTO matches (id, user_id, match_id, name, storage_prefix) "
+        f"VALUES ('m-x', '{uid_b}', 'mid-x', 'x', 'matches/mid-x')",
+        user="splitsmith_app",
+    )
+    assert bad_insert.returncode != 0, "RLS WITH CHECK let tenant A insert a row owned by tenant B"
+    assert "row-level security" in bad_insert.stderr.lower()

--- a/tests/test_tenant_session_factory.py
+++ b/tests/test_tenant_session_factory.py
@@ -1,0 +1,97 @@
+"""Tests for :func:`splitsmith.db.tenant_session_factory` and its
+``after_begin`` GUC listener.
+
+The factory pins the ``app.user_id`` GUC the Row-Level Security policies
+key on, once per transaction (``set_config(..., true)`` == ``SET LOCAL``).
+SQLite (the unit-test engine) has no RLS or ``set_config``, so on SQLite
+the listener must be a transparent no-op -- that is what the integration
+test proves. The actual RLS enforcement is proven against live Postgres
+in ``tests/test_hosted_docker_smoke.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from splitsmith.db import (
+    Base,
+    PostgresMatchStore,
+    User,
+    create_engine,
+    sessionmaker,
+    tenant_session_factory,
+)
+from splitsmith.db.engine import _tenant_guc_after_begin
+
+
+class _FakeDialect:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeConnection:
+    """Records ``execute`` calls so the listener's SQL can be asserted
+    without a live database."""
+
+    def __init__(self, dialect_name: str) -> None:
+        self.dialect = _FakeDialect(dialect_name)
+        self.calls: list[tuple[str, dict | None]] = []
+
+    def execute(self, statement, params=None):  # noqa: ANN001
+        self.calls.append((str(statement), params))
+
+
+def test_after_begin_sets_local_guc_on_postgres() -> None:
+    """On a postgres-dialect connection the listener issues exactly one
+    transaction-local ``set_config('app.user_id', <uid>, true)``."""
+    listener = _tenant_guc_after_begin("user-123")
+    conn = _FakeConnection("postgresql")
+
+    listener(session=None, transaction=None, connection=conn)  # type: ignore[arg-type]
+
+    assert len(conn.calls) == 1
+    sql, params = conn.calls[0]
+    assert "set_config('app.user_id'" in sql
+    # ``, true)`` == is_local: scoped to the current transaction (SET LOCAL).
+    assert sql.strip().endswith(", true)")
+    assert params == {"uid": "user-123"}
+
+
+def test_after_begin_is_noop_on_non_postgres() -> None:
+    """SQLite has no ``set_config``; the listener must not touch it."""
+    listener = _tenant_guc_after_begin("user-xyz")
+    conn = _FakeConnection("sqlite")
+
+    listener(session=None, transaction=None, connection=conn)  # type: ignore[arg-type]
+
+    assert conn.calls == []
+
+
+def test_store_round_trips_through_wrapped_factory_on_sqlite() -> None:
+    """The per-user stores consume the wrapped factory unchanged -- this
+    is the no-store-change guarantee the prod wiring relies on. On SQLite
+    the listener is a no-op, so a clean round-trip proves the wrapper
+    doesn't break the session lifecycle (open -> begin -> commit)."""
+    engine = create_engine("sqlite+aiosqlite:///:memory:")
+    base = sessionmaker(engine)
+
+    async def _setup() -> str:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with base() as s:
+            user = User(email="m@thias.se")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            return user.id
+
+    uid = asyncio.run(_setup())
+    factory = tenant_session_factory(base, uid)
+    store = PostgresMatchStore(factory, user_id=uid)
+
+    # upsert exercises the multi-statement (SELECT -> INSERT -> commit)
+    # path through the wrapped session.
+    asyncio.run(store.upsert("brm-abc", "Bromma", "matches/brm-abc"))
+    row = asyncio.run(store.get("brm-abc"))
+    assert row is not None
+    assert row.match_id == "brm-abc"


### PR DESCRIPTION
## What

Database-enforced tenant isolation via Postgres Row-Level Security on the three per-user tables (`recent_projects`, `matches`, `compute_jobs`). App-layer `WHERE user_id = ...` filters in every store stay as the first line of defence; RLS is the backstop that survives a future raw-SQL helper that forgets the clause -- the failure mode the per-query guards can't catch.

This is the committed next SaaS chunk: the 3-tenant-table threshold from the multi-tenant invariants doc is now tripped.

## How

- **Migration `a7c4e9d21b06`** -- `ENABLE` + `FORCE ROW LEVEL SECURITY` + one `tenant_isolation` policy per table:
  ```sql
  USING      (user_id = current_setting('app.user_id', true))
  WITH CHECK (user_id = current_setting('app.user_id', true))
  ```
  `current_setting(..., true)` returns NULL when the GUC is unset -> predicate false -> **fail closed** (0 rows / rejected writes). Dialect-guarded so the SQLite unit engine no-ops it.

- **Least-privilege `splitsmith_app` role** (`docker/postgres-init/10-app-role.sql`) -- the API, worker, and Alembic connect as a **non-superuser owner** so the policies actually apply. Superusers bypass RLS unconditionally; the owner bypasses it unless `FORCE` is set. This mirrors Neon's default role (a non-super owner), so one runtime URL works in both. Both compose services now use it; the `splitsmith` superuser stays for seeding/inspection only.

- **`tenant_session_factory`** (`db/engine.py`) sets the GUC **per transaction** via an `after_begin` listener (the `SET LOCAL` form, `set_config(..., true)`). Per-transaction rather than per-session because the `NullPool` engine hands each transaction a fresh connection -- a session-level `SET` would be lost the moment a store method runs a query after a commit (e.g. `PostgresMatchStore.upsert`'s IntegrityError retry). Wired into `_apply_hosted_mode_wiring`, so all four stores **and the worker** inherit it with no store-class changes; auth keeps the raw factory (`users` has no RLS).

## Tests

- Unit (`test_tenant_session_factory.py`): the `after_begin` listener sets the GUC on postgres and no-ops on sqlite; stores round-trip through the wrapped factory.
- Docker (`test_hosted_docker_smoke.py`, `pytest -m docker`): two tenants seeded as superuser, then as the **non-super `splitsmith_app`** role a deliberately *unfiltered* `SELECT` returns only the GUC's tenant, returns **zero** rows when the GUC is unset, and a cross-tenant `INSERT` is rejected by `WITH CHECK`. Plus guards that `splitsmith_app` is not super / not `BYPASSRLS` and that all three tables are FORCED with the policy present.

## Out of scope / residual risk

- **`users` is deliberately not under RLS** -- auth resolves a user by email *before* any `app.user_id` exists, so an RLS'd `users` would break login. Its `scoreboard_identity` JSON column stays guarded by the app-layer `User.id == user_id` filter (possible follow-up: move it to its own RLS'd table).
- **Sharing is not built here.** Per-user tables stay owner-only. The future `project_members` ACL adds a *membership* policy clause on the same `app.user_id` substrate -- tracked in #449.
- `procrastinate_*` queue tables are infra, excluded.
- App-layer `user_id` filters stay in every store (defence in depth).

## Gates

- `ruff` + `black` clean repo-wide
- **1613 unit passed**, 16 skipped
- **`pytest -m docker` 7 passed** (6 existing smoke + the new isolation test)

Related: #449 (sharing data model), #348, #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
