### PR TITLE
feat(saas): per-request/per-job tenant seam (auth-swap PR1)

### DIFF
--- a/src/splitsmith/db/job_backend.py
+++ b/src/splitsmith/db/job_backend.py
@@ -119,6 +119,7 @@ class PostgresJobBackend:
         user_id: str,
         deferrer: JobDeferrer | None = None,
         sweep_on_boot: bool = True,
+        bodies: JobBodyRegistry | None = None,
     ) -> None:
         # Defence-in-depth: see :class:`PostgresRecentProjectsStore`
         # for the same fail-loud-on-empty-user_id rationale.
@@ -136,8 +137,12 @@ class PostgresJobBackend:
         self._deferrer = deferrer
         # Populated by ``register_job_bodies(state)`` in ``create_app``
         # (API) and the worker bootstrap, same as the local
-        # :class:`JobRegistry`. Each process holds its own copy.
-        self.bodies = JobBodyRegistry()
+        # :class:`JobRegistry`. The kind -> body mapping is a process-level
+        # constant, so when the hosted wiring builds a fresh backend per
+        # request / per job it injects one shared registry rather than
+        # re-registering bodies on every instance. ``None`` (the default,
+        # used by tests + the boot-time backend) creates a private one.
+        self.bodies = bodies if bodies is not None else JobBodyRegistry()
 
         self._lock = threading.RLock()
         self._subprocs: dict[str, subprocess.Popen] = {}

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -151,6 +151,7 @@ def make_deferrer(database_url: str) -> Callable[..., Awaitable[None]]:
         async with app.open_async():
             await app.configure_task(name=RUN_COMPUTE_JOB_TASK, queue=queue).defer_async(
                 job_id=job_id,
+                user_id=user_id,
                 kind=kind,
                 args=args,
                 match_id=match_id,
@@ -171,17 +172,32 @@ def register_compute_task(app: procrastinate.App, state: Any) -> None:
     :meth:`procrastinate.App.run_worker_async`.
     """
     from .match_registry import MatchNotRegisteredError
-    from .ui.server import current_match_id, current_match_root
+    from .ui.server import current_match_id, current_match_root, current_tenant
 
     @app.task(name=RUN_COMPUTE_JOB_TASK, queue="default")
     async def _run_compute_job(
         *,
         job_id: str,
+        user_id: str,
         kind: str,
         args: dict[str, Any] | None = None,
         match_id: str | None = None,
     ) -> None:
         call_args = _rehydrate_args(kind, args or {})
+
+        # Build this job's tenant context from the queued ``user_id`` and
+        # pin it for the lifetime of the run. ``state.jobs`` / ``state.storage``
+        # / ``state.matches_store`` are tenant-resolving properties, so they
+        # must see ``current_tenant`` before any of them is touched -- the
+        # very next line reads ``state.jobs``. ``run_job`` offloads the body
+        # via ``asyncio.to_thread``, which copies this context, so the GUC the
+        # tenant session factory sets (and the per-user S3 prefix) follow the
+        # body onto the worker thread. ``user_id`` is required: there is no
+        # fallback to the ``user-<id>`` queue name (a queued job always
+        # carries its owner; a missing one is a wire-format bug, not a
+        # recoverable state).
+        tenant = state.build_tenant(user_id)
+        tenant_token = current_tenant.set(tenant)
 
         def _bind_match() -> None:
             """Re-set the match ContextVars from the queued ``match_id``.
@@ -201,14 +217,17 @@ def register_compute_task(app: procrastinate.App, state: Any) -> None:
                 root = state.matches.resolve(match_id)
             except MatchNotRegisteredError as exc:
                 raise RuntimeError(
-                    f"hosted worker cannot resolve match {match_id!r}: its match "
-                    "metadata is not reachable cross-process yet (a later chunk). "
-                    "Only match-less kinds (e.g. model_download) run on the worker today."
+                    f"hosted worker cannot resolve match {match_id!r}: it is not in "
+                    f"this user's matches table (or its metadata is unreachable). "
+                    "Match-less kinds (e.g. model_download) need no resolution."
                 ) from exc
             current_match_root.set(root)
             current_match_id.set(match_id)
 
-        await state.jobs.run_job(job_id=job_id, kind=kind, args=call_args, before_body=_bind_match)
+        try:
+            await state.jobs.run_job(job_id=job_id, kind=kind, args=call_args, before_body=_bind_match)
+        finally:
+            current_tenant.reset(tenant_token)
 
 
 def _rehydrate_args(kind: str, args: dict[str, Any]) -> dict[str, Any]:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -148,7 +148,15 @@ from . import audio as audio_helpers
 from . import export_storage
 from . import exports as export_helpers
 from . import match_exports as match_export_helpers
-from .jobs import Job, JobBackend, JobCancelled, JobHandle, JobRegistry, ShutdownInProgressError
+from .jobs import (
+    Job,
+    JobBackend,
+    JobBodyRegistry,
+    JobCancelled,
+    JobHandle,
+    JobRegistry,
+    ShutdownInProgressError,
+)
 from .project import (
     PROJECT_FILE,
     VIDEO_EXTENSIONS,
@@ -578,6 +586,38 @@ current_match_id: ContextVar[str | None] = ContextVar("splitsmith_current_match_
 
 
 @dataclass
+class TenantContext:
+    """The per-user stores resolved for the lifetime of one request / job.
+
+    In hosted mode every ``/api/*`` request and every worker job runs as a
+    distinct user, so the per-user stores cannot be process singletons --
+    a singleton bound to user A would serve user B's request with A's
+    Row-Level-Security GUC. The hosted wiring builds one of these per
+    request (in the auth-gate middleware, from the resolved ``User``) and
+    per job (in the queue task, from the queued ``user_id``); the matching
+    :class:`AppState` properties read it via the :data:`current_tenant`
+    ContextVar. In local mode there is exactly one operator, so this is
+    never populated and the properties fall back to the process singletons.
+    """
+
+    recent_projects: user_config.RecentProjectsStore
+    scoreboard_identity: user_config.ScoreboardIdentityStore
+    jobs: JobBackend
+    matches_store: PostgresMatchStore | None
+    storage: Storage | None
+
+
+# Per-request / per-job tenant resolved by the hosted-mode auth gate
+# (API) and the ``run_compute_job`` queue task (worker). When set, the
+# per-user ``AppState`` properties (``jobs``, ``recent_projects``,
+# ``scoreboard_identity``, ``matches_store``, ``storage``) read from it
+# instead of the local-mode singleton -- the same pattern
+# ``current_match_root`` uses for match scoping. ``None`` in local mode
+# and on boot/non-request code paths.
+current_tenant: ContextVar[TenantContext | None] = ContextVar("splitsmith_current_tenant", default=None)
+
+
+@dataclass
 class AppState:
     """Process state. One bound Match folder at a time.
 
@@ -607,26 +647,30 @@ class AppState:
 
     # The ``JobBackend`` Protocol (see ``splitsmith.ui.jobs``) is
     # what handlers depend on; ``JobRegistry`` is the local in-memory
-    # implementation. A hosted-mode backend swaps in here per
-    # Tier 2 of doc 10.
-    jobs: JobBackend = field(default_factory=JobRegistry)
+    # implementation. In hosted mode the per-request / per-job tenant
+    # backend resolves through the ``jobs`` property below; this backing
+    # slot then holds the boot-time backend (bodies registry + restart
+    # sweep). See ``_apply_hosted_mode_wiring``.
+    _jobs: JobBackend = field(default_factory=JobRegistry)
     matches: MatchRegistry = field(default_factory=MatchRegistry)
     # Per-user ``matches`` table store (PR-delta). ``None`` in local mode;
-    # set by ``_apply_hosted_mode_wiring`` so the API can upsert a row when
-    # a match is opened and the worker can resolve a ``match_id`` it never
-    # opened locally. See ``splitsmith.db.matches.PostgresMatchStore``.
-    matches_store: PostgresMatchStore | None = None
+    # in hosted mode resolved per request / per job via the property below.
+    # See ``splitsmith.db.matches.PostgresMatchStore``.
+    _matches_store: PostgresMatchStore | None = None
     # Per-user preference stores (Tier 3 of doc 10). Local mode
     # delegates to the ``~/.splitsmith/*.json`` module functions;
-    # the hosted-mode backend will be per-user Postgres rows
-    # constructed per-request after the auth check. See
-    # ``splitsmith.user_config``.
-    recent_projects: user_config.RecentProjectsStore = field(
+    # in hosted mode resolved per request from the authenticated user
+    # via the properties below. See ``splitsmith.user_config``.
+    _recent_projects: user_config.RecentProjectsStore = field(
         default_factory=user_config.JsonRecentProjectsStore
     )
-    scoreboard_identity: user_config.ScoreboardIdentityStore = field(
+    _scoreboard_identity: user_config.ScoreboardIdentityStore = field(
         default_factory=user_config.JsonScoreboardIdentityStore
     )
+    # Hosted-mode factory: build a :class:`TenantContext` for a ``user_id``.
+    # ``None`` in local mode. Set by ``_apply_hosted_mode_wiring``; called
+    # per request (auth gate) and per job (queue task).
+    _build_tenant: Callable[[str], TenantContext] | None = None
     # Auth backend. ``LoopbackAuth`` in local mode (every request
     # resolves to the same sentinel user); a hosted-mode backend will
     # be injected here when SaaS lands. See ``splitsmith.auth``.
@@ -646,8 +690,9 @@ class AppState:
     # constructs a per-user :class:`S3Storage` scoped to
     # ``users/<user_id>/`` so the upload endpoints can stream raw
     # footage into R2 / MinIO without ever touching the API
-    # container's filesystem. See ``docs/saas-readiness/03-storage-layer.md``.
-    storage: Storage | None = None
+    # container's filesystem. Resolved per request / per job via the
+    # property below. See ``docs/saas-readiness/03-storage-layer.md``.
+    _storage: Storage | None = None
     # Stop callback registered by :func:`splitsmith.ui.embedded.run_embedded`
     # so the /api/shutdown route can ask uvicorn to exit. None under the
     # ``splitsmith ui`` CLI path -- Ctrl-C via _JobAwareServer.handle_exit
@@ -656,6 +701,78 @@ class AppState:
     # Idempotency latch for /api/shutdown: first call kicks the drain
     # thread, subsequent calls return 202 without rescheduling.
     shutdown_initiated: bool = False
+
+    # ------------------------------------------------------------------
+    # Per-user stores -- tenant-resolving in hosted mode, singletons local
+    # ------------------------------------------------------------------
+    #
+    # Each getter returns the request/job's :class:`TenantContext` store
+    # when ``current_tenant`` is set (hosted mode), else the process
+    # singleton in the backing field (local mode + boot/non-request code).
+    # The setters write the backing field so tests + the local path can
+    # inject fakes; hosted requests never assign these (they set
+    # ``current_tenant`` instead). This mirrors ``shooter_root`` reading
+    # ``current_match_root``.
+
+    @property
+    def jobs(self) -> JobBackend:
+        tenant = current_tenant.get()
+        return tenant.jobs if tenant is not None else self._jobs
+
+    @jobs.setter
+    def jobs(self, value: JobBackend) -> None:
+        self._jobs = value
+
+    @property
+    def recent_projects(self) -> user_config.RecentProjectsStore:
+        tenant = current_tenant.get()
+        return tenant.recent_projects if tenant is not None else self._recent_projects
+
+    @recent_projects.setter
+    def recent_projects(self, value: user_config.RecentProjectsStore) -> None:
+        self._recent_projects = value
+
+    @property
+    def scoreboard_identity(self) -> user_config.ScoreboardIdentityStore:
+        tenant = current_tenant.get()
+        return tenant.scoreboard_identity if tenant is not None else self._scoreboard_identity
+
+    @scoreboard_identity.setter
+    def scoreboard_identity(self, value: user_config.ScoreboardIdentityStore) -> None:
+        self._scoreboard_identity = value
+
+    @property
+    def matches_store(self) -> PostgresMatchStore | None:
+        tenant = current_tenant.get()
+        return tenant.matches_store if tenant is not None else self._matches_store
+
+    @matches_store.setter
+    def matches_store(self, value: PostgresMatchStore | None) -> None:
+        self._matches_store = value
+
+    @property
+    def storage(self) -> Storage | None:
+        tenant = current_tenant.get()
+        return tenant.storage if tenant is not None else self._storage
+
+    @storage.setter
+    def storage(self, value: Storage | None) -> None:
+        self._storage = value
+
+    def build_tenant(self, user_id: str) -> TenantContext:
+        """Build the :class:`TenantContext` for ``user_id`` (hosted mode).
+
+        Raises if called in local mode -- there is no per-user tenancy
+        there, and a caller reaching this in local mode is a bug. The
+        hosted wiring sets :attr:`_build_tenant`.
+        """
+        if self._build_tenant is None:
+            raise RuntimeError(
+                "AppState.build_tenant called without a hosted-mode tenant "
+                "factory; this is only valid when SPLITSMITH_MODE=hosted "
+                "wiring has run."
+            )
+        return self._build_tenant(user_id)
 
     @property
     def match_root(self) -> Path:
@@ -3245,24 +3362,27 @@ def _hosted_mode_active() -> bool:
 
 
 def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
-    """Swap AppState's local-mode defaults for Postgres-backed impls.
+    """Wire AppState for hosted mode: a per-tenant store factory + the
+    process-level resources it needs.
 
     Runs only when :func:`_hosted_mode_active` is True. Requires
     ``SPLITSMITH_DATABASE_URL`` to point at a Postgres (or SQLite)
-    engine the migrations have already applied. Constructs:
+    engine the migrations have already applied.
 
-    - :class:`HostedLoopbackAuth` (upserts the loopback hosted user
-      row + remembers its id).
-    - :class:`PostgresRecentProjectsStore` bound to that user.
-    - :class:`PostgresScoreboardIdentityStore` bound to that user.
-    - :class:`PostgresJobBackend` bound to that user.
+    Unlike the original single-user wiring, this does **not** bind the
+    per-user stores to one user at boot. It installs
+    :meth:`AppState.build_tenant`, which constructs a fresh
+    :class:`TenantContext` for a given ``user_id`` -- the auth gate calls
+    it per request, the queue task per job. Each context's stores open
+    sessions through :func:`tenant_session_factory`, so the ``app.user_id``
+    GUC the RLS policies key on is set per transaction for the right user.
 
-    Single-user binding is deliberate: while :class:`LoopbackAuth`
-    is the only auth backend, every request resolves to the same
-    user, so the stores can be process-singletons. Once
-    :class:`MagicLinkAuth` lands and requests resolve different
-    users, this wiring is replaced with FastAPI ``Depends``-based
-    per-request construction.
+    Process-level resources are built once and shared across tenants: the
+    engine + session factory, the queue deferrer, the S3 client, and the
+    job-body registry (the ``kind`` -> body mapping is a process constant).
+    The ``HostedLoopbackAuth`` boot user is still resolved here -- in this
+    chunk it remains the only user, and the backing job backend uses its id
+    for restart-sweep hygiene. :class:`MagicLinkAuth` replaces it next.
     """
     from ..db import (
         HostedLoopbackAuth,
@@ -3274,6 +3394,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
         sessionmaker,
         tenant_session_factory,
     )
+    from ..queue import make_deferrer
 
     url = os.environ.get(SPLITSMITH_DATABASE_URL_ENV)
     if not url:
@@ -3295,38 +3416,59 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     # upsert the user row; that's safe here because ``create_app``
     # itself runs outside any event loop.
     auth = HostedLoopbackAuth(session_factory)
-    user_id = auth.user_id
-
-    # Every per-user store opens its sessions through a tenant-scoped
-    # factory that sets the ``app.user_id`` GUC the RLS policies key on
-    # (no-op on SQLite). The auth backend keeps the raw ``session_factory``
-    # because it resolves identity from ``users`` -- which has no RLS --
-    # before any GUC exists. ``build_worker_state`` reaches this same seam,
-    # so the worker's stores get the GUC too.
-    tenant_factory = tenant_session_factory(session_factory, user_id)
-
     state.auth = auth
-    state.recent_projects = PostgresRecentProjectsStore(tenant_factory, user_id=user_id)
-    state.scoreboard_identity = PostgresScoreboardIdentityStore(tenant_factory, user_id=user_id)
-    # The API process enqueues via the deferrer; the worker executes and
-    # must not sweep jobs queued for it to run. The worker also enqueues
-    # (job chaining defers a follow-up onto the queue), so it gets a
-    # deferrer too.
-    from ..queue import make_deferrer
 
-    state.jobs = PostgresJobBackend(
-        tenant_factory,
-        user_id=user_id,
-        deferrer=make_deferrer(url),
+    # Process-level, tenant-agnostic resources shared by every
+    # ``TenantContext``. The deferrer routes per-user inside ``_defer``
+    # (queue name from ``user_id``); the S3 client is stateless w.r.t. the
+    # tenant (only the key prefix is per-user, see ``_build_hosted_storage``);
+    # the body registry is the fixed ``kind`` -> body mapping.
+    deferrer = make_deferrer(url)
+    s3_client, s3_bucket = _build_hosted_s3_client()
+    job_bodies = JobBodyRegistry()
+
+    def _build_tenant(user_id: str) -> TenantContext:
+        # Every per-user store opens its sessions through a tenant-scoped
+        # factory that sets the ``app.user_id`` GUC the RLS policies key on
+        # (no-op on SQLite). ``sweep_on_boot=False``: a per-request /
+        # per-job backend must never fail the in-flight jobs of the user it
+        # was just built for. The shared ``job_bodies`` registry is injected
+        # so a fresh backend resolves the same kinds without re-registration.
+        tenant_factory = tenant_session_factory(session_factory, user_id)
+        return TenantContext(
+            recent_projects=PostgresRecentProjectsStore(tenant_factory, user_id=user_id),
+            scoreboard_identity=PostgresScoreboardIdentityStore(tenant_factory, user_id=user_id),
+            jobs=PostgresJobBackend(
+                tenant_factory,
+                user_id=user_id,
+                deferrer=deferrer,
+                sweep_on_boot=False,
+                bodies=job_bodies,
+            ),
+            matches_store=PostgresMatchStore(tenant_factory, user_id=user_id),
+            storage=_tenant_s3_storage(s3_client, s3_bucket, user_id),
+        )
+
+    state._build_tenant = _build_tenant
+
+    # Backing job backend (read via ``state.jobs`` only when no tenant is
+    # pinned, i.e. boot + non-request code). It holds the shared body
+    # registry so ``register_job_bodies(state)`` -- which runs at boot with
+    # no ``current_tenant`` -- populates the registry every per-request
+    # backend shares. The API also uses it for one-shot restart hygiene:
+    # ``sweep_on_boot`` fails the boot user's stranded PENDING/RUNNING rows.
+    # The worker disables the sweep (it must not fail jobs queued for it to
+    # run). Multi-tenant restart hygiene -- sweeping *every* user's stranded
+    # rows, which can't be enumerated per-request -- is a follow-up for when
+    # MagicLinkAuth makes a second user real.
+    state._jobs = PostgresJobBackend(
+        tenant_session_factory(session_factory, auth.user_id),
+        user_id=auth.user_id,
+        deferrer=deferrer,
         sweep_on_boot=not worker,
+        bodies=job_bodies,
     )
-    state.storage = _build_hosted_storage(user_id)
 
-    # Per-user ``matches`` table. The API upserts a row when a match is
-    # opened (see the open path); the worker resolves a queued ``match_id``
-    # through it (it never opened the match locally).
-    match_store = PostgresMatchStore(tenant_factory, user_id=user_id)
-    state.matches_store = match_store
     if worker:
         worker_root = Path(
             os.environ.get(SPLITSMITH_PROJECTS_DIR_ENV, "").strip() or SPLITSMITH_PROJECTS_DIR_DEFAULT
@@ -3335,14 +3477,20 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
         def _resolve_match_for_worker(match_id: str) -> Path | None:
             """Map a queued ``match_id`` to a worker-local working root.
 
-            Returns ``None`` (-> ``MatchNotRegisteredError``, surfaced as a
-            clean job failure) when the match isn't in this user's table --
-            no fallback to the local recent-projects scan, which a separate
-            worker process can't satisfy anyway. The match's metadata +
-            inputs are mirrored down from S3 lazily by the ``state``
-            accessors once ``current_match_root`` points here.
+            Reads the job's tenant ``matches_store`` (``current_tenant`` is
+            pinned by the queue task before ``run_job``), so resolution is
+            scoped to the job's owner. Returns ``None`` (->
+            ``MatchNotRegisteredError``, surfaced as a clean job failure)
+            when the match isn't in that user's table -- no fallback to the
+            local recent-projects scan, which a separate worker process
+            can't satisfy anyway. The match's metadata + inputs are mirrored
+            down from S3 lazily by the ``state`` accessors once
+            ``current_match_root`` points here.
             """
-            row = asyncio.run(match_store.get(match_id))
+            store = state.matches_store
+            if store is None:
+                return None
+            row = asyncio.run(store.get(match_id))
             if row is None:
                 return None
             root = worker_root / match_id
@@ -3371,26 +3519,30 @@ def build_worker_state() -> AppState:
     return state
 
 
-def _build_hosted_storage(user_id: str) -> Storage | None:
-    """Construct the per-user :class:`S3Storage` from ``SPLITSMITH_S3_*``
-    env vars, or return ``None`` if the bucket is unset.
+def _build_hosted_s3_client() -> tuple[Any, str | None]:
+    """Build the process-level S3 client + bucket from ``SPLITSMITH_S3_*``,
+    or ``(None, None)`` if the bucket is unset.
 
-    Hosted mode without S3 wiring is a valid configuration -- a
-    developer iterating on the Postgres-backed stores doesn't need
-    MinIO running just to hit ``/api/me/recent-projects``. The
-    upload endpoint guards on ``state.storage is None`` and returns
-    a 503 in that case, so the contract is "set the bucket to get
-    upload support, leave it unset to disable that surface".
+    Built once at hosted-mode wiring and shared across tenants -- a boto3
+    client is thread-safe for calls and stateless w.r.t. the tenant (the
+    per-user isolation is purely the key prefix, applied per request by
+    :func:`_tenant_s3_storage`). Constructing a client per request would
+    add tens of milliseconds (boto3 parses service models on creation) to
+    every ``/api/*`` call.
 
-    When the bucket *is* set, the rest of the credentials must be
-    present too -- a half-configured S3 wiring would crash on the
-    first request, which is worse than failing loud at boot.
+    Hosted mode without S3 wiring is a valid configuration -- a developer
+    iterating on the Postgres-backed stores doesn't need MinIO running
+    just to hit ``/api/me/recent-projects``. The upload endpoint guards on
+    ``state.storage is None`` and returns a 503, so the contract is "set
+    the bucket to get upload support, leave it unset to disable it".
+
+    When the bucket *is* set, the rest of the credentials must be present
+    too -- a half-configured S3 wiring would crash on the first request,
+    which is worse than failing loud at boot.
     """
-    from ..storage import S3Storage
-
     bucket = os.environ.get(SPLITSMITH_S3_BUCKET_ENV, "").strip()
     if not bucket:
-        return None
+        return None, None
     endpoint = os.environ.get(SPLITSMITH_S3_ENDPOINT_URL_ENV, "").strip() or None
     region = os.environ.get(SPLITSMITH_S3_REGION_ENV, "").strip() or "auto"
     access_key = os.environ.get(SPLITSMITH_S3_ACCESS_KEY_ID_ENV, "").strip()
@@ -3411,10 +3563,22 @@ def _build_hosted_storage(user_id: str) -> Storage | None:
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
     )
-    # Per-user prefix is the multi-tenant isolation boundary: every
-    # caller gets their own ``users/<id>/`` namespace and can't
-    # construct a key that escapes it (the path-traversal guard
-    # inside ``S3Storage._key`` enforces this).
+    return client, bucket
+
+
+def _tenant_s3_storage(client: Any, bucket: str | None, user_id: str) -> Storage | None:
+    """Wrap the shared S3 client in a per-user :class:`S3Storage`, or
+    ``None`` when S3 is unconfigured.
+
+    The per-user prefix is the multi-tenant isolation boundary: every
+    caller gets their own ``users/<id>/`` namespace and can't construct a
+    key that escapes it (the path-traversal guard inside ``S3Storage._key``
+    enforces this). Cheap -- it only wraps an already-built client.
+    """
+    if client is None or bucket is None:
+        return None
+    from ..storage import S3Storage
+
     return S3Storage(bucket=bucket, prefix=f"users/{user_id}/", client=client)
 
 
@@ -3503,11 +3667,20 @@ def create_app(
     #
     # All job bodies register here, after any hosted-mode backend swap
     # above, so ``submit(kind=...)`` resolves against whichever backend is
-    # bound. Must precede the prefetch submit below, which fires
-    # ``model_download`` during create_app itself. ``register_job_bodies``
-    # is shared with the Procrastinate worker bootstrap.
+    # bound. In hosted mode ``state.jobs`` (no ``current_tenant`` at boot)
+    # falls back to the backing backend that holds the shared body
+    # registry, so every per-request backend resolves these kinds. Must
+    # precede the prefetch submit below. ``register_job_bodies`` is shared
+    # with the Procrastinate worker bootstrap.
     register_job_bodies(state)
-    asyncio.run(_maybe_submit_model_download(state))
+    # The slim-ONNX prefetch is a local-mode convenience: it submits a
+    # ``model_download`` job when artifacts are missing. Hosted mode bakes
+    # the slim models into the image (nothing to fetch) and has no boot
+    # tenant to own the job -- model prefetch is a process concern, not a
+    # per-user one -- so skip it there entirely rather than route an
+    # ownerless job through the per-tenant ``state.jobs`` property.
+    if not _hosted_mode_active():
+        asyncio.run(_maybe_submit_model_download(state))
 
     async def get_current_user(request: Request) -> User:
         """FastAPI dependency: resolve the operator behind a request.
@@ -3607,6 +3780,16 @@ def create_app(
     # the feature flag the SPA reads on mount (both are needed before a
     # user is established) plus ``/api/shutdown`` (which has its own
     # loopback gate that's stricter than auth).
+    #
+    # In hosted mode this gate also pins ``current_tenant`` for the
+    # resolved user before the handler runs, so the per-user ``AppState``
+    # store properties resolve to that user's Postgres/S3 stores. The set
+    # happens *before* ``call_next`` (same forward-propagation contract the
+    # ``_match_id_alias`` middleware relies on) and is reset in ``finally``.
+    # Local mode leaves it unset -- there is one operator and the
+    # properties fall back to the process singletons.
+    hosted = _hosted_mode_active()
+
     @app.middleware("http")
     async def _auth_gate(request, call_next):
         path = request.url.path
@@ -3620,7 +3803,13 @@ def create_app(
                 status_code=401,
                 content={"detail": "not authenticated"},
             )
-        return await call_next(request)
+        if not hosted:
+            return await call_next(request)
+        tenant_token = current_tenant.set(state.build_tenant(user.id))
+        try:
+            return await call_next(request)
+        finally:
+            current_tenant.reset(tenant_token)
 
     # ----------------------------------------------------------------------
     # API

--- a/tests/test_hosted_mode_boot.py
+++ b/tests/test_hosted_mode_boot.py
@@ -101,30 +101,82 @@ def test_hosted_loopback_auth_bootstraps_a_user_row(hosted_db: str) -> None:
     assert asyncio.run(_count_rows()) == 1
 
 
-def test_create_app_swaps_in_postgres_backends(hosted_db: str) -> None:
-    """``create_app`` under ``SPLITSMITH_MODE=hosted`` must replace
-    the local-mode default stores on AppState with Postgres-backed
-    impls, all bound to the same user id."""
+def test_create_app_builds_postgres_tenant_per_user(hosted_db: str) -> None:
+    """``create_app`` under ``SPLITSMITH_MODE=hosted`` installs a tenant
+    factory that builds Postgres-backed stores bound to a given user id.
+
+    Stores are resolved per request (via ``current_tenant``) rather than
+    bound to one user at boot, so the assertion is on ``build_tenant`` --
+    every store in the returned context talks to the requested user."""
     from splitsmith.ui.server import create_app
 
     app = create_app()
     state = app.state.splitsmith_state
 
     assert isinstance(state.auth, HostedLoopbackAuth)
-    assert isinstance(state.recent_projects, PostgresRecentProjectsStore)
-    assert isinstance(state.scoreboard_identity, PostgresScoreboardIdentityStore)
-    assert isinstance(state.jobs, PostgresJobBackend)
+
+    uid = state.auth.user_id
+    tenant = state.build_tenant(uid)
+    assert isinstance(tenant.recent_projects, PostgresRecentProjectsStore)
+    assert isinstance(tenant.scoreboard_identity, PostgresScoreboardIdentityStore)
+    assert isinstance(tenant.jobs, PostgresJobBackend)
     # No S3 env vars set in this fixture -> storage stays unwired.
+    assert tenant.storage is None
+
+    # Probe the private attr so the test fails loudly if a future refactor
+    # renames it -- the invariant is that every store in a tenant context
+    # talks to that tenant's user, not the exact attr name.
+    assert tenant.recent_projects._user_id == uid
+    assert tenant.scoreboard_identity._user_id == uid
+    assert tenant.jobs._user_id == uid
+
+    # With no request in flight (no ``current_tenant`` pinned), the
+    # per-user properties fall back to the local-mode singletons. The
+    # hosted wiring never binds them, so ``storage`` reads back as None.
     assert state.storage is None
 
-    expected_uid = state.auth.user_id
-    # Probe the private attr so the test fails loudly if a future
-    # refactor renames it -- the invariant we want to lock down is
-    # that every store talks to the same user, not the exact attr
-    # name.
-    assert state.recent_projects._user_id == expected_uid
-    assert state.scoreboard_identity._user_id == expected_uid
-    assert state.jobs._user_id == expected_uid
+
+def test_per_user_properties_resolve_through_current_tenant(hosted_db: str) -> None:
+    """The seam itself: ``state.jobs`` / ``recent_projects`` /
+    ``scoreboard_identity`` / ``matches_store`` resolve to whichever
+    tenant is pinned in ``current_tenant``, and fall back to the local
+    singleton when none is. Two different tenants must resolve to stores
+    bound to two different user ids through the *same* AppState -- this is
+    what lets one process serve concurrent users without leaking across
+    them once MagicLinkAuth lands."""
+    from splitsmith.ui.server import create_app, current_tenant
+
+    app = create_app()
+    state = app.state.splitsmith_state
+
+    # No tenant pinned -> the backing slot. In hosted mode that's the
+    # boot backend (Postgres, holds the shared body registry + ran the
+    # restart sweep), not a per-request one.
+    assert current_tenant.get() is None
+    assert isinstance(state.jobs, PostgresJobBackend)
+
+    tenant_a = state.build_tenant("user-a")
+    tenant_b = state.build_tenant("user-b")
+
+    token = current_tenant.set(tenant_a)
+    try:
+        assert state.jobs._user_id == "user-a"
+        assert state.recent_projects._user_id == "user-a"
+        assert state.scoreboard_identity._user_id == "user-a"
+        assert state.matches_store._user_id == "user-a"
+    finally:
+        current_tenant.reset(token)
+
+    token = current_tenant.set(tenant_b)
+    try:
+        assert state.jobs._user_id == "user-b"
+        assert state.recent_projects._user_id == "user-b"
+    finally:
+        current_tenant.reset(token)
+
+    # The shared body registry is the same object across tenants (the
+    # kind -> body mapping is a process constant, not per-user).
+    assert tenant_a.jobs.bodies is tenant_b.jobs.bodies
 
 
 def test_hosted_storage_wired_when_bucket_env_set(
@@ -151,11 +203,12 @@ def test_hosted_storage_wired_when_bucket_env_set(
 
     with mock_aws():
         app = create_app()
-    state = app.state.splitsmith_state
+        state = app.state.splitsmith_state
+        storage = state.build_tenant(state.auth.user_id).storage
 
-    assert isinstance(state.storage, S3Storage)
-    assert state.storage.bucket == "splitsmith-test"
-    assert state.storage.prefix == f"users/{state.auth.user_id}/"
+    assert isinstance(storage, S3Storage)
+    assert storage.bucket == "splitsmith-test"
+    assert storage.prefix == f"users/{state.auth.user_id}/"
 
 
 def test_hosted_storage_misconfig_bucket_without_creds_fails_loud(
@@ -183,10 +236,11 @@ def test_recent_projects_round_trip_through_hosted_app(hosted_db: str) -> None:
 
     app = create_app()
     state = app.state.splitsmith_state
+    store = state.build_tenant(state.auth.user_id).recent_projects
 
     async def _flow() -> None:
-        await state.recent_projects.record_open(Path("/tmp/hosted-test-match"), "Hosted Test", kind="match")
-        rows = await state.recent_projects.list()
+        await store.record_open(Path("/tmp/hosted-test-match"), "Hosted Test", kind="match")
+        rows = await store.list()
         assert len(rows) == 1
         assert rows[0].name == "Hosted Test"
         assert rows[0].kind == "match"

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -77,10 +77,14 @@ def hosted_db(tmp_path: Path) -> Iterator[str]:
 def hosted_client(hosted_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[TestClient, S3Storage]]:
     """Boot the FastAPI app in hosted mode against a moto bucket.
 
-    Replaces ``_build_hosted_storage`` so the S3Storage instance is
-    constructed with a client bound to the mock S3 backend that's
-    already created the bucket. This avoids the chicken-and-egg of
-    "the wiring needs a bucket to exist before boto3 will GET it".
+    Replaces ``_tenant_s3_storage`` (the per-request wrapper) so each
+    tenant ``S3Storage`` is built with a client bound to the mock S3
+    backend that already created the bucket -- avoiding the chicken-and-
+    egg of "the wiring needs a bucket to exist before boto3 will GET it".
+    Storage is now resolved per request via ``current_tenant`` rather than
+    held on ``AppState``, so the stub captures the constructed instance for
+    the test to assert against (every request rebuilds an equivalent one
+    against the same bucket/prefix/client).
     """
     monkeypatch.setenv("SPLITSMITH_S3_BUCKET", BUCKET)
     monkeypatch.setenv("SPLITSMITH_S3_ENDPOINT_URL", "http://moto")
@@ -94,14 +98,22 @@ def hosted_client(hosted_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[t
 
         from splitsmith.ui import server as server_mod
 
-        def _stub_build_storage(user_id: str) -> S3Storage:
-            return S3Storage(bucket=BUCKET, prefix=f"users/{user_id}/", client=s3)
+        captured: dict[str, S3Storage] = {}
 
-        monkeypatch.setattr(server_mod, "_build_hosted_storage", _stub_build_storage)
+        def _stub_tenant_storage(client: object, bucket: object, user_id: str) -> S3Storage:
+            storage = S3Storage(bucket=BUCKET, prefix=f"users/{user_id}/", client=s3)
+            captured["storage"] = storage
+            return storage
+
+        monkeypatch.setattr(server_mod, "_tenant_s3_storage", _stub_tenant_storage)
 
         app = server_mod.create_app()
         with TestClient(app) as client:
-            yield client, app.state.splitsmith_state.storage
+            # Drive one request so the per-request tenant builds a storage
+            # the test can read back; ``/api/me/raw`` resolves the tenant
+            # without needing a project. Any captured instance is equivalent.
+            client.get("/api/me/recent-projects")
+            yield client, captured["storage"]
 
 
 def test_upload_returns_path_size_sha256(hosted_client) -> None:

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5704,7 +5704,26 @@ def test_create_match_manual_hosted_mode_synthesizes_path(
             return self._user
 
     def _stub_wiring(state):
+        # Stand in for the Postgres wiring: set the stub auth and a tenant
+        # factory backed by local in-memory stores, so the per-request auth
+        # gate can pin a ``current_tenant`` without a real database. The
+        # create-manual flow only needs ``recent_projects`` here (no S3, no
+        # matches table), so the rest are minimal.
         state.auth = _StubAuth()
+        from splitsmith.ui.jobs import JobRegistry
+        from splitsmith.ui.server import TenantContext
+        from splitsmith.user_config import (
+            JsonRecentProjectsStore,
+            JsonScoreboardIdentityStore,
+        )
+
+        state._build_tenant = lambda uid: TenantContext(
+            recent_projects=JsonRecentProjectsStore(),
+            scoreboard_identity=JsonScoreboardIdentityStore(),
+            jobs=JobRegistry(),
+            matches_store=None,
+            storage=None,
+        )
 
     monkeypatch.setattr(server_mod, "_apply_hosted_mode_wiring", _stub_wiring)
 


### PR DESCRIPTION
## What

The structural half of the auth swap: make hosted-mode per-user stores resolve **per request** (API) and **per job** (worker) instead of binding to one user at boot, so one process can serve distinct users without leaking across them.

Ships under the existing `HostedLoopbackAuth` -- still one user, so this is a **pure refactor with no behavior change**. `MagicLinkAuth` flips the switch in PR2.

## Why now

RLS (#450) is invisible until a second user exists. The auth swap is what creates that user -- but `MagicLinkAuth` cannot land on top of singleton stores (a singleton bound to user A would serve B's request with A's RLS GUC -> cross-tenant leak). So the per-request/per-job seam is mandatory and lands first, de-risked from the new auth surface.

## How

- **`AppState`**: the five per-user slots (`jobs`, `recent_projects`, `scoreboard_identity`, `matches_store`, `storage`) become properties resolving through a new `current_tenant` ContextVar, falling back to the local singleton when none is pinned. Mirrors how `match_root` reads `current_match_root`. Setters preserved -> local/test injection and the ~69 handlers are untouched.
- **`_apply_hosted_mode_wiring`**: no longer boot-binds stores to one user; installs `AppState.build_tenant(user_id)` building a `TenantContext` per call. Engine, session factory, deferrer, S3 client, and the job-body registry are process-level and shared; only tenant-scoped stores are per-call.
- **Auth gate**: pins `current_tenant` for the resolved user before `call_next` (forward-propagation, like the match-id alias middleware).
- **Worker**: `run_compute_job` takes `user_id` **strictly** (no fallback to the `user-<id>` queue name) and builds the job's tenant before `run_job`; `to_thread` copies the context so the RLS GUC + per-user S3 prefix follow the body onto the worker thread. The per-job match resolver is user-scoped.
- **Perf**: split `_build_hosted_storage` into a process-level boto3 client builder + a cheap per-user `S3Storage` wrapper, so we don't construct a boto3 client on every `/api/*` request.
- `PostgresJobBackend` accepts a shared `bodies` registry so per-request backends resolve kinds without re-registration.
- Hosted mode skips the model-download prefetch (ownerless infra; the image bakes models in) so boot never touches the per-tenant jobs slot.

## Tests / gates

- 1614 unit passed; new `test_per_user_properties_resolve_through_current_tenant` proves two tenants resolve to stores bound to two user ids through the same `AppState`.
- `ruff` + `black` clean.
- `pytest -m docker` 7 passed -- the worker compute-job and cross-process match-resolution smoke tests now exercise the per-job tenant build + `user_id` task arg against live Postgres.

## Follow-ups before PR2 makes a 2nd user real

1. **Match-registry ownership check (security)**: the in-memory `MatchRegistry` backing `/api/matches/{id}/` is process-global, keyed by ULID, and not gated by the RLS `matches_store`. With two users, B could resolve A's match path. Harmless today (one user). Planned for PR2/PR1.5.
2. **Multi-tenant restart sweep**: PR1 keeps a one-shot boot sweep for the loopback user only; an all-users sweep can't enumerate users per-request and needs a maintenance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)