### PR TITLE
feat(saas): hard-delete projects with full resource cleanup + confirm dialogs

### DIFF
--- a/src/splitsmith/db/job_backend.py
+++ b/src/splitsmith/db/job_backend.py
@@ -430,6 +430,39 @@ class PostgresJobBackend:
             row = (await session.execute(stmt)).scalars().first()
         return _row_to_job(row) if row is not None else None
 
+    async def cancel_active_for_user(self) -> int:
+        """Cancel every PENDING/RUNNING job this user owns; return the count.
+
+        Used by the project-delete cascade to stop in-flight compute
+        before tearing a match's storage/state down, so a worker can't
+        re-write objects we're about to delete. ``compute_jobs`` carries
+        no ``match_id`` (the match link lives only in the Procrastinate
+        queue payload, not the row), so this is deliberately *coarse* --
+        it cancels the user's other in-flight jobs too. That is acceptable
+        when a user is tearing a match down; per-match scoping would need a
+        schema column we chose not to add for ephemeral, boot-swept rows.
+        Reuses :meth:`cancel` so subprocess teardown + PENDING->CANCELLED
+        semantics stay in one place.
+        """
+        async with self._session_factory() as session:
+            ids = (
+                (
+                    await session.execute(
+                        select(ComputeJobRow.id).where(
+                            ComputeJobRow.user_id == self._user_id,
+                            ComputeJobRow.status.in_([JobStatus.PENDING.value, JobStatus.RUNNING.value]),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        cancelled = 0
+        for job_id in ids:
+            if await self.cancel(job_id) is not None:
+                cancelled += 1
+        return cancelled
+
     # ------------------------------------------------------------------
     # Internal worker glue
     # ------------------------------------------------------------------

--- a/src/splitsmith/db/matches.py
+++ b/src/splitsmith/db/matches.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -124,6 +124,23 @@ class PostgresMatchStore:
                     )
                 )
             ).scalar_one_or_none()
+
+    async def delete(self, match_id: str) -> bool:
+        """Drop the user's row for ``match_id``; return ``True`` if one went.
+
+        Used by the project-delete cascade. Idempotent: deleting an
+        already-gone match returns ``False`` without error. Mirrors
+        :meth:`PostgresRecentProjectsStore.remove`.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(MatchRow).where(
+                    MatchRow.user_id == self._user_id,
+                    MatchRow.match_id == match_id,
+                )
+            )
+            await session.commit()
+            return (result.rowcount or 0) > 0
 
     async def list(self) -> list[MatchRow]:
         """Return all of the user's matches, newest first."""

--- a/src/splitsmith/db/project_state.py
+++ b/src/splitsmith/db/project_state.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -132,6 +132,52 @@ class ProjectStateStore:
             slug=slug,
             stage_number=stage_number,
         )
