### PR TITLE
feat(saas): Resend email sender for production magic-link delivery

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -540,7 +540,9 @@ def serve(
 
     - ``SPLITSMITH_S3_*`` (when the storage backend is swapped to S3).
     - ``SPLITSMITH_EMAIL_BACKEND`` -- magic-link transport (default
-      ``console``, which logs the link for docker / self-host).
+      ``console``, which logs the link for docker / self-host). Set to
+      ``resend`` for production, with ``RESEND_API_KEY`` +
+      ``SPLITSMITH_EMAIL_FROM`` (e.g. ``Splitsmith <login@yourdomain>``).
 
     No browser auto-open, no ``--project`` (paths live in Postgres).
     Defaults bind ``0.0.0.0`` because the typical caller is a

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -21,7 +21,7 @@ what handlers depend on; the future ``PostgresJobBackend`` /
 this DB layer internally without leaking SQL into handler code.
 """
 
-from .email import ConsoleEmailSender, EmailSender, build_email_sender
+from .email import ConsoleEmailSender, EmailSender, ResendEmailSender, build_email_sender
 from .engine import create_engine, sessionmaker, tenant_session_factory
 from .job_backend import PostgresJobBackend
 from .magic_link import (
@@ -56,6 +56,7 @@ __all__ = [
     "MagicLinkAuth",
     "MagicLinkTokenRow",
     "MatchRow",
+    "ResendEmailSender",
     "PostgresJobBackend",
     "PostgresMatchStore",
     "PostgresRecentProjectsStore",

--- a/src/splitsmith/db/email.py
+++ b/src/splitsmith/db/email.py
@@ -10,16 +10,17 @@ different transports without touching the backend:
   :class:`ConsoleEmailSender` logs the link. ``docker compose up`` works
   with zero external configuration, and the smoke test reads the link
   back from the container logs.
-- **production hosted**: an HTTP sender (Resend / Postmark / ...) selected
-  by ``SPLITSMITH_EMAIL_BACKEND``. Not implemented here -- it lands when
-  the provider is picked; :func:`build_email_sender` fails loud for any
-  backend other than ``console`` so a misconfigured prod deploy can't
-  silently drop sign-in mail.
+- **production hosted**: :class:`ResendEmailSender`, selected by
+  ``SPLITSMITH_EMAIL_BACKEND=resend`` (+ ``RESEND_API_KEY`` /
+  ``SPLITSMITH_EMAIL_FROM``). :func:`build_email_sender` fails loud for any
+  unknown backend so a misconfigured prod deploy can't silently drop
+  sign-in mail.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Protocol
 
 logger = logging.getLogger(__name__)
@@ -27,10 +28,16 @@ logger = logging.getLogger(__name__)
 # Env var selecting the transport. Unset -> console (the dev / self-host
 # default). Any recognised provider name selects its HTTP sender.
 SPLITSMITH_EMAIL_BACKEND_ENV = "SPLITSMITH_EMAIL_BACKEND"
+# Resend transport config (only read when the backend is ``resend``).
+RESEND_API_KEY_ENV = "RESEND_API_KEY"
+# The verified ``From`` address, e.g. ``Splitsmith <login@splitsmith.app>``.
+SPLITSMITH_EMAIL_FROM_ENV = "SPLITSMITH_EMAIL_FROM"
 
 # Marker the console transport prefixes each link with, so log scrapers
 # (the docker smoke's login dance) can pull the URL back out reliably.
 CONSOLE_MAGIC_LINK_MARKER = "MAGIC_LINK"
+
+RESEND_API_URL = "https://api.resend.com/emails"
 
 
 class EmailSender(Protocol):
@@ -58,22 +65,86 @@ class ConsoleEmailSender:
         logger.info("%s %s %s", CONSOLE_MAGIC_LINK_MARKER, to, link)
 
 
+def _magic_link_email_body(link: str) -> tuple[str, str]:
+    """Return ``(text, html)`` bodies for a sign-in e-mail. Deliberately
+    plain -- one link, the 15-minute validity, and a no-op-if-you-didn't-ask
+    line (a phishing-resistance norm for magic links)."""
+    text = (
+        "Sign in to Splitsmith:\n\n"
+        f"{link}\n\n"
+        "This link is valid for 15 minutes and can be used once. "
+        "If you didn't request it, you can ignore this e-mail."
+    )
+    html = (
+        '<div style="font-family:system-ui,sans-serif;font-size:15px;line-height:1.5">'
+        "<p>Sign in to Splitsmith:</p>"
+        f'<p><a href="{link}">Sign in</a></p>'
+        '<p style="color:#666;font-size:13px">This link is valid for 15 minutes '
+        "and can be used once. If you didn't request it, you can ignore this e-mail.</p>"
+        "</div>"
+    )
+    return text, html
+
+
+class ResendEmailSender:
+    """Sends magic links via the Resend HTTP API (production transport).
+
+    Uses ``httpx`` (already a runtime dep) rather than the ``resend`` SDK to
+    avoid a new dependency for one POST. A transport / provider error raises
+    (the contract allows it) -- ``begin_login`` then surfaces it; the SPA
+    shows a "couldn't send, retry" message. It never inspects the recipient,
+    so it can't leak whether an address has an account.
+    """
+
+    def __init__(self, *, api_key: str, from_address: str) -> None:
+        self._api_key = api_key
+        self._from = from_address
+
+    async def send_magic_link(self, *, to: str, link: str) -> None:
+        import httpx
+
+        text, html = _magic_link_email_body(link)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                RESEND_API_URL,
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json={
+                    "from": self._from,
+                    "to": [to],
+                    "subject": "Your Splitsmith sign-in link",
+                    "text": text,
+                    "html": html,
+                },
+            )
+        resp.raise_for_status()
+
+
 def build_email_sender(backend: str | None) -> EmailSender:
     """Resolve the :class:`EmailSender` for ``backend`` (the value of
     ``SPLITSMITH_EMAIL_BACKEND``).
 
