### PR TITLE
feat(saas): Tier-1 job observability -- per-phase timings, JSON logs, Sentry

### DIFF
--- a/alembic/versions/20aa31aeca11_add_timings_to_compute_jobs.py
+++ b/alembic/versions/20aa31aeca11_add_timings_to_compute_jobs.py
@@ -1,0 +1,46 @@
+"""add timings to compute_jobs
+
+Adds a nullable ``timings`` column to ``compute_jobs`` holding per-job
+observability metadata: ``{queue_wait_ms, total_ms, phases[], meta{}}``.
+It is plain metadata on an already-tenant-scoped, already-RLS'd row -- the
+``tenant_isolation`` policy (a7c4e9d21b06) keys on ``user_id`` only and is
+unchanged by adding a column, so this migration issues no RLS DDL. A plain
+``ADD COLUMN`` preserves ``relrowsecurity``/``relforcerowsecurity`` and the
+existing policy.
+
+The column is created as generic ``JSON`` so ``create``/``upgrade`` works on
+both SQLite (the unit-test + clean-DB smoke engine) and Postgres; on Postgres
+it is then ALTERed to ``JSONB`` (same dialect-guarded pattern as
+d1f7b25c8a3e's ``doc`` column). Nullable, no server_default -- it is populated
+once by the job backend when a job reaches a terminal status, matching the
+``result`` column which also omits a default.
+
+Revision ID: 20aa31aeca11
+Revises: e2a5f9c4b318
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20aa31aeca11"
+down_revision: str | Sequence[str] | None = "e2a5f9c4b318"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("compute_jobs", sa.Column("timings", sa.JSON(), nullable=True))
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER TABLE compute_jobs ALTER COLUMN timings TYPE JSONB USING timings::jsonb")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("compute_jobs", "timings")

--- a/docs/saas-readiness/11-environment-strategy.md
+++ b/docs/saas-readiness/11-environment-strategy.md
@@ -105,9 +105,21 @@ Both `serve` and `worker` in a given environment share these. The
 | `SPLITSMITH_SIGNUPS_OPEN` | `false` at launch (allowlist only) | `false` |
 | `SPLITSMITH_SIGNUP_ALLOWLIST` | the launch allowlist (emails / `@domain`) | your own address |
 | `SPLITSMITH_S3_*` | `splitsmith-uploads-prod` bucket creds | `splitsmith-uploads-staging` bucket creds |
+| `SENTRY_DSN` | prod Sentry project DSN | staging Sentry project DSN |
+| `SPLITSMITH_ENV` | `production` (optional override) | `staging` (optional override) |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.0`-`1.0` (optional, default `0.0`) | same |
 
 A public https `SPLITSMITH_PUBLIC_URL` turns on the Secure cookie flag
 in both environments.
+
+`SENTRY_DSN` gates error monitoring for both `serve` and `worker`
+(`splitsmith.observability.init_sentry`): leave it unset and Sentry is a
+no-op, so local and test runs never phone home. The Sentry environment tag
+comes from `SPLITSMITH_ENV` when set, otherwise it falls back to
+`SPLITSMITH_MODE` (so a bare hosted process still tags `hosted`). PII is
+scrubbed (`send_default_pii=False` plus a `before_send` hook that drops
+cookies, the `Authorization` header, and the magic-link `token` query
+param), and cancelled jobs are logged but not raised as Sentry events.
 
 ## DNS plan (Cloudflare zone `splitsmith.app`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,12 @@ hosted = [
     # pure ``psycopg[pool]`` and leaves the backend choice to us.
     "procrastinate>=2.0.0",
     "psycopg[binary]>=3.2.0",
+    # Error + performance monitoring for the hosted web + worker processes
+    # (doc: observability primitives). The ``[fastapi]`` extra pulls the
+    # Starlette/FastAPI integration; ``splitsmith.observability.init_sentry``
+    # is a no-op when ``SENTRY_DSN`` is unset, and the import is guarded so
+    # a slim local install without the wheel is also a no-op.
+    "sentry-sdk[fastapi]>=2.0.0",
 ]
 
 [build-system]

--- a/src/splitsmith/db/job_backend.py
+++ b/src/splitsmith/db/job_backend.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
+from ..observability import PhaseTimer, capture_job_exception, emit_job_event
 from ..ui.jobs import (
     Job,
     JobBodyRegistry,
@@ -87,6 +88,7 @@ _ROW_TO_JOB_FIELDS = (
     "cancel_requested",
     "acknowledged",
     "result",
+    "timings",
     "created_at",
     "updated_at",
     "started_at",
@@ -482,16 +484,26 @@ class PostgresJobBackend:
                 # worker; the row is already terminal. Nothing to run.
                 return
 
-            handle = JobHandle(self, job_id)  # type: ignore[arg-type]
+            # Build the timer from the row's wall-clock timestamps so
+            # queue_wait_ms (enqueue->start, across processes) is derived from
+            # the persisted ts, not perf_counter. The body opens phases via
+            # ``handle.timer``; this thread owns the single persist + emit.
+            timer = PhaseTimer(
+                created_at=row_snapshot.created_at,
+                started_at=row_snapshot.started_at,
+            )
+            handle = JobHandle(self, job_id, timer=timer)  # type: ignore[arg-type]
+            kind = row_snapshot.kind
             try:
                 fn(handle)
             except JobCancelled:
-                asyncio.run(self._finalize_run(job_id, JobStatus.CANCELLED, error=None))
+                self._finalize_with_timings(job_id, kind, JobStatus.CANCELLED, timer, error=None)
                 return
             except Exception as exc:  # noqa: BLE001 -- surface as FAILED
-                asyncio.run(self._finalize_run(job_id, JobStatus.FAILED, error=str(exc)))
+                capture_job_exception(exc, kind=kind, user_id=self._user_id)
+                self._finalize_with_timings(job_id, kind, JobStatus.FAILED, timer, error=str(exc))
                 return
-            asyncio.run(self._finalize_run(job_id, JobStatus.SUCCEEDED, error=None))
+            self._finalize_with_timings(job_id, kind, JobStatus.SUCCEEDED, timer, error=None)
         finally:
             with self._lock:
                 self._inflight = max(0, self._inflight - 1)
@@ -531,7 +543,45 @@ class PostgresJobBackend:
             await session.commit()
             return _row_to_job(row)
 
-    async def _finalize_run(self, job_id: str, status: JobStatus, *, error: str | None) -> None:
+    def _finalize_with_timings(
+        self,
+        job_id: str,
+        kind: str,
+        status: JobStatus,
+        timer: PhaseTimer,
+        *,
+        error: str | None,
+    ) -> None:
+        """Persist terminal status + timings in one write, then emit one event.
+
+        Runs on the worker thread (synchronous, bridges to async DB via
+        ``asyncio.run`` exactly like the existing finalize path -- no second
+        event loop). The timer is built once here so a body that raised
+        mid-phase still carries its partial timeline. The structured
+        ``job.completed`` / ``job.failed`` log is emitted once per job from
+        this single terminal path.
+        """
+        timings = timer.build()
+        asyncio.run(self._finalize_run(job_id, status, error=error, timings=timings))
+        event = "job.completed" if status == JobStatus.SUCCEEDED else "job.failed"
+        emit_job_event(
+            logger,
+            event=event,
+            kind=kind,
+            user_id=self._user_id,
+            status=status.value,
+            timings=timings,
+            error=error,
+        )
+
+    async def _finalize_run(
+        self,
+        job_id: str,
+        status: JobStatus,
+        *,
+        error: str | None,
+        timings: dict[str, Any] | None = None,
+    ) -> None:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             row = (
@@ -547,6 +597,8 @@ class PostgresJobBackend:
             row.status = status.value
             row.finished_at = now
             row.updated_at = now
+            if timings is not None:
+                row.timings = timings
             if status == JobStatus.SUCCEEDED:
                 row.progress = 1.0
                 row.error = None

--- a/src/splitsmith/db/models.py
+++ b/src/splitsmith/db/models.py
@@ -18,7 +18,17 @@ from __future__ import annotations
 from datetime import datetime
 
 import ulid
-from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -460,6 +470,10 @@ class ComputeJobRow(Base):
     cancel_requested: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     acknowledged: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     result: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # Per-job observability metadata (queue_wait_ms, total_ms, phases[], meta{}).
+    # Generic ``JSON`` on SQLite (unit tests); the migration ALTERs to JSONB on
+    # Postgres. Nullable: populated once by the backend on job completion.
+    timings: Mapped[dict | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/splitsmith/observability.py
+++ b/src/splitsmith/observability.py
@@ -1,0 +1,321 @@
+"""Per-job observability primitives: phase timing, structured logging, Sentry.
+
+Why this is a top-level module
+------------------------------
+It is imported by both the web (``ui.server``) and the worker (``queue``)
+and by the job backends. To avoid an import cycle it depends ONLY on the
+standard library plus pydantic, and imports NOTHING from ``splitsmith.ui.*``
+or ``splitsmith.db.*``. ``server.py`` and ``job_backend.py`` import FROM
+it; it imports from nobody in-package.
+
+It is also mode-agnostic. :func:`emit_job_event` always logs one INFO
+record carrying structured extras; whether that record is serialised as a
+single JSON line or a plain text line is decided by which formatter the
+logging config selected (:class:`StructuredJsonFormatter` in hosted mode,
+the plain formatter locally). This keeps mode detection out of this module
+and out of any ``server.py`` import.
+
+The pieces
+----------
+- :class:`PhaseTimer` -- pure, no I/O: ``perf_counter`` phase contextmanager
+  that records each closed phase EVEN IF its body raises, plus a small
+  ``meta`` dict and a ``build()`` that returns the persisted timings shape.
+- :func:`_queue_wait_ms` -- derive enqueue->start latency from the row's
+  ``created_at`` / ``started_at`` wall-clock timestamps (perf_counter has no
+  shared epoch across enqueue and run, especially across processes).
+- :class:`StructuredJsonFormatter` -- one JSON line per record; folds in the
+  observability extras when present, never absolute paths or other tenants.
+- :func:`emit_job_event` -- emit exactly one ``job.completed`` /
+  ``job.failed`` record from a timings dict + job metadata.
+- :func:`init_sentry` -- no-op when ``SENTRY_DSN`` is unset; PII-scrubbed
+  init otherwise.
+
+Timings contract (persisted to ``compute_jobs.timings`` and emitted verbatim
+in the job event)::
+
+    {
+      "queue_wait_ms": float | null,  # (started - created) ms, null if unknown
+      "total_ms": float,              # whole-body perf_counter delta, always present
+      "phases": [ {"name": str, "ms": float}, ... ],  # closed phases, in order
+      "meta": { ...small scalars... } # job-specific: input_bytes, encoder, ...
+    }
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+# Job-event field names that ride on a LogRecord as ``extra=`` and that the
+# JSON formatter folds into its output. Centralised so the formatter and the
+# emitter cannot drift.
+_EVENT_EXTRA_FIELDS = ("event", "job_kind", "user_id", "status", "timings", "job_error")
+
+
+def _queue_wait_ms(created_at: datetime | None, started_at: datetime | None) -> float | None:
+    """Enqueue->start latency in milliseconds, or ``None`` when unknowable.
+
+    Returns ``None`` when either timestamp is missing or when ``started_at``
+    precedes ``created_at`` (a clock-skew guard: a negative queue wait is
+    never meaningful, so we report unknown rather than a bogus negative).
+    """
+    if created_at is None or started_at is None:
+        return None
+    # Production rows are tz-aware (Postgres TIMESTAMPTZ); SQLite (unit tests)
+    # round-trips naive datetimes. Normalise naive values to UTC so the
+    # subtraction never raises on a mixed-awareness pair.
+    created = created_at if created_at.tzinfo is not None else created_at.replace(tzinfo=UTC)
+    started = started_at if started_at.tzinfo is not None else started_at.replace(tzinfo=UTC)
+    delta = (started - created).total_seconds()
+    if delta < 0:
+        return None
+    return delta * 1000.0
+
+
+class PhaseTimer:
+    """Records per-phase and whole-body durations for one job run.
+
+    Pure: no file I/O, no DB, no logging. The backend ``_run`` owns the
+    instance (built from the row's ``created_at`` / ``started_at``), the body
+    opens phases through it, and the backend persists ``build()`` once and
+    emits the event once. The body never persists or logs the timings itself.
+    """
+
+    def __init__(
+        self,
+        *,
+        created_at: datetime | None = None,
+        started_at: datetime | None = None,
+    ) -> None:
+        # Wall-clock row timestamps drive queue_wait_ms (perf_counter cannot:
+        # it has no epoch shared across enqueue and run, which in hosted mode
+        # happen in different processes).
+        self._created_at = created_at
+        self._started_at = started_at
+        # perf_counter origin for total_ms.
+        self._t0 = time.perf_counter()
+        self._phases: list[dict[str, Any]] = []
+        self._meta: dict[str, Any] = {}
+        self._open: str | None = None
+
+    @contextlib.contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        """Time a phase, recording its duration EVEN IF the body raises.
+
+        The recorded ``{"name", "ms"}`` is appended in a ``finally`` so a
+        crash mid-phase still leaves the phases that ran (including this one)
+        in ``build()``'s output -- that is what lets ``job.failed`` carry the
+        partial timeline. Nesting is allowed but discouraged; each phase
+        records independently. The original exception propagates unchanged.
+        """
+        prev_open = self._open
+        self._open = name
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            self._phases.append({"name": name, "ms": elapsed_ms})
+            self._open = prev_open
+
+    def set_meta(self, **kv: object) -> None:
+        """Merge small scalars into the per-job ``meta`` dict."""
+        self._meta.update(kv)
+
+    def add_meta(self, key: str, value: object) -> None:
+        """Set a single ``meta`` scalar."""
+        self._meta[key] = value
+
+    def build(self) -> dict[str, Any]:
+        """Return the timings dict. ``total_ms`` is computed at call time.
+
+        Safe to call multiple times (e.g. once on the failure path and once
+        on success); each call recomputes ``total_ms`` from the perf_counter
+        origin and re-derives ``queue_wait_ms`` from the row timestamps.
+        """
+        total_ms = (time.perf_counter() - self._t0) * 1000.0
+        return {
+            "queue_wait_ms": _queue_wait_ms(self._created_at, self._started_at),
+            "total_ms": total_ms,
+            "phases": list(self._phases),
+            "meta": dict(self._meta),
+        }
+
+
+class StructuredJsonFormatter(logging.Formatter):
+    """Render each record as a single JSON line.
+
+    Always emits ``ts`` / ``level`` / ``logger`` / ``msg``. When a record
+    carries the observability extras (``event`` etc., set by
+    :func:`emit_job_event`), those are folded in. Records WITHOUT the extras
+    (ordinary log lines) still produce a valid JSON line -- the hosted stdout
+    stream stays uniformly JSON for log capture.
+
+    Safety: this never reaches into the record for absolute paths or other
+    tenants' identifiers. The only tenant id it emits is ``user_id`` (the
+    owning tenant, which the spec marks safe to log); callers are responsible
+    for not putting paths or foreign ids into the extras in the first place.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if hasattr(record, "event"):
+            for field in _EVENT_EXTRA_FIELDS:
+                if hasattr(record, field):
+                    value = getattr(record, field)
+                    if field == "job_error" and value is None:
+                        continue
+                    payload[field] = value
+        return json.dumps(payload, ensure_ascii=True, default=str)
+
+
+def emit_job_event(
+    logger: logging.Logger,
+    *,
+    event: str,
+    kind: str,
+    user_id: str,
+    status: str,
+    timings: dict[str, Any],
+    error: str | None = None,
+) -> None:
+    """Emit exactly one structured job-lifecycle log record.
+
+    ``event`` is ``"job.completed"`` or ``"job.failed"``. The record carries
+    the observability extras the :class:`StructuredJsonFormatter` serialises
+    in hosted mode; in local mode the same record renders as a plain INFO
+    line. The caller emits this once per job from the backend's terminal
+    path, so partial timings from a raised body are still logged.
+
+    Never pass absolute paths or another tenant's id in any argument:
+    ``user_id`` is the owning tenant (safe), and ``error`` should be a
+    path-free ``str(exc)``.
+    """
+    extra: dict[str, Any] = {
+        "event": event,
+        "job_kind": kind,
+        "user_id": user_id,
+        "status": status,
+        "timings": timings,
+    }
+    if error is not None:
+        extra["job_error"] = error
+    logger.info("%s kind=%s status=%s", event, kind, status, extra=extra)
+
+
+def init_sentry(*, component: str) -> None:
+    """Initialise Sentry for ``component`` (``"web"`` / ``"worker"``).
+
+    No-op when ``SENTRY_DSN`` is unset or empty, and a no-op when the
+    ``sentry_sdk`` wheel is absent (slim local installs do not ship it).
+    Integrations are imported defensively: a missing or renamed integration
+    is skipped, never fatal, so the hosted ``uv lock`` stays unpinned within
+    its group.
+
+    PII is scrubbed: ``send_default_pii=False`` plus a ``before_send`` hook
+    that drops request cookies, the ``Authorization`` header, and the
+    magic-link token query parameter before an event leaves the process.
+    """
+    dsn = os.environ.get("SENTRY_DSN", "").strip()
+    if not dsn:
+        return
+
+    try:
+        import sentry_sdk
+    except ImportError:  # pragma: no cover - wheel absent in slim local installs
+        return
+
+    environment = os.environ.get("SPLITSMITH_ENV") or os.environ.get("SPLITSMITH_MODE") or "unknown"
+
+    try:
+        traces_sample_rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+    except ValueError:
+        traces_sample_rate = 0.0
+
+    integrations: list[Any] = []
+    try:
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
+
+        integrations.append(FastApiIntegration())
+    except Exception:  # noqa: BLE001 - missing/renamed integration is skipped, not fatal
+        pass
+    try:
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        integrations.append(LoggingIntegration(event_level=logging.ERROR))
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from sentry_sdk.integrations.asyncpg import AsyncPGIntegration
+
+        integrations.append(AsyncPGIntegration())
+    except Exception:  # noqa: BLE001
+        pass
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=environment,
+        send_default_pii=False,
+        traces_sample_rate=traces_sample_rate,
+        integrations=integrations,
+        before_send=_scrub_event,
+    )
+    sentry_sdk.set_tag("component", component)
+
+
+def capture_job_exception(exc: BaseException, *, kind: str, user_id: str) -> None:
+    """Report a failed worker job to Sentry, tagged with its kind + owner.
+
+    The worker converts a job-body exception into a ``job.failed`` INFO log
+    (not ERROR), so the ``LoggingIntegration`` event floor never picks it up;
+    this is the explicit hook that surfaces worker crashes in Sentry the way
+    the FastAPI integration already surfaces web errors. No-op when the
+    ``sentry_sdk`` wheel is absent (slim installs) or Sentry was never
+    initialised (no ``SENTRY_DSN``): ``capture_exception`` is itself a no-op
+    against the disabled default hub.
+    """
+    try:
+        import sentry_sdk
+    except ImportError:  # pragma: no cover - wheel absent in slim local installs
+        return
+    with sentry_sdk.push_scope() as scope:
+        scope.set_tag("job_kind", kind)
+        scope.set_tag("user_id", user_id)
+        sentry_sdk.capture_exception(exc)
+
+
+def _scrub_event(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+    """Strip cookies, the Authorization header, and the magic-link token.
+
+    Belt-and-braces on top of ``send_default_pii=False``: we never want a
+    session cookie, bearer token, or sign-in token landing in Sentry.
+    """
+    request = event.get("request")
+    if isinstance(request, dict):
+        request.pop("cookies", None)
+        headers = request.get("headers")
+        if isinstance(headers, dict):
+            for key in list(headers):
+                if key.lower() == "authorization":
+                    headers.pop(key)
+        query_string = request.get("query_string")
+        if isinstance(query_string, str) and "token=" in query_string:
+            request["query_string"] = _drop_token_param(query_string)
+    return event
+
+
+def _drop_token_param(query_string: str) -> str:
+    """Remove a ``token=...`` pair from a raw query string."""
+    parts = [p for p in query_string.split("&") if not p.startswith("token=")]
+    return "&".join(parts)

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -41,12 +41,17 @@ today is zero.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import procrastinate
+
+from .observability import init_sentry
+
+logger = logging.getLogger(__name__)
 
 # asyncpg-only SQLAlchemy URL query params that libpq / psycopg3 does not
 # understand and rejects with "invalid URI query parameter". They're
@@ -309,10 +314,31 @@ async def run_worker(
     bootstrap upserts the user row synchronously), so it can't run inside
     this coroutine's event loop -- it's offloaded to a worker thread,
     which has no running loop of its own.
+
+    Sentry is initialised first (no-op unless ``SENTRY_DSN`` is set). After
+    the state is built, ``_configure_app_logging`` attaches the same stdout
+    handler the web process uses -- in hosted mode that is the structured
+    JSON formatter, so worker ``job.completed`` / ``job.failed`` events are
+    captured by the platform the same way. Finally the ensemble singleton is
+    warmed on a worker thread so the first ``shot_detect`` does not pay a
+    hidden cold model load; a warmup failure is logged and swallowed so the
+    worker still drains non-shot_detect jobs (the cold cost is then timed as
+    the ``cold_model_load`` phase on the first detection).
     """