+
+    # -- cascade cleanup ----------------------------------------------
+
+    async def list_project_docs(self, match_id: str) -> list[tuple[str, dict]]:
+        """Return ``(slug, doc)`` for every per-shooter project doc.
+
+        Used by the delete cascade to harvest each shooter's attached
+        ``raw_videos[].storage_path`` (for the storage cleanup loop and
+        the cross-match raw-upload refcount). ``slug`` is non-NULL for
+        project docs, so it is always a real string here.
+        """
+        async with self._session_factory() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(StateDocRow).where(
+                            StateDocRow.user_id == self._user_id,
+                            StateDocRow.match_id == match_id,
+                            StateDocRow.doc_kind == _KIND_PROJECT,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        return [(row.slug, row.doc) for row in rows]
+
+    async def delete_match(self, match_id: str) -> int:
+        """Delete every doc for ``match_id``; return the row count.
+
+        Sweeps the match doc, every per-shooter project doc, and every
+        per-stage audit doc in one statement -- they all share
+        ``match_id``, so the WHERE deliberately omits
+        ``doc_kind``/``slug``/``stage_number``. This closes the
+        long-standing orphaned-``state_docs`` gap left by shooter/match
+        removal (see ``remove_match_shooter`` in the UI server). Idempotent.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(StateDocRow).where(
+                    StateDocRow.user_id == self._user_id,
+                    StateDocRow.match_id == match_id,
+                )
+            )
+            await session.commit()
+            return result.rowcount or 0
 
     # -- shared lifecycle ---------------------------------------------
 

--- a/src/splitsmith/ui/jobs.py
+++ b/src/splitsmith/ui/jobs.py
@@ -393,6 +393,8 @@ class JobBackend(Protocol):
 
     async def cancel(self, job_id: str) -> Job | None: ...
 
+    async def cancel_active_for_user(self) -> int: ...
+
     async def acknowledge(self, job_id: str) -> Job | None: ...
 
     async def acknowledge_all_failures(self) -> list[Job]: ...
@@ -604,6 +606,25 @@ class JobRegistry:
             except OSError:
                 logger.warning("cancel: terminate() failed for job %s", job_id, exc_info=True)
         return snapshot
+
+    async def cancel_active_for_user(self) -> int:
+        """Cancel every PENDING/RUNNING job; return the count cancelled.
+
+        The local registry is already single-user (one process == one
+        operator), so "for user" is the whole registry. Used by the
+        project-delete cascade to stop in-flight compute before teardown.
+        Snapshots the active ids under the lock, then cancels each outside
+        it so :meth:`cancel`'s subprocess ``terminate()`` doesn't stall.
+        """
+        with self._lock:
+            active_ids = [
+                jid for jid, j in self._jobs.items() if j.status in (JobStatus.PENDING, JobStatus.RUNNING)
+            ]
+        cancelled = 0
+        for job_id in active_ids:
+            if await self.cancel(job_id) is not None:
+                cancelled += 1
+        return cancelled
 
     async def acknowledge(self, job_id: str) -> Job | None:
         """Mark a failed job as seen by the user (issue #73).

--- a/src/splitsmith/ui/match_delete.py
+++ b/src/splitsmith/ui/match_delete.py
@@ -1,0 +1,285 @@
+"""Cascade delete for a project/match and all the resources it owns.
+
+The picker's old "forget" only dropped the ``recent_projects`` row, which
+in hosted mode left an invisible-but-still-billing orphan: the ``matches``
+row, every ``state_docs`` doc, the R2 storage prefix, and any enqueued
+compute all survived with no UI path back to them. This module replaces
+that with a real teardown.
+
+The work lives here (not inline in ``server.py``) so it can be unit-tested
+against a fake :class:`~splitsmith.storage.Storage` + sqlite stores without
+spinning the FastAPI app.
+
+**Modes diverge.** Hosted mode (``state.matches_store is not None``) cleans
+DB rows + object storage + the in-memory registry. Local desktop mode has
+no storage/matches/state stores, so a delete reduces to dropping the picker
+row plus an opt-in ``rmtree`` of the on-disk match folder.
+
+**Best-effort, not transactional.** S3 deletes can't join a DB transaction
+and there's no atomic multi-object delete here, so every step is made
+idempotent and wrapped so one failure is recorded in ``errors`` without
+aborting the rest. The picker row is dropped *last* so a crash mid-cascade
+leaves the entry visible to retry cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..match_model import MATCH_FILE
+
+if TYPE_CHECKING:
+    from .server import AppState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DeletionSummary:
+    """What the cascade actually removed, for the SPA to report back.
+
+    Returned even on partial failure (with ``errors`` populated) so the
+    UI can show "removed X, N errors" rather than a bare 500.
+    """
+
+    match_id: str | None
+    recent_project_removed: bool = False
+    match_row_removed: bool = False
+    state_docs_removed: int = 0
+    storage_objects_deleted: int = 0
+    raw_uploads_deleted: list[str] = field(default_factory=list)
+    raw_uploads_skipped_shared: list[str] = field(default_factory=list)
+    jobs_cancelled: int = 0
+    local_dir_removed: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+def _raw_paths_from_docs(docs: list[tuple[str, dict]]) -> set[str]:
+    """Collect every ``raw_videos[].storage_path`` across project docs.
+
+    Reads the raw dict shape rather than validating ``MatchProject`` so a
+    schema migration or a malformed legacy doc can't crash a teardown.
+    """
+    paths: set[str] = set()
+    for _slug, doc in docs:
+        for rv in doc.get("raw_videos", []) or []:
+            storage_path = rv.get("storage_path") if isinstance(rv, dict) else None
+            if isinstance(storage_path, str) and storage_path:
+                paths.add(storage_path)
+    return paths
+
+
+async def _safe_to_delete_raws(
+    state: AppState, match_id: str, attached_raws: set[str]
+) -> tuple[set[str], set[str]]:
+    """Split this match's raws into (safe-to-delete, still-shared-elsewhere).
+
+    A raw object is safe to delete only when no *other* match of the same
+    user still references it (raws are shared by reference, not copied).
+    O(matches x project-docs) reads -- a user's match count is bounded, so
+    this is fine; revisit with a covering query if it ever isn't.
+    """
+    assert state.matches_store is not None and state.project_state is not None
+    still_referenced: set[str] = set()
+    for other in await state.matches_store.list():
+        if other.match_id == match_id:
+            continue
+        other_docs = await state.project_state.list_project_docs(other.match_id)
+        still_referenced |= _raw_paths_from_docs(other_docs)
+    safe = attached_raws - still_referenced
+    skipped = attached_raws & still_referenced
+    return safe, skipped
+
+
+def _delete_storage_prefix(state: AppState, prefix: str, summary: DeletionSummary) -> None:
+    """List + delete every object under ``prefix``; record per-object errors.
+
+    Materialises the listing first so we don't mutate a generator we're
+    iterating (the filesystem backend walks via ``rglob``). ``prefix`` is
+    normalised with a trailing slash so ``matches/<id>`` can't also sweep a
+    sibling ``matches/<id>extra>``.
+    """
+    assert state.storage is not None
+    normalised = prefix.rstrip("/") + "/"
+    try:
+        objects = list(state.storage.list(normalised))
+    except Exception as exc:  # noqa: BLE001 -- best-effort teardown
+        summary.errors.append(f"list storage {normalised!r}: {exc}")
+        return
+    for obj in objects:
+        try:
+            state.storage.delete(obj.path)
+            summary.storage_objects_deleted += 1
+        except Exception as exc:  # noqa: BLE001
+            summary.errors.append(f"delete {obj.path!r}: {exc}")
+
+
+async def _delete_hosted(
+    state: AppState,
+    *,
+    path: str,
+    match_id: str | None,
+    storage_prefix: str | None,
+    delete_raw_uploads: bool,
+    summary: DeletionSummary,
+) -> None:
+    # 1. Stop in-flight compute first so no worker re-writes storage/state
+    #    under us. Coarse (cancels the user's other active jobs too) -- see
+    #    PostgresJobBackend.cancel_active_for_user.
+    try:
+        summary.jobs_cancelled = await state.jobs.cancel_active_for_user()
+    except Exception as exc:  # noqa: BLE001
+        summary.errors.append(f"cancel jobs: {exc}")
+
+    if match_id is None:
+        # Older recent-projects rows predate match_id (record_open allows
+        # None). Nothing in the stores/storage to key off -- degrade to a
+        # picker-row drop and say so.
+        summary.errors.append("no match_id on picker row; removed picker entry only")
+        summary.recent_project_removed = await _drop_picker_row(state, path, summary)
+        return
+
+    # 2. Read project docs to harvest this match's attached raws.
+    attached_raws: set[str] = set()
+    if state.project_state is not None:
+        try:
+            docs = await state.project_state.list_project_docs(match_id)
+            attached_raws = _raw_paths_from_docs(docs)
+        except Exception as exc:  # noqa: BLE001
+            summary.errors.append(f"read project docs: {exc}")
+
+    # 3. Compute the safe-to-delete raw set (only if opted in).
+    safe_raws: set[str] = set()
+    if delete_raw_uploads and attached_raws and state.matches_store is not None:
+        try:
+            safe_raws, skipped = await _safe_to_delete_raws(state, match_id, attached_raws)
+            summary.raw_uploads_skipped_shared = sorted(skipped)
+        except Exception as exc:  # noqa: BLE001
+            summary.errors.append(f"raw refcount: {exc}")
+
+    # 4. Delete the match's own storage prefix.
+    if state.storage is not None and storage_prefix:
+        _delete_storage_prefix(state, storage_prefix, summary)
+
+    # 5. Delete the safe raw objects.
+    if state.storage is not None:
+        for raw_path in sorted(safe_raws):
+            try:
+                state.storage.delete(raw_path)
+                summary.raw_uploads_deleted.append(raw_path)
+            except Exception as exc:  # noqa: BLE001
+                summary.errors.append(f"delete raw {raw_path!r}: {exc}")
+
+    # 6. Delete the match's state docs (match + project + audit, all kinds).
+    if state.project_state is not None:
+        try:
+            summary.state_docs_removed = await state.project_state.delete_match(match_id)
+        except Exception as exc:  # noqa: BLE001
+            summary.errors.append(f"delete state docs: {exc}")
+
+    # 7. Delete the matches-registry row.
+    if state.matches_store is not None:
+        try:
+            summary.match_row_removed = await state.matches_store.delete(match_id)
+        except Exception as exc:  # noqa: BLE001
+            summary.errors.append(f"delete match row: {exc}")
+
+    # 8. Drop the in-memory MatchRegistry cache entry, else a stale id keeps
+    #    resolving to a now-deleted root.
+    state.matches.forget(match_id)
+
+    # 9. Drop the picker row (last, so a retry re-runs cleanly).
+    summary.recent_project_removed = await _drop_picker_row(state, path, summary)
+
+
+async def _delete_local(
+    state: AppState,
+    *,
+    path: str,
+    match_id: str | None,
+    delete_local_files: bool,
+    summary: DeletionSummary,
+) -> None:
+    if delete_local_files:
+        _rmtree_match_dir(path, summary)
+    if match_id:
+        state.matches.forget(match_id)
+    summary.recent_project_removed = await _drop_picker_row(state, path, summary)
+
+
+def _rmtree_match_dir(path: str, summary: DeletionSummary) -> None:
+    """Remove the on-disk match folder, guarded by the match.json marker.
+
+    The marker check is the safety rail: it refuses to ``rmtree`` a
+    directory that isn't actually a splitsmith match, so a malformed or
+    empty ``path`` can't nuke an unrelated tree.
+    """
+    target = Path(path).expanduser().resolve()
+    if not (target / MATCH_FILE).is_file():
+        summary.errors.append(
+            f"refusing to delete {str(target)!r}: no {MATCH_FILE} marker (not a match folder)"
+        )
+        return
+    try:
+        shutil.rmtree(target, ignore_errors=True)
+        summary.local_dir_removed = not target.exists()
+        if not summary.local_dir_removed:
+            summary.errors.append(f"delete folder {str(target)!r}: some files could not be removed")
+    except Exception as exc:  # noqa: BLE001
+        summary.errors.append(f"delete folder {str(target)!r}: {exc}")
+
+
+async def _drop_picker_row(state: AppState, path: str, summary: DeletionSummary) -> bool:
+    try:
+        return await state.recent_projects.remove(Path(path))
+    except Exception as exc:  # noqa: BLE001
+        summary.errors.append(f"remove picker row: {exc}")
+        return False
+
+
+async def delete_match_cascade(
+    state: AppState,
+    *,
+    path: str,
+    match_id: str | None,
+    storage_prefix: str | None,
+    delete_local_files: bool,
+    delete_raw_uploads: bool,
+) -> DeletionSummary:
+    """Tear down a project/match and everything it owns. See module docstring.
+
+    ``delete_local_files`` is honoured only in local mode; ``delete_raw_uploads``
+    only in hosted mode. The server enforces these semantics regardless of
+    which flags the client sent, so a wrong client-mode guess can't cause
+    damage.
+    """
+    summary = DeletionSummary(match_id=match_id)
+    if state.matches_store is not None:
+        await _delete_hosted(
+            state,
+            path=path,
+            match_id=match_id,
+            storage_prefix=storage_prefix,
+            delete_raw_uploads=delete_raw_uploads,
+            summary=summary,
+        )
+    else:
+        await _delete_local(
+            state,
+            path=path,
+            match_id=match_id,
+            delete_local_files=delete_local_files,
+            summary=summary,
+        )
+    if summary.errors:
+        logger.warning(
+            "project delete for match_id=%s completed with %d error(s): %s",
+            match_id,
+            len(summary.errors),
+            "; ".join(summary.errors),
+        )
+    return summary

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -50,7 +50,7 @@ Endpoints (locked v1 surface):
   GET  /api/fixture/video?path=...  -- serve a fixture-bound video file (Range)
   GET  /api/me                      -- current operator (LoopbackAuth user in local mode)
   GET  /api/user/recent-projects    -- recently-opened MatchProject roots (#75)
-  POST /api/user/recent-projects/forget -- drop one entry from the list
+  POST /api/me/recent-projects/delete   -- delete a project/match + all its resources
   POST /api/user/recent-projects/bind   -- switch the in-memory project
   POST /api/user/recent-projects/unbind -- drop the bound project (back to picker)
   GET  /api/user/scoreboard-identity -- saved SSI identity (404 if none)
@@ -160,6 +160,7 @@ from .jobs import (
     JobRegistry,
     ShutdownInProgressError,
 )
+from .match_delete import DeletionSummary, delete_match_cascade
 from .project import (
     VIDEO_EXTENSIONS,
     MatchProject,
@@ -2879,10 +2880,42 @@ class ScoreboardImportRequest(BaseModel):
     overwrite: bool = False
 
 
-class ForgetRecentProjectRequest(BaseModel):
-    """Body for POST /api/user/recent-projects/forget (#75)."""
+class DeleteProjectRequest(BaseModel):
+    """Body for POST /api/me/recent-projects/delete.
+
+    Replaces the old soft "forget" (which only dropped the picker row and
+    orphaned everything else). This is a real teardown of the match and the
+    resources it owns. The two opt-in flags are mode-specific and the
+    server ignores the one that doesn't apply:
+
+    - ``delete_local_files`` (desktop only): also ``rmtree`` the project
+      folder on disk. Ignored in hosted mode (ephemeral container fs).
+    - ``delete_raw_uploads`` (hosted only): also delete raw uploads that
+      fed this match and no other. Ignored in local mode (no object store).
+    """
 
     path: str
+    delete_local_files: bool = False
+    delete_raw_uploads: bool = False
+
+
+class DeletionSummaryModel(BaseModel):
+    """Serialisable view of :class:`~splitsmith.ui.match_delete.DeletionSummary`."""
+
+    match_id: str | None
+    recent_project_removed: bool
+    match_row_removed: bool
+    state_docs_removed: int
+    storage_objects_deleted: int
+    raw_uploads_deleted: list[str]
+    raw_uploads_skipped_shared: list[str]
+    jobs_cancelled: int
+    local_dir_removed: bool
+    errors: list[str]
+
+    @classmethod
+    def from_summary(cls, summary: DeletionSummary) -> DeletionSummaryModel:
+        return cls(**summary.__dict__)
 
 
 class AttachRawVideoRequest(BaseModel):
@@ -8408,16 +8441,44 @@ def create_app(
             return JSONResponse({"projects": [p.model_dump(mode="json") for p in enriched]})
         return JSONResponse({"projects": [p.model_dump(mode="json") for p in projects]})
 
-    @app.post("/api/me/recent-projects/forget")
-    async def forget_recent_project(
-        req: ForgetRecentProjectRequest,
+    @app.post("/api/me/recent-projects/delete")
+    async def delete_recent_project(
+        req: DeleteProjectRequest,
         user: User = Depends(get_current_user),
     ) -> JSONResponse:
-        removed = await state.recent_projects.remove(Path(req.path))
+        """Delete a project/match and clean up every resource it owns.
+
+        Resolves ``match_id`` (and, hosted, the storage prefix) from the
+        picker row, then runs the cascade in :mod:`splitsmith.ui.match_delete`.
+        Returns the deletion summary plus the refreshed picker list. Always
+        200 -- partial failures are reported in ``summary.errors`` so the SPA
+        can show "removed X, N errors" rather than a bare 500. (POST, not a
+        body-carrying DELETE, so proxies that strip DELETE payloads don't eat
+        the opt-in flags.)
+        """
+        resolved = str(Path(req.path).expanduser().resolve())
+        entry = next(
+            (p for p in await state.recent_projects.list() if p.path == resolved),
+            None,
+        )
+        match_id = entry.match_id if entry is not None else None
+        storage_prefix: str | None = None
+        if match_id and state.matches_store is not None:
+            row = await state.matches_store.get(match_id)
+            storage_prefix = row.storage_prefix if row is not None else f"matches/{match_id}"
+
+        summary = await delete_match_cascade(
+            state,
+            path=req.path,
+            match_id=match_id,
+            storage_prefix=storage_prefix,
+            delete_local_files=req.delete_local_files,
+            delete_raw_uploads=req.delete_raw_uploads,
+        )
         projects = await state.recent_projects.list()
         return JSONResponse(
             {
-                "removed": removed,
+                "summary": DeletionSummaryModel.from_summary(summary).model_dump(mode="json"),
                 "projects": [p.model_dump(mode="json") for p in projects],
             }
         )

--- a/src/splitsmith/ui_static/src/App.tsx
+++ b/src/splitsmith/ui_static/src/App.tsx
@@ -13,6 +13,7 @@ import { DeveloperShell } from "@/components/developer/DeveloperShell";
 import { MatchShell } from "@/components/match/MatchShell";
 import { DefaultShooterRedirect } from "@/components/match/DefaultShooterRedirect";
 import { ModeProvider } from "@/lib/mode";
+import { ConfirmProvider } from "@/components/useConfirm";
 import { AuthProvider, useAuth } from "@/lib/auth";
 import { useDeploymentMode } from "@/lib/features";
 import { ShooterScopedRoute } from "@/components/ShooterScopedRoute";
@@ -117,8 +118,9 @@ export function App() {
   return (
     <ModeProvider>
       <AuthProvider>
-        <BrowserRouter>
-          <AuthGate>
+        <ConfirmProvider>
+          <BrowserRouter>
+            <AuthGate>
             <Routes>
               <Route path="login" element={<Login />} />
           {/* Picker lives outside any shell -- it has its own header and
@@ -204,7 +206,8 @@ export function App() {
           <Route path="*" element={<LegacyMatchRedirect />} />
             </Routes>
           </AuthGate>
-        </BrowserRouter>
+          </BrowserRouter>
+        </ConfirmProvider>
       </AuthProvider>
     </ModeProvider>
   );

--- a/src/splitsmith/ui_static/src/components/BeepSection.tsx
+++ b/src/splitsmith/ui_static/src/components/BeepSection.tsx
@@ -49,6 +49,7 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/useConfirm";
 import { Waveform } from "@/components/Waveform";
 import { useSpacePlayPause } from "@/lib/keyboard";
 import { modKeyGlyph } from "@/lib/platform";
@@ -98,6 +99,7 @@ export function BeepSection({
   setError,
   bare = false,
 }: Props) {
+  const confirm = useConfirm();
   // Section-local busy. Each video's beep section runs its own
   // independent jobs (auto-queued on assignment, or user-initiated via
   // Detect / Save / Clear), so disabling controls page-wide while one
@@ -207,10 +209,12 @@ export function BeepSection({
       }
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
-        const ok = window.confirm(
-          "This video has a manual beep override. Replace it with the auto-detected value?",
-        );
-        if (ok) await detect(true);
+        const ok = await confirm({
+          title: "Replace manual beep override?",
+          body: "This video has a manual beep override. Replace it with the auto-detected value?",
+          confirmLabel: "Replace",
+        });
+        if (ok.confirmed) await detect(true);
       } else {
         const unreachable = asSourceUnreachable(e);
         if (unreachable) {

--- a/src/splitsmith/ui_static/src/components/ConfirmDialog.tsx
+++ b/src/splitsmith/ui_static/src/components/ConfirmDialog.tsx
@@ -1,0 +1,170 @@
+/**
+ * Reusable accessible confirmation dialog.
+ *
+ * One styled, focus-trapping modal for every destructive confirm in the
+ * app, replacing the mix of native ``window.confirm()`` calls and the
+ * unconfirmed picker "forget". Drive it through the {@link useConfirm}
+ * hook rather than rendering it directly.
+ *
+ * Accessibility (WCAG 2.2 AA): ``role="dialog"`` + ``aria-modal`` with
+ * labelled/described regions; focus moves into the dialog on open, is
+ * trapped on Tab/Shift-Tab, and is restored to the trigger on close; ESC
+ * cancels. Colour is never the sole signal -- the destructive variant
+ * also carries an icon and explicit button copy.
+ */
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface ConfirmCheckbox {
+  key: string;
+  label: string;
+  help?: string;
+}
+
+interface ConfirmDialogProps {
+  title: ReactNode;
+  body?: ReactNode;
+  confirmLabel: string;
+  cancelLabel: string;
+  destructive: boolean;
+  busy?: boolean;
+  checkboxes: ConfirmCheckbox[];
+  checked: Record<string, boolean>;
+  onToggle: (key: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function ConfirmDialog({
+  title,
+  body,
+  confirmLabel,
+  cancelLabel,
+  destructive,
+  busy = false,
+  checkboxes,
+  checked,
+  onToggle,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const node = cardRef.current;
+    const first = node?.querySelector<HTMLElement>(FOCUSABLE);
+    // Focus the first control (Cancel, the least destructive) so a stray
+    // Enter doesn't fire the delete.
+    (first ?? node)?.focus();
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const node = cardRef.current;
+    if (!node) return;
+    const focusables = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE));
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey) {
+      if (active === first || !node.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !node.contains(active)) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby={body ? "confirm-dialog-body" : undefined}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-4"
+      onClick={onCancel}
+      onKeyDown={onKeyDown}
+    >
+      <Card
+        ref={cardRef}
+        tabIndex={-1}
+        className="w-full max-w-md shadow-xl outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle id="confirm-dialog-title" className="flex items-center gap-2">
+            {destructive ? (
+              <AlertTriangle className="size-5 text-destructive" aria-hidden="true" />
+            ) : null}
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          {body ? (
+            <div id="confirm-dialog-body" className="text-muted-foreground">
+              {body}
+            </div>
+          ) : null}
+
+          {checkboxes.length > 0 ? (
+            <div className="space-y-2">
+              {checkboxes.map((cb) => (
+                <label
+                  key={cb.key}
+                  className="flex cursor-pointer items-start gap-2 rounded-md border border-border p-2 hover:bg-muted/40"
+                >
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={Boolean(checked[cb.key])}
+                    disabled={busy}
+                    onChange={() => onToggle(cb.key)}
+                  />
+                  <div className="flex-1 space-y-0.5">
+                    <span className="font-medium">{cb.label}</span>
+                    {cb.help ? (
+                      <p className="text-xs text-muted-foreground">{cb.help}</p>
+                    ) : null}
+                  </div>
+                </label>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2 border-t border-border pt-3">
+            <Button variant="ghost" onClick={onCancel} disabled={busy}>
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={destructive ? "destructive" : "default"}
+              onClick={onConfirm}
+              disabled={busy}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/components/useConfirm.tsx
+++ b/src/splitsmith/ui_static/src/components/useConfirm.tsx
@@ -1,0 +1,111 @@
+/**
+ * Promise-based confirmation hook backed by one {@link ConfirmDialog}.
+ *
+ * Mount {@link ConfirmProvider} once near the app root, then call
+ * ``const confirm = useConfirm()`` anywhere below it. ``confirm(opts)``
+ * opens the dialog and resolves when the user acts:
+ *
+ *   if (!(await confirm({ title: "Remove shooter?" })).confirmed) return;
+ *
+ * That shape makes the native ``window.confirm()`` callsites a near
+ * drop-in. ``opts.checkboxes`` adds opt-in toggles (e.g. the project
+ * delete's "also delete files on disk"); their state comes back on
+ * ``result.checked`` keyed by checkbox ``key``.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { ConfirmDialog, type ConfirmCheckbox } from "./ConfirmDialog";
+
+export interface ConfirmOptions {
+  title: ReactNode;
+  body?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Defaults to ``true`` -- nearly every caller is a destructive action. */
+  destructive?: boolean;
+  checkboxes?: ConfirmCheckbox[];
+}
+
+export interface ConfirmResult {
+  confirmed: boolean;
+  checked: Record<string, boolean>;
+}
+
+type ConfirmFn = (opts: ConfirmOptions) => Promise<ConfirmResult>;
+
+const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+interface PendingState {
+  opts: ConfirmOptions;
+  resolve: (result: ConfirmResult) => void;
+}
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingState | null>(null);
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  // Hold the active resolver so a backdrop/ESC cancel can still settle the
+  // promise even though it isn't passed through the dialog's own handlers.
+  const resolverRef = useRef<((result: ConfirmResult) => void) | null>(null);
+
+  const confirm = useCallback<ConfirmFn>((opts) => {
+    return new Promise<ConfirmResult>((resolve) => {
+      resolverRef.current = resolve;
+      // Checkboxes start unchecked -- opt-in by design.
+      setChecked({});
+      setPending({ opts, resolve });
+    });
+  }, []);
+
+  const settle = useCallback(
+    (confirmed: boolean) => {
+      const resolve = resolverRef.current;
+      resolverRef.current = null;
+      setPending(null);
+      resolve?.({ confirmed, checked });
+    },
+    [checked],
+  );
+
+  const toggle = useCallback((key: string) => {
+    setChecked((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const value = useMemo(() => confirm, [confirm]);
+
+  return (
+    <ConfirmContext.Provider value={value}>
+      {children}
+      {pending ? (
+        <ConfirmDialog
+          title={pending.opts.title}
+          body={pending.opts.body}
+          confirmLabel={pending.opts.confirmLabel ?? "Delete"}
+          cancelLabel={pending.opts.cancelLabel ?? "Cancel"}
+          destructive={pending.opts.destructive ?? true}
+          checkboxes={pending.opts.checkboxes ?? []}
+          checked={checked}
+          onToggle={toggle}
+          onConfirm={() => settle(true)}
+          onCancel={() => settle(false)}
+        />
+      ) : null}
+    </ConfirmContext.Provider>
+  );
+}
+
+export function useConfirm(): ConfirmFn {
+  const ctx = useContext(ConfirmContext);
+  if (ctx === null) {
+    throw new Error("useConfirm must be used within a <ConfirmProvider>");
+  }
+  return ctx;
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -1157,6 +1157,34 @@ export interface RecentProject {
   kind?: "match" | "legacy" | null;
 }
 
+/** What a project delete actually removed (mirrors the server's
+ *  DeletionSummary). Returned even on partial failure, with ``errors``
+ *  populated, so the UI can report "removed X, N errors". */
+export interface DeletionSummary {
+  match_id: string | null;
+  recent_project_removed: boolean;
+  match_row_removed: boolean;
+  state_docs_removed: number;
+  storage_objects_deleted: number;
+  raw_uploads_deleted: string[];
+  raw_uploads_skipped_shared: string[];
+  jobs_cancelled: number;
+  local_dir_removed: boolean;
+  errors: string[];
+}
+
+export interface DeleteProjectResponse {
+  summary: DeletionSummary;
+  projects: RecentProject[];
+}
+
+export interface DeleteProjectOptions {
+  /** Desktop only: also delete the project folder on disk. */
+  deleteLocalFiles?: boolean;
+  /** Hosted only: also delete raw uploads that fed only this match. */
+  deleteRawUploads?: boolean;
+}
+
 /** Detailed RecentProject with on-disk metadata (`?detail=true`, #322). */
 export interface RecentProjectDetail {
   path: string;
@@ -2457,13 +2485,19 @@ export const api = {
       json: body,
     }),
 
-  /** Drop one entry from the recent list (forget). Returns the updated
+  /** Delete a project/match and clean up every resource it owns (DB rows,
+   *  object storage, in-flight jobs, and -- when opted in -- raw uploads or
+   *  the on-disk folder). Returns the deletion summary plus the refreshed
    *  list so the picker can re-render without a follow-up GET. */
-  forgetRecentProject: (path: string) =>
-    request<{ removed: boolean; projects: RecentProject[] }>(
-      "/api/me/recent-projects/forget",
-      { method: "POST", json: { path } },
-    ),
+  deleteProject: (path: string, opts?: DeleteProjectOptions) =>
+    request<DeleteProjectResponse>("/api/me/recent-projects/delete", {
+      method: "POST",
+      json: {
+        path,
+        delete_local_files: opts?.deleteLocalFiles ?? false,
+        delete_raw_uploads: opts?.deleteRawUploads ?? false,
+      },
+    }),
 
   /** Switch the in-memory project. The picker calls this when the user
    *  selects an entry; the server updates ``last_opened_at`` and binds.

--- a/src/splitsmith/ui_static/src/pages/Audit.tsx
+++ b/src/splitsmith/ui_static/src/pages/Audit.tsx
@@ -69,6 +69,7 @@ import {
   zoomToPixelsPerSecond,
 } from "@/components/AuditControls";
 import { HelpOverlay } from "@/components/HelpOverlay";
+import { useConfirm } from "@/components/useConfirm";
 import { ListDrawer } from "@/components/ListDrawer";
 import { MarkerLayer, type AuditMarker } from "@/components/MarkerLayer";
 import type { MatchShellOutletContext } from "@/components/match/MatchShell";
@@ -2189,6 +2190,7 @@ function DetectShotsBadge({
   hasCandidates,
   onComplete,
 }: DetectShotsBadgeProps) {
+  const confirm = useConfirm();
   const [job, setJob] = useState<Job | null>(null);
   const [error, setError] = useState<string | null>(null);
   const blocked = !hasBeep || !hasStageTime;
@@ -2260,18 +2262,15 @@ function DetectShotsBadge({
   );
 
   const onClick = useCallback(() => void runDetect(false), [runDetect]);
-  const onResetClick = useCallback(() => {
-    if (
-      !window.confirm(
-        "Reset & re-detect shots for this stage?\n\n" +
-          "This wipes your kept / rejected decisions and runs detection from " +
-          "scratch. Use this when the previous detection went badly (bad beep, " +
-          "wrong stage time, etc.) and you want to start over.",
-      )
-    )
-      return;
+  const onResetClick = useCallback(async () => {
+    const ok = await confirm({
+      title: "Reset & re-detect shots for this stage?",
+      body: "This wipes your kept / rejected decisions and runs detection from scratch. Use this when the previous detection went badly (bad beep, wrong stage time, etc.) and you want to start over.",
+      confirmLabel: "Reset & re-detect",
+    });
+    if (!ok.confirmed) return;
     void runDetect(true);
-  }, [runDetect]);
+  }, [runDetect, confirm]);
 
   // CSV-only re-run. Reuses the existing exportStage job (the server
   // supports write_csv with everything else off, see ui/exports.py). The

--- a/src/splitsmith/ui_static/src/pages/Lab.tsx
+++ b/src/splitsmith/ui_static/src/pages/Lab.tsx
@@ -40,6 +40,7 @@ import {
 } from "lucide-react";
 
 import { SweepsCard } from "@/components/SweepsCard";
+import { useConfirm } from "@/components/useConfirm";
 import { Waveform } from "@/components/Waveform";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -776,6 +777,7 @@ function FixtureRow({
   onSelect: (slug: string | null) => void;
   onDeleted: (slug: string) => void;
 }) {
+  const confirm = useConfirm();
   return (
     <tr
       className={cn(
@@ -858,12 +860,11 @@ function FixtureRow({
               type="button"
               onClick={async (e) => {
                 e.stopPropagation();
-                if (
-                  !window.confirm(
-                    `Delete derived fixture "${rec.slug}"? This removes the JSON, WAV, peaks and promotion-report.`,
-                  )
-                )
-                  return;
+                const ok = await confirm({
+                  title: `Delete derived fixture "${rec.slug}"?`,
+                  body: "This removes the JSON, WAV, peaks and promotion-report.",
+                });
+                if (!ok.confirmed) return;
                 try {
                   await api.deleteFixture(rec.slug);
                   onDeleted(rec.slug);

--- a/src/splitsmith/ui_static/src/pages/Pick.tsx
+++ b/src/splitsmith/ui_static/src/pages/Pick.tsx
@@ -2,12 +2,13 @@
  * MatchPicker route (/pick) -- redesigned in the Shot Timer aesthetic (#322).
  *
  * Carries the same plumbing as the legacy picker (recent-projects list,
- * bind, forget, import-backup) but renders in the polished "Match Archive"
+ * bind, delete, import-backup) but renders in the polished "Match Archive"
  * style: telemetry readout, search + status chips, match rows with shooter
  * stack + tick progress + status pill.
  *
  * Keyboard model: ArrowUp/Down moves selection, Enter opens,
- * Cmd/Ctrl+Backspace forgets the selected entry, `/` focuses search.
+ * Cmd/Ctrl+Backspace opens the delete confirm for the selected entry,
+ * `/` focuses search.
  */
 
 import {
@@ -35,6 +36,7 @@ import {
 } from "@/components/ui";
 import { AccountChip } from "@/components/AccountChip";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/useConfirm";
 import {
   ApiError,
   api,
@@ -42,6 +44,7 @@ import {
   type ScoreboardIdentity,
   type ServerHealth,
 } from "@/lib/api";
+import { useDeploymentMode } from "@/lib/features";
 import { cn } from "@/lib/utils";
 
 type StatusFilter = "all" | "awaiting_footage" | "in_progress" | "exported" | "archived";
@@ -58,6 +61,8 @@ function matchHome(health: ServerHealth): string {
 
 export function Pick() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
+  const mode = useDeploymentMode();
   const [recents, setRecents] = useState<RecentProjectDetail[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
@@ -175,13 +180,52 @@ export function Pick() {
     }
   }
 
-  async function forget(target: RecentProjectDetail) {
+  async function deleteProject(target: RecentProjectDetail) {
+    // Mode-specific opt-in extras. Desktop can wipe the folder on disk;
+    // hosted can additionally drop raw uploads that fed only this match.
+    const checkboxes =
+      mode === "local"
+        ? [
+            {
+              key: "deleteLocalFiles",
+              label: "Also delete the project folder on disk",
+              help: "Permanently removes the footage, audit work, and exports under this match's folder. This cannot be undone.",
+            },
+          ]
+        : [
+            {
+              key: "deleteRawUploads",
+              label: "Also delete raw uploads that fed only this match",
+              help: "Uploaded videos still attached to another match are kept.",
+            },
+          ];
+
+    const result = await confirm({
+      title: `Delete ${target.name}?`,
+      body: "This removes the match and every resource it owns -- detection state, trims, exports, and any running jobs. This cannot be undone.",
+      confirmLabel: "Delete project",
+      checkboxes,
+    });
+    if (!result.confirmed) return;
+
     try {
-      const resp = await api.forgetRecentProject(target.path);
-      // Re-fetch the enriched list (the forget endpoint only returns the
-      // base shape so we'd lose `kind` etc. if we trusted its response).
+      const resp = await api.deleteProject(target.path, {
+        deleteLocalFiles: Boolean(result.checked.deleteLocalFiles),
+        deleteRawUploads: Boolean(result.checked.deleteRawUploads),
+      });
+      // Re-fetch the enriched list (the delete endpoint returns the base
+      // shape so we'd lose `kind` etc. if we trusted its response).
       const full = await api.getRecentProjectsDetail();
       setRecents(full);
+      // Best-effort teardown: surface any partial-failure detail so a
+      // half-cleaned match isn't silently reported as fully gone.
+      if (resp.summary.errors.length > 0) {
+        setError(
+          `Deleted with ${resp.summary.errors.length} issue${
+            resp.summary.errors.length === 1 ? "" : "s"
+          }: ${resp.summary.errors.join("; ")}`,
+        );
+      }
       return resp;
     } catch (e: unknown) {
       setError(e instanceof ApiError ? e.detail : String(e));
@@ -234,7 +278,9 @@ export function Pick() {
       void open(filtered[selectedIdx]);
     } else if ((e.metaKey || e.ctrlKey) && e.key === "Backspace") {
       e.preventDefault();
-      void forget(filtered[selectedIdx]);
+      // Opens the confirm dialog rather than deleting on the keystroke --
+      // this is destructive and irreversible.
+      void deleteProject(filtered[selectedIdx]);
     }
   }
 
@@ -508,7 +554,7 @@ export function Pick() {
                     }
                     busy={opening === r.path}
                     onOpen={() => open(r)}
-                    onForget={() => forget(r)}
+                    onDelete={() => deleteProject(r)}
                     onHover={() => setSelectedIdx(filtered.indexOf(r))}
                   />
                 ))}
@@ -546,7 +592,7 @@ export function Pick() {
                       }
                       busy={opening === r.path}
                       onOpen={() => open(r)}
-                      onForget={() => forget(r)}
+                      onDelete={() => deleteProject(r)}
                       onHover={() => setSelectedIdx(filtered.indexOf(r))}
                       archived
                     />
@@ -644,7 +690,7 @@ export function Pick() {
           <span className="inline-flex items-center gap-2 font-mono">
             <Kbd>Up</Kbd>/<Kbd>Down</Kbd> to select
             <Kbd>Enter</Kbd> to open
-            <Kbd>&#8984;</Kbd>+<Kbd>Backspace</Kbd> to forget
+            <Kbd>&#8984;</Kbd>+<Kbd>Backspace</Kbd> to delete
           </span>
           <span className="font-mono">
             Splitsmith <Heartbeat /> Local Worker
@@ -710,7 +756,7 @@ interface MatchRowProps {
   busy: boolean;
   archived?: boolean;
   onOpen: () => void;
-  onForget: () => void;
+  onDelete: () => void;
   onHover: () => void;
 }
 
@@ -721,7 +767,7 @@ function MatchRow({
   busy,
   archived,
   onOpen,
-  onForget,
+  onDelete,
   onHover,
 }: MatchRowProps) {
   // Build a TickStrip from stage_count + stages_audited. Missing details
@@ -908,13 +954,13 @@ function MatchRow({
         </button>
         <button
           type="button"
-          title="Forget this project"
+          title="Delete this project"
           className="inline-flex size-9 items-center justify-center rounded-md border border-transparent text-subtle transition-all hover:border-rule hover:bg-surface-3 hover:text-led"
           onClick={(e) => {
             e.stopPropagation();
-            onForget();
+            onDelete();
           }}
-          aria-label="Forget this project"
+          aria-label={`Delete ${project.name}`}
         >
           <Trash2 className="size-4" />
         </button>

--- a/src/splitsmith/ui_static/src/pages/Shooters.tsx
+++ b/src/splitsmith/ui_static/src/pages/Shooters.tsx
@@ -31,6 +31,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/useConfirm";
 import {
   ApiError,
   api,
@@ -110,6 +111,7 @@ const PICK_SECTION_LABELS: Record<string, string> = {
 
 export function Shooters() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
   const href = useMatchHref();
   const [searchParams] = useSearchParams();
   const pickSection = PICK_SECTION_LABELS[searchParams.get("pick") ?? ""] ?? null;
@@ -134,12 +136,12 @@ export function Shooters() {
   }, [reload]);
 
   async function remove(slug: string, name: string) {
-    if (
-      !window.confirm(
-        `Remove ${name} from this match? Their footage, audit, and exports inside the match folder will be deleted.`,
-      )
-    )
-      return;
+    const ok = await confirm({
+      title: `Remove ${name}?`,
+      body: "Their footage, audit, and exports inside the match folder will be deleted. This cannot be undone.",
+      confirmLabel: "Remove shooter",
+    });
+    if (!ok.confirmed) return;
     setBusy(slug);
     try {
       const next = await api.removeMatchShooter(slug);

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -82,7 +82,7 @@ _ME_ROUTES_REQUIRING_AUTH: list[tuple[str, str, str]] = [
     ("POST", "/api/me/jobs/{job_id}/acknowledge", "/api/me/jobs/does-not-exist/acknowledge"),
     ("POST", "/api/me/jobs/{job_id}/cancel", "/api/me/jobs/does-not-exist/cancel"),
     ("GET", "/api/me/recent-projects", "/api/me/recent-projects"),
-    ("POST", "/api/me/recent-projects/forget", "/api/me/recent-projects/forget"),
+    ("POST", "/api/me/recent-projects/delete", "/api/me/recent-projects/delete"),
     ("POST", "/api/me/recent-projects/bind", "/api/me/recent-projects/bind"),
     ("POST", "/api/me/recent-projects/unbind", "/api/me/recent-projects/unbind"),
     ("GET", "/api/me/scoreboard-identity", "/api/me/scoreboard-identity"),

--- a/tests/test_hosted_docker_smoke.py
+++ b/tests/test_hosted_docker_smoke.py
@@ -113,20 +113,21 @@ def test_recent_projects_round_trip_hits_postgres(hosted_stack: None) -> None:
     # public surface is /api/me/recent-projects/bind, but that also
     # validates the path is a real Match folder. For a smoke test
     # against an empty container that has no on-disk projects, we
-    # exercise the forget endpoint instead (which is the only
+    # exercise the delete endpoint instead (the only
     # /api/me/recent-projects/* mutator that doesn't require a real
-    # match.json on disk) -- it should return ``removed: false`` and
-    # the list stays empty. This proves the round-trip hits the
-    # Postgres store without needing to mount a fixture volume.
+    # match.json on disk) -- with no picker row and no match_id it
+    # cleanly reports ``recent_project_removed: false`` and the list
+    # stays empty. This proves the round-trip hits the Postgres store
+    # without needing to mount a fixture volume.
     resp = httpx.post(
-        f"{API_BASE}/api/me/recent-projects/forget",
+        f"{API_BASE}/api/me/recent-projects/delete",
         json={"path": "/nonexistent/project"},
         cookies=cookies,
         timeout=5.0,
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["removed"] is False
+    assert body["summary"]["recent_project_removed"] is False
     assert body["projects"] == []
 
     # Restart the API container and verify the empty-but-responsive

--- a/tests/test_match_delete.py
+++ b/tests/test_match_delete.py
@@ -1,0 +1,341 @@
+"""Tests for the project/match delete cascade (``ui.match_delete``).
+
+Drives :func:`delete_match_cascade` against sqlite-backed stores and a
+fake in-memory :class:`~splitsmith.storage.Storage`, so the orchestration
+(storage prefix sweep, raw-upload refcount, state/match/registry/picker
+teardown, best-effort partial failure) is exercised without spinning the
+FastAPI app or a real object store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from splitsmith.db import (
+    Base,
+    PostgresMatchStore,
+    ProjectStateStore,
+    User,
+    create_engine,
+    sessionmaker,
+)
+from splitsmith.match_model import MATCH_FILE
+from splitsmith.match_registry import MatchRegistry
+from splitsmith.storage import StorageObject
+from splitsmith.ui.match_delete import delete_match_cascade
+
+
+class FakeStorage:
+    """In-memory stand-in: a ``path -> size`` map with prefix list + delete."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, int] = {}
+        self.fail_on: set[str] = set()
+
+    def list(self, prefix: str):
+        for path, size in list(self.objects.items()):
+            if path.startswith(prefix):
+                yield StorageObject(path=path, size=size)
+
+    def delete(self, path: str) -> None:
+        if path in self.fail_on:
+            raise RuntimeError(f"boom: {path}")
+        self.objects.pop(path, None)
+
+
+class FakeJobs:
+    """Records the bulk-cancel call and returns a canned count."""
+
+    def __init__(self, count: int = 0) -> None:
+        self.count = count
+        self.called = False
+
+    async def cancel_active_for_user(self) -> int:
+        self.called = True
+        return self.count
+
+
+class FakeRecentProjects:
+    """Async ``remove`` over a set of resolved paths (matches the real store)."""
+
+    def __init__(self, paths: list[str]) -> None:
+        self._paths = {str(Path(p).expanduser().resolve()) for p in paths}
+        self.removed: list[str] = []
+
+    async def remove(self, path: Path) -> bool:
+        resolved = str(Path(path).expanduser().resolve())
+        existed = resolved in self._paths
+        self._paths.discard(resolved)
+        self.removed.append(resolved)
+        return existed
+
+
+def _hosted_state(tmp_path: Path, *, recent_paths: list[str], jobs: int = 1) -> SimpleNamespace:
+    engine = create_engine(f"sqlite+aiosqlite:///{tmp_path}/md.sqlite")
+    sf = sessionmaker(engine)
+
+    async def _setup() -> str:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with sf() as s:
+            user = User(email="m@thias.se")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            return user.id
+
+    uid = asyncio.run(_setup())
+    return SimpleNamespace(
+        matches_store=PostgresMatchStore(sf, user_id=uid),
+        project_state=ProjectStateStore(sf, user_id=uid),
+        storage=FakeStorage(),
+        jobs=FakeJobs(count=jobs),
+        recent_projects=FakeRecentProjects(recent_paths),
+        matches=MatchRegistry(),
+    )
+
+
+def _seed_match(
+    state: SimpleNamespace,
+    match_id: str,
+    *,
+    raws_by_shooter: dict[str, list[str]],
+    storage_objs: list[str],
+) -> None:
+    asyncio.run(state.matches_store.upsert(match_id, match_id, f"matches/{match_id}"))
+    asyncio.run(state.project_state.save_match(match_id, {"name": match_id}, expected_version=0))
+    for slug, raws in raws_by_shooter.items():
+        asyncio.run(
+            state.project_state.save_project(
+                match_id,
+                slug,
+                {"raw_videos": [{"storage_path": r} for r in raws]},
+                expected_version=0,
+            )
+        )
+    for path in storage_objs:
+        state.storage.objects[path] = 10
+
+
+def test_hosted_cascade_removes_everything() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        state = _hosted_state(tmp, recent_paths=["/work/m1"], jobs=1)
+        _seed_match(
+            state,
+            "m1",
+            raws_by_shooter={"ada": ["raw/ada.mp4"], "bo": ["raw/bo.mp4"]},
+            storage_objs=[
+                "matches/m1/match.json",
+                "matches/m1/shooters/ada/trim.mp4",
+                "raw/ada.mp4",
+                "raw/bo.mp4",
+            ],
+        )
+        state.matches.register("m1", Path("/work/m1"))
+
+        summary = asyncio.run(
+            delete_match_cascade(
+                state,
+                path="/work/m1",
+                match_id="m1",
+                storage_prefix="matches/m1",
+                delete_local_files=False,
+                delete_raw_uploads=True,
+            )
+        )
+
+        # Jobs stopped first.
+        assert state.jobs.called and summary.jobs_cancelled == 1
+        # Match storage prefix swept (2 objects), raw uploads removed.
+        assert summary.storage_objects_deleted == 2
+        assert not any(p.startswith("matches/m1/") for p in state.storage.objects)
+        assert summary.raw_uploads_deleted == ["raw/ada.mp4", "raw/bo.mp4"]
+        assert "raw/ada.mp4" not in state.storage.objects
+        # State docs (match + 2 project) gone.
+        assert summary.state_docs_removed == 3
+        assert asyncio.run(state.project_state.load_match("m1")) == (None, 0)
+        # Match row + registry + picker row gone.
+        assert summary.match_row_removed is True
+        assert asyncio.run(state.matches_store.get("m1")) is None
+        assert "m1" not in state.matches._by_id
+        assert summary.recent_project_removed is True
+        assert str(Path("/work/m1").resolve()) in state.recent_projects.removed
+        assert summary.errors == []
+
+
+def test_hosted_raw_refcount_skips_shared() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        state = _hosted_state(tmp, recent_paths=["/work/m1"])
+        # m2 also references raw/shared.mp4 -> it must survive m1's delete.
+        _seed_match(state, "m2", raws_by_shooter={"x": ["raw/shared.mp4"]}, storage_objs=[])
+        _seed_match(
+            state,
+            "m1",
+            raws_by_shooter={"ada": ["raw/shared.mp4", "raw/solo.mp4"]},
+            storage_objs=["matches/m1/f", "raw/shared.mp4", "raw/solo.mp4"],
+        )
+
+        summary = asyncio.run(
+            delete_match_cascade(
+                state,
+                path="/work/m1",
+                match_id="m1",
+                storage_prefix="matches/m1",
+                delete_local_files=False,
+                delete_raw_uploads=True,
+            )
+        )
+
+        assert summary.raw_uploads_deleted == ["raw/solo.mp4"]
+        assert summary.raw_uploads_skipped_shared == ["raw/shared.mp4"]
+        assert "raw/solo.mp4" not in state.storage.objects
+        assert "raw/shared.mp4" in state.storage.objects  # kept for m2
+
+
+def test_hosted_partial_failure_is_recorded_but_continues() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        state = _hosted_state(tmp, recent_paths=["/work/m1"])
+        _seed_match(
+            state,
+            "m1",
+            raws_by_shooter={"ada": []},
+            storage_objs=["matches/m1/a", "matches/m1/b"],
+        )
+        state.storage.fail_on = {"matches/m1/a"}
+
+        summary = asyncio.run(
+            delete_match_cascade(
+                state,
+                path="/work/m1",
+                match_id="m1",
+                storage_prefix="matches/m1",
+                delete_local_files=False,
+                delete_raw_uploads=False,
+            )
+        )
+
+        assert any("matches/m1/a" in e for e in summary.errors)
+        # The other object still went, and the rest of the cascade completed.
+        assert "matches/m1/b" not in state.storage.objects
+        assert asyncio.run(state.matches_store.get("m1")) is None
+        assert asyncio.run(state.project_state.load_match("m1")) == (None, 0)
+        assert summary.recent_project_removed is True
+
+
+def test_hosted_missing_match_id_drops_picker_only() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        state = _hosted_state(tmp, recent_paths=["/work/legacy"])
+
+        summary = asyncio.run(
+            delete_match_cascade(
+                state,
+                path="/work/legacy",
+                match_id=None,
+                storage_prefix=None,
+                delete_local_files=False,
+                delete_raw_uploads=True,
+            )
+        )
+
+        assert summary.recent_project_removed is True
+        assert any("no match_id" in e for e in summary.errors)
+
+
+def _local_state(recent_paths: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        matches_store=None,
+        project_state=None,
+        storage=None,
+        jobs=FakeJobs(),
+        recent_projects=FakeRecentProjects(recent_paths),
+        matches=MatchRegistry(),
+    )
+
+
+def _make_match_dir(root: Path) -> Path:
+    d = root / "mymatch"
+    d.mkdir()
+    (d / MATCH_FILE).write_text("{}")
+    (d / "video.mp4").write_text("x")
+    return d
+
+
+def test_local_delete_with_optin_rmtrees(tmp_path: Path) -> None:
+    match_dir = _make_match_dir(tmp_path)
+    state = _local_state([str(match_dir)])
+    state.matches.register("m1", match_dir)
+
+    summary = asyncio.run(
+        delete_match_cascade(
+            state,
+            path=str(match_dir),
+            match_id="m1",
+            storage_prefix=None,
+            delete_local_files=True,
+            delete_raw_uploads=False,
+        )
+    )
+
+    assert summary.local_dir_removed is True
+    assert not match_dir.exists()
+    assert summary.recent_project_removed is True
+    assert "m1" not in state.matches._by_id
+    # Local mode never touches jobs.
+    assert state.jobs.called is False
+
+
+def test_local_delete_without_optin_keeps_dir(tmp_path: Path) -> None:
+    match_dir = _make_match_dir(tmp_path)
+    state = _local_state([str(match_dir)])
+
+    summary = asyncio.run(
+        delete_match_cascade(
+            state,
+            path=str(match_dir),
+            match_id="m1",
+            storage_prefix=None,
+            delete_local_files=False,
+            delete_raw_uploads=False,
+        )
+    )
+
+    assert summary.local_dir_removed is False
+    assert match_dir.exists()  # files left intact
+    assert summary.recent_project_removed is True
+
+
+def test_local_rmtree_refuses_without_match_marker(tmp_path: Path) -> None:
+    """The MATCH_FILE guard stops a stray path from nuking an unrelated dir."""
+    not_a_match = tmp_path / "random"
+    not_a_match.mkdir()
+    (not_a_match / "keep.txt").write_text("important")
+    state = _local_state([str(not_a_match)])
+
+    summary = asyncio.run(
+        delete_match_cascade(
+            state,
+            path=str(not_a_match),
+            match_id=None,
+            storage_prefix=None,
+            delete_local_files=True,
+            delete_raw_uploads=False,
+        )
+    )
+
+    assert summary.local_dir_removed is False
+    assert not_a_match.exists()
+    assert any("marker" in e for e in summary.errors)

--- a/tests/test_matches_store.py
+++ b/tests/test_matches_store.py
@@ -95,3 +95,34 @@ def test_get_does_not_leak_across_users() -> None:
 
     # Bob has no such match -> clean None, not Alice's row.
     assert asyncio.run(PostgresMatchStore(sf, user_id=bob).get("a-only")) is None
+
+
+def test_delete_removes_row() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = PostgresMatchStore(sf, user_id=uid)
+    asyncio.run(store.upsert("brm-abc", "Bromma", "matches/brm-abc"))
+
+    assert asyncio.run(store.delete("brm-abc")) is True
+    assert asyncio.run(store.get("brm-abc")) is None
+
+
+def test_delete_absent_returns_false() -> None:
+    """Idempotent: deleting an already-gone match is a clean no-op."""
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = PostgresMatchStore(sf, user_id=uid)
+    assert asyncio.run(store.delete("never-existed")) is False
+
+
+def test_delete_tenant_isolation_same_match_id() -> None:
+    """Deleting one user's row for a shared ``match_id`` leaves the other's."""
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a_store = PostgresMatchStore(sf, user_id=alice)
+    b_store = PostgresMatchStore(sf, user_id=bob)
+    asyncio.run(a_store.upsert("shared-id", "Alice Match", "matches/shared-id"))
+    asyncio.run(b_store.upsert("shared-id", "Bob Match", "matches/shared-id"))
+
+    assert asyncio.run(a_store.delete("shared-id")) is True
+
+    assert asyncio.run(a_store.get("shared-id")) is None
+    bob_row = asyncio.run(b_store.get("shared-id"))
+    assert bob_row is not None and bob_row.name == "Bob Match"

--- a/tests/test_postgres_job_backend.py
+++ b/tests/test_postgres_job_backend.py
@@ -272,6 +272,61 @@ def test_cancel_pending_short_circuits_to_cancelled(tmp_path) -> None:
     assert not ran.is_set()
 
 
+def test_cancel_active_for_user_cancels_pending_jobs(tmp_path) -> None:
+    """The delete cascade's pre-teardown stop cancels every queued job."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=False)
+    _register(backend, "victim", lambda _h: None)
+    a = asyncio.run(backend.submit(kind="victim"))
+    b = asyncio.run(backend.submit(kind="victim"))
+
+    cancelled = asyncio.run(backend.cancel_active_for_user())
+    assert cancelled == 2
+    assert asyncio.run(backend.get(a.id)).status == JobStatus.CANCELLED
+    assert asyncio.run(backend.get(b.id)).status == JobStatus.CANCELLED
+
+
+def test_cancel_active_for_user_ignores_terminal_jobs(tmp_path) -> None:
+    """Already-finished jobs aren't re-cancelled (nothing active to stop)."""
+    backend, _, _ = _build_backend_for_new_user(tmp_path, inline=True)
+    _register(backend, "quick", lambda _h: None)
+    done = asyncio.run(backend.submit(kind="quick"))  # inline -> SUCCEEDED
+    assert asyncio.run(backend.get(done.id)).status == JobStatus.SUCCEEDED
+
+    assert asyncio.run(backend.cancel_active_for_user()) == 0
+    assert asyncio.run(backend.get(done.id)).status == JobStatus.SUCCEEDED
+
+
+def test_cancel_active_for_user_isolation(tmp_path) -> None:
+    """One user's bulk cancel never touches another user's active jobs."""
+    engine = create_engine(f"sqlite+aiosqlite:///{tmp_path}/cancel-iso.sqlite")
+    session_factory = sessionmaker(engine)
+
+    async def _setup() -> tuple[str, str]:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async with session_factory() as s:
+            alice = User(email="alice-cancel@thias.se")
+            bob = User(email="bob-cancel@thias.se")
+            s.add_all([alice, bob])
+            await s.commit()
+            await s.refresh(alice)
+            await s.refresh(bob)
+            return alice.id, bob.id
+
+    alice_id, bob_id = asyncio.run(_setup())
+    alice = PostgresJobBackend(session_factory, user_id=alice_id, deferrer=_noop_deferrer())
+    bob = PostgresJobBackend(session_factory, user_id=bob_id, deferrer=_noop_deferrer())
+    _register(alice, "probe", lambda _h: None)
+    _register(bob, "probe", lambda _h: None)
+    a_job = asyncio.run(alice.submit(kind="probe"))
+    b_job = asyncio.run(bob.submit(kind="probe"))
+
+    assert asyncio.run(alice.cancel_active_for_user()) == 1
+    assert asyncio.run(alice.get(a_job.id)).status == JobStatus.CANCELLED
+    # Bob's job is untouched.
+    assert asyncio.run(bob.get(b_job.id)).status == JobStatus.PENDING
+
+
 def test_run_job_skips_a_cancelled_row(tmp_path) -> None:
     """If a worker pops a job that was cancelled while PENDING, the body
     must not run and the row stays CANCELLED."""

--- a/tests/test_project_state_store.py
+++ b/tests/test_project_state_store.py
@@ -202,3 +202,73 @@ def test_load_does_not_leak_across_users() -> None:
     asyncio.run(ProjectStateStore(sf, user_id=alice).save_match("a-only", {"x": 1}, expected_version=0))
 
     assert asyncio.run(ProjectStateStore(sf, user_id=bob).load_match("a-only")) == (None, 0)
+
+
+# -- cascade cleanup ----------------------------------------------------
+
+
+def _seed_full_match(store: ProjectStateStore, match_id: str) -> None:
+    """A match doc + two shooters' project docs + one audit doc."""
+    asyncio.run(store.save_match(match_id, {"name": match_id}, expected_version=0))
+    asyncio.run(
+        store.save_project(
+            match_id,
+            "ada",
+            {"raw_videos": [{"storage_path": "raw/ada.mp4"}]},
+            expected_version=0,
+        )
+    )
+    asyncio.run(
+        store.save_project(
+            match_id,
+            "bo",
+            {"raw_videos": [{"storage_path": "raw/bo.mp4"}]},
+            expected_version=0,
+        )
+    )
+    asyncio.run(store.save_audit(match_id, "ada", 1, {"shots": []}, expected_version=0))
+
+
+def test_list_project_docs_returns_slug_and_doc() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    _seed_full_match(store, "brm-abc")
+
+    docs = dict(asyncio.run(store.list_project_docs("brm-abc")))
+    assert set(docs) == {"ada", "bo"}
+    assert docs["ada"]["raw_videos"][0]["storage_path"] == "raw/ada.mp4"
+
+
+def test_delete_match_removes_all_kinds() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    _seed_full_match(store, "brm-abc")
+
+    # match + 2 project + 1 audit = 4 docs.
+    assert asyncio.run(store.delete_match("brm-abc")) == 4
+
+    assert asyncio.run(store.load_match("brm-abc")) == (None, 0)
+    assert asyncio.run(store.load_project("brm-abc", "ada")) == (None, 0)
+    assert asyncio.run(store.load_audit("brm-abc", "ada", 1)) == (None, 0)
+    assert asyncio.run(store.list_project_docs("brm-abc")) == []
+
+
+def test_delete_match_absent_returns_zero() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    assert asyncio.run(store.delete_match("never-existed")) == 0
+
+
+def test_delete_match_tenant_isolation() -> None:
+    """Deleting one user's match docs leaves another user's same-id docs."""
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a = ProjectStateStore(sf, user_id=alice)
+    b = ProjectStateStore(sf, user_id=bob)
+    _seed_full_match(a, "shared")
+    _seed_full_match(b, "shared")
+
+    assert asyncio.run(a.delete_match("shared")) == 4
+
+    assert asyncio.run(a.load_match("shared")) == (None, 0)
+    assert asyncio.run(b.load_match("shared")) == ({"name": "shared"}, 1)
+    assert len(asyncio.run(b.list_project_docs("shared"))) == 2

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -5557,19 +5557,40 @@ def test_recent_projects_endpoint(tmp_path: Path, _user_config_home: Path) -> No
     assert "Alpha" in names
 
 
-def test_forget_recent_project_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
+def test_delete_recent_project_endpoint(tmp_path: Path, _user_config_home: Path) -> None:
     _match_create_app(project_root=tmp_path / "alpha", project_name="Alpha")
     app = _match_create_app(project_root=tmp_path / "beta", project_name="Beta")
     client = _MatchClient(app)
 
+    alpha_root = tmp_path / "alpha"
     resp = client.post(
-        "/api/me/recent-projects/forget",
-        json={"path": str((tmp_path / "alpha").resolve())},
+        "/api/me/recent-projects/delete",
+        json={"path": str(alpha_root.resolve())},
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["removed"] is True
+    assert body["summary"]["recent_project_removed"] is True
     assert [p["name"] for p in body["projects"]] == ["Beta"]
+    # Default delete_local_files=False -> the folder stays on disk; only the
+    # picker entry is dropped.
+    assert body["summary"]["local_dir_removed"] is False
+    assert alpha_root.exists()
+
+
+def test_delete_recent_project_optin_removes_local_dir(tmp_path: Path, _user_config_home: Path) -> None:
+    app = _match_create_app(project_root=tmp_path / "gamma", project_name="Gamma")
+    client = _MatchClient(app)
+
+    gamma_root = tmp_path / "gamma"
+    assert gamma_root.exists()
+    resp = client.post(
+        "/api/me/recent-projects/delete",
+        json={"path": str(gamma_root.resolve()), "delete_local_files": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["summary"]["local_dir_removed"] is True
+    assert not gamma_root.exists()
 
 
 def test_unbound_create_app_health_reports_unbound() -> None:


### PR DESCRIPTION
## Why

The picker's trash button was a soft **Forget** -- it deleted only the `recent_projects` row and left everything else. In hosted/SaaS mode that's a silent leak: the picker is driven *solely* by `recent_projects` (the `matches` table is never surfaced to any UI), so forgetting a match made it permanently invisible while it kept billing R2 storage and holding `matches`/`state_docs` rows. It also fired with no confirmation, including on a `Cmd/Ctrl+Backspace` keystroke. Confirmations elsewhere were a mix of native `window.confirm()` and nothing.

This replaces forget with a real **Delete** that confirms first and cascades cleanup across every resource a match owns, and standardises all destructive confirmations on one accessible dialog.

## Backend

- New multi-tenant store deletes (each with an isolation test): `PostgresMatchStore.delete`, `ProjectStateStore.delete_match` (also closes the long-standing orphaned-`state_docs` gap) + `list_project_docs`, `PostgresJobBackend.cancel_active_for_user` (+ `JobRegistry` and `JobBackend` Protocol for parity).
- `ui/match_delete.py` cascade service. **Hosted:** cancel jobs -> sweep the R2 prefix -> delete opt-in raw uploads (refcounted against the user's other matches) -> delete `state_docs` -> delete match row -> forget the in-memory registry -> drop the picker row **last**. Best-effort, idempotent, with a partial-failure summary. **Local:** optional `rmtree` behind a `match.json` marker guard.
- `POST /api/me/recent-projects/delete` replaces `/forget` (POST so the opt-in flags survive DELETE-stripping proxies).

## Frontend

- `ConfirmDialog` + promise-based `useConfirm` provider: focus trap, ESC, focus restore, `aria-modal`, icon + explicit copy so colour isn't the sole signal.
- Pick.tsx delete flow with mode-gated opt-in checkboxes (delete-on-disk for desktop, delete-raw-uploads for hosted); `Cmd/Ctrl+Backspace` now opens the confirm instead of firing.
- Converted all 4 native `window.confirm()` sites: shooter remove, beep override, fixture delete, audit reset.

## Verification

- ruff, black, full `pytest` (**1730 passed / 0 failed**), frontend `tsc` typecheck.
- `pytest -m docker` (**8 passed**) against real Postgres -- confirms the new delete query paths work beyond sqlite.

## Scope notes (deliberate)

- Job cancellation is **per-user, not per-match** -- `compute_jobs` has no match link (it lives in the queue payload), so deleting a match also cancels the user's other in-flight jobs. Avoids a migration for ephemeral, boot-swept rows.
- Raw-upload refcount considers only the **deleting user's** matches -- correct today; revisit when match sharing (#449) lands (delete becomes "leave" vs "destroy").

🤖 Generated with [Claude Code](https://claude.com/claude-code)