### PR TITLE
fix(hosted): picker detail from store + default-select a shooter for per-shooter tabs

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -3581,6 +3581,59 @@ def _enrich_recent_project(rp: user_config.RecentProject) -> RecentProjectDetail
     return detail
 
 
+async def _enrich_recent_project_hosted(
+    state: AppState, rp: user_config.RecentProject
+) -> RecentProjectDetail | None:
+    """Hosted picker detail, read from Postgres instead of the filesystem.
+
+    The recorded ``path`` is an ephemeral container working root a redeploy
+    wipes, so the filesystem enricher reports the match as ``missing`` even
+    though its state is safe in ``state_docs``. When the row carries a
+    ``match_id`` and the match doc is present, build the detail from the
+    match + per-shooter project docs. Returns ``None`` to fall back to the
+    filesystem path (local mode, or no stored match_id / doc -- a genuinely
+    gone match).
+    """
+    if state.project_state is None or not rp.match_id:
+        return None
+    match_doc, _ = await state.project_state.load_match(rp.match_id)
+    if match_doc is None:
+        return None
+    detail = RecentProjectDetail(
+        path=rp.path,
+        name=match_doc.get("name") or rp.name,
+        last_opened_at=rp.last_opened_at,
+        kind="match",
+    )
+    detail.match_id = rp.match_id
+    shooters = match_doc.get("shooters") or []
+    detail.shooter_count = len(shooters)
+    detail.stage_count = len(match_doc.get("stages") or [])
+    detail.match_date = match_doc.get("match_date")  # JSON doc -> ISO str | None
+    detail.manual = match_doc.get("scoreboard_match_id") is None
+
+    names: list[str] = []
+    video_total = 0
+    for slug in shooters:
+        pdoc, _ = await state.project_state.load_project(rp.match_id, slug)
+        if pdoc is None:
+            names.append(slug)
+            continue
+        try:
+            proj = MatchProject.model_validate(pdoc)
+            names.append(proj.competitor_name or slug)
+            video_total += len(proj.all_videos())
+        except Exception:  # noqa: BLE001 -- never break the listing on one bad doc
+            names.append(slug)
+    detail.shooter_names = names
+    detail.video_count = video_total
+    # Per-stage audited counts live in separate state_docs rows; loading
+    # them all for a list view isn't worth it, so leave stages_audited at 0
+    # (the Audit screen shows the real per-stage status).
+    detail.status = "awaiting_footage" if video_total == 0 else "in_progress"
+    return detail
+
+
 SPLITSMITH_MODE_ENV = "SPLITSMITH_MODE"
 SPLITSMITH_DATABASE_URL_ENV = "SPLITSMITH_DATABASE_URL"
 # Public origin the deployment is reached at (e.g. https://splitsmith.app,
