### PR TITLE
feat: presigned multipart upload for large raw videos (#467)

### DIFF
--- a/src/splitsmith/storage.py
+++ b/src/splitsmith/storage.py
@@ -100,6 +100,29 @@ class Storage(Protocol):
     def delete(self, path: str) -> None:
         """Remove the object. No-op if absent."""
 
+    # -- Presigned multipart upload (large files, direct browser->store) --
+    #
+    # The client uploads parts straight to the store via presigned URLs, so
+    # multi-GB raw footage never streams through the API process (which on
+    # Railway 502s past a few hundred MB). Hosted-only: only S3Storage
+    # implements it; the filesystem stand-in raises NotImplementedError.
+
+    def create_multipart_upload(self, path: str) -> str:
+        """Begin a multipart upload at ``path``; return its ``upload_id``."""
+
+    def presign_upload_part(
+        self, path: str, upload_id: str, part_number: int, *, expires_in: int = 3600
+    ) -> str:
+        """Return a presigned URL the client PUTs one part (1-based
+        ``part_number``) to. Valid for ``expires_in`` seconds."""
+
+    def complete_multipart_upload(self, path: str, upload_id: str, parts: list[tuple[int, str]]) -> int:
+        """Finalize the upload from ``parts`` (``(part_number, etag)`` pairs,
+        any order) and return the assembled object's size in bytes."""
+
+    def abort_multipart_upload(self, path: str, upload_id: str) -> None:
+        """Discard an in-progress multipart upload and its staged parts."""
+
 
 class FilesystemStorage:
     """Local-disk implementation backed by ``pathlib.Path``.
@@ -237,6 +260,24 @@ class FilesystemStorage:
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+    # Presigned multipart is an object-store (S3/R2) capability with no
+    # filesystem analogue -- there is no URL for a browser to PUT a part
+    # to. Local desktop uploads go through the on-disk raw/<name> path
+    # instead, so these never fire in local mode.
+    def create_multipart_upload(self, path: str) -> str:
+        raise NotImplementedError("FilesystemStorage has no presigned multipart upload")
+
+    def presign_upload_part(
+        self, path: str, upload_id: str, part_number: int, *, expires_in: int = 3600
+    ) -> str:
+        raise NotImplementedError("FilesystemStorage has no presigned multipart upload")
+
+    def complete_multipart_upload(self, path: str, upload_id: str, parts: list[tuple[int, str]]) -> int:
+        raise NotImplementedError("FilesystemStorage has no presigned multipart upload")
+
+    def abort_multipart_upload(self, path: str, upload_id: str) -> None:
+        raise NotImplementedError("FilesystemStorage has no presigned multipart upload")
 
 
 class _S3StreamWrapper:
@@ -448,3 +489,38 @@ class S3Storage:
         # S3 ``delete_object`` is a no-op when the key doesn't exist
         # (same contract as :class:`FilesystemStorage.delete`).
         self._client.delete_object(Bucket=self._bucket, Key=self._key(path))
+
+    def create_multipart_upload(self, path: str) -> str:
+        resp = self._client.create_multipart_upload(Bucket=self._bucket, Key=self._key(path))
+        return resp["UploadId"]
+
+    def presign_upload_part(
+        self, path: str, upload_id: str, part_number: int, *, expires_in: int = 3600
+    ) -> str:
+        return self._client.generate_presigned_url(
+            "upload_part",
+            Params={
+                "Bucket": self._bucket,
+                "Key": self._key(path),
+                "UploadId": upload_id,
+                "PartNumber": part_number,
+            },
+            ExpiresIn=expires_in,
+        )
+
+    def complete_multipart_upload(self, path: str, upload_id: str, parts: list[tuple[int, str]]) -> int:
+        # S3 requires parts ascending by PartNumber. ETags are returned to
+        # the client by the per-part PUT (the ``ETag`` response header) and
+        # echoed back here verbatim, quotes and all.
+        ordered = sorted(parts, key=lambda p: p[0])
+        self._client.complete_multipart_upload(
+            Bucket=self._bucket,
+            Key=self._key(path),
+            UploadId=upload_id,
+            MultipartUpload={"Parts": [{"PartNumber": n, "ETag": etag} for n, etag in ordered]},
+        )
+        head = self._client.head_object(Bucket=self._bucket, Key=self._key(path))
+        return int(head["ContentLength"])
+
+    def abort_multipart_upload(self, path: str, upload_id: str) -> None:
+        self._client.abort_multipart_upload(Bucket=self._bucket, Key=self._key(path), UploadId=upload_id)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -323,6 +323,12 @@ def _state_conflict_excs() -> tuple[type[BaseException], ...]:
 # thundering herd. Exhausting it re-raises -> the job fails loudly.
 _AUDIT_SAVE_MAX_ATTEMPTS = 4
 
+# Chunk size the multipart-upload client splits a file into. 16 MiB is
+# comfortably above S3/R2's 5 MiB non-final-part minimum and keeps the part
+# count modest (a 2 GB file = 128 parts), so per-part presign round-trips
+# stay cheap.
+_RAW_UPLOAD_PART_SIZE = 16 * 1024 * 1024
+
 
 def _save_audit_with_remerge(
     state: AppState,
@@ -2771,6 +2777,49 @@ class AttachRawVideoRequest(BaseModel):
     covers_stages: list[int] | None = None
 
 
+class MultipartCreateRequest(BaseModel):
+    """Body for POST /api/me/raw/upload/multipart/create (#467).
+
+    Only the filename is needed; the server sanitizes it, mints the R2
+    multipart upload, and tells the client the part size to chunk with.
+    Everything downstream keys off ``filename`` + ``upload_id`` (the
+    server re-derives the storage key), so a request body can't point the
+    upload outside the user's ``raw/`` prefix.
+    """
+
+    filename: str
+
+
+class MultipartPartUrlRequest(BaseModel):
+    """Body for POST /api/me/raw/upload/multipart/part-url (#467)."""
+
+    filename: str
+    upload_id: str
+    part_number: int
+
+
+class MultipartPart(BaseModel):
+    """One finished part: its 1-based number + the ETag R2 returned."""
+
+    part_number: int
+    etag: str
+
+
+class MultipartCompleteRequest(BaseModel):
+    """Body for POST /api/me/raw/upload/multipart/complete (#467)."""
+
+    filename: str
+    upload_id: str
+    parts: list[MultipartPart]
+
+
+class MultipartAbortRequest(BaseModel):
+    """Body for POST /api/me/raw/upload/multipart/abort (#467)."""
+
+    filename: str
+    upload_id: str
+
+
 class ScoreboardIdentityRequest(BaseModel):
     """Body for PUT /api/user/scoreboard-identity (#75).
 
@@ -4588,6 +4637,106 @@ def create_app(
                 "filename": name,
             }
         )
+
+    # ------------------------------------------------------------------
+    # Presigned multipart upload (#467): direct browser -> R2 for large
+    # files. The single-shot endpoint above proxies bytes through this
+    # process, which 502s past a few hundred MB on Railway. Here the
+    # client PUTs parts straight to R2 via presigned URLs; serve only
+    # mints the upload, signs parts, and finalizes. No bytes (and so no
+    # server-side sha256) pass through serve -- attach treats sha256 as
+    # optional, and R2's per-part ETags + the completed size are the
+    # integrity signal. Hosted-only (503 when storage is unwired).
+    # ------------------------------------------------------------------
+
+    def _require_storage() -> Storage:
+        storage = state.storage
+        if storage is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "raw video upload is hosted-mode only; "
+                    "local mode writes raw/<name> symlinks via the desktop UI"
+                ),
+            )
+        return storage
+
+    @app.post("/api/me/raw/upload/multipart/create")
+    def create_multipart_upload(
+        req: MultipartCreateRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Begin a multipart upload; return the upload id + chunk size.
+
+        The client splits the file into ``part_size``-byte parts, asks
+        ``/part-url`` for a presigned URL per part, PUTs each straight to
+        R2, then calls ``/complete`` with the parts' ETags.
+        """
+        storage = _require_storage()
+        name = _sanitize_raw_filename(req.filename)
+        key = f"raw/{name}"
+        try:
+            upload_id = storage.create_multipart_upload(key)
+        except Exception as exc:  # noqa: BLE001 -- surface as a clean 500
+            raise HTTPException(status_code=500, detail=f"could not start upload: {exc}") from exc
+        return JSONResponse(
+            {
+                "upload_id": upload_id,
+                "filename": name,
+                "key": key,
+                "part_size": _RAW_UPLOAD_PART_SIZE,
+            }
+        )
+
+    @app.post("/api/me/raw/upload/multipart/part-url")
+    def sign_multipart_part(
+        req: MultipartPartUrlRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Return a presigned URL the client PUTs one part to."""
+        storage = _require_storage()
+        if req.part_number < 1:
+            raise HTTPException(status_code=422, detail="part_number must be >= 1")
+        key = f"raw/{_sanitize_raw_filename(req.filename)}"
+        try:
+            url = storage.presign_upload_part(key, req.upload_id, req.part_number)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=f"could not sign part: {exc}") from exc
+        return JSONResponse({"url": url})
+
+    @app.post("/api/me/raw/upload/multipart/complete")
+    def complete_multipart_upload(
+        req: MultipartCompleteRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Finalize the upload. Returns the same shape the single-shot
+        endpoint echoes (minus ``sha256``, which serve never computed)."""
+        storage = _require_storage()
+        if not req.parts:
+            raise HTTPException(status_code=422, detail="parts must not be empty")
+        name = _sanitize_raw_filename(req.filename)
+        key = f"raw/{name}"
+        try:
+            size = storage.complete_multipart_upload(
+                key, req.upload_id, [(p.part_number, p.etag) for p in req.parts]
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=f"could not complete upload: {exc}") from exc
+        return JSONResponse({"path": key, "size": size, "sha256": None, "filename": name})
+
+    @app.post("/api/me/raw/upload/multipart/abort")
+    def abort_multipart_upload(
+        req: MultipartAbortRequest,
+        user: User = Depends(get_current_user),
+    ) -> JSONResponse:
+        """Discard an in-progress upload (client cancelled / failed)."""
+        storage = _require_storage()
+        key = f"raw/{_sanitize_raw_filename(req.filename)}"
+        try:
+            storage.abort_multipart_upload(key, req.upload_id)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=f"could not abort upload: {exc}") from exc
+        return JSONResponse({"ok": True})
 
     @app.get("/api/me/raw/list")
     def list_raw_uploads(user: User = Depends(get_current_user)) -> JSONResponse:

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1518,6 +1518,124 @@ async function request<T>(
   return (await resp.json()) as T;
 }
 
+/** Files at or above this size use the presigned multipart path (direct
+ *  browser -> R2); smaller files take the single-shot serve-proxied
+ *  upload. The serve proxy 502s on Railway past a few hundred MB, so the
+ *  threshold sits well below that. */
+const MULTIPART_THRESHOLD_BYTES = 64 * 1024 * 1024;
+
+interface RawUploadResult {
+  path: string;
+  size: number;
+  sha256: string | null;
+  filename: string;
+}
+
+/** PUT one part's bytes straight to R2 via its presigned URL. Resolves
+ *  with the part's ETag (which the complete call needs). The ETag header
+ *  is only readable when the R2 bucket CORS exposes it
+ *  (Access-Control-Expose-Headers: ETag). */
+function putUploadPart(
+  url: string,
+  blob: Blob,
+  opts: { onProgress?: (bytesSent: number) => void; signal?: AbortSignal },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PUT", url, true);
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) opts.onProgress?.(e.loaded);
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        const etag = xhr.getResponseHeader("ETag");
+        if (!etag) {
+          reject(
+            new ApiError(
+              0,
+              "R2 returned no ETag for the part -- check the bucket CORS exposes the ETag header",
+              null,
+            ),
+          );
+          return;
+        }
+        resolve(etag);
+        return;
+      }
+      reject(new ApiError(xhr.status, `part upload failed: ${xhr.statusText}`, null));
+    };
+    xhr.onerror = () => reject(new ApiError(0, "network error during part upload", null));
+    xhr.onabort = () => reject(new ApiError(0, "upload cancelled", null));
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        reject(new ApiError(0, "upload cancelled", null));
+        return;
+      }
+      opts.signal.addEventListener("abort", () => xhr.abort());
+    }
+    xhr.send(blob);
+  });
+}
+
+/** Upload a large file by splitting it into parts and PUTting each
+ *  straight to R2 via presigned URLs, so no bytes pass through the API
+ *  process. ``onProgress`` reports cumulative bytes across all parts. On
+ *  any failure the in-progress multipart is best-effort aborted so R2
+ *  doesn't keep staged parts. */
+async function uploadRawMultipart(
+  file: File,
+  opts: { onProgress?: (bytesSent: number, total: number) => void; signal?: AbortSignal },
+): Promise<RawUploadResult> {
+  const create = await request<{
+    upload_id: string;
+    filename: string;
+    key: string;
+    part_size: number;
+  }>("/api/me/raw/upload/multipart/create", {
+    method: "POST",
+    json: { filename: file.name },
+  });
+  const { upload_id, filename, part_size } = create;
+  const partCount = Math.max(1, Math.ceil(file.size / part_size));
+  const parts: { part_number: number; etag: string }[] = [];
+  let uploadedBytes = 0;
+
+  try {
+    for (let i = 0; i < partCount; i++) {
+      if (opts.signal?.aborted) throw new ApiError(0, "upload cancelled", null);
+      const start = i * part_size;
+      const blob = file.slice(start, Math.min(start + part_size, file.size));
+      const partNumber = i + 1;
+      const { url } = await request<{ url: string }>(
+        "/api/me/raw/upload/multipart/part-url",
+        { method: "POST", json: { filename, upload_id, part_number: partNumber } },
+      );
+      const etag = await putUploadPart(url, blob, {
+        signal: opts.signal,
+        onProgress: (sent) => opts.onProgress?.(uploadedBytes + sent, file.size),
+      });
+      uploadedBytes += blob.size;
+      opts.onProgress?.(uploadedBytes, file.size);
+      parts.push({ part_number: partNumber, etag });
+    }
+  } catch (err) {
+    try {
+      await request("/api/me/raw/upload/multipart/abort", {
+        method: "POST",
+        json: { filename, upload_id },
+      });
+    } catch {
+      /* best-effort: R2's lifecycle rule also sweeps abandoned multiparts */
+    }
+    throw err;
+  }
+
+  return request<RawUploadResult>("/api/me/raw/upload/multipart/complete", {
+    method: "POST",
+    json: { filename, upload_id, parts },
+  });
+}
+
 export const api = {
   getProject: (slug: string) =>
     request<MatchProject>(`/api/shooters/${encodeURIComponent(slug)}/project`),
@@ -2133,8 +2251,15 @@ export const api = {
       onProgress?: (bytesSent: number, totalBytes: number) => void;
       signal?: AbortSignal;
     } = {},
-  ) =>
-    new Promise<{ path: string; size: number; sha256: string; filename: string }>(
+  ): Promise<RawUploadResult> => {
+    // Large files go direct browser -> R2 via presigned multipart; the
+    // serve-proxied single-shot below 502s on Railway past a few hundred
+    // MB. Small files keep the simpler single-shot (one round-trip, and
+    // serve can still compute the integrity sha256).
+    if (file.size >= MULTIPART_THRESHOLD_BYTES) {
+      return uploadRawMultipart(file, { onProgress: opts.onProgress, signal: opts.signal });
+    }
+    return new Promise<RawUploadResult>(
       (resolve, reject) => {
         const xhr = new XMLHttpRequest();
         const url = "/api/me/raw/upload";
@@ -2195,7 +2320,8 @@ export const api = {
         }
         xhr.send(form);
       },
-    ),
+    );
+  },
 
   /** Hosted-mode only -- register an uploaded raw video on the
    *  shooter's project (``POST /api/shooters/{slug}/raw-videos/attach``).

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -90,6 +90,10 @@ _ME_ROUTES_REQUIRING_AUTH: list[tuple[str, str, str]] = [
     ("DELETE", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),
     ("POST", "/api/me/projects/import", "/api/me/projects/import"),
     ("POST", "/api/me/raw/upload", "/api/me/raw/upload"),
+    ("POST", "/api/me/raw/upload/multipart/create", "/api/me/raw/upload/multipart/create"),
+    ("POST", "/api/me/raw/upload/multipart/part-url", "/api/me/raw/upload/multipart/part-url"),
+    ("POST", "/api/me/raw/upload/multipart/complete", "/api/me/raw/upload/multipart/complete"),
+    ("POST", "/api/me/raw/upload/multipart/abort", "/api/me/raw/upload/multipart/abort"),
     ("GET", "/api/me/raw/list", "/api/me/raw/list"),
     ("DELETE", "/api/me/raw/{filename:path}", "/api/me/raw/clip.mp4"),
 ]

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -659,3 +659,95 @@ def test_attach_503_when_storage_unwired(
     assert resp.status_code in (503, 404)
     # 503 is the storage-off contract; 404 is the alias middleware
     # rejecting an unknown match_id. Either is "fails closed".
+
+
+# -- Presigned multipart upload endpoints (#467) ------------------------
+
+
+def test_multipart_create_returns_upload_id_and_part_size(hosted_client) -> None:
+    client, _ = hosted_client
+    resp = client.post(
+        "/api/me/raw/upload/multipart/create",
+        json={"filename": "GH010099.mp4"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["upload_id"]
+    assert body["filename"] == "GH010099.mp4"
+    assert body["key"] == "raw/GH010099.mp4"
+    assert body["part_size"] >= 5 * 1024 * 1024  # >= S3 non-final-part minimum
+
+
+def test_multipart_part_url_is_presigned(hosted_client) -> None:
+    client, _ = hosted_client
+    create = client.post("/api/me/raw/upload/multipart/create", json={"filename": "clip.mp4"}).json()
+    resp = client.post(
+        "/api/me/raw/upload/multipart/part-url",
+        json={"filename": "clip.mp4", "upload_id": create["upload_id"], "part_number": 1},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["url"].startswith("http")
+
+
+def test_multipart_round_trip_then_attach(hosted_client_with_match) -> None:
+    client, storage, match_id, slug = hosted_client_with_match
+
+    # 1. Create the multipart upload.
+    create = client.post("/api/me/raw/upload/multipart/create", json={"filename": "big.mp4"}).json()
+    upload_id = create["upload_id"]
+
+    # 2. Upload two parts straight to the (moto) store the way the browser
+    #    would PUT to the presigned URLs. Use the backend client + the
+    #    prefixed key the storage resolves to.
+    full_key = f"{storage.prefix}raw/big.mp4"
+    part1 = b"x" * (5 * 1024 * 1024)
+    part2 = b"y" * 2048
+    etags = []
+    for n, body in ((1, part1), (2, part2)):
+        out = storage._client.upload_part(
+            Bucket=storage.bucket, Key=full_key, UploadId=upload_id, PartNumber=n, Body=body
+        )
+        etags.append({"part_number": n, "etag": out["ETag"]})
+
+    # 3. Complete -> the object is assembled; serve returns the path.
+    done = client.post(
+        "/api/me/raw/upload/multipart/complete",
+        json={"filename": "big.mp4", "upload_id": upload_id, "parts": etags},
+    )
+    assert done.status_code == 200, done.text
+    body = done.json()
+    assert body["path"] == "raw/big.mp4"
+    assert body["size"] == len(part1) + len(part2)
+    assert body["sha256"] is None  # serve never saw the bytes
+    assert storage.read_bytes("raw/big.mp4") == part1 + part2
+
+    # 4. The completed object attaches like any raw video.
+    attach = client.post(
+        _attach_url(match_id, slug),
+        json={"filename": body["filename"], "size_bytes": body["size"]},
+    )
+    assert attach.status_code == 200, attach.text
+    project = _get_project(client, match_id, slug)
+    assert any(rv["storage_path"] == "raw/big.mp4" for rv in project["raw_videos"])
+
+
+def test_multipart_abort_discards_upload(hosted_client) -> None:
+    client, storage = hosted_client
+    create = client.post("/api/me/raw/upload/multipart/create", json={"filename": "scratch.mp4"}).json()
+    resp = client.post(
+        "/api/me/raw/upload/multipart/abort",
+        json={"filename": "scratch.mp4", "upload_id": create["upload_id"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert not storage.exists("raw/scratch.mp4")
+
+
+def test_multipart_create_503_when_storage_unwired(hosted_db: str, monkeypatch) -> None:
+    monkeypatch.delenv("SPLITSMITH_S3_BUCKET", raising=False)
+    from splitsmith.ui.server import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        _authed(client, hosted_db)
+        resp = client.post("/api/me/raw/upload/multipart/create", json={"filename": "x.mp4"})
+    assert resp.status_code == 503

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -273,3 +273,51 @@ def test_satisfies_storage_protocol() -> None:
         client.create_bucket(Bucket=BUCKET)
         store: Storage = S3Storage(bucket=BUCKET, client=client)
         assert store is not None
+
+
+# -- Presigned multipart upload (state-refactor follow-up / #467) -------
+
+
+def test_presign_upload_part_returns_url(s3_client) -> None:
+    storage = _storage(s3_client, prefix="users/u1/")
+    upload_id = storage.create_multipart_upload("raw/big.mov")
+    assert isinstance(upload_id, str) and upload_id
+    url = storage.presign_upload_part("raw/big.mov", upload_id, 1)
+    assert url.startswith("http")
+    # The presigned URL targets the prefixed key + this part of the upload.
+    assert "users/u1/raw/big.mov" in url
+    assert "partNumber=1" in url.lower().replace("part_number", "partnumber") or "partnumber=1" in url.lower()
+    storage.abort_multipart_upload("raw/big.mov", upload_id)
+
+
+def test_multipart_round_trip_assembles_object(s3_client) -> None:
+    storage = _storage(s3_client, prefix="users/u1/")
+    key = "raw/big.mov"
+    upload_id = storage.create_multipart_upload(key)
+
+    # Upload two parts via the raw client (the browser would PUT these to
+    # the presigned URLs; here we exercise create/complete + size).
+    full_key = "users/u1/raw/big.mov"
+    part1 = b"a" * (5 * 1024 * 1024)  # >=5 MiB so it's a valid non-final part
+    part2 = b"b" * 1024
+    e1 = s3_client.upload_part(Bucket=BUCKET, Key=full_key, UploadId=upload_id, PartNumber=1, Body=part1)[
+        "ETag"
+    ]
+    e2 = s3_client.upload_part(Bucket=BUCKET, Key=full_key, UploadId=upload_id, PartNumber=2, Body=part2)[
+        "ETag"
+    ]
+
+    # Parts deliberately out of order -- complete must sort them.
+    size = storage.complete_multipart_upload(key, upload_id, [(2, e2), (1, e1)])
+    assert size == len(part1) + len(part2)
+    assert storage.exists(key)
+    assert storage.read_bytes(key) == part1 + part2
+
+
+def test_abort_multipart_discards_upload(s3_client) -> None:
+    storage = _storage(s3_client)
+    key = "raw/scratch.mov"
+    upload_id = storage.create_multipart_upload(key)
+    storage.abort_multipart_upload(key, upload_id)
+    # The object was never completed, so nothing is published.
+    assert not storage.exists(key)


### PR DESCRIPTION
Closes #467.

Large raw-video uploads 502 through the serve proxy on Railway (a real 489 MB file dies at ~300 MB). This adds a direct browser->R2 path.

**Backend** -- `Storage`/`S3Storage` gain `create_multipart_upload` / `presign_upload_part` / `complete_multipart_upload` / `abort_multipart_upload` (boto3; `FilesystemStorage` raises NotImplementedError). New hosted-only, auth-gated endpoints `POST /api/me/raw/upload/multipart/{create,part-url,complete,abort}`. Everything keys off `filename` (server re-sanitizes) + `upload_id`, so a body can't escape the user's `raw/` prefix. 16 MiB parts. sha256 is dropped on this path (serve never sees the bytes; `attach` already treats it optional; R2 per-part ETags + completed size are the integrity signal). The single-shot endpoint stays for small files.

**Frontend** -- `api.uploadRawFile` dispatches on size: files >= 64 MiB go create -> per-part presigned PUT straight to R2 -> complete; smaller stay single-shot. Cumulative progress + AbortSignal cancel preserved; failure best-effort aborts the multipart. Reads the part ETag from the PUT response (needs R2 CORS to expose ETag).

**R2 CORS** -- the bucket must allow PUT + expose ETag from the app origins; configured out-of-band (not code).

## Verification
- Storage multipart round-trip (moto); endpoint round-trip create->parts->complete->attach, abort, local-mode 503; the `/api/me` 401-gate guard covers the new routes.
- Full non-docker suite green; tsc + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)