### PR TITLE
fix(serve): sentinel scorecard time for manual-stage export

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -329,6 +329,13 @@ _AUDIT_SAVE_MAX_ATTEMPTS = 4
 # stay cheap.
 _RAW_UPLOAD_PART_SIZE = 16 * 1024 * 1024
 
+# The engine's ``StageData`` requires a non-None ``scorecard_updated_at``
+# (the video-matching heuristic keys off it), but manually-timed stages on
+# scoreboard-less matches have none. Export never reads the field, so feed
+# this sentinel rather than inventing a real-looking time -- same approach
+# as ``splitsmith.mcp.export_tools``.
+_PLACEHOLDER_SCORECARD_TIME = datetime(2000, 1, 1, tzinfo=UTC)
+
 
 def _save_audit_with_remerge(
     state: AppState,
@@ -1975,7 +1982,7 @@ def register_job_bodies(state: AppState) -> None:
             stage_number=stg.stage_number,
             stage_name=stg.stage_name,
             time_seconds=stg.time_seconds,
-            scorecard_updated_at=stg.scorecard_updated_at,
+            scorecard_updated_at=stg.scorecard_updated_at or _PLACEHOLDER_SCORECARD_TIME,
         )
 
         # Phase progress is approximate; trim dominates wall time when the
@@ -2178,7 +2185,7 @@ def register_job_bodies(state: AppState) -> None:
                     stage_number=stg.stage_number,
                     stage_name=stg.stage_name,
                     time_seconds=stg.time_seconds,
-                    scorecard_updated_at=stg.scorecard_updated_at,
+                    scorecard_updated_at=stg.scorecard_updated_at or _PLACEHOLDER_SCORECARD_TIME,
                 )
                 try:
                     recut = export_helpers.export_stage(

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -6158,6 +6158,12 @@ def test_export_stage_allows_a_manually_timed_stage(tmp_path: Path) -> None:
     # Gate passed -> the job is queued (not a 400 placeholder rejection).
     assert resp.status_code == 200, resp.text
     assert resp.json()["kind"] == "export"
+    # And it runs to completion: the engine StageData requires a non-None
+    # scorecard_updated_at, which a manual stage lacks -- the job body must
+    # substitute the sentinel rather than crash. Without that fix this job
+    # fails with a pydantic datetime validation error.
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
 
 
 def test_match_export_endpoint_400_on_empty_stage_numbers(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-on to #470. Letting manually-timed stages past the export gate exposed the next blocker: the export job builds the engine `StageData` with `scorecard_updated_at=stg.scorecard_updated_at`, which is None for a scoreboard-less stage -- and `StageData` requires a non-None datetime (the video-match heuristic uses it). The gate passed but the job died with a pydantic datetime validation error.

Substitute `_PLACEHOLDER_SCORECARD_TIME` (2000-01-01Z) when absent -- the same sentinel `splitsmith.mcp.export_tools` already uses; export never reads the field for output.

Test now waits for the manual-stage export job and asserts success (caught only because the earlier test stopped at the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)