-    ``None`` / ``""`` / ``"console"`` -> :class:`ConsoleEmailSender`. Any
-    other value raises: a real provider HTTP sender is not implemented yet,
-    and falling back to console in production would silently swallow
-    sign-in mail. When a provider is chosen, add its branch here.
+    - ``None`` / ``""`` / ``"console"`` -> :class:`ConsoleEmailSender`.
+    - ``"resend"`` -> :class:`ResendEmailSender`, configured from
+      ``RESEND_API_KEY`` + ``SPLITSMITH_EMAIL_FROM`` (both required; missing
+      either fails loud rather than silently dropping sign-in mail).
+    - anything else -> raises.
     """
     name = (backend or "console").strip().lower()
     if name == "console":
         return ConsoleEmailSender()
+    if name == "resend":
+        api_key = os.environ.get(RESEND_API_KEY_ENV, "").strip()
+        from_address = os.environ.get(SPLITSMITH_EMAIL_FROM_ENV, "").strip()
+        if not api_key or not from_address:
+            raise RuntimeError(
+                f"{SPLITSMITH_EMAIL_BACKEND_ENV}=resend requires both "
+                f"{RESEND_API_KEY_ENV} and {SPLITSMITH_EMAIL_FROM_ENV} "
+                "(e.g. 'Splitsmith <login@yourdomain>') to be set."
+            )
+        return ResendEmailSender(api_key=api_key, from_address=from_address)
     raise RuntimeError(
         f"{SPLITSMITH_EMAIL_BACKEND_ENV}={backend!r} is not supported. "
-        "Only 'console' is implemented today; a production HTTP sender "
-        "(Resend / Postmark) lands when the provider is picked. Set "
+        f"Use 'console' (dev / self-host) or 'resend' (production). Set "
         f"{SPLITSMITH_EMAIL_BACKEND_ENV}=console (or leave it unset) for "
         "docker-compose / self-host."
     )

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -29,7 +29,9 @@ from splitsmith.db import (
 )
 from splitsmith.db.email import (
     CONSOLE_MAGIC_LINK_MARKER,
+    RESEND_API_URL,
     ConsoleEmailSender,
+    ResendEmailSender,
     build_email_sender,
 )
 from splitsmith.db.magic_link import (
@@ -319,6 +321,52 @@ def test_build_email_sender_defaults_to_console() -> None:
     assert isinstance(build_email_sender("CONSOLE"), ConsoleEmailSender)
 
 
-def test_build_email_sender_fails_loud_on_unimplemented_provider() -> None:
+def test_build_email_sender_fails_loud_on_unknown_provider() -> None:
     with pytest.raises(RuntimeError, match="not supported"):
+        build_email_sender("mailgun")
+
+
+def test_build_email_sender_resend_requires_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("SPLITSMITH_EMAIL_FROM", raising=False)
+    with pytest.raises(RuntimeError, match="RESEND_API_KEY"):
         build_email_sender("resend")
+
+
+def test_build_email_sender_resend_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.setenv("SPLITSMITH_EMAIL_FROM", "Splitsmith <login@splitsmith.test>")
+    assert isinstance(build_email_sender("resend"), ResendEmailSender)
+
+
+def test_resend_email_sender_posts_the_link() -> None:
+    respx = pytest.importorskip("respx")
+    import httpx
+
+    sender = ResendEmailSender(api_key="re_test", from_address="Splitsmith <login@splitsmith.test>")
+    link = f"{BASE_URL}/auth/callback?token=tok123"
+    with respx.mock:
+        route = respx.post(RESEND_API_URL).mock(return_value=httpx.Response(200, json={"id": "e1"}))
+        asyncio.run(sender.send_magic_link(to="user@example.com", link=link))
+
+    assert route.called
+    req = route.calls.last.request
+    assert req.headers["authorization"] == "Bearer re_test"
+    body = req.content.decode()
+    assert "user@example.com" in body
+    assert "tok123" in body  # the magic link is carried in the body
+
+
+def test_resend_email_sender_raises_on_provider_error() -> None:
+    respx = pytest.importorskip("respx")
+    import httpx
+
+    sender = ResendEmailSender(api_key="re_test", from_address="x@y.z")
+    with respx.mock:
+        respx.post(RESEND_API_URL).mock(
+            return_value=httpx.Response(422, json={"message": "domain not verified"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(
+                sender.send_magic_link(to="user@example.com", link=f"{BASE_URL}/auth/callback?token=x")
+            )


### PR DESCRIPTION
First of two deploy-prep PRs for Railway + Neon + R2. Unblocks **real sign-in** in hosted prod (until now only the `console` sender existed, so magic-link mail couldn't be delivered).

## What
- `build_email_sender` gains a `resend` backend: `SPLITSMITH_EMAIL_BACKEND=resend` + `RESEND_API_KEY` + `SPLITSMITH_EMAIL_FROM` (e.g. `Splitsmith <login@yourdomain>`). Missing either var fails loud.
- `ResendEmailSender` POSTs the sign-in link to Resend's HTTP API via `httpx` (already a runtime dep — no `resend` SDK, no new dependency). A provider/transport error raises, so `begin_login` surfaces it and the SPA shows the existing "couldn't send, retry" message. It never inspects the recipient, so it can't leak account existence.
- `console` stays the dev / docker-compose / self-host default.

## Tests
- `build_email_sender("resend")` with/without config; unknown backend still fails loud.
- `ResendEmailSender` POSTs the link with the bearer header (respx-mocked httpx); raises on a 4xx provider error.
- 34 auth/hosted tests green; ruff + black clean.

## Deploy note
On Railway set `SPLITSMITH_EMAIL_BACKEND=resend`, `RESEND_API_KEY`, `SPLITSMITH_EMAIL_FROM` (from a Resend-verified domain). Independent of the Dockerfile-SPA-build PR (gap #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)