### PR TITLE
fix(worker): retry DB connect so a transient Neon PoolTimeout doesn't crash the drain

### DIFF
--- a/src/splitsmith/queue.py
+++ b/src/splitsmith/queue.py
@@ -41,6 +41,7 @@ today is zero.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -48,6 +49,8 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import procrastinate
+import psycopg
+import psycopg_pool
 
 from .observability import init_sentry
 
@@ -362,10 +365,57 @@ async def run_worker(
         await asyncio.to_thread(warm_ensemble_runtime)
     except Exception:  # noqa: BLE001 - warmup is best-effort; cold load is re-timed at job time
         logger.warning("ensemble warmup failed on worker boot; first shot_detect will cold-load")
-    app = build_app(database_url)
-    register_compute_task(app, state)
-    async with app.open_async():
+    app = await _open_app_with_retry(database_url, state)
+    try:
         await app.run_worker_async(queues=queues, concurrency=concurrency, wait=wait)
+    finally:
+        await app.connector.close_async()
+
+
+# Connection failures worth retrying when the worker opens its pool against a
+# serverless Postgres (Neon). ``PoolTimeout`` is the observed crash: the
+# short-lived ``--one-shot`` cron drain reconnects every tick and
+# ``psycopg_pool.open(wait=True)`` intermittently can't fill within its 30s
+# window -- seen even against an already-awake compute, so it's a transient
+# pooler stall, not just cold start. ``OperationalError`` / ``OSError`` cover
+# transient network or pooler refusals in the same window.
+_RETRYABLE_OPEN_ERRORS = (psycopg_pool.PoolTimeout, psycopg.OperationalError, OSError)
+
+
+async def _open_app_with_retry(
+    database_url: str,
+    state: Any,
+    *,
+    attempts: int = 5,
+    base_delay: float = 3.0,
+) -> procrastinate.App:
+    """Build and open a Procrastinate :class:`~procrastinate.App`, retrying the
+    connection on transient failures.
+
+    Procrastinate hard-codes its pool open at ``open(wait=True)`` with a 30s
+    timeout we can't widen, and a timed-out pool is left closed (it will not
+    re-open), so each attempt builds a **fresh** App. ``build_app`` issues no
+    query, so rebuilding per attempt is cheap. Linear backoff between attempts:
+    the first attempt tends to warm the path (waking the compute / priming
+    Neon's pooler) and a later one connects. The caller owns
+    ``connector.close_async`` once this returns an opened App.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        app = build_app(database_url)
+        register_compute_task(app, state)
+        try:
+            await app.connector.open_async()
+            return app
+        except _RETRYABLE_OPEN_ERRORS as exc:
+            last_exc = exc
+            with contextlib.suppress(Exception):
+                await app.connector.close_async()
+            logger.warning("worker DB connect failed (attempt %d/%d): %s", attempt, attempts, exc)
+            if attempt < attempts:
+                await asyncio.sleep(base_delay * attempt)
+    assert last_exc is not None  # loop runs >=1 time; only reached after a failure
+    raise last_exc
 
 
 def queue_name_for_user(user_id: str) -> str:

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -106,18 +106,15 @@ def test_run_worker_warms_ensemble_and_inits_sentry(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: calls.append("sentry"))
 
+    class _FakeConnector:
+        async def open_async(self) -> None:
+            return None
+
+        async def close_async(self) -> None:
+            return None
+
     class _FakeApp:
-        def open_async(self) -> object:
-            outer = self
-
-            class _Ctx:
-                async def __aenter__(self) -> object:
-                    return outer
-
-                async def __aexit__(self, *exc: object) -> bool:
-                    return False
-
-            return _Ctx()
+        connector = _FakeConnector()
 
         async def run_worker_async(self, **_kwargs: object) -> None:
             calls.append("drain")
@@ -153,18 +150,15 @@ def test_run_worker_warmup_failure_is_non_fatal(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: None)
 
+    class _FakeConnector:
+        async def open_async(self) -> None:
+            return None
+
+        async def close_async(self) -> None:
+            return None
+
     class _FakeApp:
-        def open_async(self) -> object:
-            outer = self
-
-            class _Ctx:
-                async def __aenter__(self) -> object:
-                    return outer
-
-                async def __aexit__(self, *exc: object) -> bool:
-                    return False
-
-            return _Ctx()
+        connector = _FakeConnector()
 
         async def run_worker_async(self, **_kwargs: object) -> None:
             calls.append("drain")
@@ -197,18 +191,15 @@ def test_run_worker_defaults_to_blocking_drain(monkeypatch: pytest.MonkeyPatch) 
 
     captured: dict[str, object] = {}
 
+    class _FakeConnector:
+        async def open_async(self) -> None:
+            return None
+
+        async def close_async(self) -> None:
+            return None
+
     class _FakeApp:
-        def open_async(self) -> object:
-            outer = self
-
-            class _Ctx:
-                async def __aenter__(self) -> object:
-                    return outer
-
-                async def __aexit__(self, *exc: object) -> bool:
-                    return False
-
-            return _Ctx()
+        connector = _FakeConnector()
 
         async def run_worker_async(self, **kwargs: object) -> None:
             captured.update(kwargs)
@@ -242,18 +233,15 @@ def test_run_worker_one_shot_drains_and_exits(monkeypatch: pytest.MonkeyPatch) -
 
     captured: dict[str, object] = {}
 
+    class _FakeConnector:
+        async def open_async(self) -> None:
+            return None
+
+        async def close_async(self) -> None:
+            return None
+
     class _FakeApp:
-        def open_async(self) -> object:
-            outer = self
-
-            class _Ctx:
-                async def __aenter__(self) -> object:
-                    return outer
-
-                async def __aexit__(self, *exc: object) -> bool:
-                    return False
-
-            return _Ctx()
+        connector = _FakeConnector()
 
         async def run_worker_async(self, **kwargs: object) -> None:
             captured.update(kwargs)
@@ -264,6 +252,62 @@ def test_run_worker_one_shot_drains_and_exits(monkeypatch: pytest.MonkeyPatch) -
     asyncio.run(run_worker(_FAKE_PG_URL, wait=False))
 
     assert captured["wait"] is False
+
+
+def test_run_worker_retries_db_connect_then_drains(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient ``PoolTimeout`` on connect must be retried, not crash the run.
+    The short-lived cron drain reconnects to a serverless Neon pool every tick and
+    ``open(wait=True)`` intermittently times out; after a couple of failures the
+    worker connects and drains."""
+    import asyncio
+    import sys
+    import types
+
+    import psycopg_pool
+
+    server = types.ModuleType("splitsmith.ui.server")
+    server.build_worker_state = lambda: object()  # type: ignore[attr-defined]
+    server._configure_app_logging = lambda: None  # type: ignore[attr-defined]
+    server.warm_ensemble_runtime = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "splitsmith.ui.server", server)
+
+    import splitsmith.queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "init_sentry", lambda **_k: None)
+    monkeypatch.setattr(queue_mod, "register_compute_task", lambda _app, _state: None)
+
+    seen: dict[str, object] = {"opens": 0, "drained": False, "sleeps": []}
+
+    class _FakeConnector:
+        async def open_async(self) -> None:
+            seen["opens"] = int(seen["opens"]) + 1  # type: ignore[call-overload]
+            if int(seen["opens"]) <= 2:  # type: ignore[call-overload]
+                raise psycopg_pool.PoolTimeout("pool initialization incomplete after 30.0 sec")
+
+        async def close_async(self) -> None:
+            return None
+
+    class _FakeApp:
+        def __init__(self) -> None:
+            self.connector = _FakeConnector()
+
+        async def run_worker_async(self, **_kwargs: object) -> None:
+            seen["drained"] = True
+
+    # A fresh App per attempt: _open_app_with_retry rebuilds because a
+    # timed-out pool is left closed and will not re-open.
+    monkeypatch.setattr(queue_mod, "build_app", lambda _url: _FakeApp())
+
+    async def _fast_sleep(delay: float) -> None:
+        seen["sleeps"].append(delay)  # type: ignore[union-attr]
+
+    monkeypatch.setattr(queue_mod.asyncio, "sleep", _fast_sleep)
+
+    asyncio.run(run_worker(_FAKE_PG_URL, wait=False))
+
+    assert seen["opens"] == 3  # two PoolTimeouts, then a successful connect
+    assert seen["drained"] is True
+    assert seen["sleeps"] == [3.0, 6.0]  # linear backoff between the two retries
 
 
 def test_worker_command_one_shot_passes_wait_false(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Symptom (3rd worker incident)
The `--one-shot` cron worker still crashes intermittently:
```
PoolTimeout: pool initialization incomplete after 30.0 sec
```
at `run_worker` → `app.open_async()` → psycopg_pool `open(wait=True)`.

## Why min_size=1 (#489) wasn't enough
It helped (ticks succeeded right after deploy) but regressed later. Investigation this round:
- Prod compute was **continuously awake** (`started_at`) when the failures occurred -- so it's **not** cold-start.
- `max_connections=901`, ~16 total / 3 app connections, 0 idle-in-transaction -- **not** exhaustion.
- So it's a *transient stall* establishing the pool through Neon's pooler within Procrastinate's hard-coded 30s `open(wait=True)` window. Intermittent, not deterministic.

## Fix
Procrastinate hard-codes the open timeout, so instead of widening it we **retry** the connect. `_open_app_with_retry` builds a **fresh** App per attempt (a timed-out pool is left closed and won't re-open), retries `connector.open_async()` on `PoolTimeout` / `OperationalError` / `OSError` with linear backoff (3s, 6s, ...), up to 5 attempts. The first attempt tends to warm the path; a later one connects. Caller owns `close_async` once opened.

This is the agreed direction (keep the cron + burn savings, make the connect resilient) rather than reverting to the always-on worker.

## Tests
- New `test_run_worker_retries_db_connect_then_drains`: two `PoolTimeout`s then success → drains; asserts 3 open attempts + `[3.0, 6.0]` backoff.
- Updated the existing run_worker fakes to the `connector.open_async()`/`close_async()` shape.
- Full unit suite: 1733 passed, 16 skipped. ruff + black clean.

## Verify
Merge → staging deploy → release → prod deploy, then watch several prod `*/7` ticks succeed (including ones that would previously have hit the stall). `min_size=1` from #489 stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)