### PR TITLE
refactor(serve): finish state refactor (phases 3+4 -- dead-code removal + worker re-merge retry)

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -160,7 +160,6 @@ from .jobs import (
     ShutdownInProgressError,
 )
 from .project import (
-    PROJECT_FILE,
     VIDEO_EXTENSIONS,
     MatchProject,
     RawVideo,
@@ -301,6 +300,60 @@ def _configure_app_logging(stream: Any | None = None) -> None:
     pkg_logger.addHandler(handler)
     if pkg_logger.level == logging.NOTSET or pkg_logger.level > logging.INFO:
         pkg_logger.setLevel(logging.INFO)
+
+
+def _state_conflict_excs() -> tuple[type[BaseException], ...]:
+    """Resolve the optimistic-lock conflict type for the audit re-merge
+    retry, lazily so ``import splitsmith.ui.server`` never pulls the hosted
+    db deps (local-mode invariant; guarded by
+    ``test_local_mode_no_hosted_imports``). Empty tuple on a slim local
+    install without the db extras -- ``except ():`` then catches nothing,
+    which is correct: local file saves never raise a conflict."""
+    try:
+        from ..db import StateConflictError
+
+        return (StateConflictError,)
+    except Exception:  # pragma: no cover - slim local install without db extras
+        return ()
+
+
+# How many times the worker re-loads + re-merges a stage's audit doc when a
+# concurrent writer wins the optimistic-lock race before its save. Small:
+# real contention is a manual SPA edit landing while shot_detect runs, not a
+# thundering herd. Exhausting it re-raises -> the job fails loudly.
+_AUDIT_SAVE_MAX_ATTEMPTS = 4
+
+
+def _save_audit_with_remerge(
+    state: AppState,
+    slug: str,
+    stage_number: int,
+    *,
+    doc: dict,
+    version: int,
+    merge: Callable[[dict], dict],
+    default: Callable[[], dict],
+) -> int:
+    """Save an audit doc under optimistic locking with a bounded re-merge.
+
+    ``merge`` folds the caller's results into a doc; the first attempt
+    applies it to ``doc`` (loaded at ``version``). If the hosted save loses
+    the version race (a concurrent writer bumped it), re-load the winner's
+    doc and re-apply ``merge`` to *that* -- so the concurrent edit survives
+    instead of being clobbered -- then save again. ``default`` rebuilds a
+    fresh doc if the row vanished between attempts. Returns the new version.
+    Local file saves never raise, so the loop runs exactly once there.
+    """
+    conflict_excs = _state_conflict_excs()
+    for attempt in range(_AUDIT_SAVE_MAX_ATTEMPTS):
+        try:
+            return state.save_audit(slug, stage_number, merge(doc), version=version)
+        except conflict_excs:
+            if attempt + 1 >= _AUDIT_SAVE_MAX_ATTEMPTS:
+                raise  # bounded retries exhausted -> fail the job loudly
+            reloaded, version = state.load_audit(slug, stage_number)
+            doc = reloaded if reloaded is not None else default()
+    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover
 
 
 STATIC_DIR = Path(__file__).parent.parent / "ui_static" / "dist"
@@ -922,51 +975,15 @@ class AppState:
             )
         return match_model.Match.shooter_root(scoped_root, slug)
 
