### PR TITLE
feat(saas): gate signups behind an allowlist toggle (anti-spam)

### DIFF
--- a/docs/saas-readiness/11-environment-strategy.md
+++ b/docs/saas-readiness/11-environment-strategy.md
@@ -96,12 +96,14 @@ Both `serve` and `worker` in a given environment share these. The
 | Variable | prod | staging |
 | --- | --- | --- |
 | `SPLITSMITH_MODE` | `hosted` | `hosted` |
-| `SPLITSMITH_DATABASE_URL` | Neon `main`, direct endpoint | Neon `staging`, direct endpoint |
+| `SPLITSMITH_DATABASE_URL` | Neon `production` branch, direct endpoint | Neon `staging` branch, direct endpoint |
 | `SPLITSMITH_PUBLIC_URL` | `https://my.splitsmith.app` | `https://my.staging.splitsmith.app` |
 | `SPLITSMITH_EMAIL_BACKEND` | `lettermint` | `console` |
 | `LETTERMINT_API_TOKEN` | set | unset (console) |
 | `SPLITSMITH_EMAIL_FROM` | `Splitsmith <login@splitsmith.app>` | unset (console) |
 | `LETTERMINT_ROUTE` | `production` (optional) | unset |
+| `SPLITSMITH_SIGNUPS_OPEN` | `false` at launch (allowlist only) | `false` |
+| `SPLITSMITH_SIGNUP_ALLOWLIST` | the launch allowlist (emails / `@domain`) | your own address |
 | `SPLITSMITH_S3_*` | `splitsmith-uploads-prod` bucket creds | `splitsmith-uploads-staging` bucket creds |
 
 A public https `SPLITSMITH_PUBLIC_URL` turns on the Secure cookie flag