@@ -8243,7 +8296,14 @@ def create_app(
         """
         projects = await state.recent_projects.list()
         if detail:
-            enriched = [_enrich_recent_project(p) for p in projects]
+            enriched: list[RecentProjectDetail] = []
+            for p in projects:
+                # Hosted: resolve detail from Postgres so a redeploy-wiped
+                # working dir doesn't show the match as "missing". Falls
+                # back to the filesystem enricher (local mode, or no stored
+                # match_id / a genuinely-gone match).
+                hosted = await _enrich_recent_project_hosted(state, p)
+                enriched.append(hosted if hosted is not None else _enrich_recent_project(p))
             return JSONResponse({"projects": [p.model_dump(mode="json") for p in enriched]})
         return JSONResponse({"projects": [p.model_dump(mode="json") for p in projects]})
 

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -131,6 +131,16 @@ export function MatchShell() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [beepReviewPending, setBeepReviewPending] = useState<number>(0);
   const shooterCount = shooters.length || undefined;
+  // Per-shooter pages (Audit / Coach / Videos / Export) need a shooter in
+  // the URL. Rather than forcing the user to the shooter list, default to
+  // one -- the URL slug if present, else the first shooter with footage,
+  // else just the first shooter. The top shooter chips let them switch.
+  // ``undefined`` only when the match has no shooters yet.
+  const defaultShooterSlug =
+    slug ??
+    shooters.find((s) => s.video_count > 0)?.slug ??
+    shooters[0]?.slug ??
+    undefined;
 
   useEffect(() => {
     let alive = true;
@@ -412,12 +422,15 @@ export function MatchShell() {
           // (Audit / Coach / Export). See #425 for the rationale.
           hasFootage={shooters.some((s) => s.video_count > 0)}
           onStageClick={(n) => {
-            const target = slug ?? health?.default_shooter_slug;
             const mid = urlMatchId ?? health?.match_id ?? null;
             const base = mid ? `/match/${mid}` : "";
-            navigate(target ? `${base}/audit/${target}/${n}` : `${base}/shooters`);
+            navigate(
+              defaultShooterSlug
+                ? `${base}/audit/${defaultShooterSlug}/${n}`
+                : `${base}/shooters`,
+            );
           }}
-          shooterSlug={slug ?? health?.default_shooter_slug ?? undefined}
+          shooterSlug={defaultShooterSlug}
           matchId={urlMatchId ?? health?.match_id ?? undefined}
           collapsed={sidebarCollapsed}
           onCollapseToggle={toggleSidebar}

--- a/tests/test_hosted_raw_upload.py
+++ b/tests/test_hosted_raw_upload.py
@@ -781,3 +781,38 @@ def test_bind_resolves_by_match_id_when_local_path_is_gone(hosted_client) -> Non
     assert rebind.status_code == 200, rebind.text
     assert rebind.json()["match_id"] == match_id
     assert rebind.json()["bound"] is True
+
+
+def test_recent_projects_detail_reads_from_store_after_path_wiped(hosted_client) -> None:
+    """Hosted picker detail must come from Postgres, not the filesystem:
+    after a redeploy wipes the working dir, the match still shows real
+    metadata (kind=match, name, shooter/stage counts) instead of the scary
+    'missing / folder not found'."""
+    import shutil
+
+    client, _ = hosted_client
+    resp = client.post(
+        "/api/match/create-manual",
+        json={
+            "name": "Picker Detail Test",
+            "stages": [{"stage_number": 1, "stage_name": "S1"}],
+            "primary_shooter": {"name": "Anton"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    health = resp.json()
+    match_id, project_root = health["match_id"], health["project_root"]
+
+    shutil.rmtree(project_root, ignore_errors=True)
+    assert not Path(project_root).exists()
+
+    detail = client.get("/api/me/recent-projects?detail=true")
+    assert detail.status_code == 200, detail.text
+    entries = detail.json()["projects"]
+    entry = next((p for p in entries if p.get("match_id") == match_id), None)
+    assert entry is not None, entries
+    assert entry["kind"] == "match"  # not "missing"
+    assert entry["name"] == "Picker Detail Test"
+    assert entry["shooter_count"] == 1
+    assert entry["stage_count"] == 1
+    assert entry["shooter_names"] == ["Anton"]


### PR DESCRIPTION
Two fixes for the per-shooter friction surfaced in browser testing.

**Default-select a shooter (the main fix).** Per-shooter pages (Audit/Coach/Videos/Export) need a shooter in the URL. With none in focus the sidebar routed to the shooter list, and combined with the recent `?pick` banner it made the tabs feel broken: clicking Videos couldn't reach Ingest to add footage, and picking a shooter dumped you on an empty Audit ("assign a primary video on the Ingest screen") with no way back — a dead end. `MatchShell` now derives a `defaultShooterSlug` (URL slug → first shooter with footage → first shooter) so those tabs open directly for a sensible default; the top shooter chips switch shooters. Only a zero-shooter match falls back to the list.

**Picker detail from Postgres.** The picker showed hosted matches as "MISSING / FOLDER NOT FOUND" after a redeploy because the list enriched from the on-disk path. `_enrich_recent_project_hosted` now builds the detail from the match + project docs in `state_docs` via the row's `match_id`, falling back to the filesystem for local mode / genuinely-gone matches.

## Verification
Full non-docker suite green (incl. new test: picker detail survives a wiped working dir). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)