### PR TITLE
ci: bump actions/checkout v4 -> v5 across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -72,7 +72,7 @@ jobs:
           && contains(github.event.pull_request.labels.*.name, 'run-slim-smoke'))
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Railway CLI
         run: npm i -g @railway/cli

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -21,7 +21,7 @@ jobs:
     name: wrangler pages deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Once a root package.json + pnpm-lock.yaml landed (for the
       # wrangler dev dep used by the waitlist backend), wrangler-action

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,7 +30,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/splitsmith
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 


### PR DESCRIPTION
`actions/checkout@v4` runs on the deprecated Node 20 runtime — GitHub forces Node 24 on **2026-06-16** and removes Node 20 on 2026-09-16, surfaced as an annotation on the deploy runs. `v5` is a drop-in on Node 24.

Bumped in `ci.yml`, `deploy-app.yml`, `deploy-marketing.yml`, `publish-pypi.yml` (5 occurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)