### PR TITLE
fix(serve): don't drive async job dump from a live loop on SIGTERM

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -10588,8 +10588,21 @@ def _print_active_jobs(app: FastAPI) -> None:
     if state is None:
         return
     try:
-        # Signal handler runs synchronously; no event loop here. Use
-        # ``asyncio.run`` to drive the async JobBackend.list() call.
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop_running = False
+    else:
+        loop_running = True
+    if loop_running:
+        # Hosted ``serve`` under uvicorn: SIGTERM (a redeploy) is handled
+        # while uvicorn's event loop is still running, so ``asyncio.run``
+        # would raise "cannot be called from a running event loop". This
+        # job dump is a local Ctrl-C nicety, not a hosted concern -- skip
+        # it rather than spam a traceback on every redeploy.
+        return
+    try:
+        # Local ``splitsmith ui`` Ctrl-C: no loop is running, so drive the
+        # async JobBackend.list() call with ``asyncio.run``.
         jobs = asyncio.run(state.jobs.list())
     except Exception:  # pragma: no cover -- defensive: never block shutdown
         logger.warning("could not enumerate jobs on shutdown", exc_info=True)

--- a/tests/test_ui_shutdown.py
+++ b/tests/test_ui_shutdown.py
@@ -205,6 +205,37 @@ def test_shutdown_calls_handler_after_drain(tmp_path: Path) -> None:
     assert stopped.wait(timeout=2.0), "shutdown_handler not invoked after drain"
 
 
+def test_print_active_jobs_skips_quietly_under_running_loop(caplog) -> None:
+    """Regression: hosted ``serve`` handles SIGTERM (a redeploy) while
+    uvicorn's event loop is still running. ``_print_active_jobs`` must not
+    call ``asyncio.run`` there -- the old code did, caught the resulting
+    "cannot be called from a running event loop" RuntimeError, and logged a
+    traceback on every redeploy. It should now skip the job dump quietly."""
+    import logging
+
+    from fastapi import FastAPI
+
+    from splitsmith.ui.server import _print_active_jobs
+
+    class _JobsThatMustNotRun:
+        async def list(self):  # pragma: no cover -- must never be driven here
+            raise AssertionError("jobs.list() must not run from inside a live loop")
+
+    class _State:
+        jobs = _JobsThatMustNotRun()
+
+    app = FastAPI()
+    app.state.splitsmith_state = _State()
+
+    async def _call() -> None:
+        _print_active_jobs(app)  # a loop is running -> must just return
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(_call())  # must not raise
+
+    assert "could not enumerate jobs on shutdown" not in caplog.text
+
+
 def test_shutdown_drains_in_flight_job_before_calling_handler(tmp_path: Path) -> None:
     client = _make_client(tmp_path)
     state = client.app.state.splitsmith_state


### PR DESCRIPTION
## Problem

`_print_active_jobs` (the "active background jobs" dump on Ctrl-C) called `asyncio.run(state.jobs.list())`, assuming the signal handler runs with no event loop. Under hosted `serve` (uvicorn), SIGTERM — **every Railway redeploy** — is handled while uvicorn's loop is still running, so `asyncio.run` raised `RuntimeError: asyncio.run() cannot be called from a running event loop`. The broad `except` swallowed it but logged a traceback (`could not enumerate jobs on shutdown`) on every redeploy.

## Fix

Detect a running loop and skip the dump in that case — it's a local `splitsmith ui` Ctrl-C convenience, not a hosted-shutdown concern. Local single-process Ctrl-C (no running loop) drives `list()` exactly as before.

Regression test asserts that under a running loop it returns quietly (no warning logged, `list()` not driven).

Observed in the production serve logs during the Railway bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)