-    from .ui.server import build_worker_state
+    init_sentry(component="worker")
+
+    from .ui.server import (
+        _configure_app_logging,
+        build_worker_state,
+        warm_ensemble_runtime,
+    )
 
     state = await asyncio.to_thread(build_worker_state)
+    _configure_app_logging()
+    try:
+        await asyncio.to_thread(warm_ensemble_runtime)
+    except Exception:  # noqa: BLE001 - warmup is best-effort; cold load is re-timed at job time
+        logger.warning("ensemble warmup failed on worker boot; first shot_detect will cold-load")
     app = build_app(database_url)
     register_compute_task(app, state)
     async with app.open_async():

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -58,6 +58,8 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel
 
+from ..observability import PhaseTimer, emit_job_event
+
 logger = logging.getLogger(__name__)
 
 
@@ -213,6 +215,11 @@ class Job(BaseModel):
     # kind: the SPA branches on ``Job.kind`` to interpret the dict. Stays
     # ``None`` for jobs that signal success solely by writing files.
     result: dict[str, Any] | None = None
+    # Per-job observability metadata persisted on completion: queue_wait_ms,
+    # total_ms, phases[], and a small meta{} of job-specific scalars. Set once
+    # by the backend from the run's :class:`PhaseTimer`; ``None`` until the job
+    # finishes (and on jobs that pre-date the column).
+    timings: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
     started_at: datetime | None = None
