### PR TITLE
feat(ui): in-app stage reference on the ingest page

### DIFF
--- a/docs/superpowers/plans/2026-07-01-ingest-stage-reference.md
+++ b/docs/superpowers/plans/2026-07-01-ingest-stage-reference.md
@@ -1,0 +1,344 @@
+# Ingest Stage Reference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface each stage's round/target metadata and put unassigned videos in capture-time order on the Ingest page, so assigning videos no longer requires reading the SSI stage list by hand.
+
+**Architecture:** Frontend-only. The project API already sends `stage_rounds` per stage; the frontend type just discards it. Declare the field, add a sticky collapsible `StageReference` panel to the Ingest review view, and sort the unassigned video list by capture time. Reuse the existing `StageDot` status primitive and `deriveStageStatus`.
+
+**Tech Stack:** React + TypeScript, Vite, Tailwind, lucide-react icons. Package manager: pnpm.
+
+## Global Constraints
+
+- Frontend only: touch `src/splitsmith/ui_static/src/` only. No backend, no import-path, no new dependencies (runtime or dev).
+- No new JS test framework -- `ui_static` has none (scripts: `dev`, `build`, `typecheck`, `lint`). Verification is `pnpm typecheck` + `pnpm lint` + `pnpm build` + browser check.
+- Instrument-panel aesthetic: dark surfaces, mono/`font-display`, existing `--color-*` tokens. Verify token names exist in `styles/index.css` before use.
+- Accessibility WCAG 2.2 AA: color never the sole state carrier (`StageDot` already pairs color with `aria-label`); collapse control is a real `<button>` with `aria-expanded` and a visible focus ring; `rem` sizing; `tabular-nums` on counts; motion via `motion-safe:`/global reduced-motion block only.
+- Line length and style per existing eslint config.
+
+---
+
+### Task 1: Declare `stage_rounds` on the frontend stage type
+
+**Files:**
+- Modify: `src/splitsmith/ui_static/src/lib/api.ts` (near the `StageEntry` interface, ~line 178)
+
+**Interfaces:**
+- Produces: `interface StageRounds { expected: number | null; paper_targets: number | null; steel_targets: number | null }` and `StageEntry.stage_rounds: StageRounds | null`.
+
+- [ ] **Step 1: Add the `StageRounds` interface and field**
+
+Immediately before `export interface StageEntry {`, add:
+
+```ts
+/** Round count + target breakdown for a stage, mirrored from the backend
+ *  ``config.StageRounds``. Sourced from SSI Scoreboard on import; any field
+ *  may be null for manually-created stages or older imports. */
+export interface StageRounds {
+  expected: number | null;
+  paper_targets: number | null;
+  steel_targets: number | null;
+}
+```
+
+Then add this line inside `StageEntry` (after `status?: StageStatus;`):
+
+```ts
+  /** Round/target metadata already sent by the project API; surfaced in the
+   *  Ingest stage reference panel. Null when the match carries no round data. */
+  stage_rounds: StageRounds | null;
+```
+
+- [ ] **Step 2: Confirm the payload actually carries the field**
+
+Run the app (or inspect a saved project JSON) and confirm one `GET /api/match/{slug}` response has `stages[].stage_rounds`. If it is absent, STOP -- the assumption in the spec is wrong and the plan needs a backend task. Expected: present (the backend returns `ui/project.py::StageEntry`, which declares `stage_rounds`).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd src/splitsmith/ui_static && pnpm typecheck`
+Expected: clean (no errors). The new field is required, so any code constructing a bare `StageEntry` literal in tests/mocks will now error -- fix those by adding `stage_rounds: null`. Search: `rg "stage_name:" src/splitsmith/ui_static/src` for object literals that need the field.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/splitsmith/ui_static/src/lib/api.ts
+git commit -m "feat(ui): declare stage_rounds on the frontend StageEntry type"
+```
+
+---
+
+### Task 2: `StageReference` panel component
+
+**Files:**
+- Create: `src/splitsmith/ui_static/src/components/ingest/StageReference.tsx`
+
+**Interfaces:**
+- Consumes: `StageEntry` / `StageRounds` (Task 1), `StageDot` from `@/components/ui/StageDot`, `deriveStageStatus` from `@/lib/stageStatus`.
+- Produces: `export function StageReference({ stages }: { stages: StageEntry[] }): JSX.Element | null`.
+
+- [ ] **Step 1: Create the component**
+
+Create `src/splitsmith/ui_static/src/components/ingest/StageReference.tsx` with exactly:
+
+```tsx
+import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { StageDot } from "@/components/ui/StageDot";
+import type { StageEntry, StageStatus } from "@/lib/api";
+import { deriveStageStatus } from "@/lib/stageStatus";
+
+const COLLAPSE_KEY = "splitsmith:ingest:stage-reference:collapsed";
+
+function readCollapsed(defaultCollapsed: boolean): boolean {
+  if (typeof window === "undefined") return defaultCollapsed;
+  const raw = window.localStorage.getItem(COLLAPSE_KEY);
+  if (raw === "1") return true;
+  if (raw === "0") return false;
+  return defaultCollapsed;
+}
+
+function roundsLabel(stage: StageEntry): string {
+  const n = stage.stage_rounds?.expected;
+  return n == null ? "--" : `${n}rd`;
+}
+
+function targetsLabel(stage: StageEntry): string {
+  const paper = stage.stage_rounds?.paper_targets ?? null;
+  const steel = stage.stage_rounds?.steel_targets ?? null;
+  const parts: string[] = [];
+  if (paper != null) parts.push(`${paper}P`);
+  if (steel != null) parts.push(`${steel}S`);
+  return parts.length ? parts.join(" ") : "--";
+}
+
+const STATUS_LABEL: Record<StageStatus, string> = {
+  todo: "todo",
+  partial: "partial",
+  ready: "ready",
+  in_progress: "detecting",
+  audited: "audited",
+  skipped: "skipped",
+};
+
+/**
+ * StageReference -- the in-app copy of the SSI stage list, shown while
+ * assigning videos so the operator never leaves the Ingest page. Read-only:
+ * round count, paper/steel targets, assigned-video count, and lifecycle
+ * status per stage. Sticky + collapsible; collapse state persists.
+ */
+export function StageReference({ stages }: { stages: StageEntry[] }) {
+  const withFootage = stages.filter((s) => (s.videos?.length ?? 0) > 0).length;
+  const remaining = stages.length - withFootage;
+  const hasAnyRounds = stages.some((s) => s.stage_rounds?.expected != null);
+
+  const [collapsed, setCollapsed] = useState(() =>
+    readCollapsed(remaining === 0),
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
+  if (stages.length === 0) return null;
+
+  return (
+    <div className="sticky top-0 z-10 border-b border-rule-strong bg-surface-2/95 backdrop-blur">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center gap-3 px-5 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-led"
+      >
+        <span className="font-display text-sm font-bold uppercase tracking-[0.06em] text-ink">
+          Stage reference
+        </span>
+        <span className="font-mono text-[0.6875rem] tabular-nums text-muted">
+          {withFootage} / {stages.length} have footage
+          {remaining > 0 && <> &middot; {remaining} remaining</>}
+        </span>
+        <span aria-hidden className="ml-auto text-muted">
+          {collapsed ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronUp className="size-4" />
+          )}
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div className="max-h-[40vh] overflow-y-auto border-t border-rule">
+          <table className="w-full border-collapse font-mono text-[0.6875rem]">
+            <thead className="sticky top-0 bg-surface-2 text-muted">
+              <tr className="text-left uppercase tracking-[0.08em]">
+                <th className="px-5 py-1.5 font-medium">Stage</th>
+                <th className="py-1.5 font-medium">Name</th>
+                <th className="py-1.5 pr-4 text-right font-medium">Rounds</th>
+                <th className="py-1.5 pr-4 font-medium">Targets</th>
+                <th className="py-1.5 pr-4 text-right font-medium">Videos</th>
+                <th className="px-5 py-1.5 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stages.map((s) => {
+                const status = s.status ?? deriveStageStatus(s);
+                const count = s.videos?.length ?? 0;
+                return (
+                  <tr
+                    key={s.stage_number}
+                    className="border-t border-rule/60 text-ink-2 hover:bg-surface-3"
+                  >
+                    <td className="px-5 py-1.5 tabular-nums text-ink">
+                      {String(s.stage_number).padStart(2, "0")}
+                    </td>
+                    <td className="py-1.5 pr-4 text-ink">{s.stage_name}</td>
+                    <td className="py-1.5 pr-4 text-right tabular-nums">
+                      {roundsLabel(s)}
+                    </td>
+                    <td className="py-1.5 pr-4 tabular-nums">
+                      {targetsLabel(s)}
+                    </td>
+                    <td className="py-1.5 pr-4 text-right tabular-nums">
+                      {count === 0 ? (
+                        <span className="text-muted">0</span>
+                      ) : (
+                        count
+                      )}
+                    </td>
+                    <td className="px-5 py-1.5">
+                      <span className="inline-flex items-center gap-1.5">
+                        <StageDot status={status} />
+                        <span className="uppercase tracking-[0.06em] text-muted">
+                          {STATUS_LABEL[status]}
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {!hasAnyRounds && (
+            <div className="border-t border-rule px-5 py-2 font-mono text-[0.625rem] text-muted">
+              Round and target data unavailable -- re-sync this match from the
+              scoreboard to populate it.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify `deriveStageStatus` export exists and its signature**
+
+Run: `rg "export function deriveStageStatus|export const deriveStageStatus" src/splitsmith/ui_static/src/lib/stageStatus.ts`
+Expected: found, taking a stage-like arg and returning `StageStatus`. If the arg name/type differs, the call `deriveStageStatus(s)` still type-checks as long as it accepts a `StageEntry`. If it does not, adapt the call to pass the fields it needs.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `cd src/splitsmith/ui_static && pnpm typecheck && pnpm lint`
+Expected: clean. Common fixes: `--color-status-*` and `focus-visible:ring-led` must resolve -- if `ring-led` is not a configured Tailwind color, use the existing focus pattern from `Ingest.tsx` (`focus:border-led focus:shadow-[0_0_0_2px_var(--color-led-tint)]`) on the button instead.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/splitsmith/ui_static/src/components/ingest/StageReference.tsx
+git commit -m "feat(ui): add StageReference panel for the ingest page"
+```
+
+---
+
+### Task 3: Wire the panel into ReviewState and sort unassigned videos by capture time
+
+**Files:**
+- Modify: `src/splitsmith/ui_static/src/pages/Ingest.tsx` (`ReviewState`, ~lines 503-680)
+
+**Interfaces:**
+- Consumes: `StageReference` (Task 2).
+
+- [ ] **Step 1: Import the panel**
+
+Add to the imports at the top of `Ingest.tsx` (with the other `@/components` imports):
+
+```ts
+import { StageReference } from "@/components/ingest/StageReference";
+```
+
+- [ ] **Step 2: Sort the unassigned list by capture time**
+
+Replace the line (~537):
+
+```ts
+  const unassignedVideos = project.unassigned_videos ?? [];
+```
+
+with a stable capture-time sort (ISO `match_timestamp` ascending, timestamp-less last):
+
+```ts
+  // Capture-time order so videos line up with shooting/stage sequence next
+  // to the stage reference. Stable: timestamp-less videos keep their order
+  // and sink below timestamped ones. (#ingest-stage-reference)
+  const unassignedVideos = useMemo(() => {
+    const list = (project.unassigned_videos ?? []).map((v, i) => ({ v, i }));
+    list.sort((a, b) => {
+      const ta = a.v.match_timestamp;
+      const tb = b.v.match_timestamp;
+      if (ta && tb) {
+        const cmp = ta.localeCompare(tb);
+        return cmp !== 0 ? cmp : a.i - b.i;
+      }
+      if (ta) return -1;
+      if (tb) return 1;
+      return a.i - b.i;
+    });
+    return list.map((x) => x.v);
+  }, [project]);
+```
+
+(`useMemo` is already imported and used in this file.)
+
+- [ ] **Step 3: Render the panel above the review card**
+
+Change the `return (` in `ReviewState` (~line 552) so the panel is the first child of the fragment, above the card `<div>`:
+
+```tsx
+  return (
+    <>
+      <StageReference stages={project.stages} />
+      <div className="overflow-hidden rounded-2xl border border-rule-strong bg-gradient-to-b from-surface to-surface-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_18px_36px_-24px_rgba(0,0,0,0.6)]">
+```
+
+(Leave the rest of the card unchanged. The closing `</>` already exists.)
+
+- [ ] **Step 4: Typecheck + lint + build**
+
+Run: `cd src/splitsmith/ui_static && pnpm typecheck && pnpm lint && pnpm build`
+Expected: all clean, build succeeds.
+
+- [ ] **Step 5: Browser verification**
+
+Start the app, open a match created from SSI Scoreboard that has unassigned videos, go to the Ingest/videos page, and confirm:
+- The sticky "Stage reference" bar appears above the review card and stays visible while scrolling the video lists (adjust the sticky `top-0` offset if a fixed app header overlaps it).
+- Each stage row shows round count (`Nrd`), targets (`nP nS`), assigned-video count, and a `StageDot` + status label; null round/target fields render `--`.
+- The unassigned videos are in capture-time order (earliest first; any without a timestamp at the bottom).
+- Collapse/expand toggles and the state survives a page reload.
+- On a match with no round data, the "Round and target data unavailable" hint shows.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/splitsmith/ui_static/src/pages/Ingest.tsx
+git commit -m "feat(ui): show stage reference + capture-time order on ingest"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Type plumbing (Task 1), stage reference panel with round/target/videos/status + empty-state hint (Task 2), capture-time ordering + picker left unchanged (Task 3), a11y constraints (Global Constraints + Task 2 code), verification without a JS test runner (each task + Task 3 Step 5). All spec sections mapped.
+- **Placeholder scan:** No TBDs; every code step carries complete code.
+- **Type consistency:** `StageRounds`/`StageEntry.stage_rounds` defined in Task 1 and consumed in Task 2; `StageReference({ stages })` produced in Task 2 and consumed in Task 3; `StageStatus` keys in `STATUS_LABEL` match the `StageStatus` union in `lib/api.ts`.

