### PR TITLE
ci(deploy): Railway deploy workflow, .railwayignore, and Procrastinate DSN fix

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,75 @@
+name: Deploy app (Railway)
+
+# CI-controlled deploys to Railway (not Railway's auto-deploy-on-push) so
+# the timing is ours. `railway up` uploads the repo and Railway builds the
+# Dockerfile; the env-scoped project token (a per-GitHub-Environment
+# RAILWAY_TOKEN secret) decides which Railway environment it lands in.
+#
+#   push to main          -> staging
+#   release published     -> production  (release-please release, doc 11)
+#   workflow_dispatch      -> the chosen environment (manual button)
+#
+# Both services build from the same image (ENTRYPOINT `splitsmith`); the
+# `serve` and `worker` Railway services differ only by start command, set
+# on the service itself. `serve` runs `alembic upgrade head` on boot.
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        type: choice
+        options: [staging, production]
+        default: staging
+
+permissions:
+  contents: read
+
+jobs:
+  target:
+    name: resolve target environment
+    runs-on: ubuntu-latest
+    outputs:
+      env: ${{ steps.pick.outputs.env }}
+    steps:
+      - id: pick
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch) echo "env=${{ inputs.environment }}" >> "$GITHUB_OUTPUT" ;;
+            release)           echo "env=production" >> "$GITHUB_OUTPUT" ;;
+            *)                 echo "env=staging" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  deploy:
+    name: railway up (${{ needs.target.outputs.env }})
+    needs: target
+    runs-on: ubuntu-latest
+    # Pulls this GitHub Environment's RAILWAY_TOKEN (the env-scoped Railway
+    # project token), so the same workflow targets staging or production
+    # purely by which environment it runs under.
+    environment: ${{ needs.target.outputs.env }}
+    # One in-flight deploy per Railway environment; let a running deploy
+    # finish rather than cancelling it mid-build.
+    concurrency:
+      group: deploy-app-${{ needs.target.outputs.env }}
+      cancel-in-progress: false
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm i -g @railway/cli
+
+      # `--ci` streams the build log and exits non-zero if the build or
+      # deploy fails, so a broken deploy fails the job. The API service
+      # migrates the DB on boot.
+      - name: Deploy API (serve)
+        run: railway up --service serve --ci
+
+      - name: Deploy worker
+        run: railway up --service worker --ci

