### PR TITLE
fix(ui): explain why per-shooter sections route to the shooter list

### DIFF
--- a/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchSidebar.tsx
@@ -200,7 +200,7 @@ export function MatchSidebar({
           Overview
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `${base}/audit/${shooterSlug}` : `${base}/shooters`}
+          to={shooterSlug ? `${base}/audit/${shooterSlug}` : `${base}/shooters?pick=audit`}
           icon={<Crosshair className="size-[15px]" />}
           collapsed={collapsed}
           disabled={!hasFootage}
@@ -209,7 +209,7 @@ export function MatchSidebar({
           Audit
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `${base}/coach/${shooterSlug}` : `${base}/shooters`}
+          to={shooterSlug ? `${base}/coach/${shooterSlug}` : `${base}/shooters?pick=coach`}
           icon={<ClipboardCheck className="size-[15px]" />}
           collapsed={collapsed}
           disabled={!hasFootage}
@@ -227,7 +227,7 @@ export function MatchSidebar({
           Shooters
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `${base}/ingest/${shooterSlug}` : `${base}/shooters`}
+          to={shooterSlug ? `${base}/ingest/${shooterSlug}` : `${base}/shooters?pick=videos`}
           icon={<Film className="size-[15px]" />}
           collapsed={collapsed}
         >
@@ -243,7 +243,7 @@ export function MatchSidebar({
           Beep review
         </SidebarLink>
         <SidebarLink
-          to={shooterSlug ? `${base}/export/${shooterSlug}` : `${base}/shooters`}
+          to={shooterSlug ? `${base}/export/${shooterSlug}` : `${base}/shooters?pick=export`}
           icon={<ArrowDownToLine className="size-[15px]" />}
           collapsed={collapsed}
           disabled={!hasFootage}

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -27,7 +27,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
@@ -98,9 +98,21 @@ const PALETTE_STYLE: Record<Palette, {
   },
 };
 
+// Sections that are per-shooter: clicking them in the sidebar without a
+// shooter in focus routes here with ``?pick=<section>`` so we can explain
+// why, instead of silently dumping the user on the shooter list.
+const PICK_SECTION_LABELS: Record<string, string> = {
+  audit: "Audit",
+  coach: "Coach",
+  videos: "Videos",
+  export: "Export",
+};
+
 export function Shooters() {
   const navigate = useNavigate();
   const href = useMatchHref();
+  const [searchParams] = useSearchParams();
+  const pickSection = PICK_SECTION_LABELS[searchParams.get("pick") ?? ""] ?? null;
   const [data, setData] = useState<ShooterListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -195,6 +207,13 @@ export function Shooters() {
           </p>
         </div>
       </div>
+
+      {pickSection && (
+        <div className="mb-4 rounded-md border border-rule-strong bg-surface-2 px-3 py-2 text-sm text-ink">
+          <b className="font-bold">{pickSection}</b> is per-shooter — pick a
+          shooter below to open it.
+        </div>
+      )}
 
       {error && (
         <div className="mb-4 rounded-md border border-led/40 bg-led/10 px-3 py-2 text-sm text-led">


### PR DESCRIPTION
Audit / Coach / Videos / Export are per-shooter. With no shooter in focus (e.g. arriving from match-level beep review) the sidebar links them straight to the shooter list, so clicking silently dumped the user there with no explanation — it read as a broken/disabled menu item.

The per-shooter rows now carry `?pick=<section>` when there's no shooter slug, and the Shooters page renders a banner ("Audit is per-shooter — pick a shooter below to open it"). No behavior change when a shooter is in focus.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)