--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -544,6 +544,10 @@ def serve(
       ``lettermint`` for production, with ``LETTERMINT_API_TOKEN`` +
       ``SPLITSMITH_EMAIL_FROM`` (e.g. ``Splitsmith <login@yourdomain>``)
       and an optional ``LETTERMINT_ROUTE``.
+    - ``SPLITSMITH_SIGNUPS_OPEN`` -- ``true`` (default) lets anyone sign
+      up; ``false`` closes signups to all but ``SPLITSMITH_SIGNUP_ALLOWLIST``
+      (comma/space-separated exact emails or ``@domain`` entries).
+      Returning users always sign in regardless.
 
     No browser auto-open, no ``--project`` (paths live in Postgres).
     Defaults bind ``0.0.0.0`` because the typical caller is a

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -44,6 +44,7 @@ from .models import (
 )
 from .recent_projects import PostgresRecentProjectsStore
 from .scoreboard_identity import PostgresScoreboardIdentityStore
+from .signup_policy import SignupPolicy, build_signup_policy
 
 __all__ = [
     "Base",
@@ -64,8 +65,10 @@ __all__ = [
     "RecentProjectRow",
     "SESSION_COOKIE_NAME",
     "SessionRow",
+    "SignupPolicy",
     "User",
     "build_email_sender",
+    "build_signup_policy",
     "create_engine",
     "new_ulid",
     "sessionmaker",

--- a/src/splitsmith/db/magic_link.py
+++ b/src/splitsmith/db/magic_link.py
@@ -47,6 +47,7 @@ from ..auth import User
 from .email import EmailSender
 from .models import MagicLinkTokenRow, SessionRow
 from .models import User as UserRow
+from .signup_policy import SignupPolicy
 
 # Cookie the browser carries the raw session secret in. httpOnly + Secure
 # + SameSite=Lax are set by the route when it writes the cookie (doc 02);
@@ -121,12 +122,23 @@ class MagicLinkAuth:
         email_sender: EmailSender,
         *,
         now: Callable[[], datetime] = _utcnow,
+        signup_policy: SignupPolicy | None = None,
     ) -> None:
         # Raw (non-tenant) factory: this backend writes users / sessions /
         # magic_link_tokens, none under RLS, and runs before any GUC.
         self._session_factory = session_factory
         self._email = email_sender
         self._now = now
+        # Unconfigured -> open signups (local / self-host / tests). The
+        # hosted deploy passes a closed policy + allowlist.
+        self._signup_policy = signup_policy or SignupPolicy.open()
+
+    async def _email_has_account(self, email: str) -> bool:
+        async with self._session_factory() as session:
+            existing = (
+                await session.execute(select(UserRow.id).where(UserRow.email == email))
+            ).scalar_one_or_none()
+        return existing is not None
 
     # ------------------------------------------------------------------
     # Sign-in flow
@@ -141,10 +153,21 @@ class MagicLinkAuth:
         send the link regardless of whether ``email`` has an account -- the
         account is created on redemption, and not revealing account
         existence is deliberate.
+
+        Signup gating (anti-spam): when signups are closed and ``email`` is
+        neither allowlisted nor an existing account, we mint nothing and
+        send nothing, but still return a challenge-shaped handle so the
+        response is indistinguishable from a real one (no enumeration). A
+        returning user is always let through -- the gate blocks only *new*
+        accounts.
         """
         normalized = _normalize_email(email)
-        token = secrets.token_urlsafe(32)
         now = self._now()
+        if not self._signup_policy.allows_signup(normalized) and not await self._email_has_account(
+            normalized
+        ):
+            return LoginChallenge(id="blocked", email=normalized, expires_at=now + MAGIC_LINK_TTL)
+        token = secrets.token_urlsafe(32)
         row = MagicLinkTokenRow(
             email=normalized,
             token_hash=_hash(token),
@@ -206,6 +229,13 @@ class MagicLinkAuth:
                 await session.execute(select(UserRow).where(UserRow.email == link_row.email))
             ).scalar_one_or_none()
             if user_row is None:
+                # Signup gating, defense in depth: a token minted while
+                # signups were open but redeemed after they closed must not
+                # create a new account. (``begin_login`` already blocks the
+                # common path; this covers stale tokens.) The token is
+                # consumed above either way; a blocked attempt just burns it.
+                if not self._signup_policy.allows_signup(link_row.email):
+                    raise InvalidMagicLinkError("signups_closed")
                 # First sign-in creates the account. Guard the insert in a
                 # savepoint: two concurrent first logins for the same new
                 # email both see None here, and the loser's INSERT hits the

--- a/src/splitsmith/db/signup_policy.py
+++ b/src/splitsmith/db/signup_policy.py
@@ -1,0 +1,117 @@
+"""Signup gating for hosted magic-link auth.
+
+A small policy object that answers one question: may ``email`` create a
+*new* account right now? It gates **signups only** -- returning users
+(an email that already has an account) always sign in, gate or not. The
+point is anti-spam: close public signups during a beta / launch and let
+through only an allowlist, without blocking the people already in.
+
+Resolved once at boot from two env vars (configuration is data, doc 00):
+
+- ``SPLITSMITH_SIGNUPS_OPEN`` -- ``true`` (default) lets anyone sign up;
+  ``false`` closes signups to all but the allowlist. The default is open
+  so local / self-host hosted mode works with zero config; the hosted
+  production deploy sets it to ``false`` explicitly.
+- ``SPLITSMITH_SIGNUP_ALLOWLIST`` -- comma/space-separated entries, each
+  either an exact address (``a@b.com``) or a domain (``@b.com`` or bare
+  ``b.com``) that matches anyone there. Only consulted when signups are
+  closed.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+SPLITSMITH_SIGNUPS_OPEN_ENV = "SPLITSMITH_SIGNUPS_OPEN"
+SPLITSMITH_SIGNUP_ALLOWLIST_ENV = "SPLITSMITH_SIGNUP_ALLOWLIST"
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+
+
+@dataclass(frozen=True)
+class SignupPolicy:
+    """Whether new-account creation is permitted, and for whom.
+
+    Immutable; built once at boot. ``allows_signup`` is the only thing
+    callers need.
+    """
+
+    signups_open: bool = True
+    allowed_emails: frozenset[str] = frozenset()
+    allowed_domains: frozenset[str] = frozenset()
+
+    @classmethod
+    def open(cls) -> SignupPolicy:
+        """The permissive default: anyone may sign up. Used when no policy
+        is configured (local / self-host / tests)."""
+        return cls(signups_open=True)
+
+    def allows_signup(self, email: str) -> bool:
+        """True if ``email`` may create a new account.
+
+        Open signups -> always True. Closed -> True only if the address or
+        its domain is on the allowlist. This does **not** consider whether
+        the email already has an account; the caller lets returning users
+        through separately.
+        """
+        if self.signups_open:
+            return True
+        normalized = email.strip().lower()
+        if normalized in self.allowed_emails:
+            return True
+        domain = normalized.rpartition("@")[2]
+        return bool(domain) and domain in self.allowed_domains
+
+
+def _parse_bool(raw: str | None, *, default: bool) -> bool:
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in _TRUE:
+        return True
+    if value in _FALSE:
+        return False
+    return default
+
+
+def _parse_allowlist(raw: str | None) -> tuple[frozenset[str], frozenset[str]]:
+    """Split the allowlist string into (exact emails, domains).
+
+    Entries split on commas and whitespace. ``@b.com`` and bare ``b.com``
+    are domains; anything else containing ``@`` is an exact address.
+    Everything is lower-cased.
+    """
+    emails: set[str] = set()
+    domains: set[str] = set()
+    for token in (raw or "").replace(",", " ").split():
+        entry = token.strip().lower()
+        if not entry:
+            continue
+        if entry.startswith("@"):
+            domains.add(entry[1:])
+        elif "@" in entry:
+            emails.add(entry)
+        else:
+            domains.add(entry)
+    return frozenset(emails), frozenset(domains)
+
+
+def build_signup_policy(
+    *,
+    open_value: str | None = None,
+    allowlist_value: str | None = None,
+) -> SignupPolicy:
+    """Resolve the :class:`SignupPolicy` from env (or the passed overrides,
+    which exist for tests). Unset ``SPLITSMITH_SIGNUPS_OPEN`` -> open."""
+    open_raw = open_value if open_value is not None else os.environ.get(SPLITSMITH_SIGNUPS_OPEN_ENV)
+    allow_raw = (
+        allowlist_value if allowlist_value is not None else os.environ.get(SPLITSMITH_SIGNUP_ALLOWLIST_ENV)
+    )
+    emails, domains = _parse_allowlist(allow_raw)
+    return SignupPolicy(
+        signups_open=_parse_bool(open_raw, default=True),
+        allowed_emails=emails,
+        allowed_domains=domains,
+    )

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3448,6 +3448,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
         PostgresRecentProjectsStore,
         PostgresScoreboardIdentityStore,
         build_email_sender,
+        build_signup_policy,
         create_engine,
         sessionmaker,
         tenant_session_factory,
@@ -3490,7 +3491,11 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
     # The email transport is pluggable: console by default (docker / self-host),
     # an HTTP provider when ``SPLITSMITH_EMAIL_BACKEND`` selects one.
     email_sender = build_email_sender(os.environ.get(SPLITSMITH_EMAIL_BACKEND_ENV))
-    state.auth = MagicLinkAuth(session_factory, email_sender)
+    # Signup gating (anti-spam): open by default; the hosted deploy closes
+    # signups to all but an allowlist via SPLITSMITH_SIGNUPS_OPEN=false +
+    # SPLITSMITH_SIGNUP_ALLOWLIST. Returning users always sign in.
+    signup_policy = build_signup_policy()
+    state.auth = MagicLinkAuth(session_factory, email_sender, signup_policy=signup_policy)
 
     # Process-level, tenant-agnostic resources shared by every
     # ``TenantContext``. The deferrer routes per-user inside ``_defer``

--- a/tests/test_magic_link_auth.py
+++ b/tests/test_magic_link_auth.py
@@ -39,6 +39,7 @@ from splitsmith.db.magic_link import (
     InvalidMagicLinkError,
     _hash,
 )
+from splitsmith.db.signup_policy import SignupPolicy, build_signup_policy
 
 BASE_URL = "https://splitsmith.test"
 
@@ -91,11 +92,12 @@ def session_factory(tmp_path) -> Iterator[object]:
     yield sessionmaker(engine)
 
 
-def _auth(session_factory, *, sender=None, clock=None) -> MagicLinkAuth:
+def _auth(session_factory, *, sender=None, clock=None, signup_policy=None) -> MagicLinkAuth:
     return MagicLinkAuth(
         session_factory,
         sender or _CapturingSender(),
         now=clock or (lambda: datetime.now(UTC)),
+        signup_policy=signup_policy,
     )
 
 
@@ -389,3 +391,113 @@ def test_lettermint_email_sender_raises_on_provider_error() -> None:
             asyncio.run(
                 sender.send_magic_link(to="user@example.com", link=f"{BASE_URL}/auth/callback?token=x")
             )
+
+
+# ----------------------------------------------------------------------
+# Signup policy parsing
+# ----------------------------------------------------------------------
+
+
+def test_signup_policy_defaults_open_when_unset() -> None:
+    policy = build_signup_policy(open_value=None, allowlist_value=None)
+    assert policy.signups_open is True
+    assert policy.allows_signup("anyone@example.com") is True
+
+
+def test_signup_policy_closed_blocks_unlisted() -> None:
+    policy = build_signup_policy(open_value="false", allowlist_value="")
+    assert policy.signups_open is False
+    assert policy.allows_signup("stranger@example.com") is False
+
+
+def test_signup_policy_allowlist_matches_email_and_domain() -> None:
+    policy = build_signup_policy(
+        open_value="false",
+        allowlist_value="vip@example.com, @thias.se  bare.dev",
+    )
+    # exact email (case-insensitive)
+    assert policy.allows_signup("VIP@example.com") is True
+    # @domain entry
+    assert policy.allows_signup("anyone@thias.se") is True
+    # bare domain entry
+    assert policy.allows_signup("dev@bare.dev") is True
+    # not listed
+    assert policy.allows_signup("nope@elsewhere.com") is False
+
+
+@pytest.mark.parametrize("raw,expected", [("1", True), ("yes", True), ("off", False), ("0", False)])
+def test_signup_policy_bool_parsing(raw: str, expected: bool) -> None:
+    assert build_signup_policy(open_value=raw, allowlist_value="").signups_open is expected
+
+
+# ----------------------------------------------------------------------
+# Signup gating in begin_login
+# ----------------------------------------------------------------------
+
+_CLOSED = SignupPolicy(signups_open=False, allowed_emails=frozenset({"vip@example.com"}))
+
+
+def test_begin_login_blocks_new_email_when_closed(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender, signup_policy=_CLOSED)
+
+    challenge = asyncio.run(auth.begin_login("stranger@example.com", base_url=BASE_URL))
+
+    # Neutral, challenge-shaped response, but nothing minted or sent.
+    assert challenge.email == "stranger@example.com"
+    assert sender.sent == []
+
+    async def _count_tokens() -> int:
+        async with session_factory() as s:
+            return len((await s.execute(select(MagicLinkTokenRow))).scalars().all())
+
+    assert asyncio.run(_count_tokens()) == 0
+
+
+def test_begin_login_allows_allowlisted_email_when_closed(session_factory) -> None:
+    sender = _CapturingSender()
+    auth = _auth(session_factory, sender=sender, signup_policy=_CLOSED)
+
+    asyncio.run(auth.begin_login("vip@example.com", base_url=BASE_URL))
+
+    assert len(sender.sent) == 1
+    assert sender.sent[0][0] == "vip@example.com"
+
+
+def test_begin_login_allows_returning_user_when_closed(session_factory) -> None:
+    # Create the account while open, then close signups: the returning user
+    # must still be able to request a link.
+    open_sender = _CapturingSender()
+    open_auth = _auth(session_factory, sender=open_sender)
+    asyncio.run(open_auth.begin_login("member@example.com", base_url=BASE_URL))
+    asyncio.run(open_auth.complete_login(open_sender.last_token()))
+
+    closed_sender = _CapturingSender()
+    closed_auth = _auth(session_factory, sender=closed_sender, signup_policy=_CLOSED)
+    asyncio.run(closed_auth.begin_login("member@example.com", base_url=BASE_URL))
+
+    assert len(closed_sender.sent) == 1
+
+
+# ----------------------------------------------------------------------
+# Signup gating in complete_login (defense in depth)
+# ----------------------------------------------------------------------
+
+
+def test_complete_login_refuses_new_account_when_closed(session_factory) -> None:
+    # Mint a token while signups are open, then redeem it after closing.
+    open_sender = _CapturingSender()
+    open_auth = _auth(session_factory, sender=open_sender)
+    asyncio.run(open_auth.begin_login("late@example.com", base_url=BASE_URL))
+    token = open_sender.last_token()
+
+    closed_auth = _auth(session_factory, signup_policy=_CLOSED)
+    with pytest.raises(InvalidMagicLinkError) as exc:
+        asyncio.run(closed_auth.complete_login(token))
+    assert exc.value.reason == "signups_closed"
+
+    async def _count_users() -> int:
+        async with session_factory() as s:
+            return len((await s.execute(select(UserRow))).scalars().all())
+
+    assert asyncio.run(_count_users()) == 0


### PR DESCRIPTION
## What

Lets the hosted deploy **close public signups** during launch/beta and let through only an **allowlist**, without blocking users who already have an account. The point is anti-spam: don't invite a flood of stranger signups while the deploy is being shaken out.

## How

- **`SignupPolicy`** (`db/signup_policy.py`) resolved once at boot from two env vars:
  - `SPLITSMITH_SIGNUPS_OPEN` -- `true` (default) anyone can sign up; `false` closes signups to all but the allowlist. Default is **open** so local / self-host hosted mode needs zero config.
  - `SPLITSMITH_SIGNUP_ALLOWLIST` -- comma/space-separated entries, each an exact address (`a@b.com`) or a domain (`@b.com` or bare `b.com`). Only consulted when closed.
- **`MagicLinkAuth`** takes the policy:
  - `begin_login` blocks a *new*, non-allowlisted email when signups are closed -- mints nothing, sends nothing, but returns a challenge-shaped handle so the response is indistinguishable (no account enumeration). A **returning user** (existing account) always passes -- the gate blocks only new accounts.
  - `complete_login` re-checks at account creation as defense in depth, so a token minted while open can't create an account after signups close.
- Wired into the server boot; exported from `db`; `serve` docstring + doc 11 env matrix document the vars (prod launches with `SPLITSMITH_SIGNUPS_OPEN=false`).

## Tests

- Policy parsing: bool variants; exact-email, `@domain`, and bare-domain matching; case-insensitivity.
- Gating in `begin_login`: new email blocked (no token, no email), allowlisted email allowed, returning user allowed.
- Gating in `complete_login`: stale token can't create an account when closed; no user row written.

`ruff` + `black` clean; `tests/test_magic_link_auth.py` 31/31, hosted-boot + db-foundation suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)