### PR TITLE
fix(worker): survive Neon cold start in --one-shot cron drain (PoolTimeout)

### DIFF
--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -134,7 +134,20 @@ def build_app(database_url: str) -> procrastinate.App:
     # dsn}`` instead lands in the pool's *per-connection* ``kwargs`` and
     # collides with the pool's own ``conninfo`` ("got multiple values for
     # argument 'conninfo'") -- a runtime-only failure the unit tests miss.
-    connector = procrastinate.PsycopgConnector(conninfo=dsn)
+    #
+    # ``min_size=1``: Procrastinate opens the pool with ``open(wait=True)``,
+    # which blocks until ``min_size`` connections are established or its 30s
+    # default elapses. psycopg_pool defaults ``min_size`` to 4. When the
+    # worker runs as a short-lived cron drain (``worker --one-shot``) it
+    # cold-connects to a scale-to-zero Neon compute -- its OWN first query is
+    # this pool open (the worker-state wiring issues none). Filling four SSL
+    # connections through Neon's pooler while the compute resumes overruns the
+    # 30s budget and the run dies with ``PoolTimeout: pool initialization
+    # incomplete after 30.0 sec``. Requiring a single connection at open lets
+    # one land inside the window while the compute wakes; ``max_size`` keeps
+    # the same runtime capacity for the drain. The always-on worker never hit
+    # this because it kept the compute warm.
+    connector = procrastinate.PsycopgConnector(conninfo=dsn, min_size=1, max_size=4)
     app = procrastinate.App(connector=connector)
     _register_smoke_tasks(app)
     return app

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -52,6 +52,17 @@ def test_build_app_registers_ping_task() -> None:
     assert "ping" in queue_app.tasks
 
 
+def test_build_app_pool_min_size_one_for_cold_start() -> None:
+    """The connector pool must open with ``min_size=1`` so the one-shot cron
+    worker's first connection lands inside Procrastinate's 30s ``open(wait=True)``
+    window while a scale-to-zero Neon compute resumes. The psycopg_pool default
+    of 4 forced four cold SSL connections at open and timed out (PoolTimeout)."""
+    queue_app = build_app(_FAKE_PG_URL)
+    pool_args = queue_app.connector._pool_args  # type: ignore[attr-defined]
+    assert pool_args["min_size"] == 1
+    assert pool_args["max_size"] == 4
+
+
 def test_build_app_rejects_sqlite() -> None:
     """Procrastinate is Postgres-only; a SQLite URL must fail loudly at
     build time rather than dying deep in the connector."""


### PR DESCRIPTION
## Symptom
The prod (and staging) `worker` service, now a `*/7`/`*/30` cron running `splitsmith worker --one-shot`, crash-loops. Every tick:

```
splitsmith worker: one-shot drain of all queues (concurrency=1), exiting when empty
...
PoolTimeout: pool initialization incomplete after 30.0 sec
```

traceback ends at `run_worker` → `app.open_async()` → psycopg_pool `open(wait=True)`.

## Root cause
The cron cutover (#488) let the Neon compute scale to zero -- which is the point. But:
- `_apply_hosted_mode_wiring(worker=True)` only *constructs* the engine/factories/deferrer; it issues no query.
- So Procrastinate's `app.open_async()` is the worker's **first** DB connection, and a short-lived cron cold-connects to a **suspended** Neon compute.
- Procrastinate opens with `open(wait=True)`, which blocks until **min_size** connections are established or **30s** (open's default) elapses. psycopg_pool defaults `min_size=4`. Filling four SSL connections through Neon's pooler while the free-tier compute resumes overruns 30s → `PoolTimeout` → the run dies.

The always-on worker never hit this because *it kept the compute warm*. Scale-to-zero exposed the cold path.

## Fix
Build the connector with `min_size=1` (keep `max_size=4` for drain capacity). `open(wait=True)` then waits for a single connection to land while the compute wakes -- comfortably inside 30s.

## Tests
- New `test_build_app_pool_min_size_one_for_cold_start` asserts the pool args.
- Verified independently that `run_worker_async(wait=False)` itself drains+exits cleanly (the `--one-shot` mechanism was never the problem).
- Full unit suite: 1732 passed, 16 skipped. ruff + black clean.

## Verification plan
Merge → staging deploy → watch a `*/30` cron tick (hits a genuinely cold compute) complete with exit 0 / no PoolTimeout, then release → prod. If a single connection still can't beat 30s on a very cold compute, the follow-up is a connect-retry / pre-wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)