### PR TITLE
fix(ui): consistent stage counts on the match overview

### DIFF
--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -8700,7 +8700,14 @@ def create_app(
             selected_shooter_id=legacy.selected_shooter_id,
             selected_competitor_id=legacy.selected_competitor_id,
             stages_audited=stages_audited,
-            stages_total=len(match.stages),
+            # Denominator must match the numerator's source: stages_audited
+            # is counted over the shooter's OWN project (legacy.stages), so
+            # the total has to be len(legacy.stages) too. Using
+            # len(match.stages) breaks the ratio when the match-level stage
+            # list wasn't populated (e.g. stages arrived via a per-shooter
+            # scoreboard import, not match creation) -- that produced a "0
+            # stages" card next to a 12-stage match.
+            stages_total=len(legacy.stages),
             video_count=total_videos,
             cameras=cameras,
             stages_missing_trim=stages_missing_trim,

--- a/src/splitsmith/ui_static/src/pages/Home.tsx
+++ b/src/splitsmith/ui_static/src/pages/Home.tsx
@@ -398,7 +398,15 @@ function ActiveVariant({
             <ShooterCard
               key={s.slug}
               name={s.name}
-              stats={`${s.stages_total} stages`}
+              // "{audited}/{total} audited" instead of a bare "{total}
+              // stages" -- the latter read as "this shooter has N stages"
+              // and clashed with the match's stage count elsewhere. The
+              // ratio names the metric so it can't be misread.
+              stats={
+                s.stages_total > 0
+                  ? `${s.stages_audited}/${s.stages_total} audited`
+                  : "no stages yet"
+              }
               progress={
                 s.stages_total > 0 ? s.stages_audited / s.stages_total : 0
               }
@@ -422,13 +430,22 @@ function ActiveVariant({
         title="Stages"
         count={
           <>
-            <b className="font-bold text-ink-2">{pad2(totalsByTone.done)}</b>{" "}
+            <b className="font-bold text-ink-2">
+              {pad2(totalsByTone.done + totalsByTone.skipped)}
+            </b>{" "}
             audited <span className="text-whisper">&middot;</span>{" "}
             <b className="font-bold text-ink-2">
-              {pad2(totalsByTone.partial + totalsByTone.flagged)}
+              {pad2(totalsByTone.in_progress)}
             </b>{" "}
             in progress <span className="text-whisper">&middot;</span>{" "}
-            <b className="font-bold text-ink-2">{pad2(totalsByTone.todo)}</b>{" "}
+            <b className="font-bold text-ink-2">
+              {pad2(
+                totalsByTone.todo +
+                  totalsByTone.ready +
+                  totalsByTone.partial +
+                  totalsByTone.flagged,
+              )}
+            </b>{" "}
             pending
           </>
         }

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5885,6 +5885,43 @@ def test_list_match_shooters_returns_active_and_others(tmp_path: Path, _user_con
     assert slugs == ["ma", "jl"]
 
 
+def test_list_match_shooters_stages_total_from_project_not_match(
+    tmp_path: Path, _user_config_home: Path
+) -> None:
+    """stages_total must come from each shooter's own project, not
+    ``len(match.stages)``.
+
+    When stages arrive via a per-shooter scoreboard import, the
+    match-level stage list can stay empty while the project carries the
+    stages. Using ``len(match.stages)`` then rendered a "0 stages" card
+    next to a multi-stage match (and broke the audited ratio, whose
+    numerator is counted over the project). Regression for that mismatch.
+    """
+    from splitsmith import match_model
+
+    target = tmp_path / "mm"
+    match = match_model.Match.init(target, name="Empty-match-stages")
+    assert match.stages == []  # deliberately empty at the match level
+    match.save(target)
+    match.add_shooter(target, match_model.Shooter(slug="ma", name="Mathias"))
+    sroot = match_model.Match.shooter_root(target, "ma")
+    legacy = MatchProject.init(sroot, name="Empty-match-stages")
+    legacy.competitor_name = "Mathias"
+    legacy.stages = [StageEntry(stage_number=n, stage_name=f"Stage {n}", time_seconds=0.0) for n in (1, 2, 3)]
+    legacy.save(sroot)
+
+    app = create_app()
+    client = _MatchClient(app)
+    resp = client.post("/api/me/recent-projects/bind", json={"path": str(target.resolve())})
+    assert resp.status_code == 200
+    match_id = app.state.splitsmith_state.matches.known_ids()[0]
+
+    body = client.get(f"/api/matches/{match_id}/match/shooters").json()
+    me = next(s for s in body["shooters"] if s["slug"] == "ma")
+    # 3 from legacy.stages -- NOT 0 from the empty match.stages.
+    assert me["stages_total"] == 3
+
+
 def test_add_match_shooter_appends_and_scaffolds(tmp_path: Path, _user_config_home: Path) -> None:
     from splitsmith import match_model
 


### PR DESCRIPTION
Three related count bugs you spotted on the match Overview.

## 1. Per-shooter "0 STAGES" next to a 12-stage match
`_classify_shooter` set `stages_total=len(match.stages)`, but `stages_audited` is counted over the shooter's **own** project (`legacy.stages`). When stages arrive via a per-shooter scoreboard import, `match.stages` stays empty while the project carries the 12 stages -- so the ratio's denominator was 0 ("0 STAGES", and a broken progress bar). Now `stages_total=len(legacy.stages)`, so numerator and denominator share a source.

## 2. "00 AUDITED / 00 IN PROGRESS / 11 PENDING" summed to 11 of 12
The summary buckets only counted `done` / `partial+flagged` / `todo`, silently dropping `ready`, `in_progress`, and `skipped` -- so the "ready / next-up" stage vanished. Re-bucketed to cover every status and sum to the total:
- **audited** = `done + skipped` (matches the header's terminal definition + the audited %)
- **in progress** = `in_progress`
- **pending** = `todo + ready + partial + flagged`

## 3. Ambiguous shooter-card label
"{N} stages" read as "this shooter has N stages" and clashed with the match's stage count. Now "{audited}/{total} audited" (or "no stages yet").

## Test
`test_list_match_shooters_stages_total_from_project_not_match` builds the exact bug condition (empty `match.stages`, a 3-stage shooter project) and asserts `stages_total == 3`. Verified red before the fix, green after.

## Gates
- ruff + black clean; `npm run build` (tsc + vite) builds; shooter-list test subset green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)