--- a/docs/superpowers/specs/2026-07-01-ingest-stage-reference-design.md
+++ b/docs/superpowers/specs/2026-07-01-ingest-stage-reference-design.md
@@ -1,0 +1,170 @@
+# In-app stage reference for video ingest
+
+Date: 2026-07-01
+Status: design approved, pending spec review
+Issue: (none yet -- personal-tool UX gap reported during local app use)
+
+## Problem
+
+When assigning imported videos to stages on the Ingest page, the stage
+picker shows only `Stage NN -- {stage_name}`. That is not enough to tell
+which video belongs to which stage, so the user leaves the app and reads
+the stage list on SSI Scoreboard by hand. The redesign (commit `b3531b5`)
+did not cause the picker to lose data -- the richer per-stage metadata was
+never surfaced in this picker in any version. The metadata the user relies
+on (round count, paper/steel target layout, and shooting order) already
+exists in the project but is thrown away by the frontend.
+
+## What the user relies on
+
+Confirmed by the user, in priority order:
+
+1. Round count and target layout (paper vs steel) to recognize a stage.
+2. Shooting order -- videos were captured in squad-rotation order, so
+   chronological order lines up with the stage sequence.
+
+The user does NOT rely on stage time/duration or the written procedure for
+this task. The user explicitly chose "surface the data, never guess" over
+any auto-suggest that could mislead.
+
+## Goal
+
+Bring the SSI stage list into the Ingest page so the user never has to
+leave the app to assign videos. Surface round/target metadata and put
+videos in capture-time order. No guessing, no auto-assignment.
+
+## Scope
+
+Frontend only (`src/splitsmith/ui_static/src/`). No backend change, no
+import-path change, no new runtime or dev dependencies.
+
+The round/target data is already on the wire: the project API returns
+`ui/project.py::StageEntry`, which carries `stage_rounds`
+(`expected` / `paper_targets` / `steel_targets`, from `config.py`). The
+frontend `StageEntry` type in `lib/api.ts` simply does not declare it, so
+it is dropped before render.
+
+## Design
+
+### 1. Type plumbing
+
+Add to `StageEntry` in `src/splitsmith/ui_static/src/lib/api.ts` (near
+line 178):
+
+```ts
+export interface StageRounds {
+  expected: number | null;
+  paper_targets: number | null;
+  steel_targets: number | null;
+}
+
+// on StageEntry:
+stage_rounds: StageRounds | null;
+```
+
+No payload change -- this only stops the UI from discarding a field the
+server already sends. Verify one live `/api/match/{slug}` response actually
+contains `stage_rounds` before relying on it.
+
+### 2. Stage reference panel
+
+New component `StageReference` rendered on the Ingest page, pinned (sticky)
+directly under the page header, above the video lists.
+
+Behavior:
+
+- Collapsible. State persisted in `localStorage` (existing pattern in the
+  codebase, e.g. `MatchShell`/`AppShell`). Default open when at least one
+  video is unassigned; default collapsed once everything is assigned.
+- When expanded: a dense, read-only, monospace grid with one row per stage.
+  Max height ~40vh with internal vertical scroll so a 20-stage match never
+  dominates the viewport.
+- When collapsed: a single coverage readout line, e.g.
+  `STAGE COVERAGE  8 / 12 have footage  -  4 remaining`.
+
+Columns (instrument-panel styling, `tabular-nums` for all counts):
+
+```
+STAGE  NAME              ROUNDS  TARGETS   VIDEOS  STATUS
+03     El Presidente     12rd    6P 2S       1     [ready]
+04     Accelerator       24rd    12P 4S      0     [todo]
+05     Standards         18rd    9P          --    [todo]
+```
+
+- `ROUNDS` = `stage_rounds.expected` rendered as `{n}rd`; `--` when null.
+- `TARGETS` = `{paper}P {steel}S`, omitting a side whose count is null;
+  `--` when both null.
+- `VIDEOS` = count of assigned videos (`stage.videos.length`).
+- `STATUS` = existing `StatusPill` (`components/ui/StatusPill.tsx`),
+  reusing whatever `StageStatus -> tone` mapping `StageBlock` already uses.
+  Do not introduce a second mapping.
+
+Empty-data state: if NO stage in the match has any `stage_rounds`, show a
+subtle inline hint that round/target data is unavailable and that
+re-syncing from the scoreboard can backfill it (the backend already has
+`MatchProject.merge_stage_rounds`). The backfill action itself is out of
+scope for this change.
+
+Optional, low-risk nicety: clicking a stage row scrolls that stage's
+`StageBlock` into view. Read-only, no assignment side effect. Include only
+if it fits cleanly.
+
+### 3. Capture-time ordering
+
+Sort the **unassigned** video list by `video.match_timestamp` ascending.
+Videos without a timestamp sink to the bottom via a stable sort, preserving
+their existing relative order. The per-row capture timestamp is already
+rendered (`Ingest.tsx` `recordedAt`, ~line 963/1027); no change there.
+
+This is the "surface, no guess" ordering: videos appear in shooting order
+next to the reference panel so the user maps them top-down themselves.
+
+### 4. Picker unchanged
+
+The `<select>` at `Ingest.tsx` ~line 1038 stays as-is. The stage name is
+the identifier and the column is narrow; padding a round-count hint in
+would truncate the name. The reference panel is the single source of
+metadata; the picker stays a clean control.
+
+## Accessibility (WCAG 2.2 AA)
+
+- Status conveyed by `StatusPill`, which already pairs color with a text
+  label and a shape cue -- color is never the sole carrier.
+- Collapse toggle: real `<button>` with `aria-expanded`, visible focus ring
+  (existing `focus:` token pattern), keyboard operable.
+- `rem`-based sizing, `tabular-nums` for numeric alignment.
+- Reduced motion: the collapse transition respects the global
+  `prefers-reduced-motion` block; no new unguarded animation.
+- Panel exposed with appropriate table/list semantics for screen readers.
+
+## Out of scope (YAGNI)
+
+- No auto-suggest / squad-rotation computation (user chose "no guess").
+- `course_display` (Short/Med/Long), `procedure`, `firearm_condition`,
+  `max_points` stay dropped on scoreboard import -- the user does not rely
+  on them and surfacing them needs a backend/import change.
+- No scoreboard re-sync/backfill button (only the empty-state hint).
+- No change to the assigned-per-stage `StageBlock` rows.
+
+## Verification
+
+`ui_static` has no JS unit-test framework (scripts: `dev`, `build`,
+`typecheck`, `lint`). Adding one is a new dependency and out of scope
+unless the user asks. Verification for this change:
+
+- `pnpm typecheck` (`tsc -b --noEmit`) clean.
+- `pnpm lint` (eslint) clean.
+- Browser verification via Playwright MCP against a real match created
+  from SSI Scoreboard: panel renders round/target counts, `--` for nulls,
+  correct assigned counts and status pills; unassigned list is in
+  capture-time order; collapse/expand persists across reload; empty-data
+  hint shows when no stage has round data.
+
+## Files touched
+
+- `src/splitsmith/ui_static/src/lib/api.ts` -- `StageEntry` type +
+  `StageRounds`.
+- `src/splitsmith/ui_static/src/pages/Ingest.tsx` -- render
+  `StageReference`, sort unassigned list.
+- New: `src/splitsmith/ui_static/src/components/ingest/StageReference.tsx`
+  (final path to match existing component-folder convention).

