### PR TITLE
feat(ui): resolve slug-less per-shooter URLs to the default shooter

### DIFF
--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { AppShell } from "@/components/AppShell";
 import { DeveloperShell } from "@/components/developer/DeveloperShell";
 import { MatchShell } from "@/components/match/MatchShell";
+import { DefaultShooterRedirect } from "@/components/match/DefaultShooterRedirect";
 import { ModeProvider } from "@/lib/mode";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import { useDeploymentMode } from "@/lib/features";
@@ -137,7 +138,7 @@ export function App() {
               path="ingest/:slug"
               element={<ShooterScopedRoute element={<Ingest />} />}
             />
-            <Route path="ingest" element={<Navigate to="../shooters" replace />} />
+            <Route path="ingest" element={<DefaultShooterRedirect base="ingest" />} />
             <Route element={<MatchShell />}>
               <Route index element={<Home />} />
               <Route
@@ -148,7 +149,7 @@ export function App() {
                 path="audit/:slug/:stage"
                 element={<ShooterScopedRoute element={<Audit />} />}
               />
-              <Route path="audit" element={<Navigate to="../shooters" replace />} />
+              <Route path="audit" element={<DefaultShooterRedirect base="audit" />} />
               <Route path="compare/:stage" element={<Compare />} />
               <Route
                 path="coach/:slug"
@@ -158,7 +159,7 @@ export function App() {
                 path="coach/:slug/:stage"
                 element={<ShooterScopedRoute element={<Coach />} />}
               />
-              <Route path="coach" element={<Navigate to="../shooters" replace />} />
+              <Route path="coach" element={<DefaultShooterRedirect base="coach" />} />
               <Route path="shooters" element={<Shooters />} />
               <Route path="beep-review" element={<BeepReview />} />
               <Route
@@ -169,7 +170,7 @@ export function App() {
                 path="export/:slug/:stage"
                 element={<ShooterScopedRoute element={<Export />} />}
               />
-              <Route path="export" element={<Navigate to="../shooters" replace />} />
+              <Route path="export" element={<DefaultShooterRedirect base="export" />} />
             </Route>
           </Route>
           {/* Developer mode (#331). All four workflow steps + the

--- a/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
+++ b/src/splitsmith/ui_static/src/components/ShooterScopedRoute.tsx
@@ -6,25 +6,45 @@
  * via the slug-derived key so each page's effects start fresh on the new
  * shooter without page-specific reset plumbing.
  *
- * Slugless visits (e.g. ``/audit``) redirect to ``/shooters`` so the user
- * picks one explicitly -- there is no "active shooter" fallback any more.
+ * A slug-less visit shouldn't happen -- every route that mounts this
+ * supplies ``:slug`` -- but if one ever slips through, resolve it to the
+ * default shooter via ``DefaultShooterRedirect`` (base derived from the
+ * first path segment) rather than dumping the operator on the shooter
+ * list. The list is only the right destination for a genuinely empty
+ * match, which ``DefaultShooterRedirect`` already handles.
  */
 
-import { Navigate, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
+
+import { DefaultShooterRedirect } from "@/components/match/DefaultShooterRedirect";
 
 interface Props {
   element: React.ReactElement;
 }
 
+type ScopedBase = "audit" | "coach" | "export" | "ingest";
+
+function baseFromPath(pathname: string): ScopedBase {
+  // Path is /match/:matchId/<base>/... -- the segment after matchId names
+  // the page. Default to "audit" if the shape is unexpected.
+  const segs = pathname.split("/").filter(Boolean);
+  const idx = segs.indexOf("match");
+  const candidate = idx >= 0 ? segs[idx + 2] : segs[0];
+  if (
+    candidate === "coach" ||
+    candidate === "export" ||
+    candidate === "ingest"
+  ) {
+    return candidate;
+  }
+  return "audit";
+}
+
 export function ShooterScopedRoute({ element }: Props) {
-  const { slug, matchId } = useParams<{ slug: string; matchId?: string }>();
+  const { slug } = useParams<{ slug: string; matchId?: string }>();
+  const { pathname } = useLocation();
   if (!slug) {
-    return (
-      <Navigate
-        to={matchId ? `/match/${matchId}/shooters` : "/shooters"}
-        replace
-      />
-    );
+    return <DefaultShooterRedirect base={baseFromPath(pathname)} />;
   }
   return (
     <span key={slug} style={{ display: "contents" }}>

--- a/src/splitsmith/ui_static/src/components/match/DefaultShooterRedirect.tsx
+++ b/src/splitsmith/ui_static/src/components/match/DefaultShooterRedirect.tsx
@@ -1,0 +1,63 @@
+/**
+ * DefaultShooterRedirect -- resolve a slug-less per-shooter URL to a
+ * shooter instead of dumping the operator on the shooter list (#477
+ * follow-up).
+ *
+ * Per-shooter pages (Audit / Coach / Export / Ingest) carry the shooter as
+ * a URL slug. A bare visit -- a bookmark, a link that dropped the slug, or
+ * a single-shooter match -- used to ``Navigate`` straight to ``/shooters``,
+ * which is pointless friction when there's an obvious shooter to open.
+ * This resolves the default shooter (see ``pickDefaultShooterSlug``) and
+ * redirects there; it only falls back to the list when the match genuinely
+ * has zero shooters, where the empty-state list is the right destination.
+ *
+ * Self-fetches the roster rather than reading outlet context: the
+ * audit/coach/export bare routes mount under ``MatchShell`` but the ingest
+ * bare route lives outside it, so a single self-contained fetch is the one
+ * path that works everywhere. This only runs on the bare-route edge case,
+ * not the common slug-carrying path, so the extra GET is cheap.
+ */
+
+import { useEffect, useState } from "react";
+import { Navigate, useParams } from "react-router-dom";
+
+import { api } from "@/lib/api";
+import { pickDefaultShooterSlug } from "@/lib/defaultShooter";
+import { matchHref } from "@/lib/matchHref";
+
+interface Props {
+  base: "audit" | "coach" | "export" | "ingest";
+}
+
+export function DefaultShooterRedirect({ base }: Props) {
+  const { matchId } = useParams<{ matchId?: string }>();
+  const [target, setTarget] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .listMatchShooters()
+      .then((r) => {
+        if (!alive) return;
+        const slug = pickDefaultShooterSlug(r.shooters);
+        setTarget(
+          slug
+            ? matchHref(matchId, base, slug)
+            : matchHref(matchId, "shooters"),
+        );
+      })
+      .catch(() => {
+        // Unknown match / transient failure: the list handles both the
+        // empty state and the "switch project" escape hatch.
+        if (alive) setTarget(matchHref(matchId, "shooters"));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [matchId, base]);
+
+  // Brief: the roster fetch resolves fast and this only renders on the
+  // (rare) slug-less route. Render nothing rather than flash the list.
+  if (!target) return null;
+  return <Navigate to={target} replace />;
+}

--- a/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
+++ b/src/splitsmith/ui_static/src/components/match/MatchShell.tsx
@@ -36,6 +36,7 @@ import {
   type ShooterListEntry,
 } from "@/lib/api";
 import { useMode } from "@/lib/mode";
+import { pickDefaultShooterSlug } from "@/lib/defaultShooter";
 import { deriveStageStatus, isNextUpCandidate } from "@/lib/stageStatus";
 import { cn } from "@/lib/utils";
 
@@ -133,14 +134,10 @@ export function MatchShell() {
   const shooterCount = shooters.length || undefined;
   // Per-shooter pages (Audit / Coach / Videos / Export) need a shooter in
   // the URL. Rather than forcing the user to the shooter list, default to
-  // one -- the URL slug if present, else the first shooter with footage,
-  // else just the first shooter. The top shooter chips let them switch.
+  // one -- the URL slug if present, else the shared default-shooter rule
+  // (same one DefaultShooterRedirect uses, so chrome and redirect agree).
   // ``undefined`` only when the match has no shooters yet.
-  const defaultShooterSlug =
-    slug ??
-    shooters.find((s) => s.video_count > 0)?.slug ??
-    shooters[0]?.slug ??
-    undefined;
+  const defaultShooterSlug = slug ?? pickDefaultShooterSlug(shooters);
 
   useEffect(() => {
     let alive = true;

--- a/src/splitsmith/ui_static/src/lib/defaultShooter.ts
+++ b/src/splitsmith/ui_static/src/lib/defaultShooter.ts
@@ -1,0 +1,22 @@
+/**
+ * pickDefaultShooterSlug -- the one rule for "which shooter opens when the
+ * URL didn't name one".
+ *
+ * Shared by ``MatchShell`` (sidebar + onStageClick targets) and
+ * ``DefaultShooterRedirect`` (bare per-shooter URLs) so the redirect and
+ * the chrome can never disagree about the default. First shooter with
+ * footage wins -- that's the one the operator is most likely here to work
+ * on -- else the first shooter, else nothing (empty match).
+ */
+
+import type { ShooterListEntry } from "@/lib/api";
+
+export function pickDefaultShooterSlug(
+  shooters: ShooterListEntry[],
+): string | undefined {
+  return (
+    shooters.find((s) => s.video_count > 0)?.slug ??
+    shooters[0]?.slug ??
+    undefined
+  );
+}


### PR DESCRIPTION
## Problem

Per-shooter pages (Audit / Coach / Export / Ingest) live at `/match/:matchId/<page>/:slug`. #477 made the common path good (sidebar + chips inject a default shooter), but a **slug-less** visit -- a bookmark, a link that dropped the slug, or a single-shooter match -- still `Navigate`d unconditionally to `/shooters`:

```tsx
<Route path="audit"  element={<Navigate to="../shooters" replace />} />
<Route path="coach"  element={<Navigate to="../shooters" replace />} />
<Route path="export" element={<Navigate to="../shooters" replace />} />
<Route path="ingest" element={<Navigate to="../shooters" replace />} />
```

So `/match/<id>/audit` always dumped you on the list even when there was an obvious shooter to open -- worst for single-shooter matches (one target, yet a list).

## Change

Replace the four bare-route `Navigate`s with `DefaultShooterRedirect`, which resolves the default shooter (first-with-footage, else first) and only falls back to `/shooters` when the match genuinely has **zero** shooters (where the empty-state list is correct).

- **`lib/defaultShooter.ts`** -- `pickDefaultShooterSlug`, shared by the redirect and `MatchShell` so chrome and redirect can never disagree about the default.
- **`components/match/DefaultShooterRedirect.tsx`** -- self-fetches the roster (works inside `MatchShell` for audit/coach/export *and* outside it for ingest), then `Navigate`s. Renders nothing while resolving; only runs on the rare slug-less route.
- **`MatchShell`** uses the shared helper (dedupes its `defaultShooterSlug`).
- **`ShooterScopedRoute`** defensive slug-less branch now routes through the same redirect instead of the list.

The slug stays the source of truth -- deep links, bookmarks-with-slug, and clean remount-on-switch are all unchanged. This only fixes the slug-less entry points.

## Scope (deliberately unchanged)

The other `/shooters` navigations (`MatchShell` onStageClick fallback, `MatchSidebar` nav links, the explicit "Shooters" row) only fire when there's no usable default shooter, where the list is the right destination.

## Not included

`ShooterChipStrip` renders only in `MatchShell`, so **Ingest (outside the shell) has no shooter selector** -- a real gap, but "selector not always visible" wasn't the reported pain, so it's left as a follow-up.

## Verification
- `npm run typecheck` -- clean.
- `npm run build` (= CI's `tsc -b && vite build`) -- builds.
- No deps added (frozen lockfile unaffected); no backend changes.
- Manual click-through to do on staging post-merge: bare `/match/<id>/audit` -> default shooter (not the list) for multi- and single-shooter; zero-shooter -> `/shooters` (unchanged); slug URLs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)