--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,36 @@
+# `railway up` tars the working dir respecting .gitignore + THIS file (it
+# ignores .dockerignore). Without it the upload includes tests/fixtures/*.wav
+# (~150 MB of audio) and times out. Keep the upload to what the Dockerfile
+# build actually needs: the package source (incl. the SPA build inputs at
+# src/splitsmith/ui_static/), the dependency manifests, and alembic/.
+#
+# Mirror .dockerignore's exclusions. The Docker build still applies
+# .dockerignore on top; this just keeps the upload small.
+
+.git
+.github
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+**/__pycache__
+**/*.pyc
+**/*.pyo
+
+# Regenerable / redundant SPA bits (node_modules rebuilt by `npm ci`, dist
+# rebuilt by the spa stage, alternate lockfile unused).
+src/splitsmith/ui_static/node_modules
+src/splitsmith/ui_static/dist
+src/splitsmith/ui_static/pnpm-lock.yaml
+**/*.map
+
+# Dev-only trees nothing in the image reads (tests/ holds the heavy .wav
+# fixtures that caused the upload timeout).
+tests
+docs
+examples
+build
+scripts
+site
+functions
+*.egg-info

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -44,8 +44,21 @@ import asyncio
 import re
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import procrastinate
+
+# asyncpg-only SQLAlchemy URL query params that libpq / psycopg3 does not
+# understand and rejects with "invalid URI query parameter". They're
+# meaningful only to the SQLAlchemy asyncpg dialect, so we drop them when
+# building the psycopg DSN for Procrastinate.
+_ASYNCPG_ONLY_QUERY_KEYS = frozenset(
+    {
+        "prepared_statement_cache_size",
+        "statement_cache_size",
+        "prepared_statement_name_func",
+    }
+)
 
 # Procrastinate task name for the unified compute-job dispatcher. The
 # API enqueues it via :func:`make_deferrer` (``configure_task`` -- no
@@ -64,6 +77,14 @@ def _to_psycopg_dsn(sqlalchemy_url: str) -> str:
     the same ``SPLITSMITH_DATABASE_URL`` they already pass to
     SQLAlchemy.
 
+    The query string also has to be reconciled: the SQLAlchemy asyncpg
+    URL carries asyncpg-flavoured params that libpq rejects. We map
+    ``ssl=<mode>`` -> ``sslmode=<mode>`` (asyncpg's SSL knob vs libpq's)
+    and drop asyncpg-only keys like ``prepared_statement_cache_size``.
+    Without this, a Neon URL (``?ssl=require&prepared_statement_cache_size=0``)
+    makes psycopg raise ``invalid URI query parameter: "ssl"`` and the
+    worker can't connect.
+
     SQLite URLs raise: Procrastinate is Postgres-only, and the
     alembic migration that lands its schema is a no-op on SQLite.
     Callers must not construct the App against a SQLite URL.
@@ -74,7 +95,19 @@ def _to_psycopg_dsn(sqlalchemy_url: str) -> str:
             "SQLite-backed dev/smoke runs don't exercise the queue."
         )
     # ``postgresql+asyncpg://...`` -> ``postgresql://...``
-    return re.sub(r"^postgresql\+\w+://", "postgresql://", sqlalchemy_url)
+    url = re.sub(r"^postgresql\+\w+://", "postgresql://", sqlalchemy_url)
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+    translated: list[tuple[str, str]] = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key == "ssl":
+            translated.append(("sslmode", value))
+        elif key in _ASYNCPG_ONLY_QUERY_KEYS:
+            continue
+        else:
+            translated.append((key, value))
+    return urlunsplit(parts._replace(query=urlencode(translated)))
 
 
 def build_app(database_url: str) -> procrastinate.App:

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -14,9 +14,35 @@ import pytest
 from typer.testing import CliRunner
 
 from splitsmith.cli import app
-from splitsmith.queue import build_app, run_worker
+from splitsmith.queue import _to_psycopg_dsn, build_app, run_worker
 
 _FAKE_PG_URL = "postgresql+asyncpg://u:p@localhost:5432/db"
+
+
+def test_to_psycopg_dsn_strips_async_dialect() -> None:
+    assert _to_psycopg_dsn(_FAKE_PG_URL) == "postgresql://u:p@localhost:5432/db"
+
+
+def test_to_psycopg_dsn_translates_ssl_and_drops_asyncpg_params() -> None:
+    """A Neon-style asyncpg URL must become a valid libpq DSN: ``ssl`` ->
+    ``sslmode`` and asyncpg-only ``prepared_statement_cache_size`` dropped,
+    else psycopg raises ``invalid URI query parameter: "ssl"`` and the
+    worker can't connect."""
+    url = (
+        "postgresql+asyncpg://u:p@ep-x-pooler.eu-central-1.aws.neon.tech/neondb"
+        "?ssl=require&prepared_statement_cache_size=0"
+    )
+    dsn = _to_psycopg_dsn(url)
+    assert dsn.startswith("postgresql://u:p@ep-x-pooler.eu-central-1.aws.neon.tech/neondb?")
+    assert "sslmode=require" in dsn
+    assert "ssl=require" not in dsn  # the asyncpg key must be gone
+    assert "prepared_statement_cache_size" not in dsn
+
+
+def test_to_psycopg_dsn_preserves_other_query_params() -> None:
+    dsn = _to_psycopg_dsn("postgresql+asyncpg://u:p@h:5432/db?ssl=require&application_name=ss")
+    assert "sslmode=require" in dsn
+    assert "application_name=ss" in dsn
 
 
 def test_build_app_registers_ping_task() -> None:


### PR DESCRIPTION
Bring-up of the hosted Railway deploy. Three related changes, all needed to make the hosted app actually deploy and run.

## `.github/workflows/deploy-app.yml`
CI-controlled deploys via `railway up` (not Railway auto-deploy-on-push), so timing is ours:
- push to `main` -> **staging**
- a published release (release-please) -> **production**
- `workflow_dispatch` -> chosen env
Each GitHub Environment (`staging`/`production`) supplies an env-scoped `RAILWAY_TOKEN`, which selects the Railway environment. Deploys both `serve` and `worker`.

## `.railwayignore`
`railway up` tars the working dir honoring `.gitignore` + `.railwayignore` (it ignores `.dockerignore`). Without this the upload includes `tests/fixtures/*.wav` (~150 MB) and the upload **times out**. Trims the context to the Dockerfile build inputs.

## `fix(queue)`: asyncpg -> libpq SSL param translation
`_to_psycopg_dsn` only stripped the `+asyncpg` suffix, so a Neon URL (`?ssl=require&prepared_statement_cache_size=0`) reached Procrastinate's psycopg3 connector verbatim and crashed it with `invalid URI query parameter: "ssl"` — the worker crash-looped, and serve's enqueue path had the same latent bug. Now maps `ssl=<mode>` -> `sslmode=<mode>` and drops asyncpg-only keys. Other params pass through. Tests added.

## Verified live
Deployed to production (Railway, EU West) against Neon (eu-central-1) + R2: serve `/api/health` 200, magic-link login round-trips at `my.splitsmith.app`, worker drains the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)