### PR TITLE
feat(saas): swap magic-link email transport Resend -> Lettermint

### DIFF
--- a/docs/saas-readiness/00-context-and-principles.md
+++ b/docs/saas-readiness/00-context-and-principles.md
@@ -46,8 +46,8 @@ The bias order is:
 
 1. **Hosted service** -- rent, don't run. If a managed offering is
    cheap enough at our scale, we use it (Stripe for billing, Clerk
-   for auth, Cloudflare R2 for storage, Sentry for errors, Resend for
-   email, Neon for Postgres).
+   for auth, Cloudflare R2 for storage, Sentry for errors, Lettermint
+   for email, Neon for Postgres).
 2. **Library** -- open-source, well-maintained, fits the use case.
    Use it inside our own deploy (fsspec for storage abstraction,
    SQLAlchemy for ORM, Procrastinate for job queue).
@@ -70,7 +70,7 @@ is measured, not preemptively.
 | Object storage | [Cloudflare R2](https://www.cloudflare.com/products/r2/) | S3-compatible API, **$0 egress**, ~$0.015/GB stored. Massive cost advantage over S3 for media workloads. |
 | Database hosting | [Neon](https://neon.tech/) (Postgres) or [Turso](https://turso.tech/) (SQLite-as-a-service) | Free tiers for v1; both scale up with usage |
 | Background workers (hosted) | [Inngest](https://www.inngest.com/) or [Trigger.dev](https://trigger.dev/) | Use only if in-deploy Procrastinate turns into too much ops |
-| Email (magic links + transactional) | [Resend](https://resend.com/) or [Postmark](https://postmarkapp.com/) | No SMTP self-hosting; generous free tiers |
+| Email (magic links + transactional) | [Lettermint](https://lettermint.co/) | Picked + wired (`SPLITSMITH_EMAIL_BACKEND=lettermint`); no SMTP self-hosting |
 | Billing | [Stripe Checkout](https://stripe.com/docs/payments/checkout) + [Stripe webhooks](https://stripe.com/docs/webhooks) | Stripe-hosted checkout page; we never touch card data |
 | Errors / monitoring | [Sentry](https://sentry.io/) | Hosted; free tier covers our scale |
 | Analytics (optional v2) | [PostHog](https://posthog.com/) or [Plausible](https://plausible.io/) | Privacy-respecting; PostHog also handles feature flags + session replay |

--- a/docs/saas-readiness/02-tenancy-and-identity.md
+++ b/docs/saas-readiness/02-tenancy-and-identity.md
@@ -51,12 +51,10 @@ MFA setup, or password reset. Magic link is the only flow.
   All login-flow methods raise `NotImplementedError` (they should
   never be called -- the local UI doesn't render login affordances).
 
-- **`MagicLinkAuth`** -- hosted mode. Wraps Clerk or WorkOS or Auth.js
-  depending on the final pick. Routes magic-link emails through
-  Resend / Postmark.
-
-The wrapper is thin: we don't reimplement session storage, token
-rotation, etc. Whatever the provider does is fine.
+- **`MagicLinkAuth`** -- hosted mode. In-house magic-link domain (token
+  issue / verify / session), not a third-party auth wrapper. Routes
+  magic-link emails through Lettermint
+  (`SPLITSMITH_EMAIL_BACKEND=lettermint`).
 
 ## Magic-link flow (hosted mode)
 

--- a/docs/saas-readiness/09-saas-progress.md
+++ b/docs/saas-readiness/09-saas-progress.md
@@ -141,7 +141,8 @@ later steps are blocked on earlier ones.
   Procrastinate (Postgres-native) is the picked job queue
   (resolved 2026-05-27, doc 00).
 - [ ] Wire Sentry on the API + worker.
-- [ ] Wire Resend (or Postmark) for magic-link email delivery.
+- [x] Wire Lettermint for magic-link email delivery
+  (`SPLITSMITH_EMAIL_BACKEND=lettermint`; `splitsmith.app` DNS verified).
 - [ ] Set up the `splitsmith.app` domain + Cloudflare in front.
 
 ### Auth + identity (doc 02)

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -541,8 +541,9 @@ def serve(
     - ``SPLITSMITH_S3_*`` (when the storage backend is swapped to S3).
     - ``SPLITSMITH_EMAIL_BACKEND`` -- magic-link transport (default
       ``console``, which logs the link for docker / self-host). Set to
-      ``resend`` for production, with ``RESEND_API_KEY`` +
-      ``SPLITSMITH_EMAIL_FROM`` (e.g. ``Splitsmith <login@yourdomain>``).
+      ``lettermint`` for production, with ``LETTERMINT_API_TOKEN`` +
+      ``SPLITSMITH_EMAIL_FROM`` (e.g. ``Splitsmith <login@yourdomain>``)
+      and an optional ``LETTERMINT_ROUTE``.
 
     No browser auto-open, no ``--project`` (paths live in Postgres).
     Defaults bind ``0.0.0.0`` because the typical caller is a

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -21,7 +21,7 @@ what handlers depend on; the future ``PostgresJobBackend`` /
 this DB layer internally without leaking SQL into handler code.
 """
 
-from .email import ConsoleEmailSender, EmailSender, ResendEmailSender, build_email_sender
+from .email import ConsoleEmailSender, EmailSender, LettermintEmailSender, build_email_sender
 from .engine import create_engine, sessionmaker, tenant_session_factory
 from .job_backend import PostgresJobBackend
 from .magic_link import (
@@ -52,11 +52,11 @@ __all__ = [
     "EmailSender",
     "InvalidMagicLinkError",
     "IssuedSession",
+    "LettermintEmailSender",
     "LoginChallenge",
     "MagicLinkAuth",
     "MagicLinkTokenRow",
     "MatchRow",
-    "ResendEmailSender",
     "PostgresJobBackend",
     "PostgresMatchStore",
     "PostgresRecentProjectsStore",

--- a/src/splitsmith/db/email.py
+++ b/src/splitsmith/db/email.py
@@ -10,11 +10,11 @@ different transports without touching the backend:
   :class:`ConsoleEmailSender` logs the link. ``docker compose up`` works
   with zero external configuration, and the smoke test reads the link
   back from the container logs.
-- **production hosted**: :class:`ResendEmailSender`, selected by
-  ``SPLITSMITH_EMAIL_BACKEND=resend`` (+ ``RESEND_API_KEY`` /
-  ``SPLITSMITH_EMAIL_FROM``). :func:`build_email_sender` fails loud for any
-  unknown backend so a misconfigured prod deploy can't silently drop
-  sign-in mail.
+- **production hosted**: :class:`LettermintEmailSender`, selected by
+  ``SPLITSMITH_EMAIL_BACKEND=lettermint`` (+ ``LETTERMINT_API_TOKEN`` /
+  ``SPLITSMITH_EMAIL_FROM``, with an optional ``LETTERMINT_ROUTE``).
+  :func:`build_email_sender` fails loud for any unknown backend so a
+  misconfigured prod deploy can't silently drop sign-in mail.
 """
 
 from __future__ import annotations
@@ -28,8 +28,11 @@ logger = logging.getLogger(__name__)
 # Env var selecting the transport. Unset -> console (the dev / self-host
 # default). Any recognised provider name selects its HTTP sender.
 SPLITSMITH_EMAIL_BACKEND_ENV = "SPLITSMITH_EMAIL_BACKEND"
-# Resend transport config (only read when the backend is ``resend``).
-RESEND_API_KEY_ENV = "RESEND_API_KEY"
+# Lettermint transport config (only read when the backend is ``lettermint``).
+LETTERMINT_API_TOKEN_ENV = "LETTERMINT_API_TOKEN"
+# Optional Lettermint route (e.g. ``production``); omitted from the payload
+# when unset so the account default applies.
+LETTERMINT_ROUTE_ENV = "LETTERMINT_ROUTE"
 # The verified ``From`` address, e.g. ``Splitsmith <login@splitsmith.app>``.
 SPLITSMITH_EMAIL_FROM_ENV = "SPLITSMITH_EMAIL_FROM"
 
@@ -37,7 +40,7 @@ SPLITSMITH_EMAIL_FROM_ENV = "SPLITSMITH_EMAIL_FROM"
 # (the docker smoke's login dance) can pull the URL back out reliably.
 CONSOLE_MAGIC_LINK_MARKER = "MAGIC_LINK"
 
-RESEND_API_URL = "https://api.resend.com/emails"
+LETTERMINT_API_URL = "https://api.lettermint.co/v1/send"
 
 
 class EmailSender(Protocol):
@@ -86,35 +89,39 @@ def _magic_link_email_body(link: str) -> tuple[str, str]:
     return text, html
 
 
-class ResendEmailSender:
-    """Sends magic links via the Resend HTTP API (production transport).
+class LettermintEmailSender:
+    """Sends magic links via the Lettermint HTTP API (production transport).
 
-    Uses ``httpx`` (already a runtime dep) rather than the ``resend`` SDK to
-    avoid a new dependency for one POST. A transport / provider error raises
-    (the contract allows it) -- ``begin_login`` then surfaces it; the SPA
-    shows a "couldn't send, retry" message. It never inspects the recipient,
-    so it can't leak whether an address has an account.
+    Uses ``httpx`` (already a runtime dep) rather than the ``lettermint`` SDK
+    to avoid a new dependency for one POST. A transport / provider error
+    raises (the contract allows it) -- ``begin_login`` then surfaces it; the
+    SPA shows a "couldn't send, retry" message. It never inspects the
+    recipient, so it can't leak whether an address has an account.
     """
 
-    def __init__(self, *, api_key: str, from_address: str) -> None:
-        self._api_key = api_key
+    def __init__(self, *, api_token: str, from_address: str, route: str | None = None) -> None:
+        self._api_token = api_token
         self._from = from_address
+        self._route = route
 
     async def send_magic_link(self, *, to: str, link: str) -> None:
         import httpx
 
         text, html = _magic_link_email_body(link)
+        payload: dict[str, object] = {
+            "from": self._from,
+            "to": [to],
+            "subject": "Your Splitsmith sign-in link",
+            "text": text,
+            "html": html,
+        }
+        if self._route:
+            payload["route"] = self._route
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.post(
-                RESEND_API_URL,
-                headers={"Authorization": f"Bearer {self._api_key}"},
-                json={
-                    "from": self._from,
-                    "to": [to],
-                    "subject": "Your Splitsmith sign-in link",
-                    "text": text,
-                    "html": html,
-                },
+                LETTERMINT_API_URL,
+                headers={"x-lettermint-token": self._api_token},
+                json=payload,
             )
         resp.raise_for_status()
 
@@ -124,27 +131,29 @@ def build_email_sender(backend: str | None) -> EmailSender:
     ``SPLITSMITH_EMAIL_BACKEND``).
 
     - ``None`` / ``""`` / ``"console"`` -> :class:`ConsoleEmailSender`.
-    - ``"resend"`` -> :class:`ResendEmailSender`, configured from
-      ``RESEND_API_KEY`` + ``SPLITSMITH_EMAIL_FROM`` (both required; missing
-      either fails loud rather than silently dropping sign-in mail).
+    - ``"lettermint"`` -> :class:`LettermintEmailSender`, configured from
+      ``LETTERMINT_API_TOKEN`` + ``SPLITSMITH_EMAIL_FROM`` (both required;
+      missing either fails loud rather than silently dropping sign-in mail)
+      and an optional ``LETTERMINT_ROUTE``.
     - anything else -> raises.
     """
     name = (backend or "console").strip().lower()
     if name == "console":
         return ConsoleEmailSender()
-    if name == "resend":
-        api_key = os.environ.get(RESEND_API_KEY_ENV, "").strip()
+    if name == "lettermint":
+        api_token = os.environ.get(LETTERMINT_API_TOKEN_ENV, "").strip()
         from_address = os.environ.get(SPLITSMITH_EMAIL_FROM_ENV, "").strip()
-        if not api_key or not from_address:
+        if not api_token or not from_address:
             raise RuntimeError(
-                f"{SPLITSMITH_EMAIL_BACKEND_ENV}=resend requires both "
-                f"{RESEND_API_KEY_ENV} and {SPLITSMITH_EMAIL_FROM_ENV} "
+                f"{SPLITSMITH_EMAIL_BACKEND_ENV}=lettermint requires both "
+                f"{LETTERMINT_API_TOKEN_ENV} and {SPLITSMITH_EMAIL_FROM_ENV} "
                 "(e.g. 'Splitsmith <login@yourdomain>') to be set."
             )
-        return ResendEmailSender(api_key=api_key, from_address=from_address)
+        route = os.environ.get(LETTERMINT_ROUTE_ENV, "").strip() or None
+        return LettermintEmailSender(api_token=api_token, from_address=from_address, route=route)
     raise RuntimeError(
         f"{SPLITSMITH_EMAIL_BACKEND_ENV}={backend!r} is not supported. "
-        f"Use 'console' (dev / self-host) or 'resend' (production). Set "
+        f"Use 'console' (dev / self-host) or 'lettermint' (production). Set "
         f"{SPLITSMITH_EMAIL_BACKEND_ENV}=console (or leave it unset) for "
         "docker-compose / self-host."
     )

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -29,9 +29,9 @@ from splitsmith.db import (
 )
 from splitsmith.db.email import (
     CONSOLE_MAGIC_LINK_MARKER,
-    RESEND_API_URL,
+    LETTERMINT_API_URL,
     ConsoleEmailSender,
-    ResendEmailSender,
+    LettermintEmailSender,
     build_email_sender,
 )
 from splitsmith.db.magic_link import (
@@ -326,45 +326,64 @@ def test_build_email_sender_fails_loud_on_unknown_provider() -> None:
         build_email_sender("mailgun")
 
 
-def test_build_email_sender_resend_requires_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+def test_build_email_sender_lettermint_requires_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LETTERMINT_API_TOKEN", raising=False)
     monkeypatch.delenv("SPLITSMITH_EMAIL_FROM", raising=False)
-    with pytest.raises(RuntimeError, match="RESEND_API_KEY"):
-        build_email_sender("resend")
+    with pytest.raises(RuntimeError, match="LETTERMINT_API_TOKEN"):
+        build_email_sender("lettermint")
 
 
-def test_build_email_sender_resend_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+def test_build_email_sender_lettermint_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LETTERMINT_API_TOKEN", "lm_test")
     monkeypatch.setenv("SPLITSMITH_EMAIL_FROM", "Splitsmith <login@splitsmith.test>")
-    assert isinstance(build_email_sender("resend"), ResendEmailSender)
+    monkeypatch.delenv("LETTERMINT_ROUTE", raising=False)
+    assert isinstance(build_email_sender("lettermint"), LettermintEmailSender)
 
 
-def test_resend_email_sender_posts_the_link() -> None:
+def test_lettermint_email_sender_posts_the_link() -> None:
     respx = pytest.importorskip("respx")
     import httpx
 
-    sender = ResendEmailSender(api_key="re_test", from_address="Splitsmith <login@splitsmith.test>")
+    sender = LettermintEmailSender(api_token="lm_test", from_address="Splitsmith <login@splitsmith.test>")
     link = f"{BASE_URL}/auth/callback?token=tok123"
     with respx.mock:
-        route = respx.post(RESEND_API_URL).mock(return_value=httpx.Response(200, json={"id": "e1"}))
+        route = respx.post(LETTERMINT_API_URL).mock(
+            return_value=httpx.Response(200, json={"message_id": "e1", "status": "queued"})
+        )
         asyncio.run(sender.send_magic_link(to="user@example.com", link=link))
 
     assert route.called
     req = route.calls.last.request
-    assert req.headers["authorization"] == "Bearer re_test"
+    assert req.headers["x-lettermint-token"] == "lm_test"
     body = req.content.decode()
     assert "user@example.com" in body
     assert "tok123" in body  # the magic link is carried in the body
+    assert "route" not in body  # omitted when unset
 
 
-def test_resend_email_sender_raises_on_provider_error() -> None:
+def test_lettermint_email_sender_includes_route_when_set() -> None:
     respx = pytest.importorskip("respx")
     import httpx
 
-    sender = ResendEmailSender(api_key="re_test", from_address="x@y.z")
+    sender = LettermintEmailSender(api_token="lm_test", from_address="x@y.z", route="production")
     with respx.mock:
-        respx.post(RESEND_API_URL).mock(
-            return_value=httpx.Response(422, json={"message": "domain not verified"})
+        route = respx.post(LETTERMINT_API_URL).mock(
+            return_value=httpx.Response(200, json={"message_id": "e1", "status": "queued"})
+        )
+        asyncio.run(sender.send_magic_link(to="user@example.com", link=f"{BASE_URL}/auth/callback?token=x"))
+
+    body = route.calls.last.request.content.decode()
+    assert '"route"' in body and "production" in body
+
+
+def test_lettermint_email_sender_raises_on_provider_error() -> None:
+    respx = pytest.importorskip("respx")
+    import httpx
+
+    sender = LettermintEmailSender(api_token="lm_test", from_address="x@y.z")
+    with respx.mock:
+        respx.post(LETTERMINT_API_URL).mock(
+            return_value=httpx.Response(422, json={"error": "domain not verified"})
         )
         with pytest.raises(httpx.HTTPStatusError):
             asyncio.run(


### PR DESCRIPTION
## What

Swaps the production magic-link email transport from **Resend** to **Lettermint**, matching the transactional ESP already used in the freshguard project.

This is a clean replace (no shipped users yet): the Resend sender is removed rather than kept as a parallel path, per the project's "no fallbacks pre-production" convention.

## Changes

- `db/email.py`: `LettermintEmailSender` -- `httpx` POST to `https://api.lettermint.co/v1/send`, header `x-lettermint-token`, payload `{from, to:[], subject, text, html, route?}` (route omitted when unset). `build_email_sender` branch is now `"lettermint"`.
- Env: `SPLITSMITH_EMAIL_BACKEND=lettermint` + `LETTERMINT_API_TOKEN` + `SPLITSMITH_EMAIL_FROM` (both required, fail-loud) + optional `LETTERMINT_ROUTE`. The `console` transport (dev / self-host default) is unchanged.
- Update `db/__init__.py` exports, the `serve` CLI docstring, and the saas-readiness docs.
- Tests rewritten for Lettermint, including a route-included case.

## Verification

- ruff + black clean; `tests/test_magic_link_auth.py` 20/20 pass.
- `splitsmith.app` Lettermint DNS (DMARC / DKIM / bounces CNAME) added via Cloudflare and verified on both authoritative nameservers.
- A live send from `login@splitsmith.app` to a real address was accepted by the Lettermint API (HTTP 2xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)