### PR TITLE
feat(saas): in-house magic-link auth domain (auth-swap PR2a)

### DIFF
--- a/alembic/versions/c3f1a8e90d24_create_magic_link_tokens_and_sessions.py
+++ b/alembic/versions/c3f1a8e90d24_create_magic_link_tokens_and_sessions.py
@@ -1,0 +1,112 @@
+"""create magic_link_tokens and sessions tables
+
+The two tables the in-house magic-link auth backend
+(``splitsmith.db.magic_link.MagicLinkAuth``) needs:
+
+- ``magic_link_tokens`` -- one row per issued passwordless login
+  challenge. Stores the SHA-256 hash of the emailed token (never the raw
+  value), a 15-minute expiry, and a single-use ``consumed_at`` latch.
+- ``sessions`` -- one row per authenticated browser session. Stores the
+  SHA-256 hash of the cookie's session secret, the owning ``user_id``, a
+  30-day sliding ``expires_at``, and last-used / UA / IP metadata.
+
+Neither table is placed under Row-Level Security. Both are auth
+infrastructure resolved *before* any ``app.user_id`` GUC exists (you can't
+set the GUC until you've identified the user, which is what these tables
+do), exactly the reasoning that keeps ``users`` out of RLS. Isolation for
+``sessions`` is the ``user_id`` FK + the unguessable ``token_hash`` lookup.
+
+Revision ID: c3f1a8e90d24
+Revises: a7c4e9d21b06
+Create Date: 2026-05-30 09:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3f1a8e90d24"
+down_revision: str | Sequence[str] | None = "a7c4e9d21b06"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "magic_link_tokens",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_email"),
+        "magic_link_tokens",
+        ["email"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_token_hash"),
+        "magic_link_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_used_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("ip", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_sessions_token_hash"),
+        "sessions",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_sessions_user_id"),
+        "sessions",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_sessions_user_id"), table_name="sessions")
+    op.drop_index(op.f("ix_sessions_token_hash"), table_name="sessions")
+    op.drop_table("sessions")
+    op.drop_index(op.f("ix_magic_link_tokens_token_hash"), table_name="magic_link_tokens")
+    op.drop_index(op.f("ix_magic_link_tokens_email"), table_name="magic_link_tokens")
+    op.drop_table("magic_link_tokens")

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -22,25 +22,52 @@ this DB layer internally without leaking SQL into handler code.
 """
 
 from .auth import HOSTED_LOOPBACK_EMAIL, HostedLoopbackAuth
+from .email import ConsoleEmailSender, EmailSender, build_email_sender
 from .engine import create_engine, sessionmaker, tenant_session_factory
 from .job_backend import PostgresJobBackend
+from .magic_link import (
+    SESSION_COOKIE_NAME,
+    InvalidMagicLinkError,
+    IssuedSession,
+    LoginChallenge,
+    MagicLinkAuth,
+)
 from .matches import PostgresMatchStore
-from .models import Base, ComputeJobRow, MatchRow, RecentProjectRow, User, new_ulid
+from .models import (
+    Base,
+    ComputeJobRow,
+    MagicLinkTokenRow,
+    MatchRow,
+    RecentProjectRow,
+    SessionRow,
+    User,
+    new_ulid,
+)
 from .recent_projects import PostgresRecentProjectsStore
 from .scoreboard_identity import PostgresScoreboardIdentityStore
 
 __all__ = [
     "Base",
     "ComputeJobRow",
+    "ConsoleEmailSender",
+    "EmailSender",
     "HOSTED_LOOPBACK_EMAIL",
     "HostedLoopbackAuth",
+    "InvalidMagicLinkError",
+    "IssuedSession",
+    "LoginChallenge",
+    "MagicLinkAuth",
+    "MagicLinkTokenRow",
     "MatchRow",
     "PostgresJobBackend",
     "PostgresMatchStore",
     "PostgresRecentProjectsStore",
     "PostgresScoreboardIdentityStore",
     "RecentProjectRow",
+    "SESSION_COOKIE_NAME",
+    "SessionRow",
     "User",
+    "build_email_sender",
     "create_engine",
     "new_ulid",
     "sessionmaker",

--- a/src/splitsmith/db/email.py
+++ b/src/splitsmith/db/email.py
@@ -1,0 +1,79 @@
+"""Pluggable e-mail transport for magic-link delivery.
+
+The auth backend (:class:`splitsmith.db.magic_link.MagicLinkAuth`) does
+not know how mail is sent -- it builds the magic-link URL and hands it to
+an :class:`EmailSender`. That keeps the deployment-specific transport out
+of the auth logic and lets the two deployments that must stay viable use
+different transports without touching the backend:
+
+- **docker-compose / self-host** (no mail credentials): the default
+  :class:`ConsoleEmailSender` logs the link. ``docker compose up`` works
+  with zero external configuration, and the smoke test reads the link
+  back from the container logs.
+- **production hosted**: an HTTP sender (Resend / Postmark / ...) selected
+  by ``SPLITSMITH_EMAIL_BACKEND``. Not implemented here -- it lands when
+  the provider is picked; :func:`build_email_sender` fails loud for any
+  backend other than ``console`` so a misconfigured prod deploy can't
+  silently drop sign-in mail.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+# Env var selecting the transport. Unset -> console (the dev / self-host
+# default). Any recognised provider name selects its HTTP sender.
+SPLITSMITH_EMAIL_BACKEND_ENV = "SPLITSMITH_EMAIL_BACKEND"
+
+# Marker the console transport prefixes each link with, so log scrapers
+# (the docker smoke's login dance) can pull the URL back out reliably.
+CONSOLE_MAGIC_LINK_MARKER = "MAGIC_LINK"
+
+
+class EmailSender(Protocol):
+    async def send_magic_link(self, *, to: str, link: str) -> None:
+        """Deliver a magic-link sign-in URL to ``to``.
+
+        Implementations must not raise on a merely-unknown recipient --
+        sign-in must not leak whether an address has an account. A genuine
+        transport failure (provider down) may raise; the caller decides
+        how to surface it.
+        """
+
+
+class ConsoleEmailSender:
+    """Logs the magic link instead of sending mail.
+
+    The transport for docker-compose dev and credential-less self-host.
+    Emits one parseable ``MAGIC_LINK <to> <link>`` line at INFO so the
+    operator (or the docker smoke test) can copy the URL from the logs.
+    Never sends anything off-box -- safe to leave wired in any deployment
+    that hasn't configured a real provider.
+    """
+
+    async def send_magic_link(self, *, to: str, link: str) -> None:
+        logger.info("%s %s %s", CONSOLE_MAGIC_LINK_MARKER, to, link)
+
+
+def build_email_sender(backend: str | None) -> EmailSender:
+    """Resolve the :class:`EmailSender` for ``backend`` (the value of
+    ``SPLITSMITH_EMAIL_BACKEND``).
+
+    ``None`` / ``""`` / ``"console"`` -> :class:`ConsoleEmailSender`. Any
+    other value raises: a real provider HTTP sender is not implemented yet,
+    and falling back to console in production would silently swallow
+    sign-in mail. When a provider is chosen, add its branch here.
+    """
+    name = (backend or "console").strip().lower()
+    if name == "console":
+        return ConsoleEmailSender()
+    raise RuntimeError(
+        f"{SPLITSMITH_EMAIL_BACKEND_ENV}={backend!r} is not supported. "
+        "Only 'console' is implemented today; a production HTTP sender "
+        "(Resend / Postmark) lands when the provider is picked. Set "
+        f"{SPLITSMITH_EMAIL_BACKEND_ENV}=console (or leave it unset) for "
+        "docker-compose / self-host."
+    )

--- a/src/splitsmith/db/magic_link.py
+++ b/src/splitsmith/db/magic_link.py
@@ -1,0 +1,277 @@
+"""In-house passwordless (magic-link) auth backend.
+
+The hosted-mode replacement for :class:`splitsmith.db.auth.HostedLoopbackAuth`:
+real, distinct per-user accounts created on first sign-in. We own the
+whole flow (no auth vendor) so self-host stays viable and the dependency
+list stays small -- doc 02 already wanted sessions in Postgres, so owning
+tokens + sessions too is consistent.
+
+Flow (doc 02):
+
+1. ``begin_login(email)`` mints a high-entropy token, stores only its
+   SHA-256 hash with a 15-minute expiry, and e-mails a link carrying the
+   raw token via the injected :class:`EmailSender`.
+2. The user clicks the link; the callback route calls
+   ``complete_login(token)``, which verifies the token is unexpired +
+   unconsumed, marks it single-use, upserts the ``users`` row (first
+   sign-in creates the account), and issues a 30-day session.
+3. The browser carries the session secret in an httpOnly cookie;
+   ``authenticate_request`` hashes it, resolves the session, and returns
+   the :class:`User`.
+
+Security choices: tokens and session secrets are 256-bit
+``secrets.token_urlsafe`` values; only their SHA-256 hashes are persisted,
+so a database leak yields no usable links or cookies. Token redemption and
+session lookup are constant-work indexed point lookups on the hash.
+
+This backend talks to ``users`` / ``magic_link_tokens`` / ``sessions`` --
+none of which are under RLS, because identity must be resolved before the
+``app.user_id`` GUC the per-tenant stores key on can exist. It therefore
+holds the **raw** (non-tenant) session factory, same as HostedLoopbackAuth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from fastapi import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from ..auth import User
+from .email import EmailSender
+from .models import MagicLinkTokenRow, SessionRow
+from .models import User as UserRow
+
+# Cookie the browser carries the raw session secret in. httpOnly + Secure
+# + SameSite=Lax are set by the route when it writes the cookie (doc 02);
+# this module only needs the name to read it back.
+SESSION_COOKIE_NAME = "splitsmith_session"
+
+# Token / session lifetimes (doc 02).
+MAGIC_LINK_TTL = timedelta(minutes=15)
+SESSION_TTL = timedelta(days=30)
+# Sliding-expiry throttle: only bump ``last_used_at`` / ``expires_at`` when
+# the session hasn't been touched for this long, so a busy session doesn't
+# incur a write on every request.
+SESSION_TOUCH_INTERVAL = timedelta(hours=1)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _hash(secret: str) -> str:
+    """SHA-256 hex of a raw token / session secret. The only form that
+    ever touches the database."""
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+class InvalidMagicLinkError(Exception):
+    """A presented magic-link token is unknown, expired, or already used.
+
+    Carries a coarse ``reason`` for logging/telemetry; the route maps all
+    cases to one generic 400 so it never reveals which links exist.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class LoginChallenge:
+    """Handle returned by :meth:`MagicLinkAuth.begin_login`. The raw token
+    is **not** here -- it only exists in the e-mailed link."""
+
+    id: str
+    email: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class IssuedSession:
+    """Result of a successful :meth:`MagicLinkAuth.complete_login`.
+
+    ``secret`` is the raw value the route writes into the session cookie;
+    it is never persisted (only its hash is). ``user`` is the resolved
+    account; ``expires_at`` drives the cookie's Max-Age.
+    """
+
+    secret: str
+    expires_at: datetime
+    user: User
+
+
+class MagicLinkAuth:
+    """Passwordless auth backend backed by Postgres (doc 02)."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker,
+        email_sender: EmailSender,
+        *,
+        now: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        # Raw (non-tenant) factory: this backend writes users / sessions /
+        # magic_link_tokens, none under RLS, and runs before any GUC.
+        self._session_factory = session_factory
+        self._email = email_sender
+        self._now = now
+
+    # ------------------------------------------------------------------
+    # Sign-in flow
+    # ------------------------------------------------------------------
+
+    async def begin_login(self, email: str, *, base_url: str) -> LoginChallenge:
+        """Mint + e-mail a magic link for ``email`` and return its handle.
+
+        ``base_url`` is the public origin the callback lives under (e.g.
+        ``https://splitsmith.app``); the caller supplies it from config or
+        the request so this backend stays decoupled from the web layer. We
+        send the link regardless of whether ``email`` has an account -- the
+        account is created on redemption, and not revealing account
+        existence is deliberate.
+        """
+        normalized = _normalize_email(email)
+        token = secrets.token_urlsafe(32)
+        now = self._now()
+        row = MagicLinkTokenRow(
+            email=normalized,
+            token_hash=_hash(token),
+            expires_at=now + MAGIC_LINK_TTL,
+        )
+        async with self._session_factory() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            challenge = LoginChallenge(id=row.id, email=normalized, expires_at=row.expires_at)
+
+        link = f"{base_url.rstrip('/')}/auth/callback?token={token}"
+        await self._email.send_magic_link(to=normalized, link=link)
+        return challenge
+
+    async def complete_login(
+        self,
+        token: str,
+        *,
+        user_agent: str | None = None,
+        ip: str | None = None,
+    ) -> IssuedSession:
+        """Redeem ``token``: verify it, mark it single-use, upsert the user,
+        and issue a session. Raises :class:`InvalidMagicLinkError` if the
+        token is unknown / expired / already consumed."""
+        token_hash = _hash(token)
+        now = self._now()
+        async with self._session_factory() as session:
+            link_row = (
+                await session.execute(
+                    select(MagicLinkTokenRow).where(MagicLinkTokenRow.token_hash == token_hash)
+                )
+            ).scalar_one_or_none()
+            if link_row is None:
+                raise InvalidMagicLinkError("not_found")
+            if link_row.consumed_at is not None:
+                raise InvalidMagicLinkError("consumed")
+            if _aware(link_row.expires_at) < now:
+                raise InvalidMagicLinkError("expired")
+
+            # Single-use: stamp before issuing so a concurrent second
+            # redemption of the same token loses the race on commit.
+            link_row.consumed_at = now
+
+            user_row = (
+                await session.execute(select(UserRow).where(UserRow.email == link_row.email))
+            ).scalar_one_or_none()
+            if user_row is None:
+                user_row = UserRow(email=link_row.email, email_verified_at=now)
+                session.add(user_row)
+                await session.flush()
+            elif user_row.email_verified_at is None:
+                user_row.email_verified_at = now
+
+            secret = secrets.token_urlsafe(32)
+            session_row = SessionRow(
+                token_hash=_hash(secret),
+                user_id=user_row.id,
+                expires_at=now + SESSION_TTL,
+                last_used_at=now,
+                user_agent=user_agent,
+                ip=ip,
+            )
+            session.add(session_row)
+            await session.commit()
+            user = User(id=user_row.id, email=user_row.email, display_name=user_row.display_name)
+            expires_at = now + SESSION_TTL
+
+        return IssuedSession(secret=secret, expires_at=expires_at, user=user)
+
+    # ------------------------------------------------------------------
+    # Per-request resolution
+    # ------------------------------------------------------------------
+
+    async def authenticate_request(self, request: Request) -> User | None:
+        """Resolve the session cookie to a :class:`User`, or ``None``.
+
+        ``None`` (anonymous) is returned for a missing / unknown / expired
+        cookie and for a soft-deleted account; the auth gate turns that
+        into a 401. Extends the session's sliding expiry lazily.
+        """
+        cookie = request.cookies.get(SESSION_COOKIE_NAME)
+        if not cookie:
+            return None
+        token_hash = _hash(cookie)
+        now = self._now()
+        async with self._session_factory() as session:
+            session_row = (
+                await session.execute(select(SessionRow).where(SessionRow.token_hash == token_hash))
+            ).scalar_one_or_none()
+            if session_row is None:
+                return None
+            if _aware(session_row.expires_at) < now:
+                return None
+            user_row = (
+                await session.execute(select(UserRow).where(UserRow.id == session_row.user_id))
+            ).scalar_one_or_none()
+            if user_row is None or user_row.deleted_at is not None:
+                return None
+
+            # Sliding expiry, throttled so a busy session isn't a write per
+            # request.
+            if now - _aware(session_row.last_used_at) > SESSION_TOUCH_INTERVAL:
+                session_row.last_used_at = now
+                session_row.expires_at = now + SESSION_TTL
+                await session.commit()
+
+            return User(id=user_row.id, email=user_row.email, display_name=user_row.display_name)
+
+    async def end_session(self, session_secret: str) -> None:
+        """Revoke the session identified by ``session_secret`` (logout).
+
+        Idempotent: an unknown / already-revoked secret is a no-op.
+        """
+        token_hash = _hash(session_secret)
+        async with self._session_factory() as session:
+            session_row = (
+                await session.execute(select(SessionRow).where(SessionRow.token_hash == token_hash))
+            ).scalar_one_or_none()
+            if session_row is None:
+                return
+            await session.delete(session_row)
+            await session.commit()
+
+
+def _aware(value: datetime) -> datetime:
+    """Coerce a possibly-naive timestamp (SQLite drops tzinfo) to UTC-aware
+    so comparisons against :func:`_utcnow` don't raise."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/src/splitsmith/db/magic_link.py
+++ b/src/splitsmith/db/magic_link.py
@@ -39,7 +39,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from fastapi import Request
-from sqlalchemy import select
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from ..auth import User
@@ -179,22 +180,47 @@ class MagicLinkAuth:
             ).scalar_one_or_none()
             if link_row is None:
                 raise InvalidMagicLinkError("not_found")
-            if link_row.consumed_at is not None:
-                raise InvalidMagicLinkError("consumed")
             if _aware(link_row.expires_at) < now:
                 raise InvalidMagicLinkError("expired")
 
-            # Single-use: stamp before issuing so a concurrent second
-            # redemption of the same token loses the race on commit.
-            link_row.consumed_at = now
+            # Single-use, race-safe: stamp ``consumed_at`` with a conditional
+            # UPDATE guarded on it still being NULL, rather than the read-then-
+            # write above. Two concurrent redemptions of the same token (an
+            # e-mail security scanner prefetching the link, then the user
+            # clicking it, is a real vector) both pass the read checks; the DB
+            # serialises the UPDATEs on the row lock, so exactly one flips
+            # NULL -> now and the other matches zero rows. Without this, both
+            # could mint a session from one link.
+            consumed = await session.execute(
+                update(MagicLinkTokenRow)
+                .where(
+                    MagicLinkTokenRow.token_hash == token_hash,
+                    MagicLinkTokenRow.consumed_at.is_(None),
+                )
+                .values(consumed_at=now)
+            )
+            if consumed.rowcount == 0:
+                raise InvalidMagicLinkError("consumed")
 
             user_row = (
                 await session.execute(select(UserRow).where(UserRow.email == link_row.email))
             ).scalar_one_or_none()
             if user_row is None:
-                user_row = UserRow(email=link_row.email, email_verified_at=now)
-                session.add(user_row)
-                await session.flush()
+                # First sign-in creates the account. Guard the insert in a
+                # savepoint: two concurrent first logins for the same new
+                # email both see None here, and the loser's INSERT hits the
+                # ``users.email`` unique constraint. Catch it, roll back just
+                # the savepoint (the consumed-token UPDATE survives), and
+                # re-select the row the winner committed.
+                try:
+                    async with session.begin_nested():
+                        user_row = UserRow(email=link_row.email, email_verified_at=now)
+                        session.add(user_row)
+                        await session.flush()
+                except IntegrityError:
+                    user_row = (
+                        await session.execute(select(UserRow).where(UserRow.email == link_row.email))
+                    ).scalar_one()
             elif user_row.email_verified_at is None:
                 user_row.email_verified_at = now
 

--- a/src/splitsmith/db/models.py
+++ b/src/splitsmith/db/models.py
@@ -114,6 +114,95 @@ class User(Base):
         return f"<User id={self.id!r} email={self.email!r}>"
 
 
+class MagicLinkTokenRow(Base):
+    """One row per issued magic-link challenge (doc 02).
+
+    The passwordless login primitive: ``begin_login(email)`` inserts a row
+    with a freshly-minted high-entropy token (we store only its SHA-256
+    hash, never the raw value -- a DB leak must not yield usable links),
+    a 15-minute expiry, and the requested email. ``complete_login(token)``
+    hashes the presented token, finds the row, checks it is unexpired and
+    unconsumed, then stamps ``consumed_at`` so it is single-use.
+
+    The ``email`` is recorded as presented (not necessarily an existing
+    ``users`` row -- first sign-in creates the account on redemption), so
+    this table has **no** FK to ``users`` and is **not** under RLS: it is
+    auth infrastructure resolved before any ``app.user_id`` GUC exists,
+    same reasoning as ``users`` itself.
+    """
+
+    __tablename__ = "magic_link_tokens"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=new_ulid)
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    # SHA-256 hex of the raw token the email link carries. Unique so a
+    # redemption is an indexed point lookup; the raw token never lands here.
+    token_hash: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Single-use latch: set on the first successful redemption. A second
+    # redemption of the same token finds it non-null and is rejected.
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<MagicLinkTokenRow email={self.email!r} consumed={self.consumed_at is not None}>"
+
+
+class SessionRow(Base):
+    """One row per authenticated browser session (doc 02).
+
+    Created on a successful magic-link redemption; the browser carries an
+    httpOnly cookie holding the raw session secret, and we store only its
+    SHA-256 hash (``token_hash``) so the cookie is a bearer capability a DB
+    leak can't reconstruct. ``authenticate_request`` hashes the cookie,
+    looks the row up, and resolves it back to a ``users`` row.
+
+    Sessions live here (not in an auth vendor) so we can list a user's
+    devices, revoke one session without nuking the rest, and hold
+    last-used / UA metadata. 30-day sliding expiry: ``expires_at`` extends
+    on activity (bumped lazily to avoid a write per request).
+
+    Like ``magic_link_tokens`` this is auth infrastructure resolved before
+    any GUC exists, so it is **not** under RLS -- the ``user_id`` FK +
+    ``token_hash`` lookup are the isolation boundary.
+    """
+
+    __tablename__ = "sessions"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=new_ulid)
+    # SHA-256 hex of the raw session secret stored in the cookie.
+    token_hash: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    user_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    last_used_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Stored as text (not a Postgres INET) so the same model builds the
+    # SQLite test schema; the column is metadata for the "your devices"
+    # UI, never queried as a network type.
+    ip: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SessionRow id={self.id!r} user_id={self.user_id!r}>"
+
+
 class RecentProjectRow(Base):
     """One row per (user, project path) the user has opened.
 

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -229,8 +229,9 @@ def test_migrations_applied_against_postgres(hosted_stack: None) -> None:
     proc_funcs = _psql("SELECT count(*) FROM pg_proc WHERE proname LIKE 'procrastinate_%'")
     assert int(proc_funcs) > 0, "procrastinate PL/pgSQL functions missing"
 
-    # Our own tenant tables from the earlier migrations.
-    for table in ("users", "recent_projects", "compute_jobs"):
+    # Our own tenant tables from the earlier migrations + the auth-domain
+    # tables from the magic-link migration (c3f1a8e90d24).
+    for table in ("users", "recent_projects", "compute_jobs", "magic_link_tokens", "sessions"):
         exists = _psql(
             "SELECT count(*) FROM information_schema.tables "
             f"WHERE table_schema='public' AND table_name='{table}'"

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -1,0 +1,324 @@
+"""Unit tests for the in-house magic-link auth backend (doc 02).
+
+SQLite-backed (aiosqlite), in-process -- the same model code that builds
+the Postgres schema. These prove the token + session lifecycle without a
+container; the docker smoke proves the HTTP login dance end to end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from sqlalchemy import select
+
+from splitsmith.db import (
+    Base,
+    MagicLinkAuth,
+    MagicLinkTokenRow,
+    SessionRow,
+    create_engine,
+    sessionmaker,
+)
+from splitsmith.db import (
+    User as UserRow,
+)
+from splitsmith.db.email import (
+    CONSOLE_MAGIC_LINK_MARKER,
+    ConsoleEmailSender,
+    build_email_sender,
+)
+from splitsmith.db.magic_link import (
+    SESSION_COOKIE_NAME,
+    InvalidMagicLinkError,
+    _hash,
+)
+
+BASE_URL = "https://splitsmith.test"
+
+
+class _CapturingSender:
+    """Records the links it would send so a test can redeem them."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    async def send_magic_link(self, *, to: str, link: str) -> None:
+        self.sent.append((to, link))
+
+    def last_token(self) -> str:
+        _, link = self.sent[-1]
+        return parse_qs(urlparse(link).query)["token"][0]
+
+
+class _Clock:
+    """Mutable clock so expiry windows are testable without sleeping."""
+
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now = self.now + delta
+
+
+class _Req:
+    """Minimal stand-in for ``fastapi.Request`` -- the backend only reads
+    ``request.cookies``."""
+
+    def __init__(self, cookies: dict[str, str]) -> None:
+        self.cookies = cookies
+
+
+@pytest.fixture
+def session_factory(tmp_path) -> Iterator[object]:
+    url = f"sqlite+aiosqlite:///{tmp_path / 'auth.sqlite'}"
+    engine = create_engine(url)
+
+    async def _create_all() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create_all())
+    yield sessionmaker(engine)
+
+
+def _auth(session_factory, *, sender=None, clock=None) -> MagicLinkAuth:
+    return MagicLinkAuth(
+        session_factory,
+        sender or _CapturingSender(),
+        now=clock or (lambda: datetime.now(UTC)),
+    )
+
+
+# ----------------------------------------------------------------------
+# begin_login
+# ----------------------------------------------------------------------
+
+
+def test_begin_login_emails_link_and_stores_only_the_hash(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+
+    challenge = asyncio.run(auth.begin_login("Person@Example.COM", base_url=BASE_URL))
+
+    # Email normalised; a link was "sent" to it.
+    assert challenge.email == "person@example.com"
+    assert len(sender.sent) == 1
+    to, link = sender.sent[0]
+    assert to == "person@example.com"
+    assert link.startswith(f"{BASE_URL}/auth/callback?token=")
+
+    raw_token = sender.last_token()
+
+    async def _row() -> MagicLinkTokenRow:
+        async with session_factory() as s:
+            return (
+                await s.execute(select(MagicLinkTokenRow).where(MagicLinkTokenRow.id == challenge.id))
+            ).scalar_one()
+
+    row = asyncio.run(_row())
+    # The raw token is never persisted; only its hash.
+    assert row.token_hash == _hash(raw_token)
+    assert raw_token not in row.token_hash
+    assert row.email == "person@example.com"
+    assert row.consumed_at is None
+
+
+# ----------------------------------------------------------------------
+# complete_login
+# ----------------------------------------------------------------------
+
+
+def test_complete_login_creates_user_and_session(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+    asyncio.run(auth.begin_login("new@example.com", base_url=BASE_URL))
+
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+
+    assert issued.user.email == "new@example.com"
+    assert issued.secret  # raw session secret for the cookie
+
+    async def _check() -> None:
+        async with session_factory() as s:
+            user = (await s.execute(select(UserRow).where(UserRow.email == "new@example.com"))).scalar_one()
+            assert user.email_verified_at is not None
+            sess = (await s.execute(select(SessionRow).where(SessionRow.user_id == user.id))).scalar_one()
+            # Session stores only the hash of the cookie secret.
+            assert sess.token_hash == _hash(issued.secret)
+
+    asyncio.run(_check())
+
+
+def test_complete_login_is_single_use(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+    asyncio.run(auth.begin_login("once@example.com", base_url=BASE_URL))
+    token = sender.last_token()
+
+    asyncio.run(auth.complete_login(token))
+    with pytest.raises(InvalidMagicLinkError) as exc:
+        asyncio.run(auth.complete_login(token))
+    assert exc.value.reason == "consumed"
+
+
+def test_complete_login_rejects_expired_token(session_factory) -> None:
+    sender = _CapturingSender()
+    clock = _Clock(datetime(2026, 5, 30, 12, 0, tzinfo=UTC))
+    auth = _auth(session_factory, sender=sender, clock=clock)
+    asyncio.run(auth.begin_login("slow@example.com", base_url=BASE_URL))
+    token = sender.last_token()
+
+    clock.advance(timedelta(minutes=16))  # past the 15-minute TTL
+    with pytest.raises(InvalidMagicLinkError) as exc:
+        asyncio.run(auth.complete_login(token))
+    assert exc.value.reason == "expired"
+
+
+def test_complete_login_rejects_unknown_token(session_factory) -> None:
+    auth = _auth(session_factory)
+    with pytest.raises(InvalidMagicLinkError) as exc:
+        asyncio.run(auth.complete_login("not-a-real-token"))
+    assert exc.value.reason == "not_found"
+
+
+def test_complete_login_reuses_existing_user(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+
+    asyncio.run(auth.begin_login("repeat@example.com", base_url=BASE_URL))
+    first = asyncio.run(auth.complete_login(sender.last_token()))
+    asyncio.run(auth.begin_login("repeat@example.com", base_url=BASE_URL))
+    second = asyncio.run(auth.complete_login(sender.last_token()))
+
+    assert first.user.id == second.user.id  # same account, second sign-in
+
+    async def _count() -> int:
+        async with session_factory() as s:
+            rows = (
+                (await s.execute(select(UserRow).where(UserRow.email == "repeat@example.com")))
+                .scalars()
+                .all()
+            )
+            return len(rows)
+
+    assert asyncio.run(_count()) == 1
+
+
+# ----------------------------------------------------------------------
+# authenticate_request
+# ----------------------------------------------------------------------
+
+
+def test_authenticate_request_resolves_session_cookie(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+    asyncio.run(auth.begin_login("auth@example.com", base_url=BASE_URL))
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+
+    req = _Req({SESSION_COOKIE_NAME: issued.secret})
+    user = asyncio.run(auth.authenticate_request(req))
+    assert user is not None
+    assert user.id == issued.user.id
+
+
+def test_authenticate_request_anonymous_for_missing_or_unknown_cookie(session_factory) -> None:
+    auth = _auth(session_factory)
+    assert asyncio.run(auth.authenticate_request(_Req({}))) is None
+    assert asyncio.run(auth.authenticate_request(_Req({SESSION_COOKIE_NAME: "bogus"}))) is None
+
+
+def test_authenticate_request_rejects_expired_session(session_factory) -> None:
+    sender = _CapturingSender()
+    clock = _Clock(datetime(2026, 5, 1, 12, 0, tzinfo=UTC))
+    auth = _auth(session_factory, sender=sender, clock=clock)
+    asyncio.run(auth.begin_login("stale@example.com", base_url=BASE_URL))
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+
+    clock.advance(timedelta(days=31))  # past the 30-day session TTL
+    assert asyncio.run(auth.authenticate_request(_Req({SESSION_COOKIE_NAME: issued.secret}))) is None
+
+
+def test_authenticate_request_anonymous_for_soft_deleted_user(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+    asyncio.run(auth.begin_login("gone@example.com", base_url=BASE_URL))
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+
+    async def _soft_delete() -> None:
+        async with session_factory() as s:
+            user = (await s.execute(select(UserRow).where(UserRow.id == issued.user.id))).scalar_one()
+            user.deleted_at = datetime.now(UTC)
+            await s.commit()
+
+    asyncio.run(_soft_delete())
+    assert asyncio.run(auth.authenticate_request(_Req({SESSION_COOKIE_NAME: issued.secret}))) is None
+
+
+def test_session_sliding_expiry_bumps_after_touch_interval(session_factory) -> None:
+    sender = _CapturingSender()
+    clock = _Clock(datetime(2026, 5, 30, 12, 0, tzinfo=UTC))
+    auth = _auth(session_factory, sender=sender, clock=clock)
+    asyncio.run(auth.begin_login("active@example.com", base_url=BASE_URL))
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+
+    async def _expires_at() -> datetime:
+        async with session_factory() as s:
+            row = (
+                await s.execute(select(SessionRow).where(SessionRow.token_hash == _hash(issued.secret)))
+            ).scalar_one()
+            return row.expires_at
+
+    before = asyncio.run(_expires_at())
+    clock.advance(timedelta(hours=2))  # past the 1-hour touch throttle
+    asyncio.run(auth.authenticate_request(_Req({SESSION_COOKIE_NAME: issued.secret})))
+    after = asyncio.run(_expires_at())
+
+    # Compare on naive value (SQLite drops tzinfo) -- the bump is +2h.
+    assert after.replace(tzinfo=None) > before.replace(tzinfo=None)
+
+
+def test_end_session_revokes(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender)
+    asyncio.run(auth.begin_login("bye@example.com", base_url=BASE_URL))
+    issued = asyncio.run(auth.complete_login(sender.last_token()))
+    req = _Req({SESSION_COOKIE_NAME: issued.secret})
+
+    assert asyncio.run(auth.authenticate_request(req)) is not None
+    asyncio.run(auth.end_session(issued.secret))
+    assert asyncio.run(auth.authenticate_request(req)) is None
+    # Idempotent: revoking again is a no-op, not an error.
+    asyncio.run(auth.end_session(issued.secret))
+
+
+# ----------------------------------------------------------------------
+# EmailSender
+# ----------------------------------------------------------------------
+
+
+def test_console_email_sender_logs_parseable_marker(caplog) -> None:
+    sender = ConsoleEmailSender()
+    with caplog.at_level(logging.INFO, logger="splitsmith.db.email"):
+        asyncio.run(sender.send_magic_link(to="x@example.com", link=f"{BASE_URL}/auth/callback?token=abc"))
+    assert CONSOLE_MAGIC_LINK_MARKER in caplog.text
+    assert "x@example.com" in caplog.text
+    assert "token=abc" in caplog.text
+
+
+def test_build_email_sender_defaults_to_console() -> None:
+    assert isinstance(build_email_sender(None), ConsoleEmailSender)
+    assert isinstance(build_email_sender("console"), ConsoleEmailSender)
+    assert isinstance(build_email_sender("CONSOLE"), ConsoleEmailSender)
+
+
+def test_build_email_sender_fails_loud_on_unimplemented_provider() -> None:
+    with pytest.raises(RuntimeError, match="not supported"):
+        build_email_sender("resend")


### PR DESCRIPTION
**Stacked on #451** (per-tenant seam). Review/merge that first.

## What

The backend foundation for replacing `HostedLoopbackAuth` with real per-user accounts: the auth domain + tables + transport, fully unit-tested. **Not wired into the server** -- `HostedLoopbackAuth` stays the active hosted backend until PR2b, so nothing running changes.

## Contents

- **Models** `SessionRow` + `MagicLinkTokenRow`. Both persist only the SHA-256 hash of their secret (the cookie value / emailed token), never the raw -- a DB leak yields no usable links or cookies. Neither is under RLS: like `users`, they are auth infrastructure resolved *before* any `app.user_id` GUC exists.
- **Migration** `c3f1a8e90d24` creates both tables (no RLS). Applies + reverses cleanly through the chain on SQLite; the docker migration smoke now asserts both exist on live Postgres.
- **`db/email.py`** -- pluggable `EmailSender`. `ConsoleEmailSender` (default; logs a parseable `MAGIC_LINK` line) keeps docker-compose / self-host viable with **zero mail credentials**. `build_email_sender` fails loud on any other backend so a misconfigured prod deploy can't silently drop sign-in mail (a real HTTP provider -- Resend/Postmark -- lands when one is picked).
- **`db/magic_link.py`** -- `MagicLinkAuth`: `begin_login` / `complete_login` / `authenticate_request` / `end_session`. 256-bit tokens + session secrets, 15-min single-use links, 30-day sliding sessions (extended lazily to avoid a write per request), first sign-in creates the account, soft-deleted users resolve anonymous.

## Tests / gates

- 1629 unit passed (15 new in `test_magic_link_auth.py` covering issue/redeem, single-use, expiry, unknown token, user reuse, cookie auth, expired/soft-deleted -> anonymous, sliding expiry, logout, console sender, factory).
- `ruff` + `black` clean.
- `pytest -m docker` 7 passed.

## Next (PR2b)

Wire `MagicLinkAuth` into `_apply_hosted_mode_wiring`, add `/api/v1/auth/begin` + `/auth/callback` + logout routes with the httpOnly/Secure/SameSite cookie + CSRF, add the match-registry ownership check (PR1 follow-up #1), retire `HostedLoopbackAuth`, and switch the docker smoke to the real login dance. Then PR2c: SPA login surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)