--- a/src/splitsmith/ui_static/src/components/ingest/StageReference.tsx
+++ b/src/splitsmith/ui_static/src/components/ingest/StageReference.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { StageDot } from "@/components/ui/StageDot";
+import type { StageEntry, StageStatus } from "@/lib/api";
+import { deriveStageStatus } from "@/lib/stageStatus";
+
+const COLLAPSE_KEY = "splitsmith:ingest:stage-reference:collapsed";
+
+function readCollapsed(defaultCollapsed: boolean): boolean {
+  if (typeof window === "undefined") return defaultCollapsed;
+  const raw = window.localStorage.getItem(COLLAPSE_KEY);
+  if (raw === "1") return true;
+  if (raw === "0") return false;
+  return defaultCollapsed;
+}
+
+function roundsLabel(stage: StageEntry): string {
+  const n = stage.stage_rounds?.expected;
+  return n == null ? "--" : `${n}rd`;
+}
+
+function targetsLabel(stage: StageEntry): string {
+  const paper = stage.stage_rounds?.paper_targets ?? null;
+  const steel = stage.stage_rounds?.steel_targets ?? null;
+  const parts: string[] = [];
+  if (paper != null) parts.push(`${paper}P`);
+  if (steel != null) parts.push(`${steel}S`);
+  return parts.length ? parts.join(" ") : "--";
+}
+
+const STATUS_LABEL: Record<StageStatus, string> = {
+  todo: "todo",
+  partial: "partial",
+  ready: "ready",
+  in_progress: "detecting",
+  audited: "audited",
+  skipped: "skipped",
+};
+
+/**
+ * StageReference -- the in-app copy of the SSI stage list, shown while
+ * assigning videos so the operator never leaves the Ingest page. Read-only:
+ * round count, paper/steel targets, assigned-video count, and lifecycle
+ * status per stage. Sticky + collapsible; collapse state persists.
+ */
+export function StageReference({ stages }: { stages: StageEntry[] }) {
+  const withFootage = stages.filter((s) => (s.videos?.length ?? 0) > 0).length;
+  const remaining = stages.length - withFootage;
+  const hasAnyRounds = stages.some((s) => s.stage_rounds?.expected != null);
+
+  const [collapsed, setCollapsed] = useState(() =>
+    readCollapsed(remaining === 0),
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
+  if (stages.length === 0) return null;
+
+  return (
+    <div className="sticky top-0 z-10 border-b border-rule-strong bg-surface-2/95 backdrop-blur">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center gap-3 px-5 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-led"
+      >
+        <span className="font-display text-sm font-bold uppercase tracking-[0.06em] text-ink">
+          Stage reference
+        </span>
+        <span className="font-mono text-[0.6875rem] tabular-nums text-muted">
+          {withFootage} / {stages.length} have footage
+          {remaining > 0 && <> &middot; {remaining} remaining</>}
+        </span>
+        <span aria-hidden className="ml-auto text-muted">
+          {collapsed ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronUp className="size-4" />
+          )}
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div className="max-h-[40vh] overflow-y-auto border-t border-rule">
+          <table className="w-full border-collapse font-mono text-[0.6875rem]">
+            <thead className="sticky top-0 bg-surface-2 text-muted">
+              <tr className="text-left uppercase tracking-[0.08em]">
+                <th className="px-5 py-1.5 font-medium">Stage</th>
+                <th className="py-1.5 font-medium">Name</th>
+                <th className="py-1.5 pr-4 text-right font-medium">Rounds</th>
+                <th className="py-1.5 pr-4 font-medium">Targets</th>
+                <th className="py-1.5 pr-4 text-right font-medium">Videos</th>
+                <th className="px-5 py-1.5 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stages.map((s) => {
+                const status = s.status ?? deriveStageStatus(s);
+                const count = s.videos?.length ?? 0;
+                return (
+                  <tr
+                    key={s.stage_number}
+                    className="border-t border-rule/60 text-ink-2 hover:bg-surface-3"
+                  >
+                    <td className="px-5 py-1.5 tabular-nums text-ink">
+                      {String(s.stage_number).padStart(2, "0")}
+                    </td>
+                    <td className="py-1.5 pr-4 text-ink">{s.stage_name}</td>
+                    <td className="py-1.5 pr-4 text-right tabular-nums">
+                      {roundsLabel(s)}
+                    </td>
+                    <td className="py-1.5 pr-4 tabular-nums">
+                      {targetsLabel(s)}
+                    </td>
+                    <td className="py-1.5 pr-4 text-right tabular-nums">
+                      {count === 0 ? (
+                        <span className="text-muted">0</span>
+                      ) : (
+                        count
+                      )}
+                    </td>
+                    <td className="px-5 py-1.5">
+                      <span className="inline-flex items-center gap-1.5">
+                        <StageDot status={status} />
+                        <span className="uppercase tracking-[0.06em] text-muted">
+                          {STATUS_LABEL[status]}
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {!hasAnyRounds && (
+            <div className="border-t border-rule px-5 py-2 font-mono text-[0.625rem] text-muted">
+              Round and target data unavailable -- re-sync this match from the
+              scoreboard to populate it.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/splitsmith/ui_static/src/lib/api.ts
+++ b/src/splitsmith/ui_static/src/lib/api.ts
@@ -175,6 +175,15 @@ export type StageStatus =
   | "audited"
   | "skipped";
 
+/** Round count + target breakdown for a stage, mirrored from the backend
+ *  ``config.StageRounds``. Sourced from SSI Scoreboard on import; any field
+ *  may be null for manually-created stages or older imports. */
+export interface StageRounds {
+  expected: number | null;
+  paper_targets: number | null;
+  steel_targets: number | null;
+}
+
 export interface StageEntry {
   stage_number: number;
   stage_name: string;
@@ -191,6 +200,9 @@ export interface StageEntry {
    *  Optional in the type because legacy responses may omit it; callers
    *  should fall back via :func:`deriveStageStatus` when missing. */
   status?: StageStatus;
+  /** Round/target metadata already sent by the project API; surfaced in the
+   *  Ingest stage reference panel. Null when the match carries no round data. */
+  stage_rounds: StageRounds | null;
 }
 
 export interface MatchProject {

--- a/src/splitsmith/ui_static/src/pages/Ingest.tsx
+++ b/src/splitsmith/ui_static/src/pages/Ingest.tsx
@@ -35,6 +35,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { AddFootageModal } from "@/components/AddFootageModal";
+import { StageReference } from "@/components/ingest/StageReference";
 import { RelinkDialog } from "@/components/RelinkDialog";
 import { Brand, Kicker } from "@/components/ui";
 import { Button } from "@/components/ui/button";
@@ -534,7 +535,24 @@ function ReviewState({
       ),
     [project],
   );
-  const unassignedVideos = project.unassigned_videos ?? [];
+  // Capture-time order so videos line up with shooting/stage sequence next
+  // to the stage reference. Stable: timestamp-less videos keep their order
+  // and sink below timestamped ones. (#ingest-stage-reference)
+  const unassignedVideos = useMemo(() => {
+    const list = (project.unassigned_videos ?? []).map((v, i) => ({ v, i }));
+    list.sort((a, b) => {
+      const ta = a.v.match_timestamp;
+      const tb = b.v.match_timestamp;
+      if (ta && tb) {
+        const cmp = ta.localeCompare(tb);
+        return cmp !== 0 ? cmp : a.i - b.i;
+      }
+      if (ta) return -1;
+      if (tb) return 1;
+      return a.i - b.i;
+    });
+    return list.map((x) => x.v);
+  }, [project]);
 
   // Camera grouping: by camera_model+camera_mount. Label A/B/C in order.
   const cameras = useMemo(() => groupByCamera(assignedVideos), [assignedVideos]);
@@ -551,6 +569,7 @@ function ReviewState({
 
   return (
     <>
+      <StageReference stages={project.stages} />
       <div className="overflow-hidden rounded-2xl border border-rule-strong bg-gradient-to-b from-surface to-surface-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_18px_36px_-24px_rgba(0,0,0,0.6)]">
         {/* Drop summary */}
         <div className="relative flex items-center gap-4 border-b border-rule bg-gradient-to-r from-led/10 to-transparent px-6 py-4">


### PR DESCRIPTION
## Problem

On the Ingest page, the video-to-stage picker shows only `Stage NN -- {stage_name}`. That is not enough to tell which video belongs to which stage, so you have to leave the app and read the stage list on SSI Scoreboard by hand. The redesign didn't strip data from the picker -- the richer per-stage metadata was never surfaced there in any version.

The data you rely on (round count, paper/steel target layout, and shooting order) already exists in the project; the frontend just discarded it.

## What this does

Brings the SSI stage list into the Ingest page so you never have to leave it. Frontend-only, no guessing.

- **Stage reference panel** -- a sticky, collapsible bar above the review card listing every stage with round count (`Nrd`), paper/steel targets (`nP nS`), assigned-video count, and lifecycle status (reusing the canonical `StageDot`). Null round/target fields render `--`; an empty-data hint shows when a match carries no round data. Collapse state persists in `localStorage`.
- **Capture-time ordering** -- the unassigned video list is now sorted by capture time (stable; timestamp-less videos sink to the bottom), so videos line up with shooting/stage sequence next to the reference.
- The `<select>` picker is intentionally left clean -- the panel is the single source of stage metadata, so the stage name never gets truncated by a crammed-in hint.

`stage_rounds` (`expected` / `paper_targets` / `steel_targets`) was already on the wire from the project API; this just declares it on the frontend `StageEntry` type and renders it.

## Scope / decisions

- Frontend only. No backend, import-path, or dependency changes.
- No auto-suggest / squad-rotation guess (chosen: "surface the data, never guess").
- `course_display` / `procedure` / `firearm_condition` stay dropped on import -- not relied upon, and surfacing them needs a backend change.

## Verification

- `pnpm typecheck` -- clean (first-hand).
- `pnpm build` -- succeeds (first-hand; the >500 kB chunk warning is pre-existing).
- `pnpm lint` -- not run: the `lint` script references eslint, which is not installed in `ui_static` (pre-existing broken stub; CI gates on `build`).
- **Browser check still pending** -- needs the backend running with a real scoreboard match that has unassigned footage. Worth eyeballing: the sticky bar not overlapping the app header, round/target values populating, and the unassigned list ordering. Easiest to confirm in the running local app.

Design + plan: `docs/superpowers/specs/2026-07-01-ingest-stage-reference-design.md`, `docs/superpowers/plans/2026-07-01-ingest-stage-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2Z121nV8dPjgu248huLMX
