### PR TITLE
ci: disable Railway auto-deploy on push/release

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -5,19 +5,17 @@ name: Deploy app (Railway)
 # Dockerfile; the env-scoped project token (a per-GitHub-Environment
 # RAILWAY_TOKEN secret) decides which Railway environment it lands in.
 #
-#   push to main          -> staging
-#   release published     -> production  (release-please release, doc 11)
 #   workflow_dispatch      -> the chosen environment (manual button)
+#
+# Automatic deploys (push to main -> staging, release published ->
+# production) are disabled for now because the Railway build keeps
+# failing; re-add the `push`/`release` triggers below once it's stable.
 #
 # Both services build from the same image (ENTRYPOINT `splitsmith`); the
 # `serve` and `worker` Railway services differ only by start command, set
 # on the service itself. `serve` runs `alembic upgrade head` on boot.
 
 on:
-  push:
-    branches: [main]
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## What

Disable the CI-controlled Railway auto-deploys while the build is unstable. `deploy-app.yml` now triggers **only** on `workflow_dispatch`.

- Push to main → no longer auto-deploys to staging
- Release published → no longer auto-deploys to production
- Manual "Run workflow" button (staging/production) still works

Re-add the `push`/`release` triggers once the Railway build is reliable again.

## Why

The Railway deploy keeps failing on merge/release; turning off the automatic triggers stops the noise without removing the ability to deploy on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)