@@ -227,13 +234,43 @@ class JobHandle:
     the polling endpoint always observing a consistent snapshot.
     """
 
-    def __init__(self, registry: JobRegistry, job_id: str) -> None:
+    def __init__(
+        self,
+        registry: JobRegistry,
+        job_id: str,
+        *,
+        timer: PhaseTimer | None = None,
+    ) -> None:
         self._registry = registry
         self._job_id = job_id
+        # The per-run :class:`PhaseTimer`, attached by the backend's ``_run``
+        # before the body executes. A body opens phases via
+        # ``with handle.timer.phase("..."):`` and records scalars via
+        # ``handle.timer.set_meta(...)``. The backend owns the single
+        # persist + emit of ``timer.build()`` on the terminal path; the body
+        # never persists or logs the timings itself.
+        self._timer = timer if timer is not None else PhaseTimer()
 
     @property
     def id(self) -> str:
         return self._job_id
+
+    @property
+    def timer(self) -> PhaseTimer:
+        """The :class:`PhaseTimer` for this run.
+
+        Always non-``None`` so bodies can call ``handle.timer.phase(...)``
+        unconditionally in either backend (local desktop or hosted worker).
+        """
+        return self._timer
+
+    def set_timings(self, payload: dict[str, Any]) -> None:
+        """Persist the built timings dict onto the job snapshot/row.
+
+        Normally the backend persists ``handle.timer.build()`` itself on the
+        terminal path; this is the explicit bridge for that single write.
+        """
+        self._registry._patch(self._job_id, timings=payload)
 
     def update(
         self,
@@ -644,6 +681,7 @@ class JobRegistry:
     # ------------------------------------------------------------------
 
     def _run(self, job_id: str, fn: Callable[[JobHandle], None]) -> None:
+        timer: PhaseTimer | None = None
         try:
             with self._lock:
                 j = self._jobs.get(job_id)
@@ -663,17 +701,28 @@ class JobRegistry:
                 j.status = JobStatus.RUNNING
                 j.started_at = datetime.now(UTC)
                 j.updated_at = j.started_at
+                kind = j.kind
+                created_at = j.created_at
+                started_at = j.started_at
+            # Build the timer AFTER the row is RUNNING so created_at/started_at
+            # are populated; the body opens phases through ``handle.timer``.
+            timer = PhaseTimer(created_at=created_at, started_at=started_at)
             try:
-                fn(JobHandle(self, job_id))
+                fn(JobHandle(self, job_id, timer=timer))
             except JobCancelled:
                 with self._lock:
                     j = self._jobs.get(job_id)
                     if j is not None:
                         j.status = JobStatus.CANCELLED
+                        j.timings = timer.build()
                         j.finished_at = datetime.now(UTC)
                         j.updated_at = j.finished_at
+                        final_status = JobStatus.CANCELLED
+                    else:
+                        final_status = None
                     self._subprocs.pop(job_id, None)
                     self._trim_retained_locked()
+                self._emit_terminal_event(job_id, kind, final_status, timer, error=None)
                 return
             except Exception as exc:  # noqa: BLE001 -- worker exceptions become job state
                 logger.exception("job %s failed", job_id)
@@ -686,29 +735,72 @@ class JobRegistry:
                         # asked for the abort, the noisy stderr is expected.
                         if j.cancel_requested:
                             j.status = JobStatus.CANCELLED
+                            final_status = JobStatus.CANCELLED
+                            final_error = None
                         else:
                             j.status = JobStatus.FAILED
                             j.error = str(exc)
+                            final_status = JobStatus.FAILED
+                            final_error = str(exc)
+                        j.timings = timer.build()
                         j.finished_at = datetime.now(UTC)
                         j.updated_at = j.finished_at
+                    else:
+                        final_status = None
+                        final_error = None
                     self._subprocs.pop(job_id, None)
                     self._trim_retained_locked()
+                self._emit_terminal_event(job_id, kind, final_status, timer, error=final_error)
                 return
             with self._lock:
                 j = self._jobs.get(job_id)
+                final_status = None
                 if j is not None and j.status == JobStatus.RUNNING:
                     j.status = JobStatus.SUCCEEDED
                     if j.progress is None or j.progress < 1.0:
                         j.progress = 1.0
+                    j.timings = timer.build()
                     j.finished_at = datetime.now(UTC)
                     j.updated_at = j.finished_at
+                    final_status = JobStatus.SUCCEEDED
                 self._subprocs.pop(job_id, None)
                 self._trim_retained_locked()
+            self._emit_terminal_event(job_id, kind, final_status, timer, error=None)
         finally:
             with self._lock:
                 self._running_count = max(0, self._running_count - 1)
                 self._dispatch_locked()
                 self._signal_drain_if_complete_locked()
+
+    def _emit_terminal_event(
+        self,
+        job_id: str,
+        kind: str,
+        status: JobStatus | None,
+        timer: PhaseTimer,
+        *,
+        error: str | None,
+    ) -> None:
+        """Emit exactly one ``job.completed``/``job.failed`` log line.
+
+        Called once per job from each terminal path of :meth:`_run`. Local
+        mode has no tenant, so ``user_id`` is the ``"local"`` sentinel; the
+        plain-text formatter renders the record as an ordinary INFO line.
+        ``status is None`` means the row vanished mid-run (evicted) -- nothing
+        to report.
+        """
+        if status is None:
+            return
+        event = "job.completed" if status == JobStatus.SUCCEEDED else "job.failed"
+        emit_job_event(
+            logger,
+            event=event,
+            kind=kind,
+            user_id="local",
+            status=status.value,
+            timings=timer.build(),
+            error=error,
+        )
 
     def _dispatch_locked(self) -> None:
         """Hand the highest-priority pending job to the executor.

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -144,6 +144,7 @@ from ..fixture_schema import (
     probe_camera_metadata,
 )
 from ..match_registry import MatchRegistry
+from ..observability import StructuredJsonFormatter, init_sentry
 from ..runtime import runtime as process_runtime
 from ..storage import Storage
 from . import audio as audio_helpers
@@ -295,7 +296,13 @@ def _configure_app_logging(stream: Any | None = None) -> None:
     if any(getattr(h, "_splitsmith_stdout", False) for h in pkg_logger.handlers):
         return
     handler = logging.StreamHandler(stream if stream is not None else sys.stdout)
