### PR TITLE
fix(ui): keep match prefix when Audit auto-redirects to a stage (bounces to picker)

### DIFF
--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -372,11 +372,14 @@ export function Audit() {
   useEffect(() => {
     if (stageNumber != null) return;
     if (stagesWithPrimary.length === 0) return;
-    const target = slugParam
-      ? `/audit/${slugParam}/${stagesWithPrimary[0].stage_number}`
-      : `/audit/${stagesWithPrimary[0].stage_number}`;
-    navigate(target, { replace: true });
-  }, [stageNumber, stagesWithPrimary, navigate, slugParam]);
+    // Must go through ``href`` so the target keeps the ``/match/:matchId``
+    // prefix. A bare ``/audit/...`` escapes the match scope, matches no
+    // route, and the catch-all redirect dead-ends at /pick (health.bound
+    // is always false post-state-refactor, so it can't re-prefix).
+    navigate(href("audit", slug, String(stagesWithPrimary[0].stage_number)), {
+      replace: true,
+    });
+  }, [stageNumber, stagesWithPrimary, navigate, href, slug]);
 
   const stage = useMemo(() => {
     if (!project || stageNumber == null) return null;
@@ -1193,10 +1196,11 @@ export function Audit() {
       if (isDirtyRef.current) {
         await performSave({ silent: true });
       }
-      const target = slugParam ? `/audit/${slugParam}/${n}` : `/audit/${n}`;
-      navigate(target);
+      // Match-prefixed (see the stage-redirect effect above): a bare
+      // ``/audit/...`` would escape the match scope and bounce to /pick.
+      navigate(href("audit", slug, String(n)));
     },
-    [navigate, performSave, stageNumber, slugParam],
+    [navigate, performSave, stageNumber, href, slug],
   );
 
   // Open the /beep-review queue with this exact item active. Replaces


### PR DESCRIPTION
## Symptom

Click **Audit** in the sidebar -> a brief "Loading project" spinner -> dumped on the **project picker** (`/pick`). Reported on staging; also affects prod `v0.4.0`.

## Root cause

The sidebar's default-shooter "Audit" link goes to `/match/<id>/audit/<slug>` (no stage). Audit's "no stage in URL -> redirect to the first stage" effect (and the stage selector `navigateToStage`) built the target as a **bare** path:

```js
const target = slugParam ? `/audit/${slugParam}/${stage}` : `/audit/${stage}`;
navigate(target, { replace: true });
```

That has no `/match/:matchId` prefix, so it matches no route and falls through to the catch-all `LegacyMatchRedirect`. That component only re-prefixes the path back into the match when `health.bound` is true -- but the state refactor (doc 10, Tier 1 step 4) **retired `health.bound` and pins it to always `false`**. So it can never recover an un-prefixed path and dead-ends at `/pick`.

The file already had the correct helper (`useMatchHref`'s `href()`, used at line 1149); these two navigates just predated it.

## Fix

Build both targets through `href("audit", slug, String(stage))` so the `/match/:matchId` prefix is preserved:
- the stage auto-redirect effect (Audit.tsx ~372)
- `navigateToStage` stage selector (Audit.tsx ~1190)

Coach already uses `href`; Export has no such navigate -- so the bug was Audit-only.

## Why it surfaced now

`#477` (default-select a shooter) + `#479` (bare `/audit` -> default shooter) both funnel users to `/match/<id>/audit/<slug>` *without a stage*, which triggers the redirect effect. The un-prefixed navigate itself predates both.

## Verification
- `npm run typecheck` clean; `npm run build` (= CI's `tsc -b && vite build`) builds.
- Manual (staging post-merge): click Audit from Overview -> lands on `/match/<id>/audit/<slug>/<stage>`, renders the audit, no bounce. Stage selector switches stages without leaving the match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)