### PR TITLE
fix(serve): let manually-timed stages export

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -7935,11 +7935,18 @@ def create_app(
                     "finish ingest + audit before exporting"
                 ),
             )
-        if stage.time_seconds <= 0 or stage.scorecard_updated_at is None:
+        # A stage is exportable once it has a real duration: either a
+        # scoreboard import (``scorecard_updated_at`` set) OR a manually
+        # entered time (``set_stage_time`` stamps ``time_seconds_manual``
+        # for exactly the no-scoreboard flow). Blocking the manual case
+        # left manual matches able to detect but not export -- the gate
+        # only meant to reject untouched placeholders.
+        if stage.time_seconds <= 0 or (stage.scorecard_updated_at is None and not stage.time_seconds_manual):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"stage {stage_number} is a placeholder; import a real " "scoreboard before exporting"
+                    f"stage {stage_number} is a placeholder; set a stage time "
+                    "or import a scoreboard before exporting"
                 ),
             )
         # Source-reachability surfaces as a structured 424 so the SPA

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -6121,6 +6121,45 @@ def test_match_export_endpoint_writes_fcpxml(tmp_path: Path, monkeypatch: pytest
     assert result["duration_seconds"] == pytest.approx(4.0, abs=0.1)
 
 
+def _export_csv_only(client, stage_number: int = 1):
+    return client.post(
+        f"/api/shooters/me/stages/{stage_number}/export",
+        json={
+            "write_trim": False,
+            "write_csv": True,
+            "write_fcpxml": False,
+            "write_report": False,
+            "write_overlay": False,
+        },
+    )
+
+
+def test_export_stage_400_on_untouched_placeholder(tmp_path: Path) -> None:
+    """A stage with neither a scoreboard import nor a manual time is a
+    placeholder and must not export."""
+    client, _ = _seed_match_export_project(tmp_path, stage_count=1)
+    # The seed leaves scorecard_updated_at unset + time not manually
+    # stamped, so the stage is an untouched placeholder.
+    resp = _export_csv_only(client)
+    assert resp.status_code == 400
+    assert "placeholder" in resp.json()["detail"]
+
+
+def test_export_stage_allows_a_manually_timed_stage(tmp_path: Path) -> None:
+    """Manual matches (no scoreboard) set the duration via
+    ``set_stage_time``; the export gate must then accept the stage rather
+    than demanding a scoreboard import. Regression for manual matches
+    being able to detect but not export."""
+    client, _ = _seed_match_export_project(tmp_path, stage_count=1)
+    # The no-scoreboard flow: stamp a manual duration.
+    r = client.post("/api/shooters/me/stages/1/time", json={"time_seconds": 12.0})
+    assert r.status_code == 200, r.text
+    resp = _export_csv_only(client)
+    # Gate passed -> the job is queued (not a 400 placeholder rejection).
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["kind"] == "export"
+
+
 def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> None:
     client, _ = _seed_match_export_project(tmp_path, stage_count=1)
     resp = client.post("/api/shooters/me/export/match", json={"stage_numbers": []})


### PR DESCRIPTION
The per-stage export gate rejected any stage with `scorecard_updated_at is None`. Manual matches (created via create-manual, no scoreboard) never set that field, so they could detect (beep + shot-detect gate on `time_seconds` only) but never export -- `set_stage_time` stamps `time_seconds_manual=True` for exactly that flow. The gate now accepts a positive duration that is scoreboard-sourced OR manually set, and still rejects untouched placeholders.

Found running the full hosted ingest+detect+export e2e on staging (a create-manual match with a 45.57s manual stage time detected 44 shots but 400'd on export).

Tests: manually-timed stage reaches job submission; untouched placeholder still 400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)