### PR TITLE
feat(worker): --one-shot drain mode so the DB compute can scale to zero

### DIFF
--- a/src/splitsmith/cli.py
+++ b/src/splitsmith/cli.py
@@ -608,13 +608,29 @@ def serve(
 @app.command()
 def worker(
     concurrency: int = typer.Option(1, "--concurrency", "-c", help="Max jobs this worker runs in parallel."),
+    one_shot: bool = typer.Option(
+        False,
+        "--one-shot",
+        help="Drain the jobs already queued, then exit (Railway cron mode). "
+        "Default is a long-lived worker that blocks for new jobs.",
+    ),
 ) -> None:
-    """Run a long-lived hosted-mode worker that drains the job queue.
+    """Run a hosted-mode worker that drains the job queue.
 
     The other half of the worker fleet (doc 04): ``splitsmith serve``
     enqueues jobs onto per-tenant ``user-<id>`` queues; this process
     pops and runs them. Loads the ensemble models once and stays warm
     across many jobs -- the reason the fleet isn't serverless.
+
+    Two run modes:
+
+    - default (long-lived) -- blocks on LISTEN/NOTIFY and drains forever.
+    - ``--one-shot`` -- processes the currently-queued jobs and exits.
+      Run it on a schedule (Railway cron) so nothing holds a Postgres
+      connection between runs and the Neon compute can scale to zero. An
+      always-on worker polls often enough to keep the DB awake 24/7; the
+      one-shot drain trades up-to-interval pickup latency for a DB that
+      actually suspends when idle.
 
     Subscribes to **all** queues (Procrastinate has no queue-glob), so
     a single worker covers every tenant. Run several for more
@@ -642,11 +658,17 @@ def worker(
         )
         raise typer.Exit(2)
 
-    console.print(
-        f"[green]splitsmith worker[/]: draining all queues (concurrency={concurrency})   (Ctrl+C to stop)"
-    )
+    if one_shot:
+        console.print(
+            f"[green]splitsmith worker[/]: one-shot drain of all queues (concurrency={concurrency}), "
+            "exiting when empty"
+        )
+    else:
+        console.print(
+            f"[green]splitsmith worker[/]: draining all queues (concurrency={concurrency})   (Ctrl+C to stop)"
+        )
     try:
-        _asyncio.run(_run_worker(db_url, concurrency=concurrency))
+        _asyncio.run(_run_worker(db_url, concurrency=concurrency, wait=not one_shot))
     except KeyboardInterrupt:
         console.print("\n[yellow]Stopped.[/]")
 

--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -291,8 +291,18 @@ async def run_worker(
     *,
     concurrency: int = 1,
     queues: list[str] | None = None,
+    wait: bool = True,
 ) -> None:
-    """Run a long-lived worker that drains the job queue until killed.
+    """Run a worker that drains the job queue.
+
+    ``wait=True`` (the default) is the long-lived fleet worker: it blocks
+    on LISTEN/NOTIFY and keeps draining new jobs until killed. ``wait=False``
+    is the one-shot/cron drain: it processes the jobs already queued and then
+    returns. The one-shot mode is what lets the Postgres compute scale to
+    zero between runs -- an always-connected worker polls the queue often
+    enough that Neon's idle-suspend window never opens, so a periodic
+    ``wait=False`` drain (Railway cron) trades a little pickup latency for an
+    idle DB that actually suspends. See ``splitsmith worker --one-shot``.
 
     ``queues=None`` (the default) subscribes to **every** queue --
     Procrastinate has no queue-glob, so one worker covers all
@@ -342,7 +352,7 @@ async def run_worker(
     app = build_app(database_url)
     register_compute_task(app, state)
     async with app.open_async():
-        await app.run_worker_async(queues=queues, concurrency=concurrency)
+        await app.run_worker_async(queues=queues, concurrency=concurrency, wait=wait)
 
 
 def queue_name_for_user(user_id: str) -> str:

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -166,6 +166,116 @@ def test_run_worker_warmup_failure_is_non_fatal(monkeypatch: pytest.MonkeyPatch)
     assert calls == ["drain"]  # warmup raised but the worker still reached drain
 
 
+def test_run_worker_defaults_to_blocking_drain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default long-lived worker must pass ``wait=True`` to
+    ``run_worker_async`` so it blocks on LISTEN/NOTIFY and keeps draining new
+    jobs forever -- the always-on fleet behaviour."""
+    import asyncio
+    import sys
+    import types
+
+    server = types.ModuleType("splitsmith.ui.server")
+    server.build_worker_state = lambda: object()  # type: ignore[attr-defined]
+    server._configure_app_logging = lambda: None  # type: ignore[attr-defined]
+    server.warm_ensemble_runtime = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "splitsmith.ui.server", server)
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: None)
+
+    captured: dict[str, object] = {}
+
+    class _FakeApp:
+        def open_async(self) -> object:
+            outer = self
+
+            class _Ctx:
+                async def __aenter__(self) -> object:
+                    return outer
+
+                async def __aexit__(self, *exc: object) -> bool:
+                    return False
+
+            return _Ctx()
+
+        async def run_worker_async(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(queue_mod, "build_app", lambda _url: _FakeApp())
+    monkeypatch.setattr(queue_mod, "register_compute_task", lambda _app, _state: None)
+
+    asyncio.run(run_worker(_FAKE_PG_URL))
+
+    assert captured["wait"] is True
+
+
+def test_run_worker_one_shot_drains_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run_worker(wait=False)`` must forward ``wait=False`` to
+    ``run_worker_async`` -- the cron/one-shot drain that processes the jobs
+    already queued and then returns, so nothing holds a connection open and
+    the Neon compute can scale to zero between runs."""
+    import asyncio
+    import sys
+    import types
+
+    server = types.ModuleType("splitsmith.ui.server")
+    server.build_worker_state = lambda: object()  # type: ignore[attr-defined]
+    server._configure_app_logging = lambda: None  # type: ignore[attr-defined]
+    server.warm_ensemble_runtime = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "splitsmith.ui.server", server)
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: None)
+
+    captured: dict[str, object] = {}
+
+    class _FakeApp:
+        def open_async(self) -> object:
+            outer = self
+
+            class _Ctx:
+                async def __aenter__(self) -> object:
+                    return outer
+
+                async def __aexit__(self, *exc: object) -> bool:
+                    return False
+
+            return _Ctx()
+
+        async def run_worker_async(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(queue_mod, "build_app", lambda _url: _FakeApp())
+    monkeypatch.setattr(queue_mod, "register_compute_task", lambda _app, _state: None)
+
+    asyncio.run(run_worker(_FAKE_PG_URL, wait=False))
+
+    assert captured["wait"] is False
+
+
+def test_worker_command_one_shot_passes_wait_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``splitsmith worker --one-shot`` runs the drain with ``wait=False`` so a
+    Railway cron run exits once the queue is empty instead of blocking."""
+    captured: dict[str, object] = {}
+
+    async def _fake_run_worker(_db_url: str, *, concurrency: int = 1, wait: bool = True) -> None:
+        captured["concurrency"] = concurrency
+        captured["wait"] = wait
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "run_worker", _fake_run_worker)
+    monkeypatch.setenv("SPLITSMITH_MODE", "hosted")
+    monkeypatch.setenv("SPLITSMITH_DATABASE_URL", "postgresql+asyncpg://u:p@h/db")
+
+    result = CliRunner().invoke(app, ["worker", "--one-shot"])
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["wait"] is False
+
+
 def test_worker_command_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Missing ``SPLITSMITH_DATABASE_URL`` exits 2 with a clear message,
     before any attempt to connect."""


### PR DESCRIPTION
## Why

A Neon quota warning fired (80% of monthly compute-hours by the 7th) with **zero user traffic**. Root cause: the always-on Procrastinate worker polls the job queue on a short interval (LISTEN/NOTIFY + ~5s safety poll). Every poll resets Neon's idle timer, so the ~5-min scale-to-zero window never opens and the compute bills 24/7. Worse, an always-connected worker re-wakes the compute on every reconnect -- an always-on worker and scale-to-zero fundamentally can't coexist.

`serve` already uses `NullPool` with no pre-ping and a DB-free `/api/health`, so it does *not* keep the compute awake -- only the worker's polling does. That makes an on-demand worker viable.

## What

- `run_worker(..., wait=True)` -- new `wait` param, forwarded to `procrastinate` `run_worker_async`. Default unchanged (long-lived fleet worker).
- `splitsmith worker --one-shot` -- sets `wait=False`: drain the currently-queued jobs, then exit.

Run the worker on a schedule (Railway cron) instead of always-on. Between runs nothing holds a Postgres connection, so the compute suspends when idle. Trade-off: a job waits up to the cron interval before processing starts -- fine for offline batch video work.

## Deploy sequence (after merge)

1. merge -> staging
2. release tag -> prod
3. **only then** convert the prod Railway `worker` service to a cron schedule with start command `splitsmith worker --one-shot` (referencing the flag before the image ships would crash the service).

## Tests

- `run_worker` defaults to `wait=True`; `wait=False` is forwarded.
- `splitsmith worker --one-shot` runs the drain with `wait=False`.
- Full unit suite: 1731 passed, 16 skipped. ruff + black clean.

Docker smoke (`-m docker`) judged not required: this is a pure flag forwarded into Procrastinate's own worker loop -- no SQL, connector/DSN, or migration change. Happy to run it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)