-    # ------------------------------------------------------------------
-    # Hosted-mode JSON storage seam (PR-delta)
-    # ------------------------------------------------------------------
-    #
-    # match.json / project.json / audit stage<N>.json are the small,
-    # mutable JSON files that carry match + shooter state. In hosted mode
-    # they round-trip through S3 so a worker process can read the inputs
-    # the API wrote and the API can read the results the worker wrote.
-    # S3 is the source of truth: load pulls fresh (overwrite local),
-    # save/write pushes. JSON is tiny, so always-pull is cheap. Whole-file
-    # last-writer-wins -- a compute job and a manual SPA edit don't touch
-    # the same stage concurrently (the SPA shows the job in progress).
-    # All four helpers no-op in local mode (storage is None).
-
-    def _pull_json(self, key: str | None, dest: Path) -> None:
-        """Mirror a JSON object down from storage, overwriting ``dest``."""
-        if self.storage is None or key is None:
-            return
-        MatchProject._mirror_from_storage(self.storage, key, dest)
-
-    def _push_json(self, key: str | None, src: Path) -> None:
-        """Push a locally-written JSON file up to storage."""
-        if self.storage is None or key is None or not src.exists():
-            return
-        self.storage.write_bytes(key, src.read_bytes())
-
-    def _audit_key(self, slug: str, stage_number: int) -> str | None:
-        mid = current_match_id.get()
-        if mid is None:
-            return None
-        return f"matches/{mid}/shooters/{slug}/audit/stage{stage_number}.json"
-
     def _audit_file(self, slug: str, stage_number: int) -> Path:
+        """The on-disk path for a stage's audit JSON. Used only by the
+        *local-mode* branches of ``load_audit`` / ``save_audit`` /
+        ``materialize_audit`` -- hosted mode keeps audit docs in
+        ``state_docs`` and never touches this file."""
         scoped_root = current_match_root.get()
         if scoped_root is None:
             raise _no_project_error()
         return match_model.Match.shooter_root(scoped_root, slug) / "audit" / f"stage{stage_number}.json"
-
-    def pull_audit(self, slug: str, stage_number: int) -> None:
-        """Pull a stage's audit JSON down before reading it (hosted)."""
-        self._pull_json(self._audit_key(slug, stage_number), self._audit_file(slug, stage_number))
-
-    def push_audit(self, slug: str, stage_number: int) -> None:
-        """Push a stage's audit JSON up after writing it (hosted)."""
-        self._push_json(self._audit_key(slug, stage_number), self._audit_file(slug, stage_number))
 
     # ------------------------------------------------------------------
     # State-doc accessors (state refactor)
@@ -1093,16 +1110,6 @@ class AppState:
             project = MatchProject.load(shooter_root)
         project.bind_storage(self.storage, scope=scope)
         return project
-
-    def register_match(self, root: Path) -> str | None:
-        """Load the match at ``root`` and pin its ``match_id`` into
-        the registry so the alias middleware can resolve it
-        immediately. Returns the match_id (``None`` if the on-disk
-        file somehow lacks one)."""
-        match = match_model.Match.load(root)
-        if match.match_id:
-            self.matches.register(match.match_id, root)
-        return match.match_id
 
 
 async def _any_active_job(state: AppState) -> Job | None:
@@ -1837,57 +1844,90 @@ def register_job_bodies(state: AppState) -> None:
             )
 
         handle.update(progress=0.85, message="Saving audit JSON...")
-        existing_json["_candidates_pending_audit"] = {
-            "_note": (
-                "3-voter ensemble (PANN gunshot folded into voter C). "
-                "vote_a/b/c=1 means the voter kept the candidate; "
-                "ensemble_score = vote_total + apriori_boost. shots[] is "
-                "seeded from candidates with ensemble_score >= consensus."
-            ),
-            "consensus": result.consensus,
-            "expected_rounds": result.expected_rounds,
-            "candidates": candidates,
-        }
-        if reset:
-            existing_json["shots"] = []
-        seeded_shots = False
-        if not existing_json.get("shots"):
-            kept = [c for c in result.candidates if c.kept]
-            existing_json["shots"] = [
-                {
-                    "shot_number": i,
-                    "candidate_number": c.candidate_number,
-                    "time": c.time,
-                    "ms_after_beep": c.ms_after_beep,
-                    "source": "detected",
-                    "ensemble_votes": c.vote_total,
-                    "apriori_boost": c.apriori_boost,
-                    "ensemble_score": c.ensemble_score,
-                }
-                for i, c in enumerate(kept, start=1)
-            ]
-            seeded_shots = True
-        events = list(existing_json.get("audit_events") or [])
-        events.append(
-            {
-                "ts": _now_iso(),
-                "kind": "shot_detect_run",
-                "payload": {
-                    "candidate_count": len(candidates),
-                    "kept_count": sum(1 for c in result.candidates if c.kept),
-                    "consensus": result.consensus,
-                    "expected_rounds": result.expected_rounds,
-                    "seeded_shots": seeded_shots,
-                },
-            }
-        )
-        existing_json["audit_events"] = events
 
