### PR TITLE
fix(serve): chain shot-detect when a beep review lands mid-trim

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -1667,18 +1667,27 @@ def register_job_bodies(state: AppState) -> None:
             fresh.save(root)
         # Worker callback runs in a ThreadPoolExecutor thread with no
         # event loop; bridge to the async JobBackend via ``asyncio.run``.
+        #
+        # Read ``beep_reviewed`` from the freshly reloaded video, NOT the
+        # snapshot captured at job start: a "Mark reviewed" click that
+        # lands while ffmpeg is running flips the flag on disk but
+        # ``set_beep_reviewed`` no-ops (the trim isn't cached yet), so
+        # this is the only place left to honor it. Falls back to the
+        # snapshot when the video vanished mid-flight.
+        beep_reviewed_now = v_fresh.beep_reviewed if v_fresh is not None else video.beep_reviewed
         if (
             chain_shot_detect
             and video.role == "primary"
-            and video.beep_reviewed
+            and beep_reviewed_now
             and asyncio.run(state.jobs.find_active(kind="shot_detect", stage_number=stage_number)) is None
         ):
             # Same gate as the detect-then-trim path (#71): don't burn
             # CLAP / GBDT / PANN cycles on a beep the user hasn't
             # confirmed. Manual entries pre-set ``beep_reviewed`` to True
-            # so this still runs; the auto-detect path waits for the
-            # user's explicit "Mark reviewed" click which re-fires
-            # shot_detect from there.
+            # so this still runs; the auto-detect / select-candidate path
+            # leaves it False until the user's explicit "Mark reviewed"
+            # click -- which fires shot_detect itself when the trim is
+            # already cached, or relies on this fresh read when it isn't.
             #
             # Layered automation gate (#215): a global / project
             # opt-out can suppress this auto-trigger.

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5310,6 +5310,57 @@ def test_marking_reviewed_kicks_off_shot_detect(tmp_path: Path, monkeypatch) -> 
     assert any(j["kind"] == "shot_detect" for j in jobs_after)
 
 
+def test_trim_chains_shot_detect_when_reviewed_lands_mid_trim(tmp_path: Path, monkeypatch) -> None:
+    """A "Mark reviewed" click that lands WHILE the trim is encoding must
+    still unblock shot detection.
+
+    Repro for "approved a beep, then nothing to audit": the user selects a
+    ranked candidate (beep_reviewed -> False, trim cache cleared), the
+    re-trim starts, and the user immediately marks the beep reviewed. At
+    that moment ``set_beep_reviewed`` no-ops because the trim isn't cached
+    yet, so the running trim worker is the only thing left that can chain
+    shot-detect. It must read ``beep_reviewed`` from the freshly reloaded
+    project, not the stale snapshot it captured at job start.
+    """
+    import splitsmith.ui.server as server_mod
+    from splitsmith.ui import audio as audio_helpers_mod
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    shooter_root = project_root / "shooters" / "me"
+    project = MatchProject.load(shooter_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    primary.beep_reviewed = False  # candidate just selected; not yet reviewed
+    project.stages[0].time_seconds = 10.0
+    project.save(shooter_root)
+    project.resolve_video_path(shooter_root, primary.path).resolve().write_bytes(b"S")
+
+    monkeypatch.setattr(server_mod, "_get_ensemble_runtime", lambda: object())
+
+    def fake_trim(root, *a, **kw):  # type: ignore[no-untyped-def]
+        # Simulate the user clicking "Mark reviewed" while ffmpeg runs:
+        # the flag flips on disk, but set_beep_reviewed has already
+        # no-op'd because processed["trim"] was still False.
+        proj = MatchProject.load(root)
+        prim = proj.stages[0].primary()
+        assert prim is not None
+        prim.beep_reviewed = True
+        proj.save(root)
+        return Path("dummy.mp4")
+
+    monkeypatch.setattr(audio_helpers_mod, "ensure_video_audit_trim", fake_trim)
+
+    resp = client.post("/api/shooters/me/stages/1/trim")
+    assert resp.status_code == 200
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
+
+    jobs_after = client.get("/api/me/jobs").json()
+    assert any(j["kind"] == "shot_detect" for j in jobs_after), [(j["kind"], j["status"]) for j in jobs_after]
+
+
 # ---------------------------------------------------------------------------
 # Global user-config endpoints (#75)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

User report: *approved a beep, then "nothing to audit."*

Selecting a ranked beep candidate (`POST .../beep/select`) deliberately resets `beep_reviewed=False` (a fresh claim about which moment is the beep, #71), clears the trim cache, and chains a re-trim. The user is then expected to click **Mark reviewed**.

If that click lands **while the re-trim is still encoding**:
- `set_beep_reviewed` no-ops its shot-detect kick because `processed["trim"]` is still `False` (the re-trim hasn't finished).
- The running `_run_trim` worker captured a stale `beep_reviewed=False` snapshot at job start, so its end-of-job chain gate doesn't fire either.

Net result: trim completes, **no shot-detect runs**, Audit is empty.

## Fix

`_run_trim` already reloads the project fresh (`v_fresh`) right before the chain decision (to avoid stomping concurrent edits). Read `beep_reviewed` from that fresh reload instead of the stale start-of-job snapshot.

Covers all three timing windows:
- **before trim** -- manual beep entry pre-sets `beep_reviewed=True` -> chains (unchanged)
- **during trim** -- the mid-flight "Mark reviewed" is now honored when the trim finishes (this fix)
- **after trim** -- `set_beep_reviewed` fires shot-detect itself since the trim is cached (unchanged)

Keeps the #71 contract intact: selecting a candidate still requires an explicit review; this only stops the review from being silently dropped.

## Test

`test_trim_chains_shot_detect_when_reviewed_lands_mid_trim` -- the stubbed trim flips `beep_reviewed=True` on disk mid-run to simulate the concurrent click. Verified it **fails** against the old stale-snapshot code and **passes** with the fresh read.

## Gates
- ruff clean, black applied
- all 251 `tests/test_ui_server.py` pass (incl. 71 beep/trim/shot-detect)
- server-side only, no DB/migration changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)