### PR TITLE
fix(serve): hosted match state in Postgres (state refactor phases 1-2) + match resolution

### DIFF
--- a/alembic/versions/d1f7b25c8a3e_create_state_docs_table.py
+++ b/alembic/versions/d1f7b25c8a3e_create_state_docs_table.py
@@ -1,0 +1,126 @@
+"""create state_docs table
+
+Hosted match-state JSON docs (match / per-shooter project / per-stage
+audit) move out of ephemeral-disk JSON files mirrored to S3 and into this
+Postgres table with optimistic-concurrency versioning. See
+:class:`splitsmith.db.models.StateDocRow` and
+:class:`splitsmith.db.project_state.ProjectStateStore`.
+
+The sharp edge here is uniqueness. A doc is logically unique on
+``(user_id, match_id, doc_kind, slug, stage_number)`` -- but a plain
+unique constraint over those columns is wrong: ``slug`` is NULL for the
+``match`` kind and ``stage_number`` is NULL for ``match``/``project``,
+and SQL treats NULL as distinct-from-NULL in a unique index, so two
+``match`` rows (both NULL slug + stage) would coexist. On Postgres we use
+an expression unique index over ``coalesce(slug,'')`` and
+``coalesce(stage_number,-1)`` so the NULLs collapse to real values and
+the constraint bites. SQLite (the unit-test engine, and the clean-DB
+migration smoke test) has no expression-index-as-constraint story we need
+here and never sees concurrent writers, so it gets a plain unique index --
+its NULL-distinct weakness is harmless in tests.
+
+The ``doc`` column starts as generic JSON (so ``create_table`` works on
+both engines) and is ALTERed to JSONB on Postgres. RLS enablement is
+inlined, same body as ``a7c4e9d21b06`` -- ``state_docs`` joins the
+``tenant_isolation`` policy family.
+
+Revision ID: d1f7b25c8a3e
+Revises: c3f1a8e90d24
+Create Date: 2026-06-01 09:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d1f7b25c8a3e"
+down_revision: str | Sequence[str] | None = "c3f1a8e90d24"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_POLICY = "tenant_isolation"
+_EXPR_INDEX = "uq_state_docs_identity"
+_USER_INDEX = "ix_state_docs_user_id"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "state_docs",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("match_id", sa.String(), nullable=False),
+        sa.Column("doc_kind", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=True),
+        sa.Column("stage_number", sa.Integer(), nullable=True),
+        sa.Column("doc", sa.JSON(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(_USER_INDEX, "state_docs", ["user_id"], unique=False)
+
+    is_pg = op.get_bind().dialect.name == "postgresql"
+    if is_pg:
+        # Read whole / written whole, but JSONB is the correct column type
+        # and keeps future indexed access open without another migration.
+        op.execute("ALTER TABLE state_docs ALTER COLUMN doc TYPE JSONB USING doc::jsonb")
+        # The NULL-collapsing expression index is the real uniqueness
+        # guard (see module docstring).
+        op.execute(
+            f"CREATE UNIQUE INDEX {_EXPR_INDEX} ON state_docs "
+            "(user_id, match_id, doc_kind, coalesce(slug, ''), coalesce(stage_number, -1))"
+        )
+    else:
+        # SQLite test/smoke engine: plain unique index over the columns.
+        # No concurrent writers + no duplicate-creating tests, so the
+        # NULL-distinct weakness never triggers.
+        op.create_index(
+            _EXPR_INDEX,
+            "state_docs",
+            ["user_id", "match_id", "doc_kind", "slug", "stage_number"],
+            unique=True,
+        )
+
+    if is_pg:
+        # state_docs joins the tenant_isolation RLS policy family. Same
+        # body as a7c4e9d21b06; each statement issued separately because
+        # asyncpg can't run multiple commands in one prepared statement.
+        op.execute("ALTER TABLE state_docs ENABLE ROW LEVEL SECURITY")
+        op.execute("ALTER TABLE state_docs FORCE ROW LEVEL SECURITY")
+        op.execute(
+            f"CREATE POLICY {_POLICY} ON state_docs "
+            f"FOR ALL "
+            f"USING (user_id = current_setting('app.user_id', true)) "
+            f"WITH CHECK (user_id = current_setting('app.user_id', true))"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    is_pg = op.get_bind().dialect.name == "postgresql"
+    if is_pg:
+        op.execute(f"DROP POLICY IF EXISTS {_POLICY} ON state_docs")
+        op.execute("ALTER TABLE state_docs NO FORCE ROW LEVEL SECURITY")
+        op.execute("ALTER TABLE state_docs DISABLE ROW LEVEL SECURITY")
+        op.execute(f"DROP INDEX IF EXISTS {_EXPR_INDEX}")
+    else:
+        op.drop_index(_EXPR_INDEX, table_name="state_docs")
+    op.drop_index(_USER_INDEX, table_name="state_docs")
+    op.drop_table("state_docs")

--- a/src/splitsmith/async_bridge.py
+++ b/src/splitsmith/async_bridge.py
@@ -1,0 +1,52 @@
+"""Run an async coroutine to completion from synchronous code.
+
+The hosted-mode per-user stores (``ProjectStateStore`` et al.) are async,
+but the call sites that drive them are a mix:
+
+- **Sync FastAPI handlers** run in a threadpool with *no* event loop on
+  the thread, so ``asyncio.run`` works directly.
+- **Async FastAPI handlers** run on the event loop; ``asyncio.run`` there
+  raises ``RuntimeError: asyncio.run() cannot be called from a running
+  event loop``.
+- The model ``save()`` methods and the ``AppState`` state accessors are
+  *sync* (so the ~100 handler call sites that use them stay unchanged --
+  the whole point of the state-refactor seam) yet are reached from both
+  kinds of handler.
+
+:func:`run_sync` papers over the difference: no running loop -> run inline
+with ``asyncio.run``; a loop is already running -> run the coroutine on a
+throwaway worker thread (its own fresh loop) and block the caller on the
+result. Blocking the event loop for the duration of one small state query
+matches the blocking character the prior synchronous-boto3 JSON mirror
+already had, so this is not a regression in loop-friendliness.
+
+The hosted engine uses :class:`~sqlalchemy.pool.NullPool` precisely so a
+fresh per-call event loop is tolerated: asyncpg connections are
+loop-bound, and NullPool opens + closes one per session rather than
+reusing a connection across loops. See ``splitsmith.db.engine``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+def run_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Drive ``coro`` to completion regardless of the caller's loop state."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop on this thread (sync handler in the threadpool, worker
+        # callback, boot path) -- run inline.
+        return asyncio.run(coro)
+    # A loop is already running here (async handler). asyncio.run would
+    # reject; hand the coroutine to a worker thread with its own loop and
+    # block on it. Single-use executor: the call rate is handler I/O, not
+    # a hot loop, and a fresh thread keeps the loops cleanly separated.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()

--- a/src/splitsmith/db/__init__.py
+++ b/src/splitsmith/db/__init__.py
@@ -39,9 +39,11 @@ from .models import (
     MatchRow,
     RecentProjectRow,
     SessionRow,
+    StateDocRow,
     User,
     new_ulid,
 )
+from .project_state import ProjectStateStore, StateConflictError
 from .recent_projects import PostgresRecentProjectsStore
 from .scoreboard_identity import PostgresScoreboardIdentityStore
 from .signup_policy import SignupPolicy, build_signup_policy
@@ -62,10 +64,13 @@ __all__ = [
     "PostgresMatchStore",
     "PostgresRecentProjectsStore",
     "PostgresScoreboardIdentityStore",
+    "ProjectStateStore",
     "RecentProjectRow",
     "SESSION_COOKIE_NAME",
     "SessionRow",
     "SignupPolicy",
+    "StateConflictError",
+    "StateDocRow",
     "User",
     "build_email_sender",
     "build_signup_policy",

--- a/src/splitsmith/db/models.py
+++ b/src/splitsmith/db/models.py
@@ -19,6 +19,7 @@ from datetime import datetime
 
 import ulid
 from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -304,6 +305,109 @@ class MatchRow(Base):
 
     def __repr__(self) -> str:
         return f"<MatchRow user_id={self.user_id!r} match_id={self.match_id!r}>"
+
+
+class StateDocRow(Base):
+    """One row per hosted match-state JSON document (state refactor).
+
+    Hosted-mode per-match state used to live in JSON files on each
+    serve/worker container's ephemeral local disk, mirrored whole to S3
+    (``match.json``, per-shooter ``project.json``, ``audit/stage<N>.json``).
+    That model lost the state on every redeploy (empty working dir) and,
+    even fully mirrored, was whole-file last-writer-wins on S3 -- two
+    writers silently clobbered each other. This table holds those same
+    small JSON docs in Postgres with optimistic-concurrency versioning, so
+    match resolution is stateless across redeploys/replicas and concurrent
+    edits are *detected* (409) instead of lost.
+
+    **Polymorphic on ``doc_kind``** -- one table for all three kinds
+    because they share an identical load-whole / save-whole lifecycle and
+    are never queried *into* (the ``doc`` column is read and written
+    whole, never filtered on a key). Three near-duplicate tables would buy
+    nothing. The shape per kind:
+
+    - ``"match"``   -- the match-level doc (``Match`` model). ``slug`` and
+      ``stage_number`` are NULL.
+    - ``"project"`` -- a per-shooter project doc (``MatchProject`` model).
+      ``slug`` is the shooter slug; ``stage_number`` is NULL.
+    - ``"audit"``   -- a per-stage audit doc (raw dict, no model).
+      ``slug`` is the shooter slug; ``stage_number`` is the 1-based stage.
+
+    The existing ``matches`` table (:class:`MatchRow`) stays as the
+    ownership/index registry resolved by ``(user_id, match_id)``; this
+    table holds the bodies.
+
+    **Uniqueness.** Logically a doc is unique on
+    ``(user_id, match_id, doc_kind, slug, stage_number)``. But NULL is
+    distinct-from-NULL in a SQL unique index, so a plain
+    :class:`UniqueConstraint` over those columns would happily admit two
+    ``match`` rows (both with NULL slug + stage). The real guard is a
+    Postgres ``coalesce`` expression index created in the migration
+    (``coalesce(slug,'')``, ``coalesce(stage_number,-1)``). The
+    ``UniqueConstraint`` declared here is only so SQLite's ``create_all``
+    builds *a* unique index for the test engine -- tests never create
+    duplicates, so its NULL-distinct weakness is harmless there.
+
+    **Optimistic concurrency.** ``version`` starts at 1 on insert and the
+    store bumps it on every save guarded by ``WHERE version =
+    expected_version``; a stale writer's UPDATE matches 0 rows and raises
+    ``StateConflictError`` (-> 409). See
+    :class:`splitsmith.db.project_state.ProjectStateStore`.
+
+    **Multi-tenant:** ``user_id`` is non-nullable, CASCADEs on user
+    delete, and is added to the ``tenant_isolation`` RLS policy in the
+    migration. Every query in ``ProjectStateStore`` filters by
+    ``user_id``; isolation tests guard the invariant.
+    """
+
+    __tablename__ = "state_docs"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "match_id",
+            "doc_kind",
+            "slug",
+            "stage_number",
+            name="uq_state_docs_identity",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=new_ulid)
+    user_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    match_id: Mapped[str] = mapped_column(String, nullable=False)
+    doc_kind: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str | None] = mapped_column(String, nullable=True)
+    stage_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Read whole, written whole, never queried into -> generic JSON for
+    # SQLite tests, JSONB on Postgres (migration ALTERs the type). JSONB
+    # buys nothing on read-whole access but is the right column type and
+    # keeps the door open to future indexed access without a migration.
+    doc: Mapped[dict] = mapped_column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<StateDocRow user_id={self.user_id!r} match_id={self.match_id!r} "
+            f"kind={self.doc_kind!r} slug={self.slug!r} stage={self.stage_number!r} "
+            f"v={self.version}>"
+        )
 
 
 class ComputeJobRow(Base):

