### PR TITLE
build(docker): build the SPA inside the image (Node stage)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,18 +14,13 @@
 **/*.pyc
 **/*.pyo
 
-# SPA build *inputs* -- only the built dist/ ships. node_modules alone is
-# ~280 MB and never needed at runtime; the TS source + tooling configs are
-# build-time only. Mirrors the wheel's hatch excludes.
+# SPA build inputs ARE needed: the ``spa`` Docker stage builds dist/ from
+# them. Keep only the regenerable / redundant bits out of the context --
+# node_modules (~280 MB, rebuilt by ``npm ci``), any host-built dist (the
+# image rebuilds it), and the alternate pnpm lockfile (we install with npm).
 src/splitsmith/ui_static/node_modules
-src/splitsmith/ui_static/src
-src/splitsmith/ui_static/package.json
-src/splitsmith/ui_static/package-lock.json
+src/splitsmith/ui_static/dist
 src/splitsmith/ui_static/pnpm-lock.yaml
-src/splitsmith/ui_static/vite.config.ts
-src/splitsmith/ui_static/tsconfig*.json
-src/splitsmith/ui_static/index.html
-src/splitsmith/ui_static/*.config.js
 **/*.map
 
 # Dev-only trees nothing in the image reads.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@
 # the final image to {venv + ffmpeg + baked models + base} only.
 #
 # Layout:
-# - builder: installs the venv (deps + the splitsmith package, editable)
-#   and bakes the slim ONNX models.
+# - spa: a Node stage that builds ``src/splitsmith/ui_static`` into dist/.
+#   This makes the image self-contained from a clean git checkout -- dist/
+#   is gitignored, so a host-prebuilt dist/ is no longer required (e.g. a
+#   Railway / Cloud build straight from the repo).
+# - builder: installs the venv (deps + the splitsmith package, editable),
+#   overlays the SPA dist from the ``spa`` stage, and bakes the slim ONNX
+#   models.
 # - runtime: a clean base + ffmpeg, with the venv, the (slim) source tree,
 #   alembic migrations, and baked models copied in. No uv, no SPA build
 #   inputs, no chown dup layer.
@@ -20,8 +25,10 @@
 # moves the package into site-packages and breaks that path math (alembic
 # then runs with no script_location). Editable keeps cli.py at
 # /app/src/splitsmith/cli.py so the repo-root assumption holds. The
-# ``.dockerignore`` strips ui_static/node_modules + the TS source so the
-# copied tree stays small; only ui_static/dist (the built SPA) ships.
+# The builder drops the ui_static TS source after copying ``src`` and
+# overlays the dist built in the ``spa`` stage, so only ui_static/dist (the
+# built SPA) ships in the runtime image -- the same lean result as before,
+# now without depending on a host-prebuilt dist.
 #
 # CRITICAL invariant: both stages use the SAME base image so the venv's
 # interpreter path (pyvenv.cfg -> /usr/local/bin/python3.11) stays valid
@@ -40,6 +47,22 @@
 #   API nor a worker downloads models at runtime (doc 04).
 
 ARG PYTHON_IMAGE=python:3.11-slim-bookworm
+ARG NODE_IMAGE=node:22-bookworm-slim
+
+# --------------------------------------------------------------------------
+# SPA build (Node)
+# --------------------------------------------------------------------------
+# Builds the React SPA into dist/ so the runtime image is self-contained
+# from a clean checkout. node_modules is regenerated here via ``npm ci``
+# (the repo's node_modules + the alternate pnpm lockfile are kept out of the
+# build context by .dockerignore).
+FROM ${NODE_IMAGE} AS spa
+WORKDIR /spa
+# Lockfile-first so ``npm ci`` caches across SPA source-only edits.
+COPY src/splitsmith/ui_static/package.json src/splitsmith/ui_static/package-lock.json ./
+RUN npm ci
+COPY src/splitsmith/ui_static/ ./
+RUN npm run build
 
 # --------------------------------------------------------------------------
 # Builder
@@ -90,12 +113,13 @@ RUN uv sync --frozen --no-dev --extra hosted --no-install-project
 
 # Now the source + the editable project install.
 COPY src ./src
-# Fail fast if the SPA wasn't built before docker build: dist/ is not
-# committed, so a build from a clean checkout would otherwise ship an
-# image that serves no UI. Run ``npm --prefix src/splitsmith/ui_static run
-# build`` first (or copy a prebuilt dist into the context).
-RUN test -f src/splitsmith/ui_static/dist/index.html \
-    || (echo "ERROR: src/splitsmith/ui_static/dist/index.html missing -- build the SPA before docker build" && exit 1)
+# Replace the ui_static tree with just the dist built in the ``spa`` stage:
+# drop the TS source / configs / any stale host dist that rode in via the
+# context, then overlay the freshly-built SPA. The runtime image therefore
+# carries only ui_static/dist regardless of what was (or wasn't) prebuilt on
+# the host -- so ``docker build`` works from a clean git checkout.
+RUN rm -rf src/splitsmith/ui_static
+COPY --from=spa /spa/dist ./src/splitsmith/ui_static/dist
 RUN uv sync --frozen --no-dev --extra hosted
 
 # Slim the venv before it's copied to the runtime stage: drop bundled

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -211,6 +211,20 @@ def test_magic_link_login_round_trip(hosted_stack: None) -> None:
     assert body["email"] == "login-roundtrip@example.com"
 
 
+def test_spa_index_served_from_in_image_build(hosted_stack: None) -> None:
+    """The SPA is built inside the image (Node ``spa`` stage), not from a
+    host-prebuilt dist/. Prove the runtime container actually serves it: a
+    non-API route returns the SPA shell, with a content-addressed asset
+    reference the Vite build emitted."""
+    resp = httpx.get(f"{API_BASE}/login", timeout=5.0)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+    assert '<div id="root">' in resp.text
+    # Vite emits a hashed module bundle under /assets/ -- its presence proves
+    # the in-image build produced + wired the dist, not just an empty shell.
+    assert "/assets/index-" in resp.text
+
+
 def _psql_run(query: str, *, user: str = "splitsmith") -> subprocess.CompletedProcess[str]:
     """Run ``query`` in the compose Postgres as ``user`` and return the
     completed process (no return-code assertion).


### PR DESCRIPTION
Second of two deploy-prep PRs for Railway + Neon + R2. Makes the image build from a **clean git checkout**, so a Railway/cloud build straight from the repo works.

## Problem
The Dockerfile required a host-prebuilt `dist/` (`test -f dist/index.html || exit 1`), and `.dockerignore` stripped the SPA source. That's fine when you build `dist/` locally before `docker build`, but Railway builds from git where `dist/` is gitignored -> the image build would fail.

## Fix
- New Node `spa` stage: `npm ci` + `npm run build` -> `dist/`.
- The Python builder drops the ui_static TS source after `COPY src` and overlays the dist from the `spa` stage, so only `ui_static/dist` ships in the runtime image (same lean result as before, no host dependency).
- `.dockerignore` stops stripping the SPA inputs (the `spa` stage needs them); `node_modules`, host `dist/`, and the alternate pnpm lockfile stay out of the context.

## Validation
- `docker build --target spa` builds clean (npm ci in sync with `package-lock.json`).
- `pytest -m docker`: **8 passed** — the full multi-stage image builds with **no host-prebuilt dist**, and a new assertion confirms the in-image-built SPA actually serves (`/login` returns the shell + a hashed `/assets/` bundle).

Independent of the Resend PR (#456). Together they close the two code gaps before a Railway + Neon + R2 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)