### PR TITLE
fix(saas): clean up shooter state_docs on removal

### DIFF
--- a/src/splitsmith/db/project_state.py
+++ b/src/splitsmith/db/project_state.py
@@ -159,6 +159,25 @@ class ProjectStateStore:
             )
         return [(row.slug, row.doc) for row in rows]
 
+    async def delete_shooter(self, match_id: str, slug: str) -> int:
+        """Delete one shooter's docs within a match; return the row count.
+
+        Sweeps that shooter's project doc and every per-stage audit doc
+        (both carry ``slug``); the match doc has ``slug IS NULL`` so it is
+        untouched. Called when a single shooter is removed from a match,
+        the per-shooter analogue of :meth:`delete_match`. Idempotent.
+        """
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(StateDocRow).where(
+                    StateDocRow.user_id == self._user_id,
+                    StateDocRow.match_id == match_id,
+                    StateDocRow.slug == slug,
+                )
+            )
+            await session.commit()
+            return result.rowcount or 0
+
     async def delete_match(self, match_id: str) -> int:
         """Delete every doc for ``match_id``; return the row count.
 

--- a/src/splitsmith/ui/server.py
+++ b/src/splitsmith/ui/server.py
@@ -9053,11 +9053,13 @@ def create_app(
         return list_match_shooters()
 
     @app.delete("/api/match/shooters/{slug}", response_model=ShooterListResponse)
-    def remove_match_shooter(slug: str) -> ShooterListResponse:
+    async def remove_match_shooter(slug: str) -> ShooterListResponse:
         """Remove a shooter from the bound match.
 
-        Drops the slug from ``match.json`` and deletes
-        ``<match>/shooters/<slug>/`` from disk.
+        Drops the slug from ``match.json``, deletes
+        ``<match>/shooters/<slug>/`` from disk, and (hosted) sweeps that
+        shooter's project + audit ``state_docs`` so no orphaned rows are
+        left behind.
         """
         match_root, match = _resolve_match_context()
         if slug not in match.shooters:
@@ -9068,9 +9070,11 @@ def create_app(
         match.shooters = [s for s in match.shooters if s != slug]
         match.save(match_root)
         # The store-bound match.save above persists the dropped roster.
-        # (The shooter's now-orphaned project/audit state_docs rows are
-        # unreachable -- shooter_root rejects the slug -- and are left for a
-        # future cascade-delete; harmless meanwhile.)
+        # Hosted: also delete the shooter's project + per-stage audit docs
+        # from state_docs -- the on-disk rmtree doesn't touch Postgres, and
+        # the rows are otherwise unreachable (shooter_root rejects the slug).
+        if state.project_state is not None and match.match_id:
+            await state.project_state.delete_shooter(match.match_id, slug)
         return list_match_shooters()
 
     @app.post("/api/match/shooters/{slug}/build-trim-caches")

--- a/tests/test_project_state_store.py
+++ b/tests/test_project_state_store.py
@@ -272,3 +272,46 @@ def test_delete_match_tenant_isolation() -> None:
     assert asyncio.run(a.load_match("shared")) == (None, 0)
     assert asyncio.run(b.load_match("shared")) == ({"name": "shared"}, 1)
     assert len(asyncio.run(b.list_project_docs("shared"))) == 2
+
+
+def test_delete_shooter_removes_project_and_audit_only() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    _seed_full_match(store, "brm-abc")
+
+    # ada's project doc + ada's stage-1 audit doc = 2.
+    assert asyncio.run(store.delete_shooter("brm-abc", "ada")) == 2
+
+    assert asyncio.run(store.load_project("brm-abc", "ada")) == (None, 0)
+    assert asyncio.run(store.load_audit("brm-abc", "ada", 1)) == (None, 0)
+    # The match doc (slug NULL) and the other shooter are untouched.
+    assert asyncio.run(store.load_match("brm-abc")) == ({"name": "brm-abc"}, 1)
+    assert asyncio.run(store.load_project("brm-abc", "bo")) == (
+        {"raw_videos": [{"storage_path": "raw/bo.mp4"}]},
+        1,
+    )
+
+
+def test_delete_shooter_absent_returns_zero() -> None:
+    sf, (uid,) = _engine_with_users("m@thias.se")
+    store = ProjectStateStore(sf, user_id=uid)
+    _seed_full_match(store, "brm-abc")
+    assert asyncio.run(store.delete_shooter("brm-abc", "ghost")) == 0
+
+
+def test_delete_shooter_tenant_isolation() -> None:
+    sf, (alice, bob) = _engine_with_users("alice@thias.se", "bob@thias.se")
+    a = ProjectStateStore(sf, user_id=alice)
+    b = ProjectStateStore(sf, user_id=bob)
+    _seed_full_match(a, "shared")
+    _seed_full_match(b, "shared")
+
+    assert asyncio.run(a.delete_shooter("shared", "ada")) == 2
+
+    assert asyncio.run(a.load_project("shared", "ada")) == (None, 0)
+    # Bob's same-slug docs survive.
+    assert asyncio.run(b.load_project("shared", "ada")) == (
+        {"raw_videos": [{"storage_path": "raw/ada.mp4"}]},
+        1,
+    )
+    assert asyncio.run(b.load_audit("shared", "ada", 1)) == ({"shots": []}, 1)


### PR DESCRIPTION
## Why

Follow-up to #486. Removing a single shooter from a match (`DELETE /api/match/shooters/{slug}`) deleted its on-disk folder and dropped the slug from `match.json`, but in hosted mode left the shooter's project + per-stage audit rows orphaned in `state_docs` -- the on-disk `rmtree` never touches Postgres, and the rows are otherwise unreachable (`shooter_root` rejects the slug). The whole-match delete cascade in #486 closed this at match granularity; this closes it at shooter granularity.

## What

- `ProjectStateStore.delete_shooter(match_id, slug)`: sweeps the shooter's project doc + every per-stage audit doc (both carry `slug`); the match doc has `slug IS NULL` so it's untouched. Idempotent, multi-tenant scoped, with project-state-store tests (removes project+audit only, leaves match doc + other shooters, absent->0, tenant isolation).
- `remove_match_shooter` is now async and, when `state.project_state` is wired (hosted) and the match has a `match_id`, calls it after persisting the dropped roster.

## Verification

- ruff, black, full `pytest` (**1733 passed**), `pytest -m docker` against real Postgres.
- The new `DELETE ... WHERE user_id AND match_id AND slug` is the same shape as #486's already-Postgres-validated `delete_match`, plus a trivial `slug =` predicate (NULL match doc correctly excluded on both sqlite and Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)