-        # Persist the merged audit. Hosted: state_docs under optimistic
-        # locking; local: atomic file write. Phase 4 wraps this in a
-        # re-load + re-merge retry on StateConflictError for the worker's
-        # concurrent read-modify-write case.
-        state.save_audit(slug, stage_number, existing_json, version=audit_version)
+        def _default_audit_doc() -> dict[str, Any]:
+            return {
+                "stage_number": stg.stage_number,
+                "stage_name": stg.stage_name,
+                "stage_time_seconds": stg.time_seconds,
+                "beep_time": round(beep_in_clip, 4),
+                "shots": [],
+            }
+
+        def _merge_detection_into(doc: dict[str, Any]) -> dict[str, Any]:
+            """Fold this run's detection results into ``doc``.
+
+            Re-appliable against a freshly-loaded doc so a lost
+            optimistic-lock race re-merges into the winner's document
+            instead of clobbering it: project ``stage_rounds`` wins, the
+            candidate block is rewritten, ``shots[]`` is seeded only when
+            empty (or on ``reset``) so a concurrent manual edit survives,
+            and the run is appended to the ``audit_events`` log.
+            """
+            if stg.stage_rounds is not None:
+                doc["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
+            doc["_candidates_pending_audit"] = {
+                "_note": (
+                    "3-voter ensemble (PANN gunshot folded into voter C). "
+                    "vote_a/b/c=1 means the voter kept the candidate; "
+                    "ensemble_score = vote_total + apriori_boost. shots[] is "
+                    "seeded from candidates with ensemble_score >= consensus."
+                ),
+                "consensus": result.consensus,
+                "expected_rounds": result.expected_rounds,
+                "candidates": candidates,
+            }
+            if reset:
+                doc["shots"] = []
+            seeded_shots = False
+            if not doc.get("shots"):
+                kept = [c for c in result.candidates if c.kept]
+                doc["shots"] = [
+                    {
+                        "shot_number": i,
+                        "candidate_number": c.candidate_number,
+                        "time": c.time,
+                        "ms_after_beep": c.ms_after_beep,
+                        "source": "detected",
+                        "ensemble_votes": c.vote_total,
+                        "apriori_boost": c.apriori_boost,
+                        "ensemble_score": c.ensemble_score,
+                    }
+                    for i, c in enumerate(kept, start=1)
+                ]
+                seeded_shots = True
+            events = list(doc.get("audit_events") or [])
+            events.append(
+                {
+                    "ts": _now_iso(),
+                    "kind": "shot_detect_run",
+                    "payload": {
+                        "candidate_count": len(candidates),
+                        "kept_count": sum(1 for c in result.candidates if c.kept),
+                        "consensus": result.consensus,
+                        "expected_rounds": result.expected_rounds,
+                        "seeded_shots": seeded_shots,
+                    },
+                }
+            )
+            doc["audit_events"] = events
+            return doc
+
+        # Persist the merged audit with a bounded re-load + re-merge retry.
+        # Hosted state_docs saves are optimistic-locked: a concurrent manual
+        # SPA edit (or another job) can bump the version between our load and
+        # save -> StateConflictError. Re-loading and re-merging into the
+        # winner's doc preserves that edit (this job *merges*, never blindly
+        # overwrites). Local file saves never raise, so this runs once.
+        _save_audit_with_remerge(
+            state,
+            slug,
+            stage_number,
+            doc=existing_json,
+            version=audit_version,
+            merge=_merge_detection_into,
+            default=_default_audit_doc,
+        )
 
         # Read-modify-write the project file: a long-running shot_detect
         # job must not save the snapshot it loaded at start, because the
@@ -3322,30 +3362,6 @@ async def _register_match_at(
         if state.matches_store is not None:
             await state.matches_store.upsert(match.match_id, name, f"matches/{match.match_id}")
     return name, match.match_id
-
-
-def _sync_match_json_to_storage(state: AppState, root: Path, match: match_model.Match) -> None:
-    """Seed S3 with a match's JSON so a worker process can read it.
-
-    ``match.json`` is pushed unconditionally -- the API is its sole
-    writer, so there is no worker result to clobber. Each shooter's
-    ``project.json`` is seeded only when absent in storage: a worker job
-    may already have written newer results (beep_time/processed), and S3
-    is authoritative for that file, so the API must not overwrite it with
-    its possibly-stale local copy. Subsequent project.json writes (API or
-    worker) push via :meth:`MatchProject.save`. No-op without storage.
-    """
-    if state.storage is None or not match.match_id:
-        return
-    state.storage.write_bytes(
-        f"matches/{match.match_id}/{match_model.MATCH_FILE}",
-        (root / match_model.MATCH_FILE).read_bytes(),
-    )
-    for slug in match.shooters:
-        key = f"matches/{match.match_id}/shooters/{slug}/{PROJECT_FILE}"
-        local = match_model.Match.shooter_root(root, slug) / PROJECT_FILE
-        if local.exists() and not state.storage.exists(key):
-            state.storage.write_bytes(key, local.read_bytes())
 
 
 def _resolve_create_target(

--- a/tests/test_audit_remerge_retry.py
+++ b/tests/test_audit_remerge_retry.py
@@ -1,0 +1,102 @@
+"""Worker audit save: bounded re-load + re-merge on optimistic-lock loss.
+
+State-refactor phase 4. When ``_run_shot_detect`` saves its merged audit
+doc to hosted ``state_docs`` and a concurrent writer (a manual SPA edit,
+another job) bumps the version in between, the save raises
+``StateConflictError``. The worker must re-load the winner's doc, re-apply
+its merge to *that* (so the concurrent edit survives -- this job merges,
+never blindly overwrites), and save again, bounded.
+
+Tests the extracted ``_save_audit_with_remerge`` helper against a fake
+state so the concurrency logic is exercised without standing up the whole
+detection job.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from splitsmith.db import StateConflictError
+from splitsmith.ui.server import _AUDIT_SAVE_MAX_ATTEMPTS, _save_audit_with_remerge
+
+
+class _FakeState:
+    """Minimal state exposing load_audit / save_audit with a scripted
+    conflict on the first N saves."""
+
+    def __init__(self, *, conflicts: int, reloaded_doc: dict) -> None:
+        self._conflicts = conflicts
+        self._reloaded_doc = reloaded_doc
+        self.saved: list[tuple[dict, int]] = []
+        self.load_calls = 0
+        self._version = 7  # the winner's current version after a conflict
+
+    def save_audit(self, slug: str, stage_number: int, doc: dict, *, version: int) -> int:
+        if self._conflicts > 0:
+            self._conflicts -= 1
+            raise StateConflictError("scripted conflict")
+        self.saved.append((doc, version))
+        return version + 1
+
+    def load_audit(self, slug: str, stage_number: int) -> tuple[dict | None, int]:
+        self.load_calls += 1
+        # Hand back a copy so the merge can't mutate the test's fixture.
+        return dict(self._reloaded_doc), self._version
+
+
+def _merge(doc: dict) -> dict:
+    # Seed shots only when empty (mirrors the real merge) + append an event.
+    if not doc.get("shots"):
+        doc["shots"] = [{"shot_number": 1, "source": "detected"}]
+    doc.setdefault("audit_events", []).append({"kind": "shot_detect_run"})
+    return doc
+
+
+def _default() -> dict:
+    return {"shots": []}
+
+
+def test_no_conflict_saves_once() -> None:
+    state = _FakeState(conflicts=0, reloaded_doc={})
+    doc = {"shots": []}
+    new_version = _save_audit_with_remerge(
+        state, "alice", 1, doc=doc, version=3, merge=_merge, default=_default
+    )
+    assert new_version == 4
+    assert state.load_calls == 0  # never re-loaded
+    assert len(state.saved) == 1
+    saved_doc, saved_version = state.saved[0]
+    assert saved_version == 3
+    assert saved_doc["shots"] == [{"shot_number": 1, "source": "detected"}]
+
+
+def test_one_conflict_reloads_remerges_preserving_concurrent_edit() -> None:
+    # The winner's doc already carries a manual edit (a kept shot + an
+    # event). Our re-merge must preserve it: shots[] is non-empty so we
+    # don't reseed, and our event appends after theirs.
+    winner = {
+        "shots": [{"shot_number": 1, "source": "manual"}],
+        "audit_events": [{"kind": "manual_edit"}],
+    }
+    state = _FakeState(conflicts=1, reloaded_doc=winner)
+    doc = {"shots": []}  # what we loaded before the race
+    new_version = _save_audit_with_remerge(
+        state, "alice", 1, doc=doc, version=3, merge=_merge, default=_default
+    )
+    assert state.load_calls == 1  # re-loaded once after the conflict
+    assert new_version == 8  # winner version 7 -> 8
+    saved_doc, saved_version = state.saved[0]
+    assert saved_version == 7  # saved against the re-loaded version
+    # Concurrent manual shot preserved (not reseeded), our event appended.
+    assert saved_doc["shots"] == [{"shot_number": 1, "source": "manual"}]
+    assert [e["kind"] for e in saved_doc["audit_events"]] == ["manual_edit", "shot_detect_run"]
+
+
+def test_exhausting_retries_reraises() -> None:
+    state = _FakeState(conflicts=_AUDIT_SAVE_MAX_ATTEMPTS, reloaded_doc={"shots": []})
+    with pytest.raises(StateConflictError):
+        _save_audit_with_remerge(
+            state, "alice", 1, doc={"shots": []}, version=3, merge=_merge, default=_default
+        )
+    # One save attempt per allowed try; load between all but the last.
+    assert state.load_calls == _AUDIT_SAVE_MAX_ATTEMPTS - 1


### PR DESCRIPTION
Completes the state refactor (#465).

**Phase 3 -- delete dead JSON-mirror code.** With match/project/audit state in Postgres, the S3 JSON-mirror helpers are unreachable: removes `AppState._pull_json`/`_push_json`/`_audit_key`/`pull_audit`/`push_audit`, the module-level `_sync_match_json_to_storage`, and the call-less `AppState.register_match`. Kept `_audit_file` (local-mode audit path) and `MatchProject._mirror_from_storage` (media -- raw video/trims/exports still ride S3).

**Phase 4 -- worker re-merge retry.** `_run_shot_detect` read-merge-writes the audit doc; its save was a bare optimistic-locked write, so a concurrent manual SPA edit landing mid-detection would fail the job. `_save_audit_with_remerge` re-loads the winner's doc on `StateConflictError`, re-applies the detection merge to it (preserving the concurrent edit -- `shots[]` reseeded only when empty, the run appended to `audit_events`), and retries, bounded at 4. The conflict type resolves lazily so module import stays free of hosted db deps (local-mode invariant).

## Verification
- Full non-docker suite: 1670 passed (incl. 3 new `_save_audit_with_remerge` tests).
- `pytest -m docker`: 8 passed (serve->worker round-trip + state_docs RLS).
- ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)