### PR TITLE
feat(saas): SPA magic-link login surface (auth-swap PR2c)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,11 @@ dev = [
     # ``test_hosted_raw_upload.py``. Dev-only; production never
     # imports moto.
     "moto[s3]>=5.0.0",
+    # Headless-browser driver for UI walkthroughs / screenshots of the
+    # hosted SPA (e.g. the magic-link login flow). Dev-only; needs a
+    # one-time ``uv run playwright install chromium`` to fetch the browser
+    # binary (not vendored in the repo or the wheel).
+    "playwright>=1.60.0",
     # Ensemble sweep analysis (issue #281 follow-up). pyarrow for the
     # signals/runs parquet store, matplotlib for the PNG plot layer.
     # Dev-only: the production API does not read these files.

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   BrowserRouter,
   Navigate,
@@ -12,7 +12,9 @@ import { AppShell } from "@/components/AppShell";
 import { DeveloperShell } from "@/components/developer/DeveloperShell";
 import { MatchShell } from "@/components/match/MatchShell";
 import { ModeProvider } from "@/lib/mode";
+import { AuthProvider, useAuth } from "@/lib/auth";
 import { ShooterScopedRoute } from "@/components/ShooterScopedRoute";
+import { Login } from "@/pages/Login";
 import { Audit } from "@/pages/Audit";
 import { BeepReview } from "@/pages/BeepReview";
 import { Coach } from "@/pages/Coach";
@@ -74,11 +76,44 @@ function LegacyMatchRedirect() {
   return <Navigate to={target} replace />;
 }
 
+/* Auth gate. Blocks the app on the initial ``/api/me`` resolve so an
+ * anonymous hosted visitor never flashes protected chrome, then:
+ *  - ``authed`` (local mode is always authed via the loopback user; hosted
+ *    when the session cookie resolves) -> render the app,
+ *  - ``anon`` (hosted, signed out) -> redirect to /login, except when
+ *    already there.
+ * Local mode never reaches the ``anon`` branch -- ``/api/me`` returns the
+ * loopback user -- so the desktop app sees no login surface. */
+function AuthGate({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+  const location = useLocation();
+  if (status === "loading") {
+    return (
+      <div
+        className="grid min-h-dvh place-items-center bg-bg"
+        role="status"
+        aria-label="Loading"
+      >
+        <span className="font-mono text-xs uppercase tracking-[0.16em] text-subtle">
+          Standby...
+        </span>
+      </div>
+    );
+  }
+  if (status === "anon" && location.pathname !== "/login") {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}
+
 export function App() {
   return (
     <ModeProvider>
-      <BrowserRouter>
-        <Routes>
+      <AuthProvider>
+        <BrowserRouter>
+          <AuthGate>
+            <Routes>
+              <Route path="login" element={<Login />} />
           {/* Picker lives outside any shell -- it has its own header and
               runs whether or not a project is bound. MatchShell redirects
               here when it sees /api/health.bound === false. */}
@@ -160,8 +195,10 @@ export function App() {
               also goes through here so a fresh-bound match lands on its
               own overview without the picker needing to plumb the id. */}
           <Route path="*" element={<LegacyMatchRedirect />} />
-        </Routes>
-      </BrowserRouter>
+            </Routes>
+          </AuthGate>
+        </BrowserRouter>
+      </AuthProvider>
     </ModeProvider>
   );
 }

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -13,6 +13,7 @@ import { DeveloperShell } from "@/components/developer/DeveloperShell";
 import { MatchShell } from "@/components/match/MatchShell";
 import { ModeProvider } from "@/lib/mode";
 import { AuthProvider, useAuth } from "@/lib/auth";
+import { useDeploymentMode } from "@/lib/features";
 import { ShooterScopedRoute } from "@/components/ShooterScopedRoute";
 import { Login } from "@/pages/Login";
 import { Audit } from "@/pages/Audit";
@@ -78,14 +79,17 @@ function LegacyMatchRedirect() {
 
 /* Auth gate. Blocks the app on the initial ``/api/me`` resolve so an
  * anonymous hosted visitor never flashes protected chrome, then:
- *  - ``authed`` (local mode is always authed via the loopback user; hosted
- *    when the session cookie resolves) -> render the app,
+ *  - ``authed`` (hosted, when the session cookie resolves) -> render the app,
  *  - ``anon`` (hosted, signed out) -> redirect to /login, except when
  *    already there.
- * Local mode never reaches the ``anon`` branch -- ``/api/me`` returns the
- * loopback user -- so the desktop app sees no login surface. */
+ * Local mode is NEVER redirected: the login surface is hosted-only, so even
+ * if ``/api/me`` fails for a transient reason in local mode (which would set
+ * status to ``anon``), the desktop user must not be stranded on /login. The
+ * mode check is the hard guarantee; ``/api/me`` returning the loopback user
+ * is the normal-case reason status stays ``authed`` there. */
 function AuthGate({ children }: { children: ReactNode }) {
   const { status } = useAuth();
+  const mode = useDeploymentMode();
   const location = useLocation();
   if (status === "loading") {
     return (
@@ -100,6 +104,8 @@ function AuthGate({ children }: { children: ReactNode }) {
       </div>
     );
   }
+  // Desktop is never gated -- no login route, no redirect, whatever /api/me did.
+  if (mode === "local") return <>{children}</>;
   if (status === "anon" && location.pathname !== "/login") {
     return <Navigate to="/login" replace />;
   }

--- a/src/splitsmith/ui_static/src/components/AccountChip.tsx
+++ b/src/splitsmith/ui_static/src/components/AccountChip.tsx
@@ -27,6 +27,11 @@ export function AccountChip({ className }: { className?: string }) {
     setBusy(true);
     try {
       await logout();
+    } catch {
+      // logout() only flips to anon on a confirmed server revoke; if it
+      // threw, the session is still live and the user stays signed in.
+      // Swallow so it isn't an unhandled rejection -- the button re-enables
+      // (finally) and they can retry.
     } finally {
       setBusy(false);
     }

--- a/src/splitsmith/ui_static/src/components/AccountChip.tsx
+++ b/src/splitsmith/ui_static/src/components/AccountChip.tsx
@@ -1,0 +1,56 @@
+/**
+ * Signed-in account chip + sign-out (auth-swap PR2c).
+ *
+ * Self-gating: renders nothing outside hosted mode or before the account
+ * resolves, so it can be dropped into any shell header and stays invisible
+ * on the desktop app. Shows the account email and a sign-out button that
+ * revokes the session and drops to the login surface (the deployment-mode
+ * gate redirects once the auth status flips to anonymous).
+ */
+
+import * as React from "react";
+import { LogOut } from "lucide-react";
+
+import { IconButton } from "@/components/ui/IconButton";
+import { useDeploymentMode } from "@/lib/features";
+import { useAuth } from "@/lib/auth";
+
+export function AccountChip({ className }: { className?: string }) {
+  const mode = useDeploymentMode();
+  const { status, user, logout } = useAuth();
+  const [busy, setBusy] = React.useState(false);
+
+  // Hosted-only, and only once a real account is resolved.
+  if (mode !== "hosted" || status !== "authed" || !user) return null;
+
+  async function onLogout() {
+    setBusy(true);
+    try {
+      await logout();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-full border border-rule bg-surface-2 py-1 pl-3 pr-1 ${className ?? ""}`}
+    >
+      <span
+        className="max-w-[16rem] truncate text-[0.8125rem] text-ink-2"
+        title={user.email}
+      >
+        {user.display_name ?? user.email}
+      </span>
+      <IconButton
+        variant="subtle"
+        size="sm"
+        label="Sign out"
+        onClick={onLogout}
+        disabled={busy}
+      >
+        <LogOut className="size-3.5" />
+      </IconButton>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -21,6 +21,7 @@ import {
   useParams,
 } from "react-router-dom";
 
+import { AccountChip } from "@/components/AccountChip";
 import { ShooterChipStrip } from "@/components/match/ShooterChipStrip";
 import { Brand, IconButton } from "@/components/ui";
 import {
@@ -363,6 +364,7 @@ export function MatchShell() {
             />
           ) : null}
           <div className="flex-1" />
+          <AccountChip />
           <IconButton variant="subtle" size="md" label="Help">
             <HelpCircle className="size-[18px]" />
           </IconButton>

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1125,6 +1125,16 @@ export interface ServerHealth {
   schema_version: number | null;
 }
 
+/** The authenticated account behind a request. ``GET /api/me`` returns
+ *  this (200) or 401 when unauthenticated. In local mode it is always the
+ *  loopback sentinel (``id === "local"``); in hosted mode it is the
+ *  database user resolved from the session cookie. */
+export interface AuthUser {
+  id: string;
+  email: string;
+  display_name: string | null;
+}
+
 /** Saved SSI Scoreboard identity for the operator. Returned by
  *  ``GET /api/me/scoreboard-identity``; null when nothing is pinned. */
 export interface ScoreboardIdentity {
@@ -1414,6 +1424,13 @@ class ApiError extends Error {
   ) {
     super(`${status}: ${detail}`);
   }
+}
+
+/** True when ``err`` is a 401 from the API -- i.e. the caller is not
+ *  authenticated. The auth context uses this to distinguish "logged out"
+ *  (expected, render the login surface) from a real server error. */
+export function isUnauthorized(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401;
 }
 
 /** Match id parsed from the current URL.
@@ -2061,6 +2078,23 @@ export const api = {
    *    filesystem pickers / project-folder inputs in hosted mode. */
   getServerFeatures: () =>
     request<{ lab: boolean; mode: "local" | "hosted" }>("/api/server/features"),
+
+  /** The authenticated account, or a 401 (caught via ``isUnauthorized``)
+   *  when signed out. Always 200 in local mode (loopback user). */
+  getMe: () => request<AuthUser>("/api/me"),
+
+  /** Hosted mode -- start a magic-link sign-in: the server e-mails a link
+   *  to ``email``. Always 200 (never reveals whether the address has an
+   *  account); the account is created when the link is redeemed. */
+  authBegin: (email: string) =>
+    request<{ ok: true }>("/api/v1/auth/begin", {
+      method: "POST",
+      json: { email },
+    }),
+
+  /** Hosted mode -- revoke the current session + clear the cookie. */
+  authLogout: () =>
+    request<{ ok: true }>("/api/v1/auth/logout", { method: "POST" }),
 
   /** Hosted-mode only -- list the operator's uploaded raw videos.
    *  Empty array (not 404) when nothing has been uploaded yet. The

--- a/src/splitsmith/ui_static/src/lib/auth.tsx
+++ b/src/splitsmith/ui_static/src/lib/auth.tsx
@@ -38,11 +38,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(me);
       setStatus("authed");
     } catch (err) {
-      // 401 is the expected "signed out" path; any other failure also
-      // resolves to anonymous so the login surface (not a broken shell)
-      // is what an unauthenticated visitor sees.
+      // 401 is the genuine "signed out" path. A transport/5xx failure is
+      // NOT proof of being signed out, but on the initial resolve we have
+      // no prior session to preserve, so both fall through to anonymous --
+      // the login surface, not a broken shell. The desktop app is protected
+      // separately: AuthGate never redirects in local mode (see App.tsx),
+      // so a flaky /api/me there can't strand the user on /login.
       if (!isUnauthorized(err)) {
-        // Surface unexpected failures for debugging without blocking render.
         console.warn("auth: /api/me failed", err);
       }
       setUser(null);
@@ -51,12 +53,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const logout = React.useCallback(async () => {
-    try {
-      await api.authLogout();
-    } finally {
-      setUser(null);
-      setStatus("anon");
-    }
+    // Only claim signed-out once the server actually revoked the session.
+    // If authLogout throws (network / 5xx) the cookie is still live, so we
+    // must NOT flip the UI to anonymous -- that would falsely report a
+    // logout on a shared machine. The error propagates so the caller can
+    // reset its busy state; the user stays signed in and can retry.
+    await api.authLogout();
+    setUser(null);
+    setStatus("anon");
   }, []);
 
   React.useEffect(() => {

--- a/src/splitsmith/ui_static/src/lib/auth.tsx
+++ b/src/splitsmith/ui_static/src/lib/auth.tsx
@@ -1,0 +1,78 @@
+/**
+ * Auth context -- the current account + sign-out, for the magic-link
+ * hosted deployment (auth-swap PR2c).
+ *
+ * On mount it resolves ``GET /api/me``: 200 -> authenticated (the session
+ * cookie is valid), 401 -> anonymous (render the login surface). In local
+ * mode ``/api/me`` always returns the loopback user, so the status is
+ * always ``"authed"`` and no login UI is ever shown -- the desktop app is
+ * untouched. The deployment-mode gate (``mode === "hosted"``) is what
+ * decides whether the login route + account chrome render at all; this
+ * context only reports who the caller is.
+ */
+
+import * as React from "react";
+
+import { api, isUnauthorized, type AuthUser } from "./api";
+
+export type AuthStatus = "loading" | "authed" | "anon";
+
+interface AuthContextValue {
+  status: AuthStatus;
+  user: AuthUser | null;
+  /** Re-resolve ``/api/me`` (e.g. after a sign-in lands back on the SPA). */
+  refresh: () => Promise<void>;
+  /** Revoke the session server-side and drop to anonymous. */
+  logout: () => Promise<void>;
+}
+
+const AuthContext = React.createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = React.useState<AuthStatus>("loading");
+  const [user, setUser] = React.useState<AuthUser | null>(null);
+
+  const refresh = React.useCallback(async () => {
+    try {
+      const me = await api.getMe();
+      setUser(me);
+      setStatus("authed");
+    } catch (err) {
+      // 401 is the expected "signed out" path; any other failure also
+      // resolves to anonymous so the login surface (not a broken shell)
+      // is what an unauthenticated visitor sees.
+      if (!isUnauthorized(err)) {
+        // Surface unexpected failures for debugging without blocking render.
+        console.warn("auth: /api/me failed", err);
+      }
+      setUser(null);
+      setStatus("anon");
+    }
+  }, []);
+
+  const logout = React.useCallback(async () => {
+    try {
+      await api.authLogout();
+    } finally {
+      setUser(null);
+      setStatus("anon");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = React.useMemo<AuthContextValue>(
+    () => ({ status, user, refresh, logout }),
+    [status, user, refresh, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = React.useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
+  return ctx;
+}

--- a/src/splitsmith/ui_static/src/pages/Login.tsx
+++ b/src/splitsmith/ui_static/src/pages/Login.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { Link, Navigate, useSearchParams } from "react-router-dom";
+import { Navigate, useSearchParams } from "react-router-dom";
 import { CheckCircle2, Mail } from "lucide-react";
 
 import { Brand } from "@/components/ui/Brand";
@@ -146,15 +146,6 @@ export function Login() {
             </form>
           )}
         </div>
-
-        <p className="mt-6 text-center text-xs text-subtle">
-          <Link
-            to="/"
-            className="underline-offset-4 transition-colors hover:text-muted hover:underline"
-          >
-            Back to splitsmith
-          </Link>
-        </p>
       </div>
     </main>
   );

--- a/src/splitsmith/ui_static/src/pages/Login.tsx
+++ b/src/splitsmith/ui_static/src/pages/Login.tsx
@@ -1,0 +1,161 @@
+/**
+ * Magic-link sign-in surface (auth-swap PR2c).
+ *
+ * Hosted-mode only -- the deployment-mode gate routes anonymous hosted
+ * visitors here. The user enters an email; the server e-mails a link
+ * (``POST /api/v1/auth/begin``); clicking it hits the server's
+ * ``/auth/callback``, which sets the session cookie and redirects back to
+ * "/". A failed redemption bounces to ``/login?error=invalid_link``, shown
+ * as a banner here.
+ *
+ * Instrument-panel aesthetic: dark surface, Antonio wordmark, LED-red CTA,
+ * the canonical focus-ring input. Accessible: the error is a live region,
+ * the LED is never the sole state carrier (text + icon accompany it), and
+ * the form is keyboard-operable with visible focus.
+ */
+
+import * as React from "react";
+import { Link, Navigate, useSearchParams } from "react-router-dom";
+import { CheckCircle2, Mail } from "lucide-react";
+
+import { Brand } from "@/components/ui/Brand";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+export function Login() {
+  const { status } = useAuth();
+  const [params] = useSearchParams();
+  const [email, setEmail] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+  const [sentTo, setSentTo] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Already signed in (e.g. navigated to /login with a live session) ->
+  // send them on to the app.
+  if (status === "authed") return <Navigate to="/" replace />;
+
+  const linkError = params.get("error") === "invalid_link";
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = email.trim();
+    if (!value || !value.includes("@")) {
+      setError("Enter a valid email address.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.authBegin(value);
+      setSentTo(value);
+    } catch {
+      // begin is always 200 server-side; a throw here means the request
+      // never reached the server (offline / 5xx). Don't leak specifics.
+      setError("Could not send the link. Check your connection and retry.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="grid min-h-dvh place-items-center bg-bg px-6 py-12">
+      <div className="w-full max-w-[26rem]">
+        <div className="mb-8 flex justify-center">
+          <Brand serial={<>SS &middot; SIGN IN</>} />
+        </div>
+
+        <div className="rounded-lg border border-rule bg-surface p-7 shadow-[0_1px_0_0_var(--color-rule)]">
+          {sentTo ? (
+            <div className="flex flex-col items-center gap-3 text-center">
+              <CheckCircle2 className="size-7 text-led" aria-hidden />
+              <h1 className="font-display text-xl font-semibold text-ink">
+                Check your email
+              </h1>
+              <p className="text-sm text-ink-2">
+                A sign-in link is on its way to{" "}
+                <span className="font-medium text-ink">{sentTo}</span>. The link
+                is valid for 15 minutes.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setSentTo(null);
+                  setError(null);
+                }}
+                className="mt-1 text-sm text-muted underline-offset-4 transition-colors hover:text-ink hover:underline"
+              >
+                Use a different email
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={onSubmit} noValidate>
+              <h1 className="font-display text-xl font-semibold text-ink">
+                Sign in
+              </h1>
+              <p className="mt-1.5 text-sm text-ink-2">
+                Enter your email and we'll send a one-time sign-in link. No
+                password needed.
+              </p>
+
+              {linkError && (
+                <p
+                  role="alert"
+                  className="mt-4 flex items-start gap-2 rounded-md border border-led/40 bg-[color:var(--color-led-tint)] px-3 py-2 text-sm text-led-text"
+                >
+                  <span aria-hidden>!</span>
+                  That sign-in link was invalid or expired. Request a new one
+                  below.
+                </p>
+              )}
+
+              <label
+                htmlFor="login-email"
+                className="mt-5 block text-xs font-medium uppercase tracking-wide text-muted"
+              >
+                Email
+              </label>
+              <input
+                id="login-email"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                disabled={submitting}
+                className="mt-1.5 w-full rounded-md border border-rule bg-surface-3 px-3.5 py-2.5 text-sm text-ink outline-none focus:border-led focus:shadow-[0_0_0_3px_var(--color-led-tint)] disabled:opacity-50"
+              />
+
+              <p
+                role="alert"
+                aria-live="polite"
+                className="mt-2 min-h-4 text-sm text-led-text"
+              >
+                {error ?? ""}
+              </p>
+
+              <Button
+                type="submit"
+                disabled={submitting}
+                className="mt-3 w-full"
+              >
+                <Mail className="size-4" aria-hidden />
+                {submitting ? "Sending..." : "Send sign-in link"}
+              </Button>
+            </form>
+          )}
+        </div>
+
+        <p className="mt-6 text-center text-xs text-subtle">
+          <Link
+            to="/"
+            className="underline-offset-4 transition-colors hover:text-muted hover:underline"
+          >
+            Back to splitsmith
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -33,6 +33,7 @@ import {
   TickStrip,
   type TickState,
 } from "@/components/ui";
+import { AccountChip } from "@/components/AccountChip";
 import { Button } from "@/components/ui/button";
 import {
   ApiError,
@@ -270,24 +271,27 @@ export function Pick() {
               </>
             }
           />
-          {identity?.display_name && (
-            <span className="ml-auto inline-flex items-center gap-2 rounded-full border border-rule bg-surface-2 py-1.5 pl-1.5 pr-4">
-              <span
-                className="inline-flex size-7 items-center justify-center rounded-full font-mono text-[0.6875rem] font-bold text-ink"
-                style={{
-                  background:
-                    "linear-gradient(135deg, var(--color-led), var(--color-led-deep))",
-                  boxShadow:
-                    "0 0 0 1px rgba(255,45,45,0.4), 0 0 12px var(--color-led-glow)",
-                }}
-              >
-                {shooterInitials(identity.display_name).toUpperCase()}
+          <div className="ml-auto flex items-center gap-3">
+            {identity?.display_name && (
+              <span className="inline-flex items-center gap-2 rounded-full border border-rule bg-surface-2 py-1.5 pl-1.5 pr-4">
+                <span
+                  className="inline-flex size-7 items-center justify-center rounded-full font-mono text-[0.6875rem] font-bold text-ink"
+                  style={{
+                    background:
+                      "linear-gradient(135deg, var(--color-led), var(--color-led-deep))",
+                    boxShadow:
+                      "0 0 0 1px rgba(255,45,45,0.4), 0 0 12px var(--color-led-glow)",
+                  }}
+                >
+                  {shooterInitials(identity.display_name).toUpperCase()}
+                </span>
+                <span className="text-[0.8125rem] font-medium text-ink-2">
+                  {identity.display_name}
+                </span>
               </span>
-              <span className="text-[0.8125rem] font-medium text-ink-2">
-                {identity.display_name}
-              </span>
-            </span>
-          )}
+            )}
+            <AccountChip />
+          </div>
         </div>
         <div className="border-t border-rule bg-bg">
           <div className="mx-auto flex max-w-[1440px] items-center gap-4 px-8 py-2.5 text-xs text-muted">

--- a/uv.lock
+++ b/uv.lock
@@ -2309,6 +2309,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2645,6 +2664,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -3435,6 +3466,7 @@ dev = [
     { name = "onnx" },
     { name = "onnxscript" },
     { name = "panns-inference" },
+    { name = "playwright" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -3486,6 +3518,7 @@ dev = [
     { name = "onnx", specifier = ">=1.16.0" },
     { name = "onnxscript", specifier = ">=0.1.0" },
     { name = "panns-inference", specifier = ">=0.1.1" },
+    { name = "playwright", specifier = ">=1.60.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },


### PR DESCRIPTION
**Stacked on #453** (auth wiring) -> #452 -> #451. Review/merge those first.

## What

The frontend half of the auth swap: a sign-in page + account/logout chrome, gated on hosted mode so the **desktop app is untouched**.

## How

- **`lib/auth.tsx`** -- `AuthProvider` + `useAuth`. Resolves `GET /api/me` on mount (200 -> authed, 401 -> anon). Local mode is always authed (loopback user), so no login UI ever renders there.
- **`App.tsx`** -- `AuthProvider` wrap + a `/login` route + `AuthGate`. The gate blocks on the initial `/api/me` resolve (brief "Standby..."), then redirects an anonymous hosted visitor to `/login`; local + authed render the app unchanged. No protected chrome flashes before the redirect.
- **`pages/Login.tsx`** -- instrument-panel sign-in: email -> `POST /api/v1/auth/begin`, then a "check your email" confirmation. Reads `?error=invalid_link` (the server's failed-redemption bounce) into a banner. Accessible: live-region errors, LED never the sole state carrier, autofocus, visible focus ring, the canonical input pattern.
- **`components/AccountChip.tsx`** -- self-gating (hosted + authed only) email + sign-out chip; calls `useAuth().logout()` (`POST /api/v1/auth/logout`) and drops to `/login` via the gate. Dropped into the Pick + MatchShell headers.
- **`lib/api.ts`** -- `AuthUser` type, `getMe` / `authBegin` / `authLogout`, and an `isUnauthorized(err)` helper.

## Desktop unchanged

The gate resolves authed via the loopback user, no login route renders, `AccountChip` self-hides. Verified locally: `/api/me` -> loopback user, `/` serves the SPA, `/api/v1/auth/begin` 404s in local mode.

## Gates

- `tsc -b --noEmit` clean, `vite build` clean.
- eslint isn't installed in this environment; the docker image builds the same `dist` this build produced.
- **Not browser-walked this session** -- the page is typed + built but I didn't drive it in a real browser. Happy to do a hosted-stack screenshot pass on request.

## Completes the auth-swap arc
Stack: #451 (seam) <- #452 (domain) <- #453 (wiring) <- #454 (this). After this, hosted mode has a full sign-in -> use -> sign-out loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)