--- a/src/splitsmith/db/project_state.py
+++ b/src/splitsmith/db/project_state.py
@@ -1,0 +1,249 @@
+"""Postgres-backed hosted match-state store with optimistic locking.
+
+Hosted-mode per-match state -- the match doc, per-shooter project docs,
+and per-stage audit docs -- used to live as JSON files on ephemeral
+container disk mirrored whole to S3. That lost state on redeploy and was
+last-writer-wins under concurrent edits. This store moves those small
+JSON docs into the ``state_docs`` table (:class:`StateDocRow`) with
+optimistic-concurrency versioning, so resolution is stateless across
+replicas and concurrent edits are detected instead of lost.
+
+**Local desktop mode stays file-based** -- this store only backs hosted
+mode. The seam in ``MatchProject``/``Match`` chooses store vs file at
+save time.
+
+Constructed per-request (API) / per-job (worker) with the resolved user
+id, mirroring :class:`splitsmith.db.matches.PostgresMatchStore`. The
+``session_factory`` is the tenant-scoped one (sets the ``app.user_id``
+GUC the RLS policy keys on); every query *also* filters
+``WHERE user_id == self._user_id`` as defence-in-depth.
+
+Engine-agnostic: tests use ``sqlite+aiosqlite:///:memory:``; production
+uses ``postgresql+asyncpg://``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from .models import StateDocRow
+
+
+class StateConflictError(Exception):
+    """Raised when an optimistic-locking save loses a version race.
+
+    Either an INSERT (``expected_version == 0``) hit the uniqueness guard
+    because a doc already exists, or an UPDATE matched 0 rows because the
+    stored ``version`` no longer equals the ``expected_version`` the
+    caller loaded. Surfaced to the SPA as HTTP 409 ``version_conflict``;
+    the worker re-loads + re-merges audit docs on this error.
+    """
+
+
+# The three polymorphic doc kinds. ``slug`` is NULL for ``match``;
+# ``stage_number`` is non-NULL only for ``audit``.
+_KIND_MATCH = "match"
+_KIND_PROJECT = "project"
+_KIND_AUDIT = "audit"
+
+
+class ProjectStateStore:
+    """Per-user view of the ``state_docs`` table.
+
+    **Multi-tenant invariant:** every SQL statement issued by this store
+    includes ``StateDocRow.user_id == self._user_id`` in its WHERE
+    clause. The ``state_docs`` RLS policy enforces the same boundary at
+    the DB layer; the per-method filter enforces it at the query layer.
+    Tests in ``test_project_state_store.py`` guard the invariant -- if you
+    add a method here, add an isolation test for it too.
+
+    Each doc kind gets a thin public ``load_*`` / ``save_*`` wrapper over
+    one private ``_load`` / ``_save`` keyed on ``doc_kind`` -- the wrappers
+    keep the isolation-test-per-method discipline while the lifecycle
+    lives in one place.
+
+    ``load_*`` returns ``(doc | None, version)`` -- ``(None, 0)`` when the
+    doc is absent. ``save_*`` takes ``expected_version`` and returns the
+    new version:
+
+    - ``expected_version == 0`` -> INSERT a fresh row at version 1. A
+      uniqueness collision (someone else inserted first) raises
+      :class:`StateConflictError`.
+    - ``expected_version > 0`` -> ``UPDATE ... WHERE version ==
+      expected_version``. ``rowcount == 0`` (stale read or missing row)
+      raises :class:`StateConflictError`.
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker,
+        *,
+        user_id: str,
+    ) -> None:
+        # Fail loud at construction -- a None/empty user_id from a buggy
+        # auth layer would otherwise silently scope every query to "no
+        # rows", which is its own bug. Same guard as PostgresMatchStore.
+        if not isinstance(user_id, str) or not user_id:
+            raise ValueError(
+                "ProjectStateStore requires a non-empty user_id; "
+                f"got {user_id!r}. The auth layer must resolve a real "
+                "user before constructing the per-request store."
+            )
+        self._session_factory = session_factory
+        self._user_id = user_id
+
+    # -- match doc (slug / stage NULL) --------------------------------
+
+    async def load_match(self, match_id: str) -> tuple[dict | None, int]:
+        return await self._load(match_id, _KIND_MATCH, slug=None, stage_number=None)
+
+    async def save_match(self, match_id: str, doc: dict, *, expected_version: int) -> int:
+        return await self._save(
+            match_id, _KIND_MATCH, doc, expected_version=expected_version, slug=None, stage_number=None
+        )
+
+    # -- per-shooter project doc (slug set, stage NULL) ---------------
+
+    async def load_project(self, match_id: str, slug: str) -> tuple[dict | None, int]:
+        return await self._load(match_id, _KIND_PROJECT, slug=slug, stage_number=None)
+
+    async def save_project(self, match_id: str, slug: str, doc: dict, *, expected_version: int) -> int:
+        return await self._save(
+            match_id, _KIND_PROJECT, doc, expected_version=expected_version, slug=slug, stage_number=None
+        )
+
+    # -- per-stage audit doc (slug + stage set) -----------------------
+
+    async def load_audit(self, match_id: str, slug: str, stage_number: int) -> tuple[dict | None, int]:
+        return await self._load(match_id, _KIND_AUDIT, slug=slug, stage_number=stage_number)
+
+    async def save_audit(
+        self, match_id: str, slug: str, stage_number: int, doc: dict, *, expected_version: int
+    ) -> int:
+        return await self._save(
+            match_id,
+            _KIND_AUDIT,
+            doc,
+            expected_version=expected_version,
+            slug=slug,
+            stage_number=stage_number,
+        )
+
+    # -- shared lifecycle ---------------------------------------------
+
+    def _identity_where(self, match_id: str, doc_kind: str, slug: str | None, stage_number: int | None):
+        """Build the WHERE terms uniquely identifying one doc.
+
+        ``slug``/``stage_number`` are NULL for some kinds; comparing a
+        column to NULL with ``==`` yields ``NULL`` (never true) in SQL, so
+        use ``IS NULL`` for the None case. The leading ``user_id`` term is
+        the multi-tenant guard present on every statement.
+        """
+        terms = [
+            StateDocRow.user_id == self._user_id,
+            StateDocRow.match_id == match_id,
+            StateDocRow.doc_kind == doc_kind,
+            StateDocRow.slug.is_(None) if slug is None else StateDocRow.slug == slug,
+            (
+                StateDocRow.stage_number.is_(None)
+                if stage_number is None
+                else StateDocRow.stage_number == stage_number
+            ),
+        ]
+        return terms
+
+    async def _load(
+        self, match_id: str, doc_kind: str, *, slug: str | None, stage_number: int | None
+    ) -> tuple[dict | None, int]:
+        async with self._session_factory() as session:
+            row = (
+                await session.execute(
+                    select(StateDocRow).where(*self._identity_where(match_id, doc_kind, slug, stage_number))
+                )
+            ).scalar_one_or_none()
+        if row is None:
+            return None, 0
+        return row.doc, row.version
+
+    async def _save(
+        self,
+        match_id: str,
+        doc_kind: str,
+        doc: dict,
+        *,
+        expected_version: int,
+        slug: str | None,
+        stage_number: int | None,
+    ) -> int:
+        if expected_version == 0:
+            return await self._insert(match_id, doc_kind, doc, slug=slug, stage_number=stage_number)
+        return await self._update(
+            match_id, doc_kind, doc, expected_version=expected_version, slug=slug, stage_number=stage_number
+        )
+
+    async def _insert(
+        self, match_id: str, doc_kind: str, doc: dict, *, slug: str | None, stage_number: int | None
+    ) -> int:
+        async with self._session_factory() as session:
+            session.add(
+                StateDocRow(
+                    user_id=self._user_id,
+                    match_id=match_id,
+                    doc_kind=doc_kind,
+                    slug=slug,
+                    stage_number=stage_number,
+                    doc=doc,
+                    version=1,
+                )
+            )
+            try:
+                await session.commit()
+            except IntegrityError as exc:
+                # A concurrent writer inserted the same identity first
+                # (the coalesce expression unique index on PG, or the
+                # plain unique index on SQLite, rejected our row). The
+                # caller thought this was a creation (expected_version 0)
+                # but the doc already exists -> a genuine conflict.
+                await session.rollback()
+                raise StateConflictError(
+                    f"insert conflict for {doc_kind} doc "
+                    f"(match_id={match_id!r}, slug={slug!r}, stage={stage_number!r}): "
+                    "a doc already exists"
+                ) from exc
+        return 1
+
+    async def _update(
+        self,
+        match_id: str,
+        doc_kind: str,
+        doc: dict,
+        *,
+        expected_version: int,
+        slug: str | None,
+        stage_number: int | None,
+    ) -> int:
+        new_version = expected_version + 1
+        async with self._session_factory() as session:
+            result = await session.execute(
+                update(StateDocRow)
+                .where(
+                    *self._identity_where(match_id, doc_kind, slug, stage_number),
+                    StateDocRow.version == expected_version,
+                )
+                .values(doc=doc, version=new_version, updated_at=datetime.now(UTC))
+            )
+            if result.rowcount == 0:
+                # Either the row is gone or its version moved on since the
+                # caller loaded it -- a lost optimistic-locking race.
+                await session.rollback()
+                raise StateConflictError(
+                    f"version conflict for {doc_kind} doc "
+                    f"(match_id={match_id!r}, slug={slug!r}, stage={stage_number!r}): "
+                    f"expected version {expected_version}, row was changed or removed"
+                )
+            await session.commit()
+        return new_version

--- a/src/splitsmith/match_model.py
+++ b/src/splitsmith/match_model.py
@@ -32,8 +32,9 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
+from .async_bridge import run_sync
 from .config import StageRounds
 from .ui.project import (
     PROJECT_FILE,
@@ -219,6 +220,23 @@ class Match(BaseModel):
     #: Ordered list of shooter slugs (= subdir names under ``shooters/``).
     shooters: list[str] = Field(default_factory=list)
 
+    # Hosted-mode state-doc binding (state refactor). When set, ``save()``
+    # persists the match doc to the ``state_docs`` table via the bound
+    # ``ProjectStateStore`` under optimistic locking instead of writing
+    # ``match.json``. ``state.match()`` binds these after loading the doc
+    # from Postgres; creation sites bind with ``version=0``. Not persisted.
+    _state_store: Any = PrivateAttr(default=None)
+    _state_match_id: str | None = PrivateAttr(default=None)
+    _state_version: int = PrivateAttr(default=0)
+
+    def bind_state(self, store: Any, *, match_id: str, version: int) -> None:
+        """Bind a ``ProjectStateStore`` so ``save()`` round-trips the match
+        doc through Postgres (hosted mode). ``version`` is the
+        optimistic-lock version the doc was loaded at (0 to INSERT)."""
+        self._state_store = store
+        self._state_match_id = match_id
+        self._state_version = version
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -269,8 +287,23 @@ class Match(BaseModel):
         return match
 
     def save(self, root: Path) -> None:
-        """Atomically persist the match to ``<root>/match.json``."""
+        """Persist the match.
+
+        Hosted mode (a state store bound via :meth:`bind_state`): write the
+        match doc to the ``state_docs`` table under optimistic locking; no
+        file is touched. A stale version raises ``StateConflictError`` (->
+        409). Local desktop: atomic write to ``<root>/match.json``.
+        """
         self.updated_at = datetime.now(UTC)
+        if self._state_store is not None:
+            self._state_version = run_sync(
+                self._state_store.save_match(
+                    self._state_match_id,
+                    self.model_dump(mode="json"),
+                    expected_version=self._state_version,
+                )
+            )
+            return
         atomic_write_json(root / MATCH_FILE, self.model_dump(mode="json"))
 
     # ------------------------------------------------------------------

--- a/src/splitsmith/ui/project.py
+++ b/src/splitsmith/ui/project.py
@@ -37,6 +37,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, PrivateAttr, computed_field
 
 from .. import video_match
+from ..async_bridge import run_sync
 from ..automation import AutomationOverride
 from ..config import BeepCandidate, StageData, StageRounds, VideoMatchConfig
 from ..storage import Storage
@@ -806,6 +807,30 @@ class MatchProject(BaseModel):
     # is unbound (local mode) or when there's no match scope yet.
     _storage_scope: str | None = PrivateAttr(default=None)
 
+    # Hosted-mode state-doc binding (state refactor). When set, ``save()``
+    # persists this project to the ``state_docs`` table via the bound
+    # ``ProjectStateStore`` under optimistic locking instead of writing
+    # ``project.json`` to disk. ``state.shooter_project`` binds these after
+    # loading the doc from Postgres; a creation site binds with
+    # ``version=0`` so the first ``save()`` INSERTs at version 1. Not
+    # persisted -- request-scope state, must not ride model_dump.
+    # ``Any`` rather than the concrete store type to keep this module free
+    # of the hosted-only db import.
+    _state_store: Any = PrivateAttr(default=None)
+    _state_match_id: str | None = PrivateAttr(default=None)
+    _state_slug: str | None = PrivateAttr(default=None)
+    _state_version: int = PrivateAttr(default=0)
+
+    def bind_state(self, store: Any, *, match_id: str, slug: str, version: int) -> None:
+        """Bind a ``ProjectStateStore`` so ``save()`` round-trips through
+        Postgres (hosted mode). ``version`` is the optimistic-lock version
+        the doc was loaded at (0 for a not-yet-created project, so the
+        first save INSERTs)."""
+        self._state_store = store
+        self._state_match_id = match_id
+        self._state_slug = slug
+        self._state_version = version
+
     def bind_storage(self, storage: Storage | None, *, scope: str | None = None) -> None:
         """Attach a per-request ``Storage`` so resolvers can mirror
         hosted-mode artifacts into the project's local cache on first
@@ -881,23 +906,30 @@ class MatchProject(BaseModel):
         return project
 
     def save(self, root: Path) -> None:
-        """Atomically persist the project to ``root/project.json``.
+        """Persist the project.
 
-        In hosted mode (storage + a match scope bound via
-        :meth:`bind_storage`) the saved ``project.json`` is also pushed to
-        S3. It is the worker<->API channel for a shooter's state
-        (``beep_time``, ``processed`` flags): the worker writes it during a
-        job, the API reads it back. S3 is authoritative, so every save
-        pushes and the load path (``state.shooter_project``) pulls fresh.
-        Local desktop leaves ``_storage`` ``None`` and this is a no-op.
+        Hosted mode (a :class:`ProjectStateStore` bound via
+        :meth:`bind_state`): the doc is written to the ``state_docs`` table
+        under optimistic locking and **no file is touched**. A stale
+        version raises ``StateConflictError`` (-> 409). The new version is
+        stashed back so a second ``save()`` on the same instance chains
+        cleanly.
+
+        Local desktop (no state store): atomic write to
+        ``root/project.json``, unchanged.
         """
         self.updated_at = datetime.now(UTC)
-        atomic_write_json(root / PROJECT_FILE, self.model_dump(mode="json"))
-        if self._storage is not None and self._storage_scope is not None:
-            self._storage.write_bytes(
-                f"{self._storage_scope}/{PROJECT_FILE}",
-                (root / PROJECT_FILE).read_bytes(),
+        if self._state_store is not None:
+            self._state_version = run_sync(
+                self._state_store.save_project(
+                    self._state_match_id,
+                    self._state_slug,
+                    self.model_dump(mode="json"),
+                    expected_version=self._state_version,
+                )
             )
+            return
+        atomic_write_json(root / PROJECT_FILE, self.model_dump(mode="json"))
 
     def stage(self, stage_number: int) -> StageEntry:
         """Return the stage with this number; raises ``KeyError`` if absent."""

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3924,28 +3924,53 @@ def create_app(
         # middleware runs. Local mode (no ``matches_store``) skips the check
         # -- one operator, nothing to isolate.
         owner_store = state.matches_store
-        if owner_store is not None and await owner_store.get(match_id) is None:
-            return JSONResponse(
-                status_code=404,
-                content={
-                    "detail": {
-                        "code": "match_not_found",
-                        "message": f"unknown match_id {match_id!r}",
-                    }
-                },
+        if owner_store is not None:
+            # Hosted: a match's authoritative state is Postgres (this row) +
+            # S3 (its files). The in-memory ``MatchRegistry`` is process-local
+            # and empty after a redeploy or on a second replica, so it can't
+            # be the source of truth for existence -- relying on it 404'd
+            # every match URL after a deploy until the picker re-registered.
+            # Instead: confirm ownership in the RLS-scoped store, then
+            # establish a deterministic local working root the ``state``
+            # accessors mirror match.json / project.json down into (S3 is
+            # authoritative). This makes match resolution stateless across
+            # restarts + replicas. A match the tenant doesn't own returns
+            # None -> the same 404 an unknown id gets (existence and
+            # ownership stay indistinguishable).
+            if await owner_store.get(match_id) is None:
+                return JSONResponse(
+                    status_code=404,
+                    content={
+                        "detail": {
+                            "code": "match_not_found",
+                            "message": f"unknown match_id {match_id!r}",
+                        }
+                    },
+                )
+            work_root = (
+                Path(
+                    os.environ.get(SPLITSMITH_PROJECTS_DIR_ENV, "").strip() or SPLITSMITH_PROJECTS_DIR_DEFAULT
+                )
+                / match_id
             )
-        try:
-            match_root = state.matches.resolve(match_id)
-        except KeyError:
-            return JSONResponse(
-                status_code=404,
-                content={
-                    "detail": {
-                        "code": "match_not_found",
-                        "message": f"unknown match_id {match_id!r}",
-                    }
-                },
-            )
+            work_root.mkdir(parents=True, exist_ok=True)
+            state.matches.register(match_id, work_root)
+            match_root = work_root.resolve()
+        else:
+            # Local mode: one operator, no tenancy. Resolve via the local
+            # recent-projects scan (the registry's miss_resolver is None).
+            try:
+                match_root = state.matches.resolve(match_id)
+            except KeyError:
+                return JSONResponse(
+                    status_code=404,
+                    content={
+                        "detail": {
+                            "code": "match_not_found",
+                            "message": f"unknown match_id {match_id!r}",
+                        }
+                    },
+                )
         rewritten = "/api/" + rest
         request.scope["path"] = rewritten
         request.scope["raw_path"] = rewritten.encode("utf-8")

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -92,7 +92,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Literal
 if TYPE_CHECKING:
     # Hosted-only; imported lazily at runtime inside _apply_hosted_mode_wiring
     # so local mode stays free of the db (procrastinate/psycopg) dependency.
-    from ..db import PostgresMatchStore
+    from ..db import PostgresMatchStore, ProjectStateStore
 
 from fastapi import (
     Body,
@@ -124,6 +124,7 @@ from .. import models as model_layer
 from .. import shot_detect as shot_detect_module  # noqa: F401  (kept for legacy monkeypatch points)
 from .. import thumbnail as thumbnail_helpers
 from .. import waveform as waveform_helpers
+from ..async_bridge import run_sync
 from ..auth import AuthBackend, LoopbackAuth, User
 from ..compute import ComputeBackend, LocalComputeBackend
 from ..config import (
@@ -620,6 +621,7 @@ class TenantContext:
     scoreboard_identity: user_config.ScoreboardIdentityStore
     jobs: JobBackend
     matches_store: PostgresMatchStore | None
+    project_state: ProjectStateStore | None
     storage: Storage | None
 
 
@@ -681,6 +683,12 @@ class AppState:
     # in hosted mode resolved per request / per job via the property below.
     # See ``splitsmith.db.matches.PostgresMatchStore``.
     _matches_store: PostgresMatchStore | None = None
+    # Per-user ``state_docs`` store (state refactor). Holds the match /
+    # per-shooter project / per-stage audit JSON docs in Postgres with
+    # optimistic locking. ``None`` in local mode (state stays file-based);
+    # in hosted mode resolved per request / per job via the property below.
+    # See ``splitsmith.db.project_state.ProjectStateStore``.
+    _project_state: ProjectStateStore | None = None
     # Per-user preference stores (Tier 3 of doc 10). Local mode
     # delegates to the ``~/.splitsmith/*.json`` module functions;
     # in hosted mode resolved per request from the authenticated user
@@ -793,6 +801,15 @@ class AppState:
         self._matches_store = value
 
     @property
+    def project_state(self) -> ProjectStateStore | None:
+        tenant = current_tenant.get()
+        return tenant.project_state if tenant is not None else self._project_state
+
+    @project_state.setter
+    def project_state(self, value: ProjectStateStore | None) -> None:
+        self._project_state = value
+
+    @property
     def storage(self) -> Storage | None:
         tenant = current_tenant.get()
         return tenant.storage if tenant is not None else self._storage
@@ -848,15 +865,24 @@ class AppState:
         scoped_root = current_match_root.get()
         if scoped_root is None:
             raise _no_project_error()
-        # Hosted: a separate worker process has none of the match's files
-        # on disk. Pull match.json down (S3 authoritative) before reading
-        # it so a worker can see the shooter roster the API wrote. No-op
-        # in local mode (storage is None). See _pull_json.
+        # Roster / ownership check. Hosted: the match doc lives in Postgres
+        # (state_docs), so read the shooter list from there -- a worker or a
+        # post-redeploy replica has no match.json on disk. Local: load the
+        # on-disk match.json. Either way the returned value is the on-disk
+        # path, which is where *media* (S3-mirrored) lives for ffmpeg.
         mid = current_match_id.get()
-        if mid is not None:
-            self._pull_json(f"matches/{mid}/{match_model.MATCH_FILE}", scoped_root / match_model.MATCH_FILE)
-        match = match_model.Match.load(scoped_root)
-        if slug not in match.shooters:
+        store = self.project_state
+        if store is not None and mid is not None:
+            doc, _ = run_sync(store.load_match(mid))
+            if doc is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"match {mid!r} has no state document",
+                )
+            shooters = doc.get("shooters", [])
+        else:
+            shooters = match_model.Match.load(scoped_root).shooters
+        if slug not in shooters:
             raise HTTPException(
                 status_code=404,
                 detail=f"shooter {slug!r} is not registered on this match",
@@ -909,6 +935,96 @@ class AppState:
         """Push a stage's audit JSON up after writing it (hosted)."""
         self._push_json(self._audit_key(slug, stage_number), self._audit_file(slug, stage_number))
 
+    # ------------------------------------------------------------------
+    # State-doc accessors (state refactor)
+    # ------------------------------------------------------------------
+
+    def match(self) -> match_model.Match:
+        """Load the match for the current ``/api/matches/{match_id}/`` scope.
+
+        Hosted: from the ``state_docs`` table, with the state store bound so
+        a subsequent ``.save()`` round-trips back under optimistic locking
+        (carrying the loaded version). Local: from the on-disk ``match.json``
+        (``Match.load`` may self-assign + save a pre-v4 ``match_id`` -- that
+        path is file-only and never reached for a store-backed match, whose
+        docs are born with an id).
+        """
+        scoped_root = current_match_root.get()
+        if scoped_root is None:
+            raise _no_project_error()
+        mid = current_match_id.get()
+        store = self.project_state
+        if store is not None and mid is not None:
+            doc, version = run_sync(store.load_match(mid))
+            if doc is None:
+                raise HTTPException(status_code=404, detail=f"match {mid!r} has no state document")
+            match = match_model.Match.model_validate(doc)
+            match.bind_state(store, match_id=mid, version=version)
+            return match
+        return match_model.Match.load(scoped_root)
+
+    def load_audit(self, slug: str, stage_number: int) -> tuple[dict | None, int]:
+        """Load a stage's audit doc + its version. ``(None, 0)`` when none
+        exists yet. Hosted: from ``state_docs``. Local: from the on-disk
+        ``audit/stage<N>.json`` (version always 0 -- no locking on files)."""
+        mid = current_match_id.get()
+        store = self.project_state
+        if store is not None and mid is not None:
+            return run_sync(store.load_audit(mid, slug, stage_number))
+        audit_file = self._audit_file(slug, stage_number)
+        if not audit_file.exists():
+            return None, 0
+        try:
+            return json.loads(audit_file.read_text(encoding="utf-8")), 0
+        except (OSError, json.JSONDecodeError) as exc:
+            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
+
+    def save_audit(self, slug: str, stage_number: int, doc: dict, *, version: int) -> int:
+        """Persist a stage's audit doc; return the new version.
+
+        Hosted: ``state_docs`` under optimistic locking -- ``version==0``
+        INSERTs, ``>0`` UPDATEs at that version, a stale version raises
+        ``StateConflictError`` (-> 409). Local: atomic ``.tmp`` -> ``.bak``
+        rotate -> rename file write (returns 0)."""
+        mid = current_match_id.get()
+        store = self.project_state
+        if store is not None and mid is not None:
+            return run_sync(store.save_audit(mid, slug, stage_number, doc, expected_version=version))
+        audit_file = self._audit_file(slug, stage_number)
+        audit_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
+        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
+        try:
+            tmp.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+            if audit_file.exists():
+                if backup.exists():
+                    backup.unlink()
+                audit_file.replace(backup)
+            tmp.replace(audit_file)
+        except OSError as exc:
+            if tmp.exists():
+                tmp.unlink()
+            raise HTTPException(status_code=500, detail=f"audit write failed: {exc}") from exc
+        return 0
+
+    def materialize_audit(self, slug: str, stage_number: int) -> Path:
+        """Ensure the stage's audit doc is present at its on-disk path and
+        return that path.
+
+        For file-path consumers that hand the audit *path* to downstream
+        readers (the FCPXML/report exporters, the lab). Hosted: the doc
+        lives in ``state_docs``, so write it to the local file first.
+        Local: the file is already on disk, return its path. When no audit
+        doc exists the returned path simply won't exist -- the caller's
+        existing "missing audit" handling fires, same as before."""
+        audit_file = self._audit_file(slug, stage_number)
+        if self.project_state is not None:
+            doc, _ = self.load_audit(slug, stage_number)
+            if doc is not None:
+                audit_file.parent.mkdir(parents=True, exist_ok=True)
+                audit_file.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+        return audit_file
+
     def shooter_project(self, slug: str) -> MatchProject:
         """Load the per-shooter ``MatchProject`` (each shooter slot
         inside a Match folder owns its own ``project.json``).
@@ -926,11 +1042,22 @@ class AppState:
         shooter_root = self.shooter_root(slug)
         match_id = current_match_id.get()
         scope = f"matches/{match_id}/shooters/{slug}" if match_id is not None else None
-        # Hosted: pull project.json fresh (S3 authoritative) before load so
-        # the API sees a worker's saved beep_time/processed and vice versa.
-        if scope is not None:
-            self._pull_json(f"{scope}/{PROJECT_FILE}", shooter_root / PROJECT_FILE)
-        project = MatchProject.load(shooter_root)
+        store = self.project_state
+        if store is not None and match_id is not None:
+            # Hosted: the project doc lives in Postgres. Load it, bind the
+            # store so save() round-trips back under optimistic locking
+            # (carrying the version we just read), and bind storage for
+            # media mirroring. No project.json on disk is involved.
+            doc, version = run_sync(store.load_project(match_id, slug))
+            if doc is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"shooter {slug!r} has no project document",
+                )
+            project = MatchProject.model_validate(doc)
+            project.bind_state(store, match_id=match_id, slug=slug, version=version)
+        else:
+            project = MatchProject.load(shooter_root)
         project.bind_storage(self.storage, scope=scope)
         return project
 
@@ -1602,16 +1729,8 @@ def register_job_bodies(state: AppState) -> None:
         # apriori boost) and we'll merge results back into the same dict.
         # Hosted: pull the existing audit fresh first so a prior API/worker
         # write isn't lost when we merge + push back.
-        state.pull_audit(slug, stage_number)
-        audit_dir = proj.audit_path(state.shooter_root(slug))
-        audit_dir.mkdir(parents=True, exist_ok=True)
-        audit_file = audit_dir / f"stage{stage_number}.json"
-        if audit_file.exists():
-            try:
-                existing_json = json.loads(audit_file.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                existing_json = {}
-        else:
+        existing_json, audit_version = state.load_audit(slug, stage_number)
+        if existing_json is None:
             existing_json = {
                 "stage_number": stg.stage_number,
                 "stage_name": stg.stage_name,
@@ -1731,18 +1850,11 @@ def register_job_bodies(state: AppState) -> None:
         )
         existing_json["audit_events"] = events
 
-        # Atomic write + .bak (mirrors put_stage_audit).
-        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
-        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
-        tmp.write_text(json.dumps(existing_json, indent=2) + "\n", encoding="utf-8")
-        if audit_file.exists():
-            if backup.exists():
-                backup.unlink()
-            audit_file.replace(backup)
-        tmp.replace(audit_file)
-        # Hosted: push the detected shots up so the API's audit page sees
-        # them (this is shot_detect's primary result).
-        state.push_audit(slug, stage_number)
+        # Persist the merged audit. Hosted: state_docs under optimistic
+        # locking; local: atomic file write. Phase 4 wraps this in a
+        # re-load + re-merge retry on StateConflictError for the worker's
+        # concurrent read-modify-write case.
+        state.save_audit(slug, stage_number, existing_json, version=audit_version)
 
         # Read-modify-write the project file: a long-running shot_detect
         # job must not save the snapshot it loaded at start, because the
@@ -1772,12 +1884,12 @@ def register_job_bodies(state: AppState) -> None:
         if prim is None or prim.beep_time is None:
             raise RuntimeError("primary or beep disappeared mid-flight")
 
-        # Hosted: the audit JSON was written by the detect/audit job on
-        # another worker and lives in storage, not this container's FS. Pull
-        # it before the exporter reads it (no-op in local mode). Without this
-        # a cross-process export reads a stale or absent audit file.
-        state.pull_audit(slug, stage_number)
-        audit_file = proj.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
+        # Hosted: the audit doc was written by the detect job and lives in
+        # state_docs, not this container's FS. Materialize it to the local
+        # path the exporter reads (no-op in local mode -- the file is
+        # already there). Without this a cross-process export reads a stale
+        # or absent audit file.
+        audit_file = state.materialize_audit(slug, stage_number)
         exports_dir = proj.exports_path(state.shooter_root(slug))
         source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
         engine_stage = EngineStageData(
@@ -1919,12 +2031,13 @@ def register_job_bodies(state: AppState) -> None:
             trimmed_path = exports_dir / f"{base}_trimmed.mp4"
             overlay_target = exports_dir / f"{base}_overlay.mov"
 
-            # Hosted: per-stage artifacts (audit JSON + trims + overlay) may
-            # have been produced + pushed by an earlier `export` job on a
-            # different worker. Pull them so the existence checks below reuse
-            # the cached work instead of re-cutting, and so the composer can
-            # read the audit JSON. No-op in local mode.
-            state.pull_audit(slug, stage_number)
+            # Hosted: per-stage artifacts may have been produced by an
+            # earlier job on a different worker. Materialize the audit doc
+            # (state_docs -> local file) so the composer + per-stage
+            # exporter can read it, and pull the cached trim so the
+            # existence checks below reuse it instead of re-cutting. No-op
+            # in local mode.
+            state.materialize_audit(slug, stage_number)
             export_storage.pull_export_file(proj, trimmed_path)
 
             # Decide what's missing. The match composer needs the
@@ -3141,6 +3254,16 @@ async def _register_match_at(
             status_code=400,
             detail=f"failed to load match at {resolved}: {exc}",
         ) from exc
+    # Hosted: the on-disk match.json is the stale shell Match.init wrote
+    # at creation -- the authoritative doc (with stages + shooters) lives
+    # in Postgres because the creation saves were store-bound. Reload it
+    # so the ``match_empty`` check and the registration name see the real
+    # roster. ``match_id`` itself is correct in the file (assigned before
+    # binding), so it keys the lookup.
+    if state.project_state is not None and match.match_id:
+        doc, _ = await state.project_state.load_match(match.match_id)
+        if doc is not None:
+            match = match_model.Match.model_validate(doc)
     if not match.shooters:
         raise HTTPException(
             status_code=409,
@@ -3157,14 +3280,14 @@ async def _register_match_at(
     if match.match_id:
         state.matches.register(match.match_id, resolved)
         # Hosted: record the match in Postgres so a separate worker can
-        # resolve this ``match_id``, and seed its JSON in S3 so the worker
-        # can read what the API wrote. A job is only submittable from an
-        # open match, so this runs before any worker touches it.
+        # resolve this ``match_id``. A job is only submittable from an open
+        # match, so this runs before any worker touches it. The match /
+        # project / audit docs themselves now live in ``state_docs`` (the
+        # creation saves were store-bound), so the old S3 JSON seeding is
+        # gone -- the worker reads the docs from Postgres via its tenant
+        # ``project_state``.
         if state.matches_store is not None:
             await state.matches_store.upsert(match.match_id, name, f"matches/{match.match_id}")
-            # Blocking boto3 PUT/HEAD round-trips -- offload so they don't
-            # stall the event loop (this runs inside an async handler).
-            await asyncio.to_thread(_sync_match_json_to_storage, state, resolved, match)
     return name, match.match_id
 
 
@@ -3447,6 +3570,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
         PostgresMatchStore,
         PostgresRecentProjectsStore,
         PostgresScoreboardIdentityStore,
+        ProjectStateStore,
         build_email_sender,
         build_signup_policy,
         create_engine,
@@ -3525,6 +3649,7 @@ def _apply_hosted_mode_wiring(state: AppState, *, worker: bool = False) -> None:
                 bodies=state.job_bodies,
             ),
             matches_store=PostgresMatchStore(tenant_factory, user_id=user_id),
+            project_state=ProjectStateStore(tenant_factory, user_id=user_id),
             storage=_tenant_s3_storage(s3_client, s3_bucket, user_id),
         )
 
@@ -3876,6 +4001,31 @@ def create_app(
             content={"detail": {"code": "shutting_down", "message": str(exc)}},
         )
 
+    # Optimistic-locking conflict on a hosted state_docs save -> 409 so the
+    # SPA can reload + retry. Registered only when the db layer imports
+    # (hosted, or any dev env with the deps); local slim installs never
+    # raise it -- ``project_state`` is None and every save is file-based.
+    try:
+        from ..db import StateConflictError
+
+        _have_state_conflict = True
+    except Exception:  # noqa: BLE001 -- slim local install lacks the db deps
+        _have_state_conflict = False
+    if _have_state_conflict:
+
+        @app.exception_handler(StateConflictError)
+        async def _state_conflict_handler(request: Request, exc: Exception) -> JSONResponse:
+            """Map a lost optimistic-lock race to 409 ``version_conflict``."""
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "detail": {
+                        "code": "version_conflict",
+                        "message": ("this match state changed since you loaded it; " "reload and try again"),
+                    }
+                },
+            )
+
     # ----------------------------------------------------------------------
     # /api/matches/{match_id}/... alias middleware (#353 Phase 3 PR B/C)
     # ----------------------------------------------------------------------
@@ -4073,8 +4223,13 @@ def create_app(
         this response is for; the live ``/api/health`` route never
         returns these fields anymore.
         """
-        match = match_model.Match.load(root)
-        shooters = sorted(match.shooters)
+        # Hosted: read the authoritative roster from Postgres (the on-disk
+        # match.json is the stale creation shell). Local: from disk.
+        if state.project_state is not None and match_id is not None:
+            doc, _ = run_sync(state.project_state.load_match(match_id))
+            shooters = sorted(doc.get("shooters", [])) if doc is not None else []
+        else:
+            shooters = sorted(match_model.Match.load(root).shooters)
         default_slug = shooters[0] if shooters else None
         return HealthResponse(
             bound=True,
@@ -6542,15 +6697,11 @@ def create_app(
             project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        # Hosted: pull fresh so a worker's shot_detect result is visible.
-        state.pull_audit(slug, stage_number)
-        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
-        if not audit_file.exists():
+        # Hosted: from state_docs (a worker's shot_detect result); local:
+        # from disk. 200 null when no audit exists yet.
+        payload, _ = state.load_audit(slug, stage_number)
+        if payload is None:
             return JSONResponse(None)
-        try:
-            payload = json.loads(audit_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
         return JSONResponse(payload)
 
     @app.put("/api/shooters/{slug}/stages/{stage_number}/audit")
@@ -6574,25 +6725,14 @@ def create_app(
             project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_dir = project.audit_path(state.shooter_root(slug))
-        audit_dir.mkdir(parents=True, exist_ok=True)
-        target = audit_dir / f"stage{stage_number}.json"
-        tmp = target.with_suffix(target.suffix + ".tmp")
-        backup = target.with_suffix(target.suffix + ".bak")
-        try:
-            tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-            if target.exists():
-                if backup.exists():
-                    backup.unlink()
-                target.replace(backup)
-            tmp.replace(target)
-        except OSError as exc:
-            if tmp.exists():
-                tmp.unlink()
-            raise HTTPException(status_code=500, detail=f"audit write failed: {exc}") from exc
-        # Hosted: push the manual audit edit up so the worker (and other
-        # browsers) see it.
-        state.push_audit(slug, stage_number)
+        # Read the current version so the save is optimistic-locked. The
+        # SPA PUT doesn't carry a version (it assumes last-writer-wins), so
+        # this load-then-save has a tiny race window: if a concurrent
+        # worker bumps the version in between, save_audit raises
+        # StateConflictError -> 409 and the SPA re-fetches. Local: version
+        # is always 0 and this is a plain atomic file write.
+        _, version = state.load_audit(slug, stage_number)
+        state.save_audit(slug, stage_number, payload, version=version)
         return JSONResponse(payload)
 
     @app.get("/api/shooters/{slug}/stages/{stage_number}/anomalies")
@@ -6616,13 +6756,9 @@ def create_app(
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
-        if not audit_file.exists():
+        audit_payload, _ = state.load_audit(slug, stage_number)
+        if audit_payload is None:
             return JSONResponse({"anomalies": []})
-        try:
-            audit_payload = json.loads(audit_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
 
         prim = stg.primary()
         beep_time = prim.beep_time if prim is not None and prim.beep_time is not None else 0.0
@@ -6694,45 +6830,32 @@ def create_app(
     def _load_audit_for_coach(
         slug: str,
         stage_number: int,
-    ) -> tuple[dict[str, Any], Path, float | None, Any, MatchProject]:
-        """Shared loader: validates the stage, reads the audit JSON,
-        returns (payload, path, primary_beep_in_clip, stage, project).
-        """
+    ) -> tuple[dict[str, Any], int, float | None, Any, MatchProject]:
+        """Shared loader: validates the stage, reads the audit doc,
+        returns (payload, version, primary_beep_in_clip, stage, project).
+        404 when no audit doc exists yet. The version rides back so a
+        coach mutation saves under the same optimistic lock."""
         project = state.shooter_project(slug)
         try:
             stg = project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
-        if not audit_file.exists():
+        payload, version = state.load_audit(slug, stage_number)
+        if payload is None:
             raise HTTPException(
                 status_code=404,
                 detail=f"no audit JSON yet for stage {stage_number}",
             )
-        try:
-            payload = json.loads(audit_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise HTTPException(status_code=500, detail=f"audit read failed: {exc}") from exc
         prim = stg.primary()
         primary_beep_in_clip = (
             _video_beep_in_clip(slug, project, stage_number, prim) if prim is not None else None
         )
-        return payload, audit_file, primary_beep_in_clip, stg, project
+        return payload, version, primary_beep_in_clip, stg, project
 
-    def _coach_atomic_write(audit_file: Path, payload: dict[str, Any]) -> None:
-        tmp = audit_file.with_suffix(audit_file.suffix + ".tmp")
-        backup = audit_file.with_suffix(audit_file.suffix + ".bak")
-        try:
-            tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-            if audit_file.exists():
-                if backup.exists():
-                    backup.unlink()
-                audit_file.replace(backup)
-            tmp.replace(audit_file)
-        except OSError as exc:
-            if tmp.exists():
-                tmp.unlink()
-            raise HTTPException(status_code=500, detail=f"coach write failed: {exc}") from exc
+    def _coach_save(slug: str, stage_number: int, payload: dict[str, Any], version: int) -> None:
+        """Persist a coach-mutated audit doc under optimistic locking
+        (hosted) / atomically to disk (local). A lost race -> 409."""
+        state.save_audit(slug, stage_number, payload, version=version)
 
     def _build_coach_response(
         slug: str,
@@ -6814,10 +6937,10 @@ def create_app(
             stg = project.stage(stage_number)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        audit_file = project.audit_path(state.shooter_root(slug)) / f"stage{stage_number}.json"
-        if not audit_file.exists():
+        audit_payload, _ = state.load_audit(slug, stage_number)
+        if audit_payload is None:
             return JSONResponse(None)
-        payload, _audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
+        payload, _version, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
@@ -6827,7 +6950,7 @@ def create_app(
         every shot whose source is unset or ``"auto"``. Manual entries are
         preserved. Idempotent.
         """
-        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
+        payload, version, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -6842,7 +6965,7 @@ def create_app(
             }
         )
         payload["audit_events"] = events
-        _coach_atomic_write(audit_file, payload)
+        _coach_save(slug, stage_number, payload, version)
         return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
     @app.patch("/api/shooters/{slug}/stages/{stage_number}/shots/{shot_number}/coach")
@@ -6855,7 +6978,7 @@ def create_app(
         """Patch the coaching annotation fields on one shot. Returns the
         updated coach response for the stage so the client can refresh.
         """
-        payload, audit_file, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
+        payload, version, beep_in_clip, stg, project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -6894,7 +7017,7 @@ def create_app(
             }
         )
         payload["audit_events"] = events
-        _coach_atomic_write(audit_file, payload)
+        _coach_save(slug, stage_number, payload, version)
         return JSONResponse(_build_coach_response(slug, payload, beep_in_clip, stg, project, cfg))
 
     @app.get("/api/shooters/{slug}/stages/{stage_number}/coach/distributions")
@@ -6905,7 +7028,7 @@ def create_app(
         Empty classes still appear in the response with count=0 so the
         UI can render an empty histogram without a special case.
         """
-        payload, _audit_file, _beep_in_clip, stg, _project = _load_audit_for_coach(slug, stage_number)
+        payload, _version, _beep_in_clip, stg, _project = _load_audit_for_coach(slug, stage_number)
         cfg = CoachAutoClassifyConfig()
         shots = payload.get("shots") or []
         if not isinstance(shots, list):
@@ -6926,19 +7049,11 @@ def create_app(
         """
         project = state.shooter_project(slug)
         cfg = CoachAutoClassifyConfig()
-        audit_dir = project.audit_path(state.shooter_root(slug))
         triples: list[tuple[int, str, list[dict[str, Any]]]] = []
         for stg in project.stages:
-            audit_file = audit_dir / f"stage{stg.stage_number}.json"
-            if not audit_file.exists():
+            stage_payload, _ = state.load_audit(slug, stg.stage_number)
+            if stage_payload is None:
                 continue
-            try:
-                stage_payload = json.loads(audit_file.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as exc:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"audit read failed for stage {stg.stage_number}: {exc}",
-                ) from exc
             shots = stage_payload.get("shots") or []
             if not isinstance(shots, list):
                 continue
@@ -7970,6 +8085,12 @@ def create_app(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         match = match_model.Match.init(target, name=req.name)
+        # Hosted: bind the state store so every save() from here INSERTs /
+        # UPDATEs the match doc in Postgres (the ephemeral disk file
+        # Match.init just wrote is abandoned). version=0 -> the save below
+        # is the INSERT. Local: no store, saves stay file-based.
+        if state.project_state is not None and match.match_id is not None:
+            match.bind_state(state.project_state, match_id=match.match_id, version=0)
         match.match_date = req.match_date
         match.stages = [
             match_model.MatchStageDefinition(
@@ -8003,6 +8124,8 @@ def create_app(
         # have stages to operate on. We seed it directly rather than relying
         # on the user re-importing scoreboard data.
         legacy = MatchProject.init(shooter_root, name=req.name)
+        if state.project_state is not None and match.match_id is not None:
+            legacy.bind_state(state.project_state, match_id=match.match_id, slug=shooter_slug, version=0)
         legacy.competitor_name = req.primary_shooter.name
         legacy.match_date = req.match_date
         if not legacy.stages:
@@ -8073,6 +8196,8 @@ def create_app(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         match = match_model.Match.init(target, name=req.name)
+        if state.project_state is not None and match.match_id is not None:
+            match.bind_state(state.project_state, match_id=match.match_id, version=0)
         match.scoreboard_match_id = str(req.match_id)
         match.scoreboard_content_type = req.content_type
         match.save(target)
@@ -8107,6 +8232,8 @@ def create_app(
 
             shooter_root = match_model.Match.shooter_root(target, shooter_slug)
             legacy = MatchProject.init(shooter_root, name=req.name)
+            if state.project_state is not None and match.match_id is not None:
+                legacy.bind_state(state.project_state, match_id=match.match_id, slug=shooter_slug, version=0)
             legacy.competitor_name = pick.name
             legacy.scoreboard_match_id = str(req.match_id)
             legacy.scoreboard_content_type = req.content_type
@@ -8161,11 +8288,13 @@ def create_app(
         shooter-listing / merge / compare endpoints are match-only).
         """
         match_root = state.match_root
-        return match_root, match_model.Match.load(match_root)
+        return match_root, state.match()
 
     def _classify_shooter(shooter_root: Path, match: match_model.Match) -> ShooterListEntry:
         """Build a list entry for a single shooter directory."""
-        legacy = MatchProject.load(shooter_root)
+        # ``shooter_root.name`` is the slug; the accessor loads the project
+        # doc from Postgres (hosted) or disk (local) + binds storage.
+        legacy = state.shooter_project(shooter_root.name)
         # ``audited`` requires the operator to have hit Save & next on
         # the stage (see :func:`stage_audit_status`). Set-up-but-not-
         # touched stages used to count here; they no longer do.
@@ -8386,6 +8515,11 @@ def create_app(
 
         shooter_root = match_model.Match.shooter_root(match_root, slug)
         legacy = MatchProject.init(shooter_root, name=match.name)
+        # Hosted: bind the new project doc (version=0 -> the save below
+        # INSERTs it into state_docs). ``match.add_shooter`` above already
+        # persisted the updated roster to the match doc.
+        if state.project_state is not None and match.match_id is not None:
+            legacy.bind_state(state.project_state, match_id=match.match_id, slug=slug, version=0)
         legacy.competitor_name = req.name
         legacy.match_date = match.match_date
         legacy.scoreboard_match_id = match.scoreboard_match_id
@@ -8402,12 +8536,6 @@ def create_app(
                     )
                 )
         legacy.save(shooter_root)
-        # Hosted: match.json now carries the new slug and S3 is authoritative
-        # (shooter_root always pulls it). Push the updated roster + seed the
-        # new shooter's project.json so the next request -- and the worker --
-        # see the addition instead of the stale opened-at roster. Sync call
-        # is fine: this is a sync endpoint (FastAPI runs it off the loop).
-        _sync_match_json_to_storage(state, match_root, match)
         return list_match_shooters()
 
     @app.delete("/api/match/shooters/{slug}", response_model=ShooterListResponse)
@@ -8425,9 +8553,10 @@ def create_app(
             shutil.rmtree(shooter_root, ignore_errors=True)
         match.shooters = [s for s in match.shooters if s != slug]
         match.save(match_root)
-        # Hosted: push the updated roster so the always-pull in shooter_root
-        # doesn't resurrect the removed shooter from the stale S3 copy.
-        _sync_match_json_to_storage(state, match_root, match)
+        # The store-bound match.save above persists the dropped roster.
+        # (The shooter's now-orphaned project/audit state_docs rows are
+        # unreachable -- shooter_root rejects the slug -- and are left for a
+        # future cascade-delete; harmless meanwhile.)
         return list_match_shooters()
 
     @app.post("/api/match/shooters/{slug}/build-trim-caches")
@@ -8449,7 +8578,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, slug)
         try:
-            proj = MatchProject.load(shooter_root)
+            proj = state.shooter_project(shooter_root.name)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -8538,8 +8667,8 @@ def create_app(
         for slug in match.shooters:
             shooter_root = match_model.Match.shooter_root(match_root, slug)
             try:
-                legacy = MatchProject.load(shooter_root)
-            except FileNotFoundError:
+                legacy = state.shooter_project(shooter_root.name)
+            except (FileNotFoundError, HTTPException):
                 continue
             stage = next(
                 (s for s in legacy.stages if s.stage_number == stage_number),
@@ -8585,30 +8714,27 @@ def create_app(
             # Shots come from audit; convert each shot.time to time-after-beep.
             shots: list[CompareShotPoint] = []
             if stage is not None and primary is not None and primary.beep_time is not None:
-                audit_path = shooter_root / "audit" / f"stage{stage_number}.json"
-                if audit_path.exists():
-                    try:
-                        audit_data = json.loads(audit_path.read_text(encoding="utf-8"))
-                    except (OSError, json.JSONDecodeError):
-                        audit_data = None
-                    if isinstance(audit_data, dict):
-                        for shot in audit_data.get("shots") or []:
-                            t = shot.get("time")
-                            if t is None:
-                                continue
-                            # Audit stores time in the trim's local clock;
-                            # subtract the trim's beep offset to get
-                            # time-since-beep.
-                            audit_beep = audit_data.get("beep_time")
-                            if audit_beep is None:
-                                continue
-                            shots.append(
-                                CompareShotPoint(
-                                    shot_number=int(shot.get("shot_number", 0)),
-                                    time_after_beep=float(t) - float(audit_beep),
-                                    source=("manual" if shot.get("source") == "manual" else "detected"),
-                                )
+                # ``shooter_root.name`` is the slug; load the audit doc from
+                # state_docs (hosted) or disk (local).
+                audit_data, _ = state.load_audit(shooter_root.name, stage_number)
+                if isinstance(audit_data, dict):
+                    for shot in audit_data.get("shots") or []:
+                        t = shot.get("time")
+                        if t is None:
+                            continue
+                        # Audit stores time in the trim's local clock;
+                        # subtract the trim's beep offset to get
+                        # time-since-beep.
+                        audit_beep = audit_data.get("beep_time")
+                        if audit_beep is None:
+                            continue
+                        shots.append(
+                            CompareShotPoint(
+                                shot_number=int(shot.get("shot_number", 0)),
+                                time_after_beep=float(t) - float(audit_beep),
+                                source=("manual" if shot.get("source") == "manual" else "detected"),
                             )
+                        )
 
             records.append(
                 CompareShooterRecord(
@@ -8646,7 +8772,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, slug)
         try:
-            shooter_project = MatchProject.load(shooter_root)
+            shooter_project = state.shooter_project(shooter_root.name)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=f"shooter project missing: {exc}") from exc
 
@@ -8741,8 +8867,8 @@ def create_app(
         for slug in match.shooters:
             shooter_root = match_model.Match.shooter_root(match_root, slug)
             try:
-                proj = MatchProject.load(shooter_root)
-            except FileNotFoundError:
+                proj = state.shooter_project(shooter_root.name)
+            except (FileNotFoundError, HTTPException):
                 continue
             for stage in proj.stages:
                 if stage.skipped:
@@ -8822,7 +8948,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="shooter not found")
         shooter_root = match_model.Match.shooter_root(match_root, req.slug)
         try:
-            proj = MatchProject.load(shooter_root)
+            proj = state.shooter_project(shooter_root.name)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         target_stage = next(
@@ -9020,7 +9146,7 @@ def create_app(
                 stg = project.stage(stage_n)
             except KeyError as exc:
                 raise HTTPException(status_code=404, detail=str(exc)) from exc
-            audit_json = project.audit_path(state.shooter_root(slug)) / f"stage{stage_n}.json"
+            audit_json = state.materialize_audit(slug, stage_n)
             try:
                 audit_audio = _resolve_audit_audio(slug, project, stage_n)
             except HTTPException:

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -422,9 +422,10 @@ def test_worker_resolves_match_cross_process(hosted_stack: None) -> None:
 
     Covers the chunk's new machinery against real containers:
     1. ``create-manual`` upserts a ``matches`` row on real Postgres, and
-    2. pushes ``match.json`` + the shooter's ``project.json`` to real MinIO,
+    2. writes the match + shooter project docs to ``state_docs`` (Postgres),
     3. so a ``detect_beep`` job the worker pops gets *past* match resolution
-       (no ``MatchNotRegisteredError`` -- the gamma stopgap's failure mode).
+       (no ``MatchNotRegisteredError`` -- the gamma stopgap's failure mode)
+       and reads the shooter's project doc from Postgres cross-process.
 
     The job then fails because no video is assigned -- proving resolution +
     cross-container metadata pull worked without needing an uploaded video
@@ -460,10 +461,19 @@ def test_worker_resolves_match_cross_process(hosted_stack: None) -> None:
     # 2. The API upserted a matches row on real Postgres.
     assert _psql(f"SELECT count(*) FROM matches WHERE match_id = '{match_id}'") == "1"
 
-    # 3. The API pushed match.json + project.json to real MinIO (S3).
-    prefix = f"users/{user_id}/matches/{match_id}"
-    assert _s3_object_exists(f"{prefix}/match.json"), "match.json missing in MinIO"
-    assert _s3_object_exists(f"{prefix}/shooters/{slug}/project.json"), "project.json missing in MinIO"
+    # 3. The API wrote the match + project docs to Postgres state_docs
+    #    (the state refactor replaced the old S3 match.json/project.json
+    #    seeding). The worker reads them cross-process from there.
+    assert (
+        _psql(f"SELECT count(*) FROM state_docs WHERE match_id = '{match_id}' AND doc_kind = 'match'") == "1"
+    ), "match doc missing in state_docs"
+    assert (
+        _psql(
+            f"SELECT count(*) FROM state_docs WHERE match_id = '{match_id}' "
+            f"AND doc_kind = 'project' AND slug = '{slug}'"
+        )
+        == "1"
+    ), "project doc missing in state_docs"
 
     # 4. The worker container resolves the match cross-process. Mirror the
     #    backend's submit (PENDING row + defer) for a detect_beep job with no

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -289,7 +289,7 @@ def test_migrations_applied_against_postgres(hosted_stack: None) -> None:
 
     # Our own tenant tables from the earlier migrations + the auth-domain
     # tables from the magic-link migration (c3f1a8e90d24).
-    for table in ("users", "recent_projects", "compute_jobs", "magic_link_tokens", "sessions"):
+    for table in ("users", "recent_projects", "compute_jobs", "magic_link_tokens", "sessions", "state_docs"):
         exists = _psql(
             "SELECT count(*) FROM information_schema.tables "
             f"WHERE table_schema='public' AND table_name='{table}'"
@@ -504,9 +504,9 @@ def test_worker_resolves_match_cross_process(hosted_stack: None) -> None:
     ), f"worker failed to resolve the match cross-process: {err!r}"
 
 
-# The three per-user tenant tables RLS protects. Keep in sync with the
+# The per-user tenant tables RLS protects. Keep in sync with the
 # migration's TENANT_TABLES and the multi-tenant store classes.
-_RLS_TABLES = ("recent_projects", "matches", "compute_jobs")
+_RLS_TABLES = ("recent_projects", "matches", "compute_jobs", "state_docs")
 
 
 def _seed_two_tenants() -> tuple[str, str]:
@@ -539,6 +539,12 @@ def _seed_two_tenants() -> tuple[str, str]:
         f"('j-b', '{uid_b}', 'model_download', 'pending', false, false) "
         "ON CONFLICT (id) DO NOTHING"
     )
+    _psql(
+        "INSERT INTO state_docs (id, user_id, match_id, doc_kind, doc, version) VALUES "
+        f"('sd-a', '{uid_a}', 'mid-a', 'match', '{{}}'::jsonb, 1), "
+        f"('sd-b', '{uid_b}', 'mid-b', 'match', '{{}}'::jsonb, 1) "
+        "ON CONFLICT (id) DO NOTHING"
+    )
     return uid_a, uid_b
 
 
@@ -562,16 +568,16 @@ def test_rls_blocks_cross_tenant_reads_and_writes(hosted_stack: None) -> None:
     assert (
         _psql(
             "SELECT count(*) FROM pg_policies WHERE policyname='tenant_isolation' "
-            "AND tablename IN ('recent_projects','matches','compute_jobs')"
+            "AND tablename IN ('recent_projects','matches','compute_jobs','state_docs')"
         )
-        == "3"
+        == "4"
     )
     assert (
         _psql(
             "SELECT count(*) FROM pg_class WHERE relforcerowsecurity "
-            "AND relname IN ('recent_projects','matches','compute_jobs')"
+            "AND relname IN ('recent_projects','matches','compute_jobs','state_docs')"
         )
-        == "3"
+        == "4"
     )
 
     for table in _RLS_TABLES:

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -33,7 +33,6 @@ from moto import mock_aws  # noqa: E402
 
 from splitsmith.db import Base, create_engine  # noqa: E402
 from splitsmith.storage import S3Storage  # noqa: E402
-from splitsmith.ui.project import MatchProject  # noqa: E402
 
 BUCKET = "splitsmith-uploads-test"
 
@@ -435,50 +434,51 @@ def test_delete_rejects_path_traversal(hosted_client) -> None:
 
 
 @pytest.fixture
-def hosted_client_with_match(hosted_client, tmp_path: Path) -> Iterator[tuple[TestClient, S3Storage, str]]:
-    """Extend ``hosted_client`` with a scaffolded Match + one shooter
-    so attach-endpoint tests have something to attach raw videos to.
+def hosted_client_with_match(hosted_client) -> Iterator[tuple[TestClient, S3Storage, str, str]]:
+    """Extend ``hosted_client`` with a Match + one shooter created through
+    the real create-match API so its state lands in ``state_docs`` (the
+    way production seeds it), not on ephemeral disk.
 
-    Yields ``(client, storage, match_id)``. The match has two stages
-    so tests can exercise the multi-stage ``covers_stages`` path.
+    Yields ``(client, storage, match_id, slug)``. The match has two stages
+    so tests can exercise the multi-stage ``covers_stages`` path. The slug
+    is opaque (PII-free), so it is yielded for the tests to use rather than
+    hard-coded.
     """
-    from splitsmith import match_model
-    from splitsmith.ui.project import StageEntry
-
     client, storage = hosted_client
 
-    match_root = tmp_path / "matches" / "attach-test"
-    match = match_model.Match.init(match_root, name="Attach Test")
-    match.stages = [
-        match_model.MatchStageDefinition(stage_number=1, stage_name="One"),
-        match_model.MatchStageDefinition(stage_number=2, stage_name="Two"),
-    ]
-    match.save(match_root)
-    match.add_shooter(match_root, match_model.Shooter(slug="me", name="Me"))
-    sroot = match_model.Match.shooter_root(match_root, "me")
-    project = MatchProject.init(sroot, name="Attach Test")
-    project.stages = [
-        StageEntry(stage_number=1, stage_name="One", time_seconds=10.0),
-        StageEntry(stage_number=2, stage_name="Two", time_seconds=15.0),
-    ]
-    project.save(sroot)
-
     resp = client.post(
-        "/api/me/recent-projects/bind",
-        json={"path": str(match_root.resolve())},
+        "/api/match/create-manual",
+        json={
+            # project_folder omitted: hosted mode synthesizes the path.
+            "name": "Attach Test",
+            "stages": [
+                {"stage_number": 1, "stage_name": "One"},
+                {"stage_number": 2, "stage_name": "Two"},
+            ],
+            "primary_shooter": {"name": "Me"},
+        },
     )
     assert resp.status_code == 200, resp.text
+    health = resp.json()
+    match_id = health["match_id"]
+    slug = health["default_shooter_slug"]
+    assert match_id and slug
+    yield client, storage, match_id, slug
 
-    ids = client.app.state.splitsmith_state.matches.known_ids()
-    assert len(ids) == 1
-    yield client, storage, ids[0]
 
-
-def _attach_url(match_id: str, slug: str = "me") -> str:
+def _attach_url(match_id: str, slug: str) -> str:
     # The alias middleware rewrites ``/api/matches/{id}/<rest>`` to
     # ``/api/<rest>`` -- so the prefix here is ``shooters/...``, not
     # ``api/shooters/...``. Matches the _MatchClient rewrite pattern.
     return f"/api/matches/{match_id}/shooters/{slug}/raw-videos/attach"
+
+
+def _get_project(client: TestClient, match_id: str, slug: str) -> dict:
+    """Read a shooter's project back through the API (it resolves from
+    state_docs in hosted mode, so disk reads would see nothing)."""
+    resp = client.get(f"/api/matches/{match_id}/shooters/{slug}/project")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
 
 
 def _seed_upload(client: TestClient, filename: str, payload: bytes) -> dict:
@@ -497,13 +497,11 @@ def test_attach_registers_raw_video_on_project(hosted_client_with_match) -> None
     """An upload + attach round-trip lands a RawVideo entry on the
     project's ``raw_videos[]`` with the storage_path the SPA can
     reference back to."""
-    from splitsmith import match_model
-
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     upload = _seed_upload(client, "GH010023.mp4", b"video bytes " * 1024)
 
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={
             "filename": upload["filename"],
             "sha256": upload["sha256"],
@@ -518,16 +516,14 @@ def test_attach_registers_raw_video_on_project(hosted_client_with_match) -> None
     assert body["size_bytes"] == upload["size"]
     assert body["covers_stages"] == []
 
-    # Persisted to the project on disk.
-    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
-    sroot = match_model.Match.shooter_root(match_root, "me")
-    project = MatchProject.load(sroot)
-    assert len(project.raw_videos) == 1
-    assert project.raw_videos[0].storage_path == "raw/GH010023.mp4"
+    # Persisted to the project doc (state_docs), read back through the API.
+    project = _get_project(client, match_id, slug)
+    assert len(project["raw_videos"]) == 1
+    assert project["raw_videos"][0]["storage_path"] == "raw/GH010023.mp4"
     # Without covers_stages, the file lands in unassigned_videos so the
     # ingest tray UI surfaces it -- same shape as local-mode scan.
-    assert len(project.unassigned_videos) == 1
-    assert str(project.unassigned_videos[0].path) == "raw/GH010023.mp4"
+    assert len(project["unassigned_videos"]) == 1
+    assert str(project["unassigned_videos"][0]["path"]) == "raw/GH010023.mp4"
 
 
 def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match) -> None:
@@ -535,13 +531,12 @@ def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match)
     worker has something to detect against without a separate
     auto-match call. The first stage gets primary; subsequent get
     secondary (since they already have a primary on the shared raw)."""
-    from splitsmith import match_model
 
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     upload = _seed_upload(client, "headcam.mp4", b"shared " * 4096)
 
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={
             "filename": upload["filename"],
             "sha256": upload["sha256"],
@@ -552,17 +547,14 @@ def test_attach_with_covers_stages_creates_stagevideos(hosted_client_with_match)
     assert resp.status_code == 200, resp.text
     assert resp.json()["covers_stages"] == [1, 2]
 
-    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
-    sroot = match_model.Match.shooter_root(match_root, "me")
-    project = MatchProject.load(sroot)
-    stage_one = project.stage(1)
-    stage_two = project.stage(2)
-    assert len(stage_one.videos) == 1
-    assert len(stage_two.videos) == 1
-    assert str(stage_one.videos[0].path) == "raw/headcam.mp4"
-    assert str(stage_two.videos[0].path) == "raw/headcam.mp4"
-    assert stage_one.videos[0].role == "primary"
-    assert stage_two.videos[0].role == "primary"
+    project = _get_project(client, match_id, slug)
+    stages = {s["stage_number"]: s for s in project["stages"]}
+    assert len(stages[1]["videos"]) == 1
+    assert len(stages[2]["videos"]) == 1
+    assert str(stages[1]["videos"][0]["path"]) == "raw/headcam.mp4"
+    assert str(stages[2]["videos"][0]["path"]) == "raw/headcam.mp4"
+    assert stages[1]["videos"][0]["role"] == "primary"
+    assert stages[2]["videos"][0]["role"] == "primary"
 
 
 def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> None:
@@ -570,13 +562,12 @@ def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> 
     rather than appending duplicate raw_videos entries (the same
     contract ``MatchProject.attach_raw_video`` enforces in unit
     tests)."""
-    from splitsmith import match_model
 
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     upload = _seed_upload(client, "shared.mp4", b"x" * 1024)
 
     client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={
             "filename": upload["filename"],
             "sha256": upload["sha256"],
@@ -584,7 +575,7 @@ def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> 
         },
     )
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={
             "filename": upload["filename"],
             "sha256": upload["sha256"],
@@ -594,14 +585,13 @@ def test_attach_is_idempotent_merges_covers_stages(hosted_client_with_match) -> 
     assert resp.status_code == 200, resp.text
     assert resp.json()["covers_stages"] == [1, 2]
 
-    match_root = Path(client.app.state.splitsmith_state.matches.resolve(match_id))
-    sroot = match_model.Match.shooter_root(match_root, "me")
-    project = MatchProject.load(sroot)
-    assert len(project.raw_videos) == 1
+    project = _get_project(client, match_id, slug)
+    stages = {s["stage_number"]: s for s in project["stages"]}
+    assert len(project["raw_videos"]) == 1
     # Stage 2 was added by the second attach without disturbing
     # stage 1's existing StageVideo.
-    assert len(project.stage(1).videos) == 1
-    assert len(project.stage(2).videos) == 1
+    assert len(stages[1]["videos"]) == 1
+    assert len(stages[2]["videos"]) == 1
 
 
 def test_attach_404_when_upload_missing(hosted_client_with_match) -> None:
@@ -609,9 +599,9 @@ def test_attach_404_when_upload_missing(hosted_client_with_match) -> None:
     doesn't actually have -- otherwise the manifest would point at
     a non-existent object and the worker would 500 on first
     detection."""
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={"filename": "never-uploaded.mp4"},
     )
     assert resp.status_code == 404
@@ -622,11 +612,11 @@ def test_attach_422_when_covers_stages_unknown(hosted_client_with_match) -> None
     """An unknown stage_number in ``covers_stages`` is a client bug --
     fail loudly rather than silently dropping the bogus number and
     leaving the manifest claiming coverage that doesn't exist."""
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     upload = _seed_upload(client, "clip.mp4", b"x" * 8)
 
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={
             "filename": upload["filename"],
             "covers_stages": [1, 99],
@@ -642,9 +632,9 @@ def test_attach_400_on_unsafe_filename(hosted_client_with_match) -> None:
     """``_sanitize_raw_filename`` runs at the route layer so a
     traversal attempt 400s before the storage backend's own guard
     sees it."""
-    client, _, match_id = hosted_client_with_match
+    client, _, match_id, slug = hosted_client_with_match
     resp = client.post(
-        _attach_url(match_id),
+        _attach_url(match_id, slug),
         json={"filename": "../escape.mp4"},
     )
     assert resp.status_code == 400

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -114,7 +114,9 @@ def hosted_db(tmp_path: Path) -> Iterator[str]:
 
 
 @pytest.fixture
-def hosted_client(hosted_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[TestClient, S3Storage]]:
+def hosted_client(
+    hosted_db: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[tuple[TestClient, S3Storage]]:
     """Boot the FastAPI app in hosted mode against a moto bucket.
 
     Replaces ``_tenant_s3_storage`` (the per-request wrapper) so each
@@ -131,6 +133,11 @@ def hosted_client(hosted_db: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[t
     monkeypatch.setenv("SPLITSMITH_S3_REGION", "us-east-1")
     monkeypatch.setenv("SPLITSMITH_S3_ACCESS_KEY_ID", "key")
     monkeypatch.setenv("SPLITSMITH_S3_SECRET_ACCESS_KEY", "secret")
+    # The hosted match-id alias middleware establishes a local working
+    # root at ``<SPLITSMITH_PROJECTS_DIR>/<match_id>`` for media. Point it
+    # at a writable tmp dir; the production default (/home/splitsmith/data)
+    # isn't creatable on a dev/CI box.
+    monkeypatch.setenv("SPLITSMITH_PROJECTS_DIR", str(tmp_path / "hosted-root"))
 
     with mock_aws():
         s3 = boto3.client("s3", region_name="us-east-1")

--- a/tests/test_project_state_store.py
+++ b/tests/test_project_state_store.py
@@ -1,0 +1,204 @@
+"""Tests for :class:`ProjectStateStore` (state refactor, Phase 1).
+
+Runs against SQLite in-memory via aiosqlite -- same pattern as the other
+per-user store tests. The store has no Postgres-specific behaviour beyond
+the expression unique index (proven by ``pytest -m docker``), so SQLite
+proves the load/save/version SQL shapes + the multi-tenant invariant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from splitsmith.db import (
+    Base,
+    ProjectStateStore,
+    StateConflictError,
+    User,
+    create_engine,
+    sessionmaker,
+)
+
+
+def _engine_with_users(*emails: str) -> tuple[sessionmaker, list[str]]:
+    """Fresh in-memory engine + seed one user per email; return ids."""
+    engine = create_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = sessionmaker(engine)
+
+    async def _setup() -> list[str]:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        ids: list[str] = []
+        async with session_factory() as s:
+            for email in emails:
+                user = User(email=email)
+                s.add(user)
+                await s.commit()
+                await s.refresh(user)
+                ids.append(user.id)
+        return ids
+
+    return session_factory, asyncio.run(_setup())
+
+
+@pytest.mark.parametrize("bad", ["", None, 0, b"abc"])
+def test_construction_rejects_empty_or_non_string_user_id(bad) -> None:
+    sf, _ = _engine_with_users("a@thias.se")
+    with pytest.raises(ValueError, match="non-empty user_id"):
+        ProjectStateStore(sf, user_id=bad)
+
+
+# -- match doc ----------------------------------------------------------
+
+
+def test_match_load_absent_then_insert_then_load() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    assert asyncio.run(store.load_match("brm-abc")) == (None, 0)
+    v = asyncio.run(store.save_match("brm-abc", {"name": "Bromma"}, expected_version=0))
+    assert v == 1
+    assert asyncio.run(store.load_match("brm-abc")) == ({"name": "Bromma"}, 1)
+
+
+def test_match_save_bumps_version() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    asyncio.run(store.save_match("brm-abc", {"name": "Bromma"}, expected_version=0))
+    v2 = asyncio.run(store.save_match("brm-abc", {"name": "Bromma 2026"}, expected_version=1))
+    assert v2 == 2
+    assert asyncio.run(store.load_match("brm-abc")) == ({"name": "Bromma 2026"}, 2)
+
+
+def test_insert_conflict_when_already_exists() -> None:
+    """A second expected_version==0 save for the same identity is a
+    genuine creation race -> StateConflictError, not a silent second row.
+
+    Tested with an *audit* doc on purpose: its identity columns (slug +
+    stage_number) are both non-NULL, so SQLite's plain unique index
+    catches the duplicate here. The match/project kinds carry NULL
+    slug/stage, where only Postgres's coalesce expression index bites --
+    that NULL case is proven in the ``pytest -m docker`` suite, not here.
+    """
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    asyncio.run(store.save_audit("brm-abc", "alice", 1, {"a": 1}, expected_version=0))
+    with pytest.raises(StateConflictError):
+        asyncio.run(store.save_audit("brm-abc", "alice", 1, {"a": 2}, expected_version=0))
+
+
+def test_match_stale_update_raises_conflict() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    asyncio.run(store.save_match("brm-abc", {"a": 1}, expected_version=0))  # v1
+    asyncio.run(store.save_match("brm-abc", {"a": 2}, expected_version=1))  # v2
+    # A writer still holding v1 tries to save -> loses the race.
+    with pytest.raises(StateConflictError):
+        asyncio.run(store.save_match("brm-abc", {"a": 3}, expected_version=1))
+    # The winning write is intact.
+    assert asyncio.run(store.load_match("brm-abc")) == ({"a": 2}, 2)
+
+
+def test_update_missing_row_raises_conflict() -> None:
+    """expected_version>0 against a row that never existed is a conflict,
+    not a silent no-op."""
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    with pytest.raises(StateConflictError):
+        asyncio.run(store.save_match("ghost", {"a": 1}, expected_version=1))
+
+
+# -- project doc (slug set) --------------------------------------------
+
+
+def test_project_roundtrip_and_distinct_slugs() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    assert asyncio.run(store.load_project("brm-abc", "alice")) == (None, 0)
+    asyncio.run(store.save_project("brm-abc", "alice", {"shooter": "Alice"}, expected_version=0))
+    asyncio.run(store.save_project("brm-abc", "bob", {"shooter": "Bob"}, expected_version=0))
+
+    assert asyncio.run(store.load_project("brm-abc", "alice")) == ({"shooter": "Alice"}, 1)
+    assert asyncio.run(store.load_project("brm-abc", "bob")) == ({"shooter": "Bob"}, 1)
+
+
+def test_match_and_project_coexist_for_same_match_id() -> None:
+    """The match doc (NULL slug) and a project doc (slug set) for the same
+    match_id are distinct rows -- the NULL-slug match row must not collide
+    with or be returned for a project load."""
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    asyncio.run(store.save_match("brm-abc", {"kind": "match"}, expected_version=0))
+    asyncio.run(store.save_project("brm-abc", "alice", {"kind": "project"}, expected_version=0))
+
+    assert asyncio.run(store.load_match("brm-abc")) == ({"kind": "match"}, 1)
+    assert asyncio.run(store.load_project("brm-abc", "alice")) == ({"kind": "project"}, 1)
+
+
+# -- audit doc (slug + stage set) --------------------------------------
+
+
+def test_audit_roundtrip_and_distinct_stages() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+
+    assert asyncio.run(store.load_audit("brm-abc", "alice", 1)) == (None, 0)
+    asyncio.run(store.save_audit("brm-abc", "alice", 1, {"shots": [1]}, expected_version=0))
+    asyncio.run(store.save_audit("brm-abc", "alice", 2, {"shots": [2]}, expected_version=0))
+
+    assert asyncio.run(store.load_audit("brm-abc", "alice", 1)) == ({"shots": [1]}, 1)
+    assert asyncio.run(store.load_audit("brm-abc", "alice", 2)) == ({"shots": [2]}, 1)
+    # Stage 1 update doesn't disturb stage 2.
+    asyncio.run(store.save_audit("brm-abc", "alice", 1, {"shots": [1, 1]}, expected_version=1))
+    assert asyncio.run(store.load_audit("brm-abc", "alice", 1)) == ({"shots": [1, 1]}, 2)
+    assert asyncio.run(store.load_audit("brm-abc", "alice", 2)) == ({"shots": [2]}, 1)
+
+
+# -- multi-tenant isolation, per kind ----------------------------------
+
+
+def test_tenant_isolation_match() -> None:
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a, b = ProjectStateStore(sf, user_id=alice), ProjectStateStore(sf, user_id=bob)
+
+    asyncio.run(a.save_match("shared", {"who": "alice"}, expected_version=0))
+    asyncio.run(b.save_match("shared", {"who": "bob"}, expected_version=0))
+
+    assert asyncio.run(a.load_match("shared")) == ({"who": "alice"}, 1)
+    assert asyncio.run(b.load_match("shared")) == ({"who": "bob"}, 1)
+
+
+def test_tenant_isolation_project() -> None:
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a, b = ProjectStateStore(sf, user_id=alice), ProjectStateStore(sf, user_id=bob)
+
+    asyncio.run(a.save_project("shared", "x", {"who": "alice"}, expected_version=0))
+    asyncio.run(b.save_project("shared", "x", {"who": "bob"}, expected_version=0))
+
+    assert asyncio.run(a.load_project("shared", "x")) == ({"who": "alice"}, 1)
+    assert asyncio.run(b.load_project("shared", "x")) == ({"who": "bob"}, 1)
+
+
+def test_tenant_isolation_audit() -> None:
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a, b = ProjectStateStore(sf, user_id=alice), ProjectStateStore(sf, user_id=bob)
+
+    asyncio.run(a.save_audit("shared", "x", 1, {"who": "alice"}, expected_version=0))
+    asyncio.run(b.save_audit("shared", "x", 1, {"who": "bob"}, expected_version=0))
+
+    assert asyncio.run(a.load_audit("shared", "x", 1)) == ({"who": "alice"}, 1)
+    assert asyncio.run(b.load_audit("shared", "x", 1)) == ({"who": "bob"}, 1)
+
+
+def test_load_does_not_leak_across_users() -> None:
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    asyncio.run(ProjectStateStore(sf, user_id=alice).save_match("a-only", {"x": 1}, expected_version=0))
+
+    assert asyncio.run(ProjectStateStore(sf, user_id=bob).load_match("a-only")) == (None, 0)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5723,6 +5723,7 @@ def test_create_match_manual_hosted_mode_synthesizes_path(
             scoreboard_identity=JsonScoreboardIdentityStore(),
             jobs=JobRegistry(),
             matches_store=None,
+            project_state=None,
             storage=None,
         )
 

--- a/tests/test_worker_storage_seam.py
+++ b/tests/test_worker_storage_seam.py
@@ -1,41 +1,62 @@
-"""Hosted-mode JSON storage seam (PR-delta).
+"""Hosted-mode worker<->API seam (state refactor).
 
-Proves the bidirectional round-trip that lets a separate worker process
-run match-carrying kinds: the API seeds S3 with a match's JSON, a worker
-(here: a second local working root pointed at the same storage) reads it,
-writes results back, and the API sees them on its next read. S3 is the
-source of truth for the small JSON files, so loads pull fresh.
+The small JSON state (match / project / audit docs) now lives in the
+``state_docs`` Postgres table via :class:`ProjectStateStore`, not in
+S3-mirrored files. The unit-level coverage of that round-trip lives in
+``test_project_state_store.py``; the live-Postgres RLS + serve->worker
+proof lives in ``test_hosted_docker_smoke.py``.
 
-Uses :class:`FilesystemStorage` against a temp dir as the S3 stand-in --
-it implements the full ``Storage`` protocol, so the seam exercises real
-push/pull, not a mock.
+What stays specific to this file is the **media** seam: the heavy binary
+artifacts (audit-trim MP4s, export deliverables) still round-trip through
+S3, keyed by the per-shooter ``scope`` that ``state.shooter_project``
+binds. This file proves a worker can cut media on one working root, push
+it, and the API mirrors it down on another -- with the project doc itself
+resolved from a shared Postgres store rather than a mirrored file.
+
+Uses an in-memory SQLite ``ProjectStateStore`` (the state docs) +
+:class:`FilesystemStorage` against a temp dir (the S3 media stand-in), so
+the seam exercises real reads/writes, not mocks.
 """
 
 from __future__ import annotations
 
-import json
+import asyncio
 from pathlib import Path
 
 import pytest
 
+from splitsmith.db import Base, ProjectStateStore, User, create_engine, sessionmaker
 from splitsmith.match_model import Match
 from splitsmith.storage import FilesystemStorage
 from splitsmith.ui import audio as audio_helpers
-from splitsmith.ui import server as srv
 from splitsmith.ui.project import PROJECT_FILE, MatchProject, StageEntry, StageVideo
 from splitsmith.ui.server import AppState, current_match_id, current_match_root
 
 
-def _scaffold_match(root: Path, *, name: str = "Test Match", slug: str = "alpha") -> str:
-    """Create an on-disk match with one shooter; return its match_id."""
-    match = Match.init(root, name=name)
-    shooter_root = Match.shooter_root(root, slug)
-    shooter_root.mkdir(parents=True, exist_ok=True)
-    MatchProject.init(shooter_root, name=slug)
-    match.shooters.append(slug)
-    match.save(root)
-    assert match.match_id is not None
-    return match.match_id
+def _store_with_match(slug: str = "alpha") -> tuple[ProjectStateStore, str]:
+    """Build an in-memory state store seeded with a one-shooter match +
+    its (empty) project doc. Returns ``(store, match_id)``."""
+    engine = create_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = sessionmaker(engine)
+    match_id = "m_seam_test"
+
+    async def _setup() -> ProjectStateStore:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with session_factory() as s:
+            user = User(email="seam@thias.se")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            uid = user.id
+        store = ProjectStateStore(session_factory, user_id=uid)
+        await store.save_match(match_id, {"name": "Seam", "shooters": [slug]}, expected_version=0)
+        await store.save_project(
+            match_id, slug, MatchProject(name=slug).model_dump(mode="json"), expected_version=0
+        )
+        return store
+
+    return asyncio.run(_setup()), match_id
 
 
 class _BoundMatch:
@@ -54,96 +75,74 @@ class _BoundMatch:
         current_match_root.reset(self._rt)
 
 
-def test_save_pushes_project_json_when_storage_bound(tmp_path: Path) -> None:
-    storage_root = tmp_path / "s3"
-    storage = FilesystemStorage(storage_root)
-    shooter_root = tmp_path / "local" / "shooters" / "alpha"
-    proj = MatchProject.init(shooter_root, name="alpha")
-    proj.bind_storage(storage, scope="matches/m1/shooters/alpha")
-
-    proj.competitor_name = "Pushed"
-    proj.save(shooter_root)
-
-    key = storage_root / "matches" / "m1" / "shooters" / "alpha" / PROJECT_FILE
-    assert key.exists()
-    assert json.loads(key.read_text())["competitor_name"] == "Pushed"
-
-
 def test_save_is_noop_in_local_mode(tmp_path: Path) -> None:
-    """No storage bound (desktop) -> save just writes locally, no error."""
+    """No state store bound (desktop) -> save just writes locally."""
+    import json
+
     shooter_root = tmp_path / "shooters" / "alpha"
     proj = MatchProject.init(shooter_root, name="alpha")
     proj.competitor_name = "Local"
-    proj.save(shooter_root)  # _storage is None -> push branch skipped
+    proj.save(shooter_root)  # _state_store is None -> file write
     assert json.loads((shooter_root / PROJECT_FILE).read_text())["competitor_name"] == "Local"
 
 
-def test_project_json_round_trips_api_worker_api(tmp_path: Path) -> None:
+def test_project_doc_round_trips_api_worker_api(tmp_path: Path) -> None:
     """API write -> worker read+write -> API re-read sees the worker's
-    value (always-fresh load beats the API's stale local copy)."""
-    storage = FilesystemStorage(tmp_path / "s3")
+    value, with the project doc resolved from a shared state store across
+    two distinct working roots (no file mirror involved)."""
+    store, match_id = _store_with_match()
     state = AppState()
-    state.storage = storage
+    state.project_state = store
 
     api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root)
-    # API "opens" the match: seed S3 with match.json + project.json.
-    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
-
+    api_root.mkdir()
     with _BoundMatch(api_root, match_id):
         proj = state.shooter_project("alpha")
         proj.competitor_name = "ApiWritten"
         proj.save(state.shooter_root("alpha"))
 
-    # Worker: a fresh, empty working root pointed at the same storage.
     worker_root = tmp_path / "worker"
     worker_root.mkdir()
     with _BoundMatch(worker_root, match_id):
-        wproj = state.shooter_project("alpha")  # pulls match.json + project.json down
+        wproj = state.shooter_project("alpha")
         assert wproj.competitor_name == "ApiWritten"
         wproj.competitor_name = "WorkerWritten"
-        wproj.save(state.shooter_root("alpha"))  # pushes the worker's result
+        wproj.save(state.shooter_root("alpha"))
 
-    # API re-reads: its local copy still says "ApiWritten", but the load
-    # pulls fresh from storage and sees the worker's write.
-    assert (
-        json.loads((api_root / "shooters" / "alpha" / PROJECT_FILE).read_text())["competitor_name"]
-        == "ApiWritten"
-    )
     with _BoundMatch(api_root, match_id):
         reread = state.shooter_project("alpha")
         assert reread.competitor_name == "WorkerWritten"
+    # No project.json was written on either root -- state lives in Postgres.
+    assert not (api_root / "shooters" / "alpha" / PROJECT_FILE).exists()
+    assert not (worker_root / "shooters" / "alpha" / PROJECT_FILE).exists()
 
 
-def test_audit_json_round_trips(tmp_path: Path) -> None:
-    """shot_detect's result (audit JSON) written on the worker is visible
-    to the API via push_audit / pull_audit."""
-    storage = FilesystemStorage(tmp_path / "s3")
+def test_audit_doc_round_trips_api_worker_api(tmp_path: Path) -> None:
+    """shot_detect's result (audit doc) written on the worker is visible to
+    the API via the shared state store."""
+    store, match_id = _store_with_match()
     state = AppState()
-    state.storage = storage
-
-    api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root)
+    state.project_state = store
 
     worker_root = tmp_path / "worker"
+    worker_root.mkdir()
     with _BoundMatch(worker_root, match_id):
-        audit_dir = Match.shooter_root(worker_root, "alpha") / "audit"
-        audit_dir.mkdir(parents=True)
-        (audit_dir / "stage1.json").write_text('{"shots": [0.21, 0.55]}')
-        state.push_audit("alpha", 1)
+        state.save_audit("alpha", 1, {"shots": [0.21, 0.55]}, version=0)
 
+    api_root = tmp_path / "api"
+    api_root.mkdir()
     with _BoundMatch(api_root, match_id):
-        state.pull_audit("alpha", 1)
-        api_audit = Match.shooter_root(api_root, "alpha") / "audit" / "stage1.json"
-        assert json.loads(api_audit.read_text())["shots"] == [0.21, 0.55]
+        doc, version = state.load_audit("alpha", 1)
+        assert doc == {"shots": [0.21, 0.55]}
+        assert version == 1
 
 
 def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The heavy binary seam: a worker cuts the audit-trim MP4 and pushes
-    it to storage; the API mirrors it down to serve the scrub clip. Proves
-    the scope wiring (``state.shooter_project`` bind) produces matching
-    push/pull keys across two working roots."""
-    # Fake the ffmpeg-backed trim so the test has no binary dependency.
+    it to storage; the API mirrors it down to serve the scrub clip. The
+    project doc resolves from the shared state store; only the MP4 rides
+    S3. Proves the scope wiring (``state.shooter_project`` bind) produces
+    matching push/pull keys across two working roots."""
     monkeypatch.setattr("splitsmith.trim.select_audit_encoder", lambda *a, **k: "libx264")
 
     def fake_trim_video(**kwargs: object) -> None:
@@ -153,17 +152,12 @@ def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: p
 
     monkeypatch.setattr("splitsmith.trim.trim_video", fake_trim_video)
 
+    store, match_id = _store_with_match()
     storage = FilesystemStorage(tmp_path / "s3")
     state = AppState()
+    state.project_state = store
     state.storage = storage
 
-    api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root)
-    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
-
-    # Worker: fresh root pointed at the same storage. Add a stage with a
-    # primary video (round-trips via project.json), then cut the trim ->
-    # pushes the MP4 to storage.
     worker_root = tmp_path / "worker"
     worker_root.mkdir()
     with _BoundMatch(worker_root, match_id):
@@ -177,7 +171,8 @@ def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: p
         source.write_bytes(b"video bytes")
         audio_helpers.ensure_video_audit_trim(wshooter, 1, video, source, 3.5, 10.0, project=wproj)
 
-    # API: pulls project.json (sees the stage), then mirrors the trim down.
+    api_root = tmp_path / "api"
+    api_root.mkdir()
     with _BoundMatch(api_root, match_id):
         aproj = state.shooter_project("alpha")
         prim = aproj.stage(1).primary()
@@ -190,23 +185,18 @@ def test_audit_trim_mp4_round_trips_worker_to_api(tmp_path: Path, monkeypatch: p
 
 
 def test_export_media_round_trips_worker_to_api(tmp_path: Path) -> None:
-    """PR-epsilon part 2: a worker produces export deliverables and pushes
-    them to storage; the API mirrors them down via ``pull_export_file``.
-    Proves the scope wiring (``state.shooter_project`` bind) gives matching
-    push/pull keys across two working roots, the same seam the download
-    endpoint serves through."""
+    """A worker produces export deliverables and pushes them to storage;
+    the API mirrors them down via ``pull_export_file``. Project doc from
+    the shared state store; deliverables ride S3."""
     from splitsmith.ui import export_storage
     from splitsmith.ui.exports import StageExportResult
 
+    store, match_id = _store_with_match()
     storage = FilesystemStorage(tmp_path / "s3")
     state = AppState()
+    state.project_state = store
     state.storage = storage
 
-    api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root)
-    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
-
-    # Worker: produce a stage export bundle on a fresh root and push it.
     worker_root = tmp_path / "worker"
     worker_root.mkdir()
     with _BoundMatch(worker_root, match_id):
@@ -228,7 +218,8 @@ def test_export_media_round_trips_worker_to_api(tmp_path: Path) -> None:
         )
         export_storage.push_stage_export_outputs(wproj, result)
 
-    # API: mirrors each deliverable down (the download endpoint's pull seam).
+    api_root = tmp_path / "api"
+    api_root.mkdir()
     with _BoundMatch(api_root, match_id):
         aproj = state.shooter_project("alpha")
         aed = aproj.exports_path(state.shooter_root("alpha"))
@@ -244,44 +235,14 @@ def test_export_media_round_trips_worker_to_api(tmp_path: Path) -> None:
 
 
 def test_seam_is_noop_without_storage(tmp_path: Path) -> None:
-    """Local mode (storage None): pull/push audit + sync are no-ops, no error."""
-    state = AppState()  # storage stays None
+    """Local mode (no state store, no storage): audit save/load go to disk."""
+    state = AppState()  # project_state + storage stay None
     api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root)
-    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))  # no-op
-    with _BoundMatch(api_root, match_id):
-        state.pull_audit("alpha", 1)  # no-op
-        state.push_audit("alpha", 1)  # no-op
-
-
-def test_added_shooter_survives_shooter_root_always_pull(tmp_path: Path) -> None:
-    """Regression (bug_001): a shooter added after match open must push the
-    updated roster to S3. ``shooter_root`` always-pulls match.json and
-    overwrites local, so without the push it would revert to the opened-at
-    roster and the new shooter would 404 (and corrupt local match.json)."""
-    storage = FilesystemStorage(tmp_path / "s3")
-    state = AppState()
-    state.storage = storage
-
-    api_root = tmp_path / "api"
-    match_id = _scaffold_match(api_root, slug="alpha")
-    # Open: seed match.json ([alpha]) + alpha's project.json to S3.
-    srv._sync_match_json_to_storage(state, api_root, Match.load(api_root))
-
-    # Add shooter "beta" the way add_match_shooter does: update match.json +
-    # create the shooter's project.json locally, then push (the fix).
-    match = Match.load(api_root)
-    beta_root = Match.shooter_root(api_root, "beta")
-    beta_root.mkdir(parents=True, exist_ok=True)
-    MatchProject.init(beta_root, name="beta")
-    match.shooters.append("beta")
-    match.save(api_root)
-    srv._sync_match_json_to_storage(state, api_root, match)
-
-    # A shooter-scoped request pulls match.json fresh from S3; beta must be
-    # registered (not reverted to the opened-at [alpha] roster). Without the
-    # push above, the pull overwrites local with [alpha] and this 404s.
-    with _BoundMatch(api_root, match_id):
-        assert state.shooter_root("beta").name == "beta"
-    # beta's project.json was seeded to S3 so the worker can read it.
-    assert storage.exists(f"matches/{match_id}/shooters/beta/{PROJECT_FILE}")
+    Match.init(api_root, name="Local")
+    (Match.shooter_root(api_root, "alpha")).mkdir(parents=True, exist_ok=True)
+    with _BoundMatch(api_root, "m_local"):
+        assert state.load_audit("alpha", 1) == (None, 0)
+        state.save_audit("alpha", 1, {"shots": []}, version=0)
+        doc, version = state.load_audit("alpha", 1)
+        assert doc == {"shots": []}
+        assert version == 0  # files have no optimistic-lock version


### PR DESCRIPTION
Fixes the prod bug where hosted match pages 404'd then 500'd after a redeploy: per-match state (`match.json`, per-shooter `project.json`, per-stage `audit/stage<N>.json`) lived on each container's ephemeral local disk, mirrored whole to S3 (last-writer-wins). This branch moves that state into Postgres with optimistic-concurrency versioning + RLS, so resolution is stateless across redeploys/replicas and concurrent edits are detected (409) instead of silently clobbered. Local desktop mode stays file-based.

## Commits
- **#465 base** `fix(serve): hydrate match resolution from Postgres, not in-memory only` -- the interim middleware fix (already deployed to prod via `railway up`).
- `test(serve): point hosted_client at a tmp projects dir` -- fixes #465's red CI (the `/home/splitsmith/data` mkdir on a dev/CI box).
- **Phase 1** `state_docs table + ProjectStateStore` -- polymorphic match/project/audit table, optimistic-locking store, migration `d1f7b25c8a3e` (PG `coalesce` expression unique index so NULL slug/stage can't admit duplicate match/project rows), `state_docs` joins the `tenant_isolation` RLS policy. Ships dark.
- **Phase 2** `route hosted match state through Postgres` -- `bind_state`/store-vs-file `save()` on Match + MatchProject; `async_bridge.run_sync` to drive the async store from the sync accessors in both sync and async handlers; rewritten `shooter_root`/`shooter_project`/`match()`/`load_audit`/`save_audit`/`materialize_audit` accessors; creation sites bind at version 0; `StateConflictError` -> 409. The ~30 `project.save()` handler sites are unchanged (they inherit the binding from the accessor).

## Still to come (separate PRs)
- Phase 3: delete the now-dead JSON-mirror code (`_pull_json`/`pull_audit`/`_sync_match_json_to_storage`/...).
- Phase 4: wrap the worker's shot-detect audit read-merge-write in a re-merge retry on `StateConflictError`.

## Verification
- Full non-docker suite: 1665 passed.
- `pytest -m docker`: 8 passed, incl. the serve->worker round-trip (now asserts `state_docs` rows) and `state_docs` RLS cross-tenant isolation.
- ruff + black clean.

Breaking change + data wipe is fine (no production users); existing R2 `match.json`/`project.json`/audit objects are abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)