### PR TITLE
fix(saas): hosted picker/bind resolves match by match_id, not ephemeral path

### DIFF
--- a/alembic/versions/e2a5f9c4b318_add_match_id_to_recent_projects.py
+++ b/alembic/versions/e2a5f9c4b318_add_match_id_to_recent_projects.py
@@ -1,0 +1,39 @@
+"""add match_id to recent_projects
+
+Hosted picker/bind resolved a recent project by its on-disk path, but in
+hosted mode that path is an ephemeral container working root that doesn't
+survive a redeploy -- so reopening an existing match 404'd
+(``project_path_missing``). Recording the match's stable ``match_id`` on
+the row lets hosted ``bind`` resolve the match through Postgres (this
+column + the ``matches`` ownership table) instead of the filesystem.
+
+Nullable: local-mode rows and pre-existing rows have none; the bind path
+falls back to the filesystem flow when it's absent.
+
+Revision ID: e2a5f9c4b318
+Revises: d1f7b25c8a3e
+Create Date: 2026-06-01 13:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2a5f9c4b318"
+down_revision: str | Sequence[str] | None = "d1f7b25c8a3e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("recent_projects", sa.Column("match_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("recent_projects", "match_id")

--- a/src/splitsmith/db/models.py
+++ b/src/splitsmith/db/models.py
@@ -246,6 +246,11 @@ class RecentProjectRow(Base):
     path: Mapped[str] = mapped_column(String, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
     kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Stable match identifier (hosted). Lets the picker/bind resolve the
+    # match through Postgres instead of the ephemeral on-disk ``path``,
+    # which doesn't survive a redeploy. ``None`` for local-mode rows and
+    # rows written before this column existed.
+    match_id: Mapped[str | None] = mapped_column(String, nullable=True)
     last_opened_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/src/splitsmith/db/recent_projects.py
+++ b/src/splitsmith/db/recent_projects.py
@@ -91,6 +91,7 @@ class PostgresRecentProjectsStore:
                 name=row.name,
                 last_opened_at=row.last_opened_at,
                 kind=row.kind,
+                match_id=row.match_id,
             )
             for row in rows
         ]
@@ -101,6 +102,7 @@ class PostgresRecentProjectsStore:
         name: str,
         *,
         kind: str | None = None,
+        match_id: str | None = None,
     ) -> None:
         """Insert or refresh the row for ``(user_id, resolved_path)``.
 
@@ -128,12 +130,17 @@ class PostgresRecentProjectsStore:
                         path=resolved,
                         name=name,
                         kind=kind,
+                        match_id=match_id,
                         last_opened_at=now,
                     )
                 )
             else:
                 existing.name = name
                 existing.kind = kind
+                # Don't clobber a known match_id with None on a re-open that
+                # didn't carry one (e.g. a bare bind); only update when given.
+                if match_id is not None:
+                    existing.match_id = match_id
                 existing.last_opened_at = now
             await session.commit()
             await self._trim_to_limit(session)

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3423,7 +3423,11 @@ async def _register_match_at(
             },
         )
     name = match.name or fallback_name
-    await state.recent_projects.record_open(resolved, name, kind="match")
+    # Record the match_id so the hosted picker/bind can resolve this match
+    # through Postgres on a later open, even after the ephemeral on-disk
+    # path is gone (a redeploy wiped it). Local mode stores it too; the
+    # filesystem flow there just doesn't need it.
+    await state.recent_projects.record_open(resolved, name, kind="match", match_id=match.match_id)
     loaded_env = _load_env_files(resolved)
     if loaded_env:
         logger.info("Loaded env from %s", ", ".join(str(p) for p in loaded_env))
@@ -8270,6 +8274,36 @@ def create_app(
         timestamp is bumped so the picker re-orders to the top.
         """
         target = Path(req.path).expanduser()
+        resolved_str = str(target.resolve())
+
+        # Hosted: resolve the match through Postgres, not the filesystem.
+        # The recorded path is an ephemeral container working root that a
+        # redeploy wipes, so requiring it to exist (below) 404'd every
+        # reopen of an existing match. If the recent-projects row carries a
+        # match_id and the tenant still owns it, bind succeeds regardless of
+        # local disk -- the alias middleware re-establishes the working root
+        # on the next /api/matches/{id}/ request.
+        if state.matches_store is not None:
+            entry = next(
+                (p for p in await state.recent_projects.list() if p.path == resolved_str),
+                None,
+            )
+            if entry is not None and entry.match_id:
+                if await state.matches_store.get(entry.match_id) is None:
+                    # Unknown / not owned -> same 404 an unknown id gets.
+                    raise HTTPException(
+                        status_code=404,
+                        detail={
+                            "code": "match_not_found",
+                            "message": f"unknown match_id {entry.match_id!r}",
+                        },
+                    )
+                name = entry.name or req.name or target.name or "match"
+                await state.recent_projects.record_open(
+                    target, name, kind=entry.kind or "match", match_id=entry.match_id
+                )
+                return _register_response(target, name, entry.match_id)
+
         if not target.exists():
             if not req.create:
                 # Conservative default: don't silently scaffold a brand-new

--- a/src/splitsmith/user_config.py
+++ b/src/splitsmith/user_config.py
@@ -76,6 +76,11 @@ class RecentProject(BaseModel):
     # entries written before this field existed; the picker resolves them
     # at open time. Issue #320.
     kind: str | None = None
+    # Stable match id (hosted). When set, the picker/bind resolves the
+    # match through Postgres rather than the ephemeral on-disk ``path``,
+    # which doesn't survive a redeploy. ``None`` in local mode and for
+    # rows written before this field existed.
+    match_id: str | None = None
 
 
 class ProjectsIndex(BaseModel):
@@ -244,7 +249,9 @@ def _save_projects_index(index: ProjectsIndex) -> None:
         logger.warning("Could not write %s: %s", PROJECTS_FILENAME, exc)
 
 
-def record_project_open(path: Path, name: str, *, kind: str | None = None) -> None:
+def record_project_open(
+    path: Path, name: str, *, kind: str | None = None, match_id: str | None = None
+) -> None:
     """Append or refresh a project entry in ``projects.json``.
 
     Resolves ``path`` so two opens of the same project via different
@@ -265,7 +272,7 @@ def record_project_open(path: Path, name: str, *, kind: str | None = None) -> No
     index = _load_projects_index()
     remaining = [p for p in index.projects if p.path != resolved]
     updated = [
-        RecentProject(path=resolved, name=name, last_opened_at=now, kind=kind),
+        RecentProject(path=resolved, name=name, last_opened_at=now, kind=kind, match_id=match_id),
         *remaining,
     ]
     if len(updated) > RECENT_PROJECTS_LIMIT:
@@ -370,7 +377,9 @@ class RecentProjectsStore(Protocol):
 
     async def list(self) -> list[RecentProject]: ...
 
-    async def record_open(self, path: Path, name: str, *, kind: str | None = None) -> None: ...
+    async def record_open(
+        self, path: Path, name: str, *, kind: str | None = None, match_id: str | None = None
+    ) -> None: ...
 
     async def remove(self, path: Path) -> bool: ...
 
@@ -405,8 +414,10 @@ class JsonRecentProjectsStore:
     async def list(self) -> list[RecentProject]:
         return get_recent_projects()
 
-    async def record_open(self, path: Path, name: str, *, kind: str | None = None) -> None:
-        record_project_open(path, name, kind=kind)
+    async def record_open(
+        self, path: Path, name: str, *, kind: str | None = None, match_id: str | None = None
+    ) -> None:
+        record_project_open(path, name, kind=kind, match_id=match_id)
 
     async def remove(self, path: Path) -> bool:
         return remove_recent_project(path)

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -751,3 +751,33 @@ def test_multipart_create_503_when_storage_unwired(hosted_db: str, monkeypatch) 
         _authed(client, hosted_db)
         resp = client.post("/api/me/raw/upload/multipart/create", json={"filename": "x.mp4"})
     assert resp.status_code == 503
+
+
+def test_bind_resolves_by_match_id_when_local_path_is_gone(hosted_client) -> None:
+    """Hosted picker reopen survives a redeploy: after the ephemeral
+    working dir is wiped, binding the recorded (now-missing) path resolves
+    the match through Postgres via its stored match_id instead of 404'ing
+    with project_path_missing."""
+    import shutil
+
+    client, _ = hosted_client
+    resp = client.post(
+        "/api/match/create-manual",
+        json={
+            "name": "Reopen Test",
+            "stages": [{"stage_number": 1, "stage_name": "S1"}],
+            "primary_shooter": {"name": "Me"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    health = resp.json()
+    match_id, project_root = health["match_id"], health["project_root"]
+
+    # Simulate a redeploy: the container's ephemeral working dir is gone.
+    shutil.rmtree(project_root, ignore_errors=True)
+    assert not Path(project_root).exists()
+
+    rebind = client.post("/api/me/recent-projects/bind", json={"path": project_root})
+    assert rebind.status_code == 200, rebind.text
+    assert rebind.json()["match_id"] == match_id
+    assert rebind.json()["bound"] is True

--- a/tests/test_recent_projects_store.py
+++ b/tests/test_recent_projects_store.py
@@ -261,3 +261,25 @@ def test_kind_round_trips_for_all_values(tmp_path, kind) -> None:
         assert rows[0].kind == kind
 
     asyncio.run(_go())
+
+
+def test_record_open_persists_match_id_and_list_returns_it() -> None:
+    """Hosted picker/bind resolves a match through its stable match_id
+    rather than the ephemeral on-disk path; record_open must persist it
+    and list() must surface it."""
+    store, _ = _build_store_for_new_user()
+    asyncio.run(store.record_open(Path("/work/m1"), "Oden", kind="match", match_id="oden-abc-123"))
+    rows = asyncio.run(store.list())
+    assert len(rows) == 1
+    assert rows[0].match_id == "oden-abc-123"
+
+
+def test_record_open_does_not_clobber_match_id_on_bare_reopen() -> None:
+    """A re-open that carries no match_id (e.g. a bare bind) must not wipe
+    a previously-stored one -- otherwise the next reopen loses Postgres
+    resolution and falls back to the (missing) path."""
+    store, _ = _build_store_for_new_user()
+    asyncio.run(store.record_open(Path("/work/m1"), "Oden", kind="match", match_id="oden-abc-123"))
+    asyncio.run(store.record_open(Path("/work/m1"), "Oden", kind="match"))  # no match_id
+    rows = asyncio.run(store.list())
+    assert rows[0].match_id == "oden-abc-123"


### PR DESCRIPTION
Reopening an existing hosted match from the picker 404'd (`project_path_missing`): `bind` required the recorded on-disk path to exist, but in hosted mode that path is an ephemeral container working root a redeploy wipes. The state refactor fixed match *resolution* (alias middleware via the `matches` table) but the picker/bind still went through the filesystem.

Record the match's stable `match_id` on the `recent_projects` row (new nullable column + migration; threaded through `RecentProject`, `record_open`, both stores) and have hosted `bind` resolve through Postgres: find the row's `match_id`, confirm tenant ownership via the matches store, return the match (the alias middleware re-establishes the working root on the next `/api/matches/{id}/` request). Falls back to the filesystem flow in local mode and for pre-existing rows without a stored `match_id`; a bare reopen won't clobber a stored id.

## Verification
- Store: persists + surfaces `match_id`, doesn't clobber on bare reopen.
- Hosted `bind` resolves by `match_id` after the local dir is wiped (the redeploy scenario) instead of 404.
- Full non-docker suite green; clean-SQLite migration smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)