### PR TITLE
fix(saas): populate match.stages on scoreboard-created matches

### DIFF
--- a/src/splitsmith/match_model.py
+++ b/src/splitsmith/match_model.py
@@ -41,6 +41,7 @@ from .ui.project import (
     SUBDIRS,
     MatchProject,
     StageVideo,
+    _stage_rounds_from_info,
     atomic_write_json,
 )
 
@@ -260,6 +261,28 @@ class Match(BaseModel):
         match.match_id = generate_match_id(match.name, match.created_at)
         match.save(root)
         return match
+
+    def stages_from_match_data(self, match_data: Any) -> None:
+        """Populate match-level stage definitions from a scoreboard shell.
+
+        The match-side mirror of
+        :meth:`MatchProject.populate_from_match_data`. A scoreboard-created
+        match must carry its own stage list: a shooter ADDED LATER gets a
+        project mirrored from ``match.stages`` (see the add-shooter path),
+        so an empty list would hand them zero stages -- and per-shooter
+        coverage counts that divide by ``len(match.stages)`` would read 0.
+        Stages are flagged ``placeholder`` exactly as the per-shooter
+        import flags them; per-competitor timing arrives separately.
+        """
+        self.stages = [
+            MatchStageDefinition(
+                stage_number=s.stage_number,
+                stage_name=s.name,
+                stage_rounds=_stage_rounds_from_info(s),
+                placeholder=True,
+            )
+            for s in sorted(match_data.stages, key=lambda s: s.stage_number)
+        ]
 
     @classmethod
     def load(cls, root: Path) -> Match:

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -8558,6 +8558,15 @@ def create_app(
             except ScoreboardError as exc:
                 _raise_scoreboard_http(exc)
 
+        # Carry the stage shell onto the match itself BEFORE adding shooters
+        # (mirrors the manual-create order). Without this match.stages stays
+        # empty: a shooter added later -- whose project is mirrored from
+        # match.stages -- would get zero stages, and coverage counts that
+        # divide by len(match.stages) read 0. Per-shooter projects below are
+        # populated independently via populate_from_match_data.
+        match.stages_from_match_data(match_data)
+        match.save(target)
+
         # Stable alphabetical materialisation so reruns / re-imports
         # land in the same shooter order. No "primary" shooter -- the
         # operator may not be in the roster at all (#350).

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -668,6 +668,13 @@ def test_create_from_scoreboard_creates_n_shooters_from_local(
         assert project["selected_competitor_id"] in {alice["id"], bob["id"]}
         assert len(project["stages"]) >= 1
 
+    # Regression: the match itself must carry the stage definitions, not
+    # just the per-shooter projects. An empty match.stages would hand a
+    # shooter added LATER zero stages (their project is mirrored from it)
+    # and make len(match.stages)-based coverage counts read 0.
+    assert len(match_json["stages"]) == len(project["stages"])
+    assert {s["stage_number"] for s in match_json["stages"]} == {s["stage_number"] for s in project["stages"]}
+
 
 def test_scoreboard_upload_legacy_examples_auto_merges_stage_times(tmp_path: Path) -> None:
     """Dropping the legacy ``examples/*.json`` shape (single competitor with


### PR DESCRIPTION
## Root cause (the deeper item from the stage-count investigation)

`create_match_from_scoreboard` populated each shooter's project (`populate_from_match_data`) but **never set `match.stages`** -- `Match.init` leaves it `[]` and nothing filled it. That's why this match showed `match.stages == []` while every shooter project had 12 stages.

### Why it matters
- **`add_shooter` mirrors `match.stages`** into a new shooter's project. On a scoreboard-created match that meant a shooter added later would get **zero stages**.
- `len(match.stages)`-based coverage counts read 0 (the "0 STAGES" card -- #483 made the card read the shooter project instead, but the underlying match data was still wrong).

## Fix
- New `Match.stages_from_match_data(match_data)` -- the match-side mirror of `MatchProject.populate_from_match_data`, reusing `_stage_rounds_from_info`. Stages flagged `placeholder`, same as the per-shooter import.
- `create_match_from_scoreboard` calls it **before** adding shooters -- the same order the manual-create path (`create_match_manual`) already uses (set `match.stages`, save, then `add_shooter`).

## Test
`test_create_from_scoreboard_creates_n_shooters_from_local` now asserts `match.stages` matches the per-shooter project stage set. Verified **red before** the fix, green after.

## Relationship to #483
#483 fixed the *display* (count off the shooter project, re-bucket the summary). This fixes the *data* (match.stages no longer empty), which is what unblocks add-shooter-later. Independent files/regions; either can merge first.

## Gates
ruff + black clean; scoreboard + match-shooter + compare/merge test subsets green. Backend-only (no SPA change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)