### PR TITLE
fix(ui): beep review plays source video, not the cached trim

### DIFF
--- a/src/splitsmith/ui_static/src/pages/BeepReview.tsx
+++ b/src/splitsmith/ui_static/src/pages/BeepReview.tsx
@@ -978,12 +978,18 @@ function BeepVideoMini({
           {label}
         </span>
       </div>
+      {/* kind="source": beep review must play the full source, never the
+          trim. The waveform (_resolve_video_audio) is always the source WAV
+          so a beep outside the trim window stays visible, and the shared
+          playhead (this <video>'s currentTime) only lines up with that
+          waveform when the video is source too. kind="auto" would serve the
+          cached audit trim once detect-beep has run, drifting the playhead. */}
       <video
         ref={(el) => {
           localRef.current = el;
           videoRef.current = el;
         }}
-        src={api.videoStreamUrl(slug, videoPath)}
+        src={api.videoStreamUrl(slug, videoPath, "source")}
         playsInline
         controls
         preload="metadata"


### PR DESCRIPTION
The beep-review picker's waveform is always the full **source** WAV (`_resolve_video_audio`, so a beep outside the trim window stays visible). The shared playhead is the master `<video>`'s `currentTime`, so it only aligns with that waveform when the video is source too. But the `<video>` used `videoStreamUrl`'s `kind="auto"`, which serves the cached audit trim once detect-beep has run → video became the trim, waveform stayed source, playhead drifted (you saw the trimmed clip).

Force `kind="source"` for the beep-review master video, matching its own aria-label ("Primary cam, full source"). Audit screen still uses the trimmed clip via the per-stage `/audio` + `/peaks` endpoints — unchanged.

Surfaced once #473's media-URL scoping made the video load in hosted; the same drift applies in local mode after detect-beep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)