-    handler.setFormatter(logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
+    if _hosted_mode_active():
+        # Hosted stdout is captured by the platform as structured logs: emit
+        # one JSON line per record (folding in the job.completed/job.failed
+        # observability extras). Local file logging stays plain text.
+        handler.setFormatter(StructuredJsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
     handler._splitsmith_stdout = True  # type: ignore[attr-defined]  # idempotence marker
     pkg_logger.addHandler(handler)
     if pkg_logger.level == logging.NOTSET or pkg_logger.level > logging.INFO:
@@ -1211,6 +1218,33 @@ def _get_ensemble_runtime() -> ensemble_module.EnsembleRuntime:
     return _ENSEMBLE_RUNTIME
 
 
+def _ensemble_runtime_is_warm() -> bool:
+    """``True`` when the ensemble singleton is already loaded in this process.
+
+    Cheap, lock-free read of the module global. Used by ``_run_shot_detect``
+    to decide whether the upcoming model resolution pays a cold load (timed
+    as the ``cold_model_load`` phase) or hits the warm cache. The worker's
+    boot-time warmup populates the singleton so the steady-state path reports
+    warm.
+    """
+    return _ENSEMBLE_RUNTIME is not None
+
+
+def warm_ensemble_runtime() -> None:
+    """Force the ensemble singleton to load now (worker-boot warmup).
+
+    Thin public wrapper over :func:`_get_ensemble_runtime` so the worker
+    entrypoint (``splitsmith.queue.run_worker``) can populate
+    ``_ENSEMBLE_RUNTIME`` before the first ``shot_detect`` job runs, keeping
+    the underscore-private loader internal. Returns nothing -- callers warm
+    the cache for its side effect, not its value. The model load happens on
+    a worker thread (``asyncio.to_thread``) so it never blocks the event
+    loop; a failure here is non-fatal and is re-attempted (and timed as the
+    ``cold_model_load`` phase) on the first shot-detect job.
+    """
+    _get_ensemble_runtime()
+
+
 def _run_model_download_job(handle: JobHandle) -> None:
     """Prefetch every missing slim ONNX artifact from R2.
 
@@ -1396,26 +1430,29 @@ def register_job_bodies(state: AppState) -> None:
         own and the SPA can re-trim later.
         """
         handle.update(progress=0.05, message="Loading project...")
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        video = stg.find_video_by_id(video_id)
-        if video is None:
-            raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
-        source = proj.resolve_video_path(state.shooter_root(slug), video.path)
+        with handle.timer.phase("load_project"):
+            proj = state.shooter_project(slug)
+            stg = proj.stage(stage_number)
+            video = stg.find_video_by_id(video_id)
+            if video is None:
+                raise RuntimeError(f"video {video_id} disappeared from stage {stage_number} mid-flight")
+            source = proj.resolve_video_path(state.shooter_root(slug), video.path)
+        handle.timer.set_meta(role=video.role)
         role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
         handle.update(
             progress=0.15,
             message=f"Extracting audio + detecting beep ({role_label})...",
         )
         try:
-            beep = audio_helpers.detect_video_beep(
-                state.shooter_root(slug),
-                stage_number,
-                video,
-                source,
-                project=proj,
-                ffmpeg_binary=process_runtime().ffmpeg_binary,
-            )
+            with handle.timer.phase("beep_detect"):
+                beep = audio_helpers.detect_video_beep(
+                    state.shooter_root(slug),
+                    stage_number,
+                    video,
+                    source,
+                    project=proj,
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
+                )
         except beep_detect.BeepNotFoundError as exc:
             # Primary failure is fatal -- the entire downstream pipeline
             # (trim window, shot timeline) hangs off the primary beep.
@@ -1439,7 +1476,8 @@ def register_job_bodies(state: AppState) -> None:
             # same room means the loudness envelopes line up modulo a
             # constant time offset, even when the secondary's mic missed
             # the sustained 2-5 kHz tone the in-stream detector wants.
-            aligned = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
+            with handle.timer.phase("cross_align"):
+                aligned = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
             video.beep_peak_amplitude = None
             video.beep_duration_ms = None
             video.beep_candidates = []
@@ -1518,7 +1556,10 @@ def register_job_bodies(state: AppState) -> None:
             # trust the in-stream answer; when they disagree we let the
             # user decide.
             if video.role != "primary":
-                check = _try_align_secondary_to_primary(state.shooter_root(slug), proj, stg, video, handle)
+                with handle.timer.phase("cross_align"):
+                    check = _try_align_secondary_to_primary(
+                        state.shooter_root(slug), proj, stg, video, handle
+                    )
                 if check is not None and check.confidence >= _align_confidence_floor:
                     video.beep_alignment_confidence = check.confidence
                     video.beep_alignment_delta_ms = (beep.time - check.secondary_beep_time) * 1000.0
@@ -1528,17 +1569,18 @@ def register_job_bodies(state: AppState) -> None:
             handle.check_cancel()
             handle.update(progress=0.55, message=f"Trimming audit clip ({role_label})...")
             try:
-                audio_helpers.ensure_video_audit_trim(
-                    state.shooter_root(slug),
-                    stage_number,
-                    video,
-                    source,
-                    video.beep_time,
-                    stg.time_seconds,
-                    project=proj,
-                    runner=_cancellable_runner(handle),
-                    ffmpeg_binary=process_runtime().ffmpeg_binary,
-                )
+                with handle.timer.phase("trim"):
+                    audio_helpers.ensure_video_audit_trim(
+                        state.shooter_root(slug),
+                        stage_number,
+                        video,
+                        source,
+                        video.beep_time,
+                        stg.time_seconds,
+                        project=proj,
+                        runner=_cancellable_runner(handle),
+                        ffmpeg_binary=process_runtime().ffmpeg_binary,
+                    )
                 video.processed["trim"] = True
                 trimmed_ok = True
             except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
@@ -1558,27 +1600,29 @@ def register_job_bodies(state: AppState) -> None:
         # copying our targeted fields onto the fresh project preserves
         # those concurrent edits instead of stomping them with the
         # snapshot we loaded at job start.
-        fresh = state.shooter_project(slug)
-        try:
-            stg_fresh = fresh.stage(stage_number)
-        except KeyError:
-            stg_fresh = None
-        v_fresh = stg_fresh.find_video_by_id(video_id) if stg_fresh is not None else None
-        if v_fresh is not None:
-            v_fresh.beep_time = video.beep_time
-            v_fresh.beep_source = video.beep_source
-            v_fresh.beep_peak_amplitude = video.beep_peak_amplitude
-            v_fresh.beep_duration_ms = video.beep_duration_ms
-            v_fresh.beep_confidence = video.beep_confidence
-            v_fresh.beep_candidates = list(video.beep_candidates)
-            v_fresh.beep_reviewed = video.beep_reviewed
-            v_fresh.beep_auto_detect_failed = video.beep_auto_detect_failed
-            v_fresh.beep_alignment_confidence = video.beep_alignment_confidence
-            v_fresh.beep_alignment_delta_ms = video.beep_alignment_delta_ms
-            v_fresh.processed["beep"] = True
-            if trimmed_ok:
-                v_fresh.processed["trim"] = True
-            fresh.save(state.shooter_root(slug))
+        with handle.timer.phase("persist"):
+            fresh = state.shooter_project(slug)
+            try:
+                stg_fresh = fresh.stage(stage_number)
+            except KeyError:
+                stg_fresh = None
+            v_fresh = stg_fresh.find_video_by_id(video_id) if stg_fresh is not None else None
+            if v_fresh is not None:
+                v_fresh.beep_time = video.beep_time
+                v_fresh.beep_source = video.beep_source
+                v_fresh.beep_peak_amplitude = video.beep_peak_amplitude
+                v_fresh.beep_duration_ms = video.beep_duration_ms
+                v_fresh.beep_confidence = video.beep_confidence
+                v_fresh.beep_candidates = list(video.beep_candidates)
+                v_fresh.beep_reviewed = video.beep_reviewed
+                v_fresh.beep_auto_detect_failed = video.beep_auto_detect_failed
+                v_fresh.beep_alignment_confidence = video.beep_alignment_confidence
+                v_fresh.beep_alignment_delta_ms = video.beep_alignment_delta_ms
+                v_fresh.processed["beep"] = True
+                if trimmed_ok:
+                    v_fresh.processed["trim"] = True
+                fresh.save(state.shooter_root(slug))
+        handle.timer.set_meta(trimmed=trimmed_ok)
         if trimmed_ok and video.role == "primary" and video.beep_reviewed:
             # Shot detection is primary-only AND gated on
             # ``beep_reviewed`` (#71). That flag is True either because
@@ -1635,36 +1679,40 @@ def register_job_bodies(state: AppState) -> None:
         trim caches without re-running detection over the whole match.
         """
         handle.update(progress=0.1, message="Preparing trim...")
-        proj = state.shooter_project(slug)
-        root = state.shooter_root(slug)
-        stg = proj.stage(stage_number)
-        video = stg.find_video_by_id(video_id)
-        if video is None or video.beep_time is None:
-            raise RuntimeError("video or beep disappeared mid-flight")
-        source = proj.resolve_video_path(root, video.path)
+        with handle.timer.phase("load_project"):
+            proj = state.shooter_project(slug)
+            root = state.shooter_root(slug)
+            stg = proj.stage(stage_number)
+            video = stg.find_video_by_id(video_id)
+            if video is None or video.beep_time is None:
+                raise RuntimeError("video or beep disappeared mid-flight")
+            source = proj.resolve_video_path(root, video.path)
+        handle.timer.set_meta(role=video.role)
         handle.check_cancel()
         role_label = "primary" if video.role == "primary" else f"cam {video.video_id[:6]}"
         handle.update(progress=0.3, message=f"Encoding short-GOP MP4 ({role_label})...")
-        audio_helpers.ensure_video_audit_trim(
-            root,
-            stage_number,
-            video,
-            source,
-            video.beep_time,
-            stg.time_seconds,
-            project=proj,
-            runner=_cancellable_runner(handle),
-            ffmpeg_binary=process_runtime().ffmpeg_binary,
-        )
+        with handle.timer.phase("trim"):
+            audio_helpers.ensure_video_audit_trim(
+                root,
+                stage_number,
+                video,
+                source,
+                video.beep_time,
+                stg.time_seconds,
+                project=proj,
+                runner=_cancellable_runner(handle),
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
+            )
         handle.update(progress=0.85, message="Saving project...")
-        # Read-modify-write to avoid stomping concurrent edits made
-        # while ffmpeg was running (e.g. another stage's beep review).
-        fresh = state.shooter_project(slug)
-        stg_fresh = fresh.stage(stage_number)
-        v_fresh = stg_fresh.find_video_by_id(video_id)
-        if v_fresh is not None:
-            v_fresh.processed["trim"] = True
-            fresh.save(root)
+        with handle.timer.phase("persist"):
+            # Read-modify-write to avoid stomping concurrent edits made
+            # while ffmpeg was running (e.g. another stage's beep review).
+            fresh = state.shooter_project(slug)
+            stg_fresh = fresh.stage(stage_number)
+            v_fresh = stg_fresh.find_video_by_id(video_id)
+            if v_fresh is not None:
+                v_fresh.processed["trim"] = True
+                fresh.save(root)
         # Worker callback runs in a ThreadPoolExecutor thread with no
         # event loop; bridge to the async JobBackend via ``asyncio.run``.
         #
@@ -1725,17 +1773,18 @@ def register_job_bodies(state: AppState) -> None:
         top-(K+slack) mode and the apriori boost lifts the top-K
         confidence-ranked candidates over the consensus line.
         """
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        prim = stg.primary()
-        if prim is None or prim.beep_time is None:
-            raise RuntimeError(f"stage {stage_number} has no primary or no beep yet")
-        if stg.time_seconds <= 0:
-            raise RuntimeError(
-                f"stage {stage_number} has time_seconds=0; import a "
-                "scoreboard before running shot detection"
-            )
-        source = proj.resolve_video_path(state.shooter_root(slug), prim.path)
+        with handle.timer.phase("load_project"):
+            proj = state.shooter_project(slug)
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            if prim is None or prim.beep_time is None:
+                raise RuntimeError(f"stage {stage_number} has no primary or no beep yet")
+            if stg.time_seconds <= 0:
+                raise RuntimeError(
+                    f"stage {stage_number} has time_seconds=0; import a "
+                    "scoreboard before running shot detection"
+                )
+            source = proj.resolve_video_path(state.shooter_root(slug), prim.path)
 
         # Re-detect-all on an old project (and the v1->v2 cache migration in
         # #298) leaves stages with no trimmed MP4 cached. Without that file,
@@ -1746,25 +1795,26 @@ def register_job_bodies(state: AppState) -> None:
         # the audit cache in the same state the beep-detect path would have.
         handle.update(progress=0.05, message="Ensuring audit trim...")
         try:
-            audio_helpers.ensure_video_audit_trim(
-                state.shooter_root(slug),
-                stage_number,
-                prim,
-                source,
-                prim.beep_time,
-                stg.time_seconds,
-                project=proj,
-                runner=_cancellable_runner(handle),
-                ffmpeg_binary=process_runtime().ffmpeg_binary,
-            )
-            trim_fresh = state.shooter_project(slug)
-            try:
-                v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
-            except KeyError:
-                v_fresh = None
-            if v_fresh is not None and not v_fresh.processed.get("trim"):
-                v_fresh.processed["trim"] = True
-                trim_fresh.save(state.shooter_root(slug))
+            with handle.timer.phase("ensure_trim"):
+                audio_helpers.ensure_video_audit_trim(
+                    state.shooter_root(slug),
+                    stage_number,
+                    prim,
+                    source,
+                    prim.beep_time,
+                    stg.time_seconds,
+                    project=proj,
+                    runner=_cancellable_runner(handle),
+                    ffmpeg_binary=process_runtime().ffmpeg_binary,
+                )
+                trim_fresh = state.shooter_project(slug)
+                try:
+                    v_fresh = trim_fresh.stage(stage_number).find_video_by_id(prim.video_id)
+                except KeyError:
+                    v_fresh = None
+                if v_fresh is not None and not v_fresh.processed.get("trim"):
+                    v_fresh.processed["trim"] = True
+                    trim_fresh.save(state.shooter_root(slug))
         except (FileNotFoundError, audio_helpers.AudioExtractionError) as exc:
             # Soft failure: detection can still proceed against the source
             # WAV. ensure_audit_audio's fallback handles the missing trim,
@@ -1776,14 +1826,15 @@ def register_job_bodies(state: AppState) -> None:
             )
 
         handle.update(progress=0.1, message="Preparing audio...")
-        audit = audio_helpers.ensure_audit_audio(
-            state.shooter_root(slug),
-            stage_number,
-            source,
-            prim.beep_time,
-            project=proj,
-            ffmpeg_binary=process_runtime().ffmpeg_binary,
-        )
+        with handle.timer.phase("prepare_audio"):
+            audit = audio_helpers.ensure_audit_audio(
+                state.shooter_root(slug),
+                stage_number,
+                source,
+                prim.beep_time,
+                project=proj,
+                ffmpeg_binary=process_runtime().ffmpeg_binary,
+            )
         beep_in_clip = audit.beep_in_clip if audit.beep_in_clip is not None else prim.beep_time
 
         # Read existing audit JSON up-front: we need ``stage_rounds.expected``
@@ -1791,33 +1842,34 @@ def register_job_bodies(state: AppState) -> None:
         # apriori boost) and we'll merge results back into the same dict.
         # Hosted: pull the existing audit fresh first so a prior API/worker
         # write isn't lost when we merge + push back.
-        existing_json, audit_version = state.load_audit(slug, stage_number)
-        if existing_json is None:
-            existing_json = {
-                "stage_number": stg.stage_number,
-                "stage_name": stg.stage_name,
-                "stage_time_seconds": stg.time_seconds,
-                "beep_time": round(beep_in_clip, 4),
-                "shots": [],
-            }
-        # Carry stage_rounds (min_rounds + target breakdown) from the
-        # project state into the audit JSON so the ensemble's adaptive
-        # voter C + apriori boost can consume ``stage_rounds.expected``.
-        # Project value wins over a stale audit-JSON copy: re-running
-        # detection after a scoreboard refresh should pick up the new
-        # round count without manual edits.
-        if stg.stage_rounds is not None:
-            existing_json["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
-        expected_rounds: int | None = None
-        sr_block = existing_json.get("stage_rounds")
-        if isinstance(sr_block, dict):
-            raw = sr_block.get("expected")
-            if isinstance(raw, int) and raw > 0:
-                expected_rounds = raw
+        with handle.timer.phase("load_audit_state"):
+            existing_json, audit_version = state.load_audit(slug, stage_number)
+            if existing_json is None:
+                existing_json = {
+                    "stage_number": stg.stage_number,
+                    "stage_name": stg.stage_name,
+                    "stage_time_seconds": stg.time_seconds,
+                    "beep_time": round(beep_in_clip, 4),
+                    "shots": [],
+                }
+            # Carry stage_rounds (min_rounds + target breakdown) from the
+            # project state into the audit JSON so the ensemble's adaptive
+            # voter C + apriori boost can consume ``stage_rounds.expected``.
+            # Project value wins over a stale audit-JSON copy: re-running
+            # detection after a scoreboard refresh should pick up the new
+            # round count without manual edits.
+            if stg.stage_rounds is not None:
+                existing_json["stage_rounds"] = stg.stage_rounds.model_dump(mode="json", exclude_none=True)
+            expected_rounds: int | None = None
+            sr_block = existing_json.get("stage_rounds")
+            if isinstance(sr_block, dict):
+                raw = sr_block.get("expected")
+                if isinstance(raw, int) and raw > 0:
+                    expected_rounds = raw
 
         handle.update(progress=0.2, message="Loading ensemble models...")
-        handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
-        audio_array, sr = beep_detect.load_audio(audit.audio_path)
+        with handle.timer.phase("audio_load"):
+            audio_array, sr = beep_detect.load_audio(audit.audio_path)
         # Camera-class dispatch (issue #143). When the primary's mount
         # is set, look up handheld vs. headcam thresholds; otherwise
         # the ensemble falls back to the default class (headcam).
@@ -1828,42 +1880,57 @@ def register_job_bodies(state: AppState) -> None:
         # AND the source video to be reachable.
         enable_e = os.environ.get("SPLITSMITH_ENABLE_VOTER_E") == "1"
         ensemble_cfg = ensemble_module.EnsembleConfig(enable_voter_e=enable_e)
-        result = state.compute.detect_stage(
-            audio=audio_array,
-            sample_rate=sr,
-            beep_time_in_clip=beep_in_clip,
-            stage_time_seconds=stg.time_seconds,
-            expected_rounds=expected_rounds,
-            ensemble_config=ensemble_cfg,
-            camera_class=cam_class,
-            camera_make=prim.camera_make,
-            camera_model=prim.camera_model,
-            video_path=source if enable_e else None,
-            source_beep_time=prim.beep_time if enable_e else None,
-        )
+
+        # Cold-model-load is timed as its own phase ONLY when the singleton
+        # isn't already populated (a worker that warmed at boot, or a prior
+        # detect in this process, reports warm and skips it). Forcing the
+        # resolution here so ``detect_stage`` below then hits the warm cache
+        # means the heavy weight load never hides inside ``ensemble_infer``.
+        cold = not _ensemble_runtime_is_warm()
+        handle.timer.set_meta(cold_model_load=cold, expected_rounds=expected_rounds)
+        if cold:
+            with handle.timer.phase("cold_model_load"):
+                _get_ensemble_runtime()
+
+        handle.update(progress=0.4, message="Detecting shots (4-voter ensemble)...")
+        with handle.timer.phase("ensemble_infer"):
+            result = state.compute.detect_stage(
+                audio=audio_array,
+                sample_rate=sr,
+                beep_time_in_clip=beep_in_clip,
+                stage_time_seconds=stg.time_seconds,
+                expected_rounds=expected_rounds,
+                ensemble_config=ensemble_cfg,
+                camera_class=cam_class,
+                camera_make=prim.camera_make,
+                camera_model=prim.camera_model,
+                video_path=source if enable_e else None,
+                source_beep_time=prim.beep_time if enable_e else None,
+            )
 
         candidates: list[dict[str, Any]] = []
-        for cand in result.candidates:
-            candidates.append(
-                {
-                    "candidate_number": cand.candidate_number,
-                    "time": cand.time,
-                    "ms_after_beep": cand.ms_after_beep,
-                    "peak_amplitude": cand.peak_amplitude,
-                    "confidence": cand.confidence,
-                    "vote_a": cand.vote_a,
-                    "vote_b": cand.vote_b,
-                    "vote_c": cand.vote_c,
-                    "vote_e": cand.vote_e,
-                    "vote_total": cand.vote_total,
-                    "apriori_boost": cand.apriori_boost,
-                    "ensemble_score": cand.ensemble_score,
-                    "score_c": cand.score_c,
-                    "clap_diff": cand.clap_diff,
-                    "gunshot_prob": cand.gunshot_prob,
-                    "voter_e_signal": cand.voter_e_signal,
-                }
-            )
+        with handle.timer.phase("build_candidates"):
+            for cand in result.candidates:
+                candidates.append(
+                    {
+                        "candidate_number": cand.candidate_number,
+                        "time": cand.time,
+                        "ms_after_beep": cand.ms_after_beep,
+                        "peak_amplitude": cand.peak_amplitude,
+                        "confidence": cand.confidence,
+                        "vote_a": cand.vote_a,
+                        "vote_b": cand.vote_b,
+                        "vote_c": cand.vote_c,
+                        "vote_e": cand.vote_e,
+                        "vote_total": cand.vote_total,
+                        "apriori_boost": cand.apriori_boost,
+                        "ensemble_score": cand.ensemble_score,
+                        "score_c": cand.score_c,
+                        "clap_diff": cand.clap_diff,
+                        "gunshot_prob": cand.gunshot_prob,
+                        "voter_e_signal": cand.voter_e_signal,
+                    }
+                )
 
         handle.update(progress=0.85, message="Saving audit JSON...")
 
@@ -1941,28 +2008,35 @@ def register_job_bodies(state: AppState) -> None:
         # save -> StateConflictError. Re-loading and re-merging into the
         # winner's doc preserves that edit (this job *merges*, never blindly
         # overwrites). Local file saves never raise, so this runs once.
-        _save_audit_with_remerge(
-            state,
-            slug,
-            stage_number,
-            doc=existing_json,
-            version=audit_version,
-            merge=_merge_detection_into,
-            default=_default_audit_doc,
-        )
+        with handle.timer.phase("save_audit"):
+            _save_audit_with_remerge(
+                state,
+                slug,
+                stage_number,
+                doc=existing_json,
+                version=audit_version,
+                merge=_merge_detection_into,
+                default=_default_audit_doc,
+            )
 
-        # Read-modify-write the project file: a long-running shot_detect
-        # job must not save the snapshot it loaded at start, because the
-        # user may have toggled ``beep_reviewed`` on other stages in the
-        # interim (the review action kicks shot_detect, so concurrent
-        # bursts are the common case). Reloading from disk and mutating
-        # only the targeted field preserves those concurrent edits.
-        fresh = state.shooter_project(slug)
-        stg_fresh = fresh.stage(stage_number)
-        prim_fresh = stg_fresh.primary()
-        if prim_fresh is not None:
-            prim_fresh.processed["shot_detect"] = True
-            fresh.save(state.shooter_root(slug))
+        with handle.timer.phase("persist_project"):
+            # Read-modify-write the project file: a long-running shot_detect
+            # job must not save the snapshot it loaded at start, because the
+            # user may have toggled ``beep_reviewed`` on other stages in the
+            # interim (the review action kicks shot_detect, so concurrent
+            # bursts are the common case). Reloading from disk and mutating
+            # only the targeted field preserves those concurrent edits.
+            fresh = state.shooter_project(slug)
+            stg_fresh = fresh.stage(stage_number)
+            prim_fresh = stg_fresh.primary()
+            if prim_fresh is not None:
+                prim_fresh.processed["shot_detect"] = True
+                fresh.save(state.shooter_root(slug))
+        handle.timer.set_meta(
+            candidate_count=len(candidates),
+            kept_count=sum(1 for c in result.candidates if c.kept),
+            consensus=result.consensus,
+        )
         handle.update(progress=1.0, message=f"Done -- {len(candidates)} candidates")
 
     def _run_export_for_stage(
@@ -1973,18 +2047,20 @@ def register_job_bodies(state: AppState) -> None:
         from ..config import StageData as EngineStageData
 
         handle.update(progress=0.05, message="Loading project...")
-        proj = state.shooter_project(slug)
-        stg = proj.stage(stage_number)
-        prim = stg.primary()
-        if prim is None or prim.beep_time is None:
-            raise RuntimeError("primary or beep disappeared mid-flight")
+        with handle.timer.phase("load_project"):
+            proj = state.shooter_project(slug)
+            stg = proj.stage(stage_number)
+            prim = stg.primary()
+            if prim is None or prim.beep_time is None:
+                raise RuntimeError("primary or beep disappeared mid-flight")
 
         # Hosted: the audit doc was written by the detect job and lives in
         # state_docs, not this container's FS. Materialize it to the local
         # path the exporter reads (no-op in local mode -- the file is
         # already there). Without this a cross-process export reads a stale
         # or absent audit file.
-        audit_file = state.materialize_audit(slug, stage_number)
+        with handle.timer.phase("materialize_audit"):
+            audit_file = state.materialize_audit(slug, stage_number)
         exports_dir = proj.exports_path(state.shooter_root(slug))
         source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
         engine_stage = EngineStageData(
@@ -2015,48 +2091,51 @@ def register_job_bodies(state: AppState) -> None:
         allowed_ids: set[str] | None = (
             set(req.secondary_video_ids) if req.secondary_video_ids is not None else None
         )
-        secondaries: list[export_helpers.SecondaryExport] = []
-        for sv in stg.videos:
-            if sv.role != "secondary":
-                continue
-            if sv.beep_time is None:
-                continue
-            if allowed_ids is not None and sv.video_id not in allowed_ids:
-                continue
-            sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
-            secondaries.append(
-                export_helpers.SecondaryExport(
-                    video_id=sv.video_id,
-                    source_path=sec_source,
-                    beep_time_in_source=sv.beep_time,
-                    label=f"Cam {sv.video_id}",
+        with handle.timer.phase("prepare_inputs"):
+            secondaries: list[export_helpers.SecondaryExport] = []
+            for sv in stg.videos:
+                if sv.role != "secondary":
+                    continue
+                if sv.beep_time is None:
+                    continue
+                if allowed_ids is not None and sv.video_id not in allowed_ids:
+                    continue
+                sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
+                secondaries.append(
+                    export_helpers.SecondaryExport(
+                        video_id=sv.video_id,
+                        source_path=sec_source,
+                        beep_time_in_source=sv.beep_time,
+                        label=f"Cam {sv.video_id}",
+                    )
                 )
-            )
+        handle.timer.set_meta(secondary_count=len(secondaries))
 
         try:
-            result = export_helpers.export_stage(
-                request=export_helpers.StageExportRequest(
-                    stage_number=stage_number,
-                    write_trim=req.write_trim,
-                    write_csv=req.write_csv,
-                    write_fcpxml=req.write_fcpxml,
-                    write_report=req.write_report,
-                    write_overlay=req.write_overlay,
-                    overlay_codec=req.overlay_codec,
-                    overlay_max_height=req.overlay_max_height,
-                    overlay_max_fps=req.overlay_max_fps,
-                    overlay_theme=req.overlay_theme,
-                ),
-                audit_path=audit_file,
-                exports_dir=exports_dir,
-                source_video_path=source_video if source_video.exists() else None,
-                stage_data=engine_stage,
-                beep_time_in_source=prim.beep_time,
-                pre_buffer_seconds=proj.trim_pre_buffer_seconds,
-                post_buffer_seconds=proj.trim_post_buffer_seconds,
-                config=Config(),
-                secondaries=secondaries,
-            )
+            with handle.timer.phase("export_stage"):
+                result = export_helpers.export_stage(
+                    request=export_helpers.StageExportRequest(
+                        stage_number=stage_number,
+                        write_trim=req.write_trim,
+                        write_csv=req.write_csv,
+                        write_fcpxml=req.write_fcpxml,
+                        write_report=req.write_report,
+                        write_overlay=req.write_overlay,
+                        overlay_codec=req.overlay_codec,
+                        overlay_max_height=req.overlay_max_height,
+                        overlay_max_fps=req.overlay_max_fps,
+                        overlay_theme=req.overlay_theme,
+                    ),
+                    audit_path=audit_file,
+                    exports_dir=exports_dir,
+                    source_video_path=source_video if source_video.exists() else None,
+                    stage_data=engine_stage,
+                    beep_time_in_source=prim.beep_time,
+                    pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                    post_buffer_seconds=proj.trim_post_buffer_seconds,
+                    config=Config(),
+                    secondaries=secondaries,
+                )
         except export_helpers.StageExportError as exc:
             # Surface as a job failure with the exporter's own message so
             # the JobsPanel row reads "audit JSON has no shots in shots[]"
@@ -2064,12 +2143,14 @@ def register_job_bodies(state: AppState) -> None:
             raise RuntimeError(str(exc)) from exc
 
         handle.update(progress=0.95, message="Saving project...")
-        proj.updated_at = datetime.now(UTC)
-        proj.save(state.shooter_root(slug))
+        with handle.timer.phase("persist_project"):
+            proj.updated_at = datetime.now(UTC)
+            proj.save(state.shooter_root(slug))
 
         # Hosted: push every produced deliverable to storage so the API
         # container can serve the download. No-op in local mode.
-        export_storage.push_stage_export_outputs(proj, result)
+        with handle.timer.phase("r2_upload"):
+            export_storage.push_stage_export_outputs(proj, result)
 
         # Final message summarises what shipped + flags any skipped
         # artefacts (FCPXML without a trim, etc). The full list lives in
@@ -2125,210 +2206,217 @@ def register_job_bodies(state: AppState) -> None:
         from . import exports as exports_mod
 
         handle.update(progress=0.02, message="Loading project...")
-        proj = state.shooter_project(slug)
-        exports_dir = proj.exports_path(state.shooter_root(slug))
-        audit_dir = proj.audit_path(state.shooter_root(slug))
+        with handle.timer.phase("load_project"):
+            proj = state.shooter_project(slug)
+            exports_dir = proj.exports_path(state.shooter_root(slug))
+            audit_dir = proj.audit_path(state.shooter_root(slug))
 
         n = len(req.stage_numbers)
+        handle.timer.set_meta(stage_count=n)
         # Reserve the last 10% for the match compose step; the rest is
         # split evenly across per-stage trims (the dominant wall time).
         # Stages that already have a trim skip ahead within their slice
         # instead of contributing to the wait.
         per_stage_share = 0.85 / max(1, n)
 
-        for idx, stage_number in enumerate(req.stage_numbers):
-            handle.check_cancel()
-            stg = proj.stage(stage_number)
-            prim = stg.primary()
-            if prim is None or prim.beep_time is None:
-                raise RuntimeError(f"stage {stage_number}: primary or beep disappeared mid-flight")
+        with handle.timer.phase("per_stage"):
+            for idx, stage_number in enumerate(req.stage_numbers):
+                handle.check_cancel()
+                stg = proj.stage(stage_number)
+                prim = stg.primary()
+                if prim is None or prim.beep_time is None:
+                    raise RuntimeError(f"stage {stage_number}: primary or beep disappeared mid-flight")
 
-            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
-            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
-            overlay_target = exports_dir / f"{base}_overlay.mov"
+                base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
+                trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+                overlay_target = exports_dir / f"{base}_overlay.mov"
 
-            # Hosted: per-stage artifacts may have been produced by an
-            # earlier job on a different worker. Materialize the audit doc
-            # (state_docs -> local file) so the composer + per-stage
-            # exporter can read it, and pull the cached trim so the
-            # existence checks below reuse it instead of re-cutting. No-op
-            # in local mode.
-            state.materialize_audit(slug, stage_number)
-            export_storage.pull_export_file(proj, trimmed_path)
+                # Hosted: per-stage artifacts may have been produced by an
+                # earlier job on a different worker. Materialize the audit doc
+                # (state_docs -> local file) so the composer + per-stage
+                # exporter can read it, and pull the cached trim so the
+                # existence checks below reuse it instead of re-cutting. No-op
+                # in local mode.
+                state.materialize_audit(slug, stage_number)
+                export_storage.pull_export_file(proj, trimmed_path)
 
-            # Decide what's missing. The match composer needs the
-            # lossless trim + per-cam trims (when include_secondaries) +
-            # optional overlay. Re-run the per-stage exporter for any
-            # stage where any required artefact isn't on disk.
-            wanted_secondary_ids: set[str] = set()
-            if req.include_secondaries:
-                for sv in stg.videos:
-                    if sv.role == "secondary" and sv.beep_time is not None:
-                        wanted_secondary_ids.add(sv.video_id)
-            for vid in wanted_secondary_ids:
-                export_storage.pull_export_file(proj, exports_dir / f"{base}_cam_{vid}_trimmed.mp4")
-            secondary_trims_present = all(
-                (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
-            )
-            # Treat any non-default overlay format option as "force re-render"
-            # so the dialog's codec / max-height / max-fps choices actually
-            # apply when a stale overlay sits on disk. With all defaults we
-            # keep the legacy "skip if present" behaviour for fast re-stitching.
-            overlay_format_overridden = (
-                req.overlay_codec != "auto"
-                or req.overlay_max_height is not None
-                or req.overlay_max_fps is not None
-                or req.overlay_theme != "splitsmith"
-            )
-            # Pull a cached overlay only when we'd actually reuse it -- a
-            # format override forces a re-render, so don't waste the download.
-            if req.include_overlay and not overlay_format_overridden:
-                export_storage.pull_export_file(proj, overlay_target)
-            overlay_missing = req.include_overlay and (
-                not overlay_target.exists() or overlay_format_overridden
-            )
-
-            needs_per_stage = not trimmed_path.exists() or not secondary_trims_present or overlay_missing
-            if needs_per_stage:
-                handle.update(
-                    progress=0.02 + idx * per_stage_share,
-                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."),
-                )
-                # Build the secondaries list for the per-stage exporter --
-                # mirrors the single-stage endpoint's logic.
-                secondaries_in: list[export_helpers.SecondaryExport] = []
+                # Decide what's missing. The match composer needs the
+                # lossless trim + per-cam trims (when include_secondaries) +
+                # optional overlay. Re-run the per-stage exporter for any
+                # stage where any required artefact isn't on disk.
+                wanted_secondary_ids: set[str] = set()
                 if req.include_secondaries:
                     for sv in stg.videos:
-                        if sv.role != "secondary" or sv.beep_time is None:
-                            continue
-                        sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
-                        secondaries_in.append(
-                            export_helpers.SecondaryExport(
-                                video_id=sv.video_id,
-                                source_path=sec_source,
-                                beep_time_in_source=sv.beep_time,
-                                label=f"Cam {sv.video_id}",
-                            )
-                        )
-                source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
-                engine_stage = EngineStageData(
-                    stage_number=stg.stage_number,
-                    stage_name=stg.stage_name,
-                    time_seconds=stg.time_seconds,
-                    scorecard_updated_at=stg.scorecard_updated_at or _PLACEHOLDER_SCORECARD_TIME,
+                        if sv.role == "secondary" and sv.beep_time is not None:
+                            wanted_secondary_ids.add(sv.video_id)
+                for vid in wanted_secondary_ids:
+                    export_storage.pull_export_file(proj, exports_dir / f"{base}_cam_{vid}_trimmed.mp4")
+                secondary_trims_present = all(
+                    (exports_dir / f"{base}_cam_{vid}_trimmed.mp4").exists() for vid in wanted_secondary_ids
                 )
-                try:
-                    recut = export_helpers.export_stage(
-                        request=export_helpers.StageExportRequest(
-                            stage_number=stage_number,
-                            write_trim=True,
-                            write_csv=True,
-                            write_fcpxml=True,
-                            write_report=True,
-                            write_overlay=req.include_overlay,
-                            overlay_codec=req.overlay_codec,
-                            overlay_max_height=req.overlay_max_height,
-                            overlay_max_fps=req.overlay_max_fps,
-                            overlay_theme=req.overlay_theme,
-                        ),
-                        audit_path=audit_dir / f"stage{stage_number}.json",
-                        exports_dir=exports_dir,
-                        source_video_path=source_video if source_video.exists() else None,
-                        stage_data=engine_stage,
-                        beep_time_in_source=prim.beep_time,
-                        pre_buffer_seconds=proj.trim_pre_buffer_seconds,
-                        post_buffer_seconds=proj.trim_post_buffer_seconds,
-                        config=Config(),
-                        secondaries=secondaries_in,
+                # Treat any non-default overlay format option as "force re-render"
+                # so the dialog's codec / max-height / max-fps choices actually
+                # apply when a stale overlay sits on disk. With all defaults we
+                # keep the legacy "skip if present" behaviour for fast re-stitching.
+                overlay_format_overridden = (
+                    req.overlay_codec != "auto"
+                    or req.overlay_max_height is not None
+                    or req.overlay_max_fps is not None
+                    or req.overlay_theme != "splitsmith"
+                )
+                # Pull a cached overlay only when we'd actually reuse it -- a
+                # format override forces a re-render, so don't waste the download.
+                if req.include_overlay and not overlay_format_overridden:
+                    export_storage.pull_export_file(proj, overlay_target)
+                overlay_missing = req.include_overlay and (
+                    not overlay_target.exists() or overlay_format_overridden
+                )
+
+                needs_per_stage = not trimmed_path.exists() or not secondary_trims_present or overlay_missing
+                if needs_per_stage:
+                    handle.update(
+                        progress=0.02 + idx * per_stage_share,
+                        message=(f"Stage {stage_number} ({idx + 1} of {n}): " "running per-stage export..."),
                     )
-                except export_helpers.StageExportError as exc:
-                    raise RuntimeError(f"stage {stage_number}: {exc}") from exc
-                # Hosted: a re-cut here produced the per-stage trims/overlay
-                # on this worker -- push them so other workers + the API
-                # download path see them. No-op in local mode.
-                export_storage.push_stage_export_outputs(proj, recut)
-            else:
-                handle.update(
-                    progress=0.02 + idx * per_stage_share,
-                    message=(f"Stage {stage_number} ({idx + 1} of {n}): " "trim already present; skipping"),
-                )
+                    # Build the secondaries list for the per-stage exporter --
+                    # mirrors the single-stage endpoint's logic.
+                    secondaries_in: list[export_helpers.SecondaryExport] = []
+                    if req.include_secondaries:
+                        for sv in stg.videos:
+                            if sv.role != "secondary" or sv.beep_time is None:
+                                continue
+                            sec_source = proj.resolve_video_path(state.shooter_root(slug), sv.path)
+                            secondaries_in.append(
+                                export_helpers.SecondaryExport(
+                                    video_id=sv.video_id,
+                                    source_path=sec_source,
+                                    beep_time_in_source=sv.beep_time,
+                                    label=f"Cam {sv.video_id}",
+                                )
+                            )
+                    source_video = proj.resolve_video_path(state.shooter_root(slug), prim.path)
+                    engine_stage = EngineStageData(
+                        stage_number=stg.stage_number,
+                        stage_name=stg.stage_name,
+                        time_seconds=stg.time_seconds,
+                        scorecard_updated_at=stg.scorecard_updated_at or _PLACEHOLDER_SCORECARD_TIME,
+                    )
+                    try:
+                        recut = export_helpers.export_stage(
+                            request=export_helpers.StageExportRequest(
+                                stage_number=stage_number,
+                                write_trim=True,
+                                write_csv=True,
+                                write_fcpxml=True,
+                                write_report=True,
+                                write_overlay=req.include_overlay,
+                                overlay_codec=req.overlay_codec,
+                                overlay_max_height=req.overlay_max_height,
+                                overlay_max_fps=req.overlay_max_fps,
+                                overlay_theme=req.overlay_theme,
+                            ),
+                            audit_path=audit_dir / f"stage{stage_number}.json",
+                            exports_dir=exports_dir,
+                            source_video_path=source_video if source_video.exists() else None,
+                            stage_data=engine_stage,
+                            beep_time_in_source=prim.beep_time,
+                            pre_buffer_seconds=proj.trim_pre_buffer_seconds,
+                            post_buffer_seconds=proj.trim_post_buffer_seconds,
+                            config=Config(),
+                            secondaries=secondaries_in,
+                        )
+                    except export_helpers.StageExportError as exc:
+                        raise RuntimeError(f"stage {stage_number}: {exc}") from exc
+                    # Hosted: a re-cut here produced the per-stage trims/overlay
+                    # on this worker -- push them so other workers + the API
+                    # download path see them. No-op in local mode.
+                    export_storage.push_stage_export_outputs(proj, recut)
+                else:
+                    handle.update(
+                        progress=0.02 + idx * per_stage_share,
+                        message=(
+                            f"Stage {stage_number} ({idx + 1} of {n}): " "trim already present; skipping"
+                        ),
+                    )
 
         handle.check_cancel()
         handle.update(progress=0.92, message="Stitching match FCPXML...")
 
         # Re-load the project: the per-stage worker writes processed flags
         # via project.save() side-effects, so a fresh load picks those up.
-        proj = state.shooter_project(slug)
-        stages_input: list[match_export_helpers.MatchStageInput] = []
-        for stage_number in req.stage_numbers:
-            stg = proj.stage(stage_number)
-            prim = stg.primary()
-            assert prim is not None and prim.beep_time is not None
-            base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
-            trimmed_path = exports_dir / f"{base}_trimmed.mp4"
-            audit_path = audit_dir / f"stage{stage_number}.json"
-            overlay_path = exports_dir / f"{base}_overlay.mov"
-            secondaries: list[match_export_helpers.MatchSecondaryInput] = []
-            for sv in stg.videos:
-                if sv.role != "secondary" or sv.beep_time is None:
-                    continue
-                sec_clip_beep = min(proj.trim_pre_buffer_seconds, sv.beep_time)
-                secondaries.append(
-                    match_export_helpers.MatchSecondaryInput(
-                        video_id=sv.video_id,
-                        trimmed_path=exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4",
-                        beep_offset_seconds=sec_clip_beep,
-                        label=f"Cam {sv.video_id}",
+        with handle.timer.phase("compose"):
+            proj = state.shooter_project(slug)
+            stages_input: list[match_export_helpers.MatchStageInput] = []
+            for stage_number in req.stage_numbers:
+                stg = proj.stage(stage_number)
+                prim = stg.primary()
+                assert prim is not None and prim.beep_time is not None
+                base = f"stage{stage_number}_{exports_mod._slugify(stg.stage_name)}"
+                trimmed_path = exports_dir / f"{base}_trimmed.mp4"
+                audit_path = audit_dir / f"stage{stage_number}.json"
+                overlay_path = exports_dir / f"{base}_overlay.mov"
+                secondaries: list[match_export_helpers.MatchSecondaryInput] = []
+                for sv in stg.videos:
+                    if sv.role != "secondary" or sv.beep_time is None:
+                        continue
+                    sec_clip_beep = min(proj.trim_pre_buffer_seconds, sv.beep_time)
+                    secondaries.append(
+                        match_export_helpers.MatchSecondaryInput(
+                            video_id=sv.video_id,
+                            trimmed_path=exports_dir / f"{base}_cam_{sv.video_id}_trimmed.mp4",
+                            beep_offset_seconds=sec_clip_beep,
+                            label=f"Cam {sv.video_id}",
+                        )
+                    )
+                primary_clip_beep = min(proj.trim_pre_buffer_seconds, prim.beep_time)
+                stages_input.append(
+                    match_export_helpers.MatchStageInput(
+                        stage_number=stage_number,
+                        stage_name=stg.stage_name,
+                        audit_path=audit_path,
+                        trimmed_path=trimmed_path,
+                        beep_offset_seconds=primary_clip_beep,
+                        secondaries=tuple(secondaries),
+                        overlay_path=overlay_path,
                     )
                 )
-            primary_clip_beep = min(proj.trim_pre_buffer_seconds, prim.beep_time)
-            stages_input.append(
-                match_export_helpers.MatchStageInput(
-                    stage_number=stage_number,
-                    stage_name=stg.stage_name,
-                    audit_path=audit_path,
-                    trimmed_path=trimmed_path,
-                    beep_offset_seconds=primary_clip_beep,
-                    secondaries=tuple(secondaries),
-                    overlay_path=overlay_path,
-                )
-            )
 
-        project_name = req.project_name or proj.name or "match"
-        request_data = match_export_helpers.MatchExportRequestData(
-            stage_numbers=tuple(req.stage_numbers),
-            head_pad_seconds=req.head_pad_seconds,
-            tail_pad_seconds=req.tail_pad_seconds,
-            include_secondaries=req.include_secondaries,
-            include_overlay=req.include_overlay,
-            project_name=project_name,
-            pip_layout=req.pip_layout,
-            output_format=req.output_format,
-            transition_kind=req.transition_kind,
-            transition_duration_seconds=req.transition_duration_seconds,
-            title_kind=req.title_kind,
-            title_duration_seconds=req.title_duration_seconds,
-            intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
-            outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
-            youtube_sidecar=req.youtube_sidecar,
-            youtube_preset=req.youtube_preset,
-        )
-        try:
-            result = match_export_helpers.export_match(
-                stages=stages_input,
-                request=request_data,
-                exports_dir=exports_dir,
-                config=Config().output,
+            project_name = req.project_name or proj.name or "match"
+            request_data = match_export_helpers.MatchExportRequestData(
+                stage_numbers=tuple(req.stage_numbers),
+                head_pad_seconds=req.head_pad_seconds,
+                tail_pad_seconds=req.tail_pad_seconds,
+                include_secondaries=req.include_secondaries,
+                include_overlay=req.include_overlay,
+                project_name=project_name,
+                pip_layout=req.pip_layout,
+                output_format=req.output_format,
+                transition_kind=req.transition_kind,
+                transition_duration_seconds=req.transition_duration_seconds,
+                title_kind=req.title_kind,
+                title_duration_seconds=req.title_duration_seconds,
+                intro_path=Path(req.intro_path).expanduser() if req.intro_path else None,
+                outro_path=Path(req.outro_path).expanduser() if req.outro_path else None,
+                youtube_sidecar=req.youtube_sidecar,
+                youtube_preset=req.youtube_preset,
             )
-        except match_export_helpers.MatchExportError as exc:
-            raise RuntimeError(str(exc)) from exc
+            try:
+                result = match_export_helpers.export_match(
+                    stages=stages_input,
+                    request=request_data,
+                    exports_dir=exports_dir,
+                    config=Config().output,
+                )
+            except match_export_helpers.MatchExportError as exc:
+                raise RuntimeError(str(exc)) from exc
 
         # Hosted: push the stitched match deliverable (+ optional YouTube
         # sidecars, when youtube_sidecar wrote them) so the API can serve the
         # download. push_export_file skips any that don't exist. No-op local.
-        export_storage.push_export_file(proj, result.fcpxml_path)
-        export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".srt"))
-        export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".json"))
+        with handle.timer.phase("r2_upload"):
+            export_storage.push_export_file(proj, result.fcpxml_path)
+            export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".srt"))
+            export_storage.push_export_file(proj, result.fcpxml_path.with_suffix(".json"))
 
         handle.set_result(
             {
@@ -3992,6 +4080,10 @@ def create_app(
     ``/api/server/features`` on mount to know whether to show the Lab
     nav entry). Hidden by default; opt in via ``splitsmith ui --lab``.
     """
+    # Initialise Sentry before constructing FastAPI so its integrations can
+    # hook the app. No-op unless ``SENTRY_DSN`` is set (local installs and the
+    # test suite stay untouched); see ``splitsmith.observability.init_sentry``.
+    init_sentry(component="web")
     state = AppState()
     # Route the compute backend through the module-level lazy loader so
     # the shared cache + existing test monkeypatches on

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 
@@ -714,3 +715,49 @@ def test_submit_unregistered_kind_raises_unknown_job_kind() -> None:
     reg = _Sync(JobRegistry())
     with pytest.raises(UnknownJobKindError):
         reg.submit(kind="never_registered", args={})
+
+
+def test_run_threads_timer_and_persists_timings_and_emits_completed(caplog) -> None:
+    reg = _Sync(JobRegistry(max_concurrent=1))
+
+    def work(handle):
+        with handle.timer.phase("step_one"):
+            pass
+        handle.timer.set_meta(input_bytes=42)
+
+    with caplog.at_level(logging.INFO, logger="splitsmith.ui.jobs"):
+        job = reg.submit(kind="trim", fn=work)
+        assert _wait_until(lambda: reg.get(job.id).status == JobStatus.SUCCEEDED)
+
+    snap = reg.get(job.id)
+    assert snap.timings is not None
+    assert [p["name"] for p in snap.timings["phases"]] == ["step_one"]
+    assert snap.timings["meta"] == {"input_bytes": 42}
+    assert "total_ms" in snap.timings
+
+    completed = [r for r in caplog.records if getattr(r, "event", None) == "job.completed"]
+    assert len(completed) == 1
+    assert completed[0].job_kind == "trim"
+    assert completed[0].status == JobStatus.SUCCEEDED.value
+
+
+def test_run_failed_emits_job_failed_with_partial_timings(caplog) -> None:
+    reg = _Sync(JobRegistry(max_concurrent=1))
+
+    def boom(handle):
+        with handle.timer.phase("started"):
+            raise RuntimeError("crash")
+
+    with caplog.at_level(logging.INFO, logger="splitsmith.ui.jobs"):
+        job = reg.submit(kind="trim", fn=boom)
+        assert _wait_until(lambda: reg.get(job.id).status == JobStatus.FAILED)
+
+    snap = reg.get(job.id)
+    assert snap.timings is not None
+    assert [p["name"] for p in snap.timings["phases"]] == ["started"]
+    assert "total_ms" in snap.timings
+
+    failed = [r for r in caplog.records if getattr(r, "event", None) == "job.failed"]
+    assert len(failed) == 1
+    assert failed[0].status == JobStatus.FAILED.value
+    assert failed[0].job_error == "crash"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,231 @@
+"""Unit tests for :mod:`splitsmith.observability`.
+
+Covers the pure primitives this slice introduced: :class:`PhaseTimer`
+(phase order/durations, queue_wait derivation, partial-timings on a raised
+body), :class:`StructuredJsonFormatter` (one JSON line, folds the job-event
+extras, no path/cross-tenant leakage), :func:`emit_job_event`, and the
+:func:`init_sentry` no-op gate. Also exercises the local
+:class:`JobRegistry` terminal path threading the timer through the handle
+and emitting exactly one event.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from splitsmith.observability import (
+    PhaseTimer,
+    StructuredJsonFormatter,
+    _queue_wait_ms,
+    emit_job_event,
+    init_sentry,
+)
+
+
+def test_phasetimer_records_closed_phases_in_order_and_total() -> None:
+    timer = PhaseTimer()
+    for name in ("a", "b", "c"):
+        with timer.phase(name):
+            time.sleep(0.001)
+    timer.set_meta(input_bytes=1024, encoder="h264")
+    timer.add_meta("cold_model_load", False)
+
+    built = timer.build()
+    assert [p["name"] for p in built["phases"]] == ["a", "b", "c"]
+    assert all(isinstance(p["ms"], float) and p["ms"] >= 0 for p in built["phases"])
+    phase_sum = sum(p["ms"] for p in built["phases"])
+    assert built["total_ms"] >= phase_sum
+    assert built["meta"] == {
+        "input_bytes": 1024,
+        "encoder": "h264",
+        "cold_model_load": False,
+    }
+    assert built["queue_wait_ms"] is None  # no row timestamps supplied
+
+
+def test_phasetimer_records_partial_on_exception() -> None:
+    timer = PhaseTimer()
+    with timer.phase("ran_ok"):
+        pass
+    with pytest.raises(ValueError):
+        with timer.phase("boom"):
+            raise ValueError("kaboom")
+
+    built = timer.build()
+    names = [p["name"] for p in built["phases"]]
+    assert names == ["ran_ok", "boom"]  # the raising phase is still recorded
+    assert "total_ms" in built and built["total_ms"] >= 0
+
+
+def test_queue_wait_ms_from_timestamps() -> None:
+    created = datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
+    started = created + timedelta(milliseconds=250)
+    assert _queue_wait_ms(created, started) == pytest.approx(250.0)
+    # Missing either timestamp -> None.
+    assert _queue_wait_ms(None, started) is None
+    assert _queue_wait_ms(created, None) is None
+    # Clock skew (started before created) -> None, never a negative wait.
+    assert _queue_wait_ms(started, created) is None
+
+
+def test_phasetimer_queue_wait_from_row_timestamps() -> None:
+    created = datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
+    started = created + timedelta(milliseconds=120)
+    timer = PhaseTimer(created_at=created, started_at=started)
+    assert timer.build()["queue_wait_ms"] == pytest.approx(120.0)
+
+
+def test_structured_json_formatter_emits_one_line_json_with_event_fields() -> None:
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="splitsmith.test",
+        level=logging.INFO,
+        pathname="/abs/secret/path.py",
+        lineno=1,
+        msg="job.completed",
+        args=(),
+        exc_info=None,
+    )
+    record.event = "job.completed"
+    record.job_kind = "shot_detect"
+    record.user_id = "tenant-A"
+    record.status = "succeeded"
+    record.timings = {"total_ms": 12.5, "phases": [{"name": "x", "ms": 1.0}], "meta": {}}
+
+    line = formatter.format(record)
+    assert "\n" not in line
+    parsed = json.loads(line)
+    assert parsed["event"] == "job.completed"
+    assert parsed["job_kind"] == "shot_detect"
+    assert parsed["user_id"] == "tenant-A"
+    assert parsed["status"] == "succeeded"
+    assert parsed["timings"]["total_ms"] == 12.5
+    # No absolute path from the record, no second tenant id leaked.
+    assert "/abs/secret/path.py" not in line
+    assert "tenant-B" not in line
+    # job_error omitted when not present.
+    assert "job_error" not in parsed
+
+
+def test_structured_json_formatter_plain_record_is_valid_json() -> None:
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="splitsmith.misc",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="just a line %s",
+        args=("here",),
+        exc_info=None,
+    )
+    parsed = json.loads(formatter.format(record))
+    assert parsed["msg"] == "just a line here"
+    assert parsed["level"] == "INFO"
+    assert "event" not in parsed
+    # ts is tz-aware UTC, not a naive local-time string.
+    ts = datetime.fromisoformat(parsed["ts"])
+    assert ts.tzinfo is not None
+    assert ts.utcoffset() == timedelta(0)
+
+
+def test_emit_job_event_attaches_extras(caplog) -> None:
+    log = logging.getLogger("splitsmith.test.emit")
+    with caplog.at_level(logging.INFO, logger="splitsmith.test.emit"):
+        emit_job_event(
+            log,
+            event="job.failed",
+            kind="export",
+            user_id="tenant-A",
+            status="failed",
+            timings={"total_ms": 3.0, "phases": [], "meta": {}},
+            error="boom",
+        )
+    recs = [r for r in caplog.records if getattr(r, "event", None) == "job.failed"]
+    assert len(recs) == 1
+    rec = recs[0]
+    assert rec.job_kind == "export"
+    assert rec.user_id == "tenant-A"
+    assert rec.status == "failed"
+    assert rec.job_error == "boom"
+    assert rec.timings["total_ms"] == 3.0
+
+
+def test_init_sentry_noop_without_dsn(monkeypatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    called: list[bool] = []
+
+    import sys
+    import types
+
+    fake = types.ModuleType("sentry_sdk")
+
+    def _init(**_kwargs: object) -> None:
+        called.append(True)
+
+    fake.init = _init  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+
+    init_sentry(component="web")
+    assert called == []  # returned before importing/initialising sentry
+
+
+def test_init_sentry_tags_environment(monkeypatch) -> None:
+    """With a DSN set, ``init`` is called once and ``environment`` comes from
+    ``SPLITSMITH_ENV`` (falling back to ``SPLITSMITH_MODE``)."""
+    monkeypatch.setenv("SENTRY_DSN", "https://abc@example.test/1")
+    monkeypatch.setenv("SPLITSMITH_ENV", "staging")
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
+
+    import sys
+    import types
+
+    init_kwargs: dict[str, object] = {}
+    tags: dict[str, object] = {}
+
+    fake = types.ModuleType("sentry_sdk")
+
+    def _init(**kwargs: object) -> None:
+        init_kwargs.update(kwargs)
+
+    def _set_tag(key: str, value: object) -> None:
+        tags[key] = value
+
+    fake.init = _init  # type: ignore[attr-defined]
+    fake.set_tag = _set_tag  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    # No integrations module attrs -> each defensive import is skipped.
+    monkeypatch.setitem(sys.modules, "sentry_sdk.integrations", types.ModuleType("x"))
+
+    init_sentry(component="worker")
+
+    assert init_kwargs["dsn"] == "https://abc@example.test/1"
+    assert init_kwargs["environment"] == "staging"
+    assert init_kwargs["send_default_pii"] is False
+    assert tags["component"] == "worker"
+
+
+def test_init_sentry_environment_falls_back_to_mode(monkeypatch) -> None:
+    """When ``SPLITSMITH_ENV`` is unset the environment tag uses
+    ``SPLITSMITH_MODE``."""
+    monkeypatch.setenv("SENTRY_DSN", "https://abc@example.test/1")
+    monkeypatch.delenv("SPLITSMITH_ENV", raising=False)
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
+
+    import sys
+    import types
+
+    init_kwargs: dict[str, object] = {}
+    fake = types.ModuleType("sentry_sdk")
+    fake.init = lambda **kwargs: init_kwargs.update(kwargs)  # type: ignore[attr-defined]
+    fake.set_tag = lambda *a, **k: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    monkeypatch.setitem(sys.modules, "sentry_sdk.integrations", types.ModuleType("x"))
+
+    init_sentry(component="web")
+
+    assert init_kwargs["environment"] == "hosted"

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2740,6 +2740,154 @@ def test_shot_detect_endpoint_writes_candidates(tmp_path: Path, monkeypatch) -> 
     assert proj_after["stages"][0]["videos"][0]["processed"]["shot_detect"] is True
 
 
+def test_shot_detect_job_records_phase_timings(tmp_path: Path, monkeypatch) -> None:
+    """The instrumented ``shot_detect`` body opens a phase per natural
+    boundary; the backend persists ``timer.build()`` onto the job so the
+    snapshot carries the full timings dict (phases in order + meta). The
+    runtime is warm here (``_get_ensemble_runtime`` stubbed to a value)
+    so there is NO ``cold_model_load`` phase and ``meta.cold_model_load``
+    is False."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    _shooter_root = project_root / "shooters" / "me"
+    project = MatchProject.load(_shooter_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.stages[0].time_seconds = 10.0
+    project.save(_shooter_root)
+    project.resolve_video_path(_shooter_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = _shooter_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    wav = audio_dir / "stage1_audit.wav"
+    sf.write(wav, np.zeros(48_000, dtype="float32"), 48_000)
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        audio_path = wav
+        beep_in_clip = 5.0
+        trimmed = True
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
+    # Warm runtime: the singleton resolver returns a value, and the warm
+    # probe reports True -> the body skips the cold_model_load phase.
+    monkeypatch.setattr(server_module, "_get_ensemble_runtime", lambda: object())
+    monkeypatch.setattr(server_module, "_ensemble_runtime_is_warm", lambda: True)
+    monkeypatch.setattr(
+        ensemble_module,
+        "detect_shots_ensemble",
+        lambda *a, **kw: _fake_ensemble_result(
+            [{"time": 5.5, "confidence": 0.8, "ensemble_score": 3.0, "kept": True}],
+            consensus=2,
+        ),
+    )
+
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
+    assert resp.status_code == 200
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
+
+    timings = final["timings"]
+    assert timings is not None, final
+    phase_names = [p["name"] for p in timings["phases"]]
+    # Every shot_detect phase that runs on the warm path, in completion order.
+    assert phase_names == [
+        "load_project",
+        "ensure_trim",
+        "prepare_audio",
+        "load_audit_state",
+        "audio_load",
+        "ensemble_infer",
+        "build_candidates",
+        "save_audit",
+        "persist_project",
+    ]
+    assert "cold_model_load" not in phase_names
+    assert all(isinstance(p["ms"], (int, float)) and p["ms"] >= 0 for p in timings["phases"])
+    assert isinstance(timings["total_ms"], (int, float))
+    # total_ms covers the whole body, so it is at least the sum of phases.
+    assert timings["total_ms"] >= sum(p["ms"] for p in timings["phases"]) - 1e-6
+    meta = timings["meta"]
+    assert meta["cold_model_load"] is False
+    assert meta["candidate_count"] == 1
+    assert meta["consensus"] == 2
+
+
+def test_shot_detect_job_times_cold_model_load_when_runtime_cold(tmp_path: Path, monkeypatch) -> None:
+    """When the ensemble singleton is not yet warm, the body forces the
+    resolution inside an explicit ``cold_model_load`` phase and records
+    ``meta.cold_model_load=True`` -- so the weight-load cost is visible in
+    timings instead of hiding inside ``ensemble_infer``."""
+    import numpy as np
+    import soundfile as sf
+
+    client, _ = _seed_project_with_primary(tmp_path)
+    project_root = tmp_path / "match"
+    _shooter_root = project_root / "shooters" / "me"
+    project = MatchProject.load(_shooter_root)
+    primary = project.stages[0].primary()
+    assert primary is not None
+    primary.beep_time = 5.0
+    project.stages[0].time_seconds = 10.0
+    project.save(_shooter_root)
+    project.resolve_video_path(_shooter_root, primary.path).resolve().write_bytes(b"S")
+
+    audio_dir = _shooter_root / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    wav = audio_dir / "stage1_audit.wav"
+    sf.write(wav, np.zeros(48_000, dtype="float32"), 48_000)
+
+    from splitsmith import ensemble as ensemble_module
+    from splitsmith.ui import audio as audio_helpers
+    from splitsmith.ui import server as server_module
+
+    class FakeAudit:
+        audio_path = wav
+        beep_in_clip = 5.0
+        trimmed = True
+
+    cold_loads: list[int] = []
+
+    monkeypatch.setattr(audio_helpers, "ensure_audit_audio", lambda *a, **kw: FakeAudit())
+    monkeypatch.setattr(audio_helpers, "ensure_video_audit_trim", lambda *a, **kw: None)
+    monkeypatch.setattr(server_module, "_ensemble_runtime_is_warm", lambda: False)
+    monkeypatch.setattr(
+        server_module,
+        "_get_ensemble_runtime",
+        lambda: cold_loads.append(1) or object(),
+    )
+    monkeypatch.setattr(
+        ensemble_module,
+        "detect_shots_ensemble",
+        lambda *a, **kw: _fake_ensemble_result([], consensus=2),
+    )
+
+    resp = client.post("/api/shooters/me/stages/1/shot-detect")
+    assert resp.status_code == 200
+    final = _wait_for_job(client, resp.json()["id"])
+    assert final["status"] == "succeeded", final
+
+    timings = final["timings"]
+    phase_names = [p["name"] for p in timings["phases"]]
+    assert "cold_model_load" in phase_names
+    # cold_model_load lands between audio_load and ensemble_infer.
+    assert phase_names.index("cold_model_load") == phase_names.index("audio_load") + 1
+    assert phase_names.index("cold_model_load") < phase_names.index("ensemble_infer")
+    assert timings["meta"]["cold_model_load"] is True
+    # The body forced the resolution inside the cold_model_load phase; the
+    # compute backend's runtime_loader resolves again inside detect_stage
+    # (a no-op warm-cache hit in production), so at least one load fired.
+    assert len(cold_loads) >= 1
+
+
 def test_shot_detect_endpoint_ensures_trim_before_detection(tmp_path: Path, monkeypatch) -> None:
     """Re-detect on a project whose trims were wiped (e.g. by the v1->v2
     cache migration in #298) must rebuild the trimmed MP4. Without this

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -63,11 +63,121 @@ def test_run_worker_is_async() -> None:
     assert inspect.iscoroutinefunction(run_worker)
 
 
+def test_run_worker_warms_ensemble_and_inits_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Worker boot must: init Sentry once, build state, configure logging, then
+    warm the ensemble singleton before draining -- so the first ``shot_detect``
+    does not pay a hidden cold model load."""
+    import asyncio
+    import sys
+    import types
+
+    calls: list[str] = []
+
+    # Stub the ui.server symbols run_worker imports lazily.
+    server = types.ModuleType("splitsmith.ui.server")
+
+    def _build_worker_state() -> object:
+        calls.append("build_worker_state")
+        return object()
+
+    def _configure_app_logging() -> None:
+        calls.append("configure_logging")
+
+    def _warm() -> None:
+        calls.append("warm")
+
+    server.build_worker_state = _build_worker_state  # type: ignore[attr-defined]
+    server._configure_app_logging = _configure_app_logging  # type: ignore[attr-defined]
+    server.warm_ensemble_runtime = _warm  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "splitsmith.ui.server", server)
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: calls.append("sentry"))
+
+    class _FakeApp:
+        def open_async(self) -> object:
+            outer = self
+
+            class _Ctx:
+                async def __aenter__(self) -> object:
+                    return outer
+
+                async def __aexit__(self, *exc: object) -> bool:
+                    return False
+
+            return _Ctx()
+
+        async def run_worker_async(self, **_kwargs: object) -> None:
+            calls.append("drain")
+
+    monkeypatch.setattr(queue_mod, "build_app", lambda _url: _FakeApp())
+    monkeypatch.setattr(queue_mod, "register_compute_task", lambda _app, _state: None)
+
+    asyncio.run(run_worker(_FAKE_PG_URL))
+
+    assert calls == ["sentry", "build_worker_state", "configure_logging", "warm", "drain"]
+
+
+def test_run_worker_warmup_failure_is_non_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model-load failure at boot must not crash the worker: it logs a
+    warning and still drains (non-shot_detect jobs are unaffected; the cold
+    cost is re-timed as the ``cold_model_load`` phase on the first detection)."""
+    import asyncio
+    import sys
+    import types
+
+    calls: list[str] = []
+    server = types.ModuleType("splitsmith.ui.server")
+    server.build_worker_state = lambda: object()  # type: ignore[attr-defined]
+    server._configure_app_logging = lambda: None  # type: ignore[attr-defined]
+
+    def _warm_boom() -> None:
+        raise RuntimeError("model weights unreachable")
+
+    server.warm_ensemble_runtime = _warm_boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "splitsmith.ui.server", server)
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: None)
+
+    class _FakeApp:
+        def open_async(self) -> object:
+            outer = self
+
+            class _Ctx:
+                async def __aenter__(self) -> object:
+                    return outer
+
+                async def __aexit__(self, *exc: object) -> bool:
+                    return False
+
+            return _Ctx()
+
+        async def run_worker_async(self, **_kwargs: object) -> None:
+            calls.append("drain")
+
+    monkeypatch.setattr(queue_mod, "build_app", lambda _url: _FakeApp())
+    monkeypatch.setattr(queue_mod, "register_compute_task", lambda _app, _state: None)
+
+    asyncio.run(run_worker(_FAKE_PG_URL))
+
+    assert calls == ["drain"]  # warmup raised but the worker still reached drain
+
+
 def test_worker_command_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Missing ``SPLITSMITH_DATABASE_URL`` exits 2 with a clear message,
     before any attempt to connect."""
     monkeypatch.delenv("SPLITSMITH_DATABASE_URL", raising=False)
-    # Tracked by monkeypatch so the command's ``setdefault`` is undone.
+    # The ``worker`` command ``setdefault``s SPLITSMITH_MODE=hosted in the
+    # shared ``os.environ`` (CliRunner does NOT isolate env). A bare
+    # ``delenv(raising=False)`` on an already-absent var records nothing on
+    # monkeypatch's undo stack, so the in-process mutation would leak to
+    # later tests (e.g. ui.server boots in hosted mode and raises). Setting
+    # the key first forces monkeypatch to track it, then deleting it gives
+    # the command a clean "unset" starting point; teardown restores absence.
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
     monkeypatch.delenv("SPLITSMITH_MODE", raising=False)
 
     result = CliRunner().invoke(app, ["worker"])

--- a/uv.lock
+++ b/uv.lock
@@ -3348,6 +3348,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.61.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/3b/4bc6b348bbd331daa14d4babe9f2b99bc854f4da41560eefb9488d78481d/sentry_sdk-2.61.1.tar.gz", hash = "sha256:9c6adccb3feefa9ba032c8d295ca477575c2f11896046a2b0ad686c47c4af555", size = 459429, upload-time = "2026-06-01T07:24:18.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl", hash = "sha256:fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae", size = 483735, upload-time = "2026-06-01T07:24:17.027Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3421,7 +3439,7 @@ wheels = [
 
 [[package]]
 name = "splitsmith"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -3454,6 +3472,7 @@ hosted = [
     { name = "procrastinate" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-ulid" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
@@ -3502,6 +3521,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.13.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], marker = "extra == 'hosted'", specifier = ">=2.0.0" },
     { name = "soundfile", specifier = ">=0.12.1" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'hosted'", specifier = ">=2.0.30" },
     { name = "typer", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Why

Hosted bottlenecks live in background compute jobs (detect_beep/trim/shot_detect/export/match_export) that run seconds-to-minutes, not in request latency. A request-centric APM would instrument the wrong tier. This adds **job-centric** instrumentation so we can answer "where does the wall-clock go" -- R2 transfer vs ffmpeg vs model cold-load vs queue wait -- with a SQL query and a log search, without standing up Prometheus/OTel/Grafana.

## What

- **`PhaseTimer`** (`splitsmith.observability`, a stdlib-only leaf module): `perf_counter` phases via a context manager, `queue_wait_ms` derived from the persisted enqueue->start timestamps, and an always-built timings payload even when a body raises (partial timeline survives failures).
- **`compute_jobs.timings`** -- new nullable JSONB column (migration `20aa31aeca11`, descends from current head, clean downgrade, **no RLS DDL** so the existing tenant policy is untouched). The 5 worker job bodies record their real phase boundaries + small meta scalars (input bytes, encoder, `cold_model_load`).
- **Structured JSON logging in hosted mode only** (stdout, for Railway capture). Local desktop file logging stays plain text. Exactly one `job.completed` / `job.failed` event per job carrying `timings` + `kind` + `user_id` + `status`.
- **Sentry** (`sentry-sdk[fastapi]`, **no-op when `SENTRY_DSN` unset**) initialised in both web and worker, env-tagged, PII scrubbed (cookies / `Authorization` / magic-link token). The worker FAILED path calls `capture_job_exception` explicitly, because `job.failed` logs at INFO -- below the `LoggingIntegration` ERROR floor -- so worker crashes would otherwise never reach Sentry.
- **Worker model warmup**: the ensemble singleton (CLAP/PANN/GBDT) is warmed on worker boot so the first `shot_detect` doesn't pay cold-load inside its critical path; a genuine cold load is still recorded as its own `cold_model_load` phase.

## timings shape
```json
{ "queue_wait_ms": 1234.5, "total_ms": 8800.0,
  "phases": [{"name": "load_project", "ms": 12.0}, {"name": "trim", "ms": 8100.0}],
  "meta": {"role": "primary", "encoder": "libx264", "cold_model_load": false} }
```

## Validation
- `ruff` + `black` clean; **319 targeted tests pass** (jobs/queue/logging/storage/server + new `test_observability.py`).
- **Hosted docker smoke green** (`pytest -m docker`): full stack boots, `alembic upgrade head` applies `20aa31aeca11` on real Postgres.
- The gate also caught + fixed a test-isolation bug it introduced (`SPLITSMITH_MODE` leaking via `CliRunner`).

## Deploy follow-up (not in this PR)
Set `SENTRY_DSN` (+ optional `SPLITSMITH_ENV`) in Railway staging, deploy, run one detect/trim/export, and confirm `timings` lands in `compute_jobs.timings` and Railway shows